### PR TITLE
Nightmare fixes

### DIFF
--- a/code/modules/antagonists/nightmare/nightmare.dm
+++ b/code/modules/antagonists/nightmare/nightmare.dm
@@ -14,7 +14,7 @@
 
 /datum/antagonist/nightmare/greet()
 	owner.announce_objectives()
-	to_chat(owner, span_boldannounce("Your primary goal is keeping the station dark, do not go out of your way to randomly kill people. You may attack them to snuff out their light or retaliate after they start attacking."))
+	to_chat(owner, span_boldannounce("Your primary goal is keeping the station dark, do not kill people in such a way that is likely to completely remove them from the round."))
 
 /datum/antagonist/nightmare/apply_innate_effects(mob/living/mob_override)
 	. = ..()

--- a/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
@@ -770,8 +770,9 @@
 		light_holder.forceMove(M)
 
 /datum/reagent/consumable/ethanol/tequila_sunrise/on_mob_end_metabolize(mob/living/M)
-	to_chat(M, span_notice("The warmth in your body fades."))
-	QDEL_NULL(light_holder)
+	if(light_holder)
+		to_chat(M, span_notice("The warmth in your body fades."))
+		QDEL_NULL(light_holder)
 
 /datum/reagent/consumable/ethanol/toxins_special
 	name = "Toxins Special"

--- a/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
@@ -753,16 +753,21 @@
 	icon_state = "tequilasunriseglass"
 
 /datum/reagent/consumable/ethanol/tequila_sunrise/on_mob_metabolize(mob/living/M)
+	. = ..()
+	if(isshadow(M)) //This is an uncounterable light for shadowpeople
+		return
 	to_chat(M, span_notice("You feel gentle warmth spread through your body!"))
 	light_holder = new(M)
 	light_holder.set_light(3, 0.7, "#FFCC00") //Tequila Sunrise makes you radiate dim light, like a sunrise!
 
 /datum/reagent/consumable/ethanol/tequila_sunrise/on_mob_life(mob/living/carbon/M, delta_time, times_fired)
+	. = ..()
+	if(isshadow(M))
+		return
 	if(QDELETED(light_holder))
 		M.reagents.del_reagent(/datum/reagent/consumable/ethanol/tequila_sunrise) //If we lost our light object somehow, remove the reagent
 	else if(light_holder.loc != M)
 		light_holder.forceMove(M)
-	return ..()
 
 /datum/reagent/consumable/ethanol/tequila_sunrise/on_mob_end_metabolize(mob/living/M)
 	to_chat(M, span_notice("The warmth in your body fades."))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

* Tequila sunrise no longer makes shadowpeople glow. It does still make them **very** flammable and drunk though. 
* Updated the info nightmares are told when they spawn in to accurately reflect the rules

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

* Tequila sunrise is an uncounterable light for shadowpeople and nightmares. Once it's in their system the only way they can purge it is by drinking something that purges reagents which is not a reasonable thing to expect a nightmare to have gotten. They are mostly disallowed from high impact actions so this would force them to have already targetted medbay to stand any chance of getting it purged before it kills them.
* **Current rules state nightmares are hostile and are only forbidden from high impact killings**. Nightmares are essentially told they can only harm crew in self-defense after being attacked, or for the sake of turning out a light and it is implied that they should not be killing other players with the way it is worded. This was never true and I think when @itsmeow originally questioned the wording it maybe should have been scrutinized further when the PR author claimed an admin told them to do it. I'm not sure though, this was years ago.  

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

<img width="771" height="65" alt="image" src="https://github.com/user-attachments/assets/eef35465-875a-4cb8-be75-6aad63a07f27" />

Getting drunk with no glow
<img width="1098" height="713" alt="image" src="https://github.com/user-attachments/assets/251a3449-406d-4d7f-9f87-0646ecc4d3aa" />


</details>

## Changelog
:cl:
fix: Tequila sunrise no longer makes shadowpeople and nightmares permanently glow
fix: Nightmares are now given a more accurate blurb with regard to the server rules. 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
