### PR TITLE
Pirates no longer autocalls black alert.

### DIFF
--- a/code/modules/events/pirates.dm
+++ b/code/modules/events/pirates.dm
@@ -92,7 +92,6 @@ GLOBAL_VAR_INIT(pirates_spawned, FALSE)
 	template_placer.on_completion(CALLBACK(GLOBAL_PROC, GLOBAL_PROC_REF(after_pirate_spawn), ship, candidates))
 
 	priority_announce("Unidentified armed ship detected near the station.", sound = SSstation.announcer.get_rand_alert_sound())
-	SSsecurity_level.set_level(SEC_LEVEL_BLACK)
 
 /proc/after_pirate_spawn(datum/map_template/shuttle/pirate/default/ship, list/candidates, datum/async_map_generator/async_map_generator, turf/T)
 	for(var/turf/A in ship.get_affected_turfs(T))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

I added this because ruko wanted it. I did not like it back then. I like it even less now.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Calling alert levels meant to be called by crew automatically is a blatant misuse of alerts in every way conceivable.

Alerts are purely a command level decision. We have no fucking right to make it for them. The incessant calling of black alert when only every tenth pirate spawn needs it has led to a massive level of alert fatigue that i am not sure will be easily remedied.

If pirates appear and warrant arming of the crew, the crew will arm themselves. If there are no command people to call black alert, then the crew will still arm themselves regardless. Alerts only matter in the context of a command staff calling them.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>

## Changelog
:cl:
del: Pirates no longer call black alert by default.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
