### PR TITLE
Automatic engineering emergency access

### DIFF
--- a/code/modules/power/supermatter/supermatter.dm
+++ b/code/modules/power/supermatter/supermatter.dm
@@ -1034,7 +1034,7 @@ GLOBAL_VAR_INIT(engine_emergency, FALSE)
 		minor_announce("Engineering wing emergency access will be revoked in [time_to_revoke] seconds. Qualified personnel are to assess damages and conduct repairs where possible. Station-wide chaos and potential hallucinatory events are to be expected. ", "Engine detonation confirmed.", 1, color_override = "yellow")
 	GLOB.engine_emergency = FALSE
 	// Schedule the revocation for 10 seconds from now
-	addtimer(CALLBACK(GLOBAL_PROC, .proc/engineering_emergency_revoke_final), time_to_revoke SECONDS, FALSE)
+	addtimer(CALLBACK(GLOBAL_PROC, engineering_emergency_revoke_final), time_to_revoke SECONDS, FALSE)
 
 /proc/engineering_emergency_revoke_final()
 	for(var/area/engine/E as anything in get_areas(/area/engine, SSmapping.levels_by_trait(ZTRAIT_STATION)[1]))

--- a/code/modules/power/supermatter/supermatter.dm
+++ b/code/modules/power/supermatter/supermatter.dm
@@ -1034,7 +1034,7 @@ GLOBAL_VAR_INIT(engine_emergency, FALSE)
 		minor_announce("Engineering wing emergency access will be revoked in [time_to_revoke] seconds. Qualified personnel are to assess damages and conduct repairs where possible. Station-wide chaos and potential hallucinatory events are to be expected. ", "Engine detonation confirmed.", 1, color_override = "yellow")
 	GLOB.engine_emergency = FALSE
 	// Schedule the revocation for 10 seconds from now
-	addtimer(CALLBACK(GLOBAL_PROC, engineering_emergency_revoke_final), time_to_revoke SECONDS, FALSE)
+	addtimer(CALLBACK(GLOBAL_PROC, PROC_REF(engineering_emergency_revoke_final)), time_to_revoke SECONDS, FALSE)
 
 /proc/engineering_emergency_revoke_final()
 	for(var/area/engine/E as anything in get_areas(/area/engine, SSmapping.levels_by_trait(ZTRAIT_STATION)[1]))

--- a/code/modules/power/supermatter/supermatter.dm
+++ b/code/modules/power/supermatter/supermatter.dm
@@ -1029,7 +1029,7 @@ GLOBAL_VAR_INIT(engine_emergency, FALSE)
 /proc/engineering_emergency_revoke(delamed = FALSE)
 	var/time_to_revoke = 30 // I like to make modular code, if anyone wants to alter this they can easily
 	if(!delamed)
-		minor_announce("Congratulations crew. Engineering wing emergency access will be revoked in [time_to_revoke] seconds.", "Engine calamity averted.", 1, color_override = "yellow")
+		minor_announce("Engine integrity restored. Engineering wing emergency access will be revoked in [time_to_revoke] seconds.", "Engine calamity averted.", 1, color_override = "yellow")
 	else
 		minor_announce("Engineering wing emergency access will be revoked in [time_to_revoke] seconds. Qualified personnel are to assess damages and conduct repairs where possible. Station-wide chaos and potential hallucinatory events are to be expected. ", "Engine detonation confirmed.", 1, color_override = "yellow")
 	GLOB.engine_emergency = FALSE

--- a/code/modules/power/supermatter/supermatter.dm
+++ b/code/modules/power/supermatter/supermatter.dm
@@ -1034,7 +1034,7 @@ GLOBAL_VAR_INIT(engine_emergency, FALSE)
 		minor_announce("Engineering wing emergency access will be revoked in [time_to_revoke] seconds. Qualified personnel are to assess damages and conduct repairs where possible. Station-wide chaos and potential hallucinatory events are to be expected. ", "Engine detonation confirmed.", 1, color_override = "yellow")
 	GLOB.engine_emergency = FALSE
 	// Schedule the revocation for 10 seconds from now
-	addtimer(CALLBACK(GLOBAL_PROC, PROC_REF(engineering_emergency_revoke_final)), time_to_revoke SECONDS, FALSE)
+	addtimer(CALLBACK(GLOBAL_PROC, GLOBAL_PROC_REF(engineering_emergency_revoke_final)), time_to_revoke SECONDS, FALSE)
 
 /proc/engineering_emergency_revoke_final()
 	for(var/area/engine/E as anything in get_areas(/area/engine, SSmapping.levels_by_trait(ZTRAIT_STATION)[1]))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

When the SM starts losing integrity, upon reaching its first threshold, it will announce itself to the station and put engineering doors into emergency access.

<img width="793" height="94" alt="image" src="https://github.com/user-attachments/assets/bea4054c-fb74-4f0a-84d3-37832f37abeb" />

When the SM's integrity goes to an acceptable threshold the access will be revoked.

<img width="798" height="82" alt="image" src="https://github.com/user-attachments/assets/ccfefc37-2f8b-4719-9a58-0f0f2900f0e5" />


But, in the event of a delamination the same will happen, but with a different announcement.

<img width="800" height="111" alt="image" src="https://github.com/user-attachments/assets/546fef81-bf76-4a1b-9597-60dc0ec6e5b8" />
 

## Why It's Good For The Game

I have recently experienced the follwing:

Being an Atmos technician, the newbie engineer makes a mistake and the SM starts delaming.

I have no way of avoiding that at all if I don't have access.

This serves so that when the SM starts delaming people that know how to act try to stop it.
It also gives access to characters of ill repute for the duration of the event and 30 seconds afterwards.

This sort of opens up a part of the station, under the right conditions, that is generally closed off to the world which is also kind of cool?

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

Up there.

</details>

## Changelog
:cl:
add: When SM starts losing integrity and alert will go out and enable emergency access to engineering, which will be revoked when the crisis is either solved or reaches an unfavorable conclusion (if it fucking explodes).
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
