### PR TITLE
Autotransfer changes again

### DIFF
--- a/code/controllers/subsystem/autotransfer.dm
+++ b/code/controllers/subsystem/autotransfer.dm
@@ -34,8 +34,8 @@ SUBSYSTEM_DEF(autotransfer)
 		if(isnewplayer(c.mob))
 			continue
 
-		//Only players that are still alive count as "active", reducing the amount of votes needed to leave
-		if(isliving(c.mob))
+		//Only non-antagonist players count as "active" for the sake of determining how many votes are necessary to leave
+		if(isliving(c.mob) && !c.mob?.mind?.special_role)
 			active_playercount ++
 
 		//All players not in the lobby can vote to leave, living and dead

--- a/code/controllers/subsystem/autotransfer.dm
+++ b/code/controllers/subsystem/autotransfer.dm
@@ -47,7 +47,7 @@ SUBSYSTEM_DEF(autotransfer)
 			decay_count++
 
 		//After a certain point votes are ignored and the shuttle is called unless config is set to this doesn't happen. Indefinite rounds are not possible.
-		required_votes_to_leave = length(GLOB.clients) * (CONFIG_GET(number/autotransfer_percentage) - CONFIG_GET(number/autotransfer_decay_amount) * decay_count)
+		required_votes_to_leave = active_playercount * (CONFIG_GET(number/autotransfer_percentage) - CONFIG_GET(number/autotransfer_decay_amount) * decay_count)
 
 		if(connected_votes_to_leave >= required_votes_to_leave)
 			if(SSshuttle.canEvac() == TRUE) //This must include the == TRUE because all returns for this proc have a value, we specifically want to check for TRUE

--- a/code/controllers/subsystem/autotransfer.dm
+++ b/code/controllers/subsystem/autotransfer.dm
@@ -30,17 +30,24 @@ SUBSYSTEM_DEF(autotransfer)
 	active_playercount = 0
 
 	for(var/client/c in GLOB.clients)
+		//Clients that are still in the lobby cannot vote and are also not counted as active
 		if(isnewplayer(c.mob))
-			continue //We don't count them or their votes
+			continue
+
+		//Only players that are still alive count as "active", reducing the amount of votes needed to leave
+		if(isliving(c.mob))
+			active_playercount ++
+
+		//All players not in the lobby can vote to leave, living and dead
 		if (c.player_details.voted_to_leave)
 			connected_votes_to_leave ++
-		active_playercount ++
 
 	if(REALTIMEOFDAY > checkvotes_time)
 		if(decay_start)
 			decay_count++
 
-		required_votes_to_leave = max(active_playercount * (CONFIG_GET(number/autotransfer_percentage) - CONFIG_GET(number/autotransfer_decay_amount) * decay_count), 1)
+		//After a certain point votes are ignored and the shuttle is called unless config is set to this doesn't happen. Indefinite rounds are not possible.
+		required_votes_to_leave = length(GLOB.clients) * (CONFIG_GET(number/autotransfer_percentage) - CONFIG_GET(number/autotransfer_decay_amount) * decay_count)
 
 		if(connected_votes_to_leave >= required_votes_to_leave)
 			if(SSshuttle.canEvac() == TRUE) //This must include the == TRUE because all returns for this proc have a value, we specifically want to check for TRUE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Reverts #12418
Antagonists and dead players are no longer factored into the number of votes required to leave
Dead players are still allowed to vote for a new round

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

I was initially against #12418 but caved because dynamic would naturally bring rounds to a close by force if necessary, or it would otherwise only affect the game when there was just a single person online. This has been proven incorrect on multiple occasions now and I again believe rounds should never exceed a certain threshold of time, even during very low population times. Many players avoid rounds until a new one has started, and autism fort players complain loudly and discourage people from utilizing the system as intended. 

As for changing the logic on votes required to leave: Even when those players wish to utilize this system they often don't have the sway to actually cause a shuttle call even when they should. While we're still working out the finer details of #12316 a unique problem has presented itself a couple of times: Antagonists have completely taken over the station, and ghosts can make up 25-30% of connected players weighing down the ability for normal crew who this system is designed for to be able to end a round. 

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->

There is no reasonable way to show testing evidence for this, I don't have the capability of connecting enough fake clients for testing. 

## Changelog
:cl:
tweak: Autotransfer will now trigger automatically once a certain amount of time has passed again even with no votes due to players heckling others for using the system as intended.
tweak: Dead players an antagonists are no longer factored into the calculation for how many votes are required to leave. If the number of living non-antagonist crew is dwindling, votes to begin a new round should be given a heavier weight to offset total antagonist takeover situations.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
