### PR TITLE
Reduces maximum toxic gas damage

### DIFF
--- a/code/__DEFINES/atmospherics/atmos_mob_interaction.dm
+++ b/code/__DEFINES/atmospherics/atmos_mob_interaction.dm
@@ -16,11 +16,8 @@
 #define EUPHORIA_ACTIVE 1
 #define EUPHORIA_LAST_FLAG 2
 
-#define MIASMA_CORPSE_MOLES 0.02
-#define MIASMA_GIBS_MOLES 0.005
-
-#define MIN_TOXIC_GAS_DAMAGE 1
-#define MAX_TOXIC_GAS_DAMAGE 10
+#define MIN_TOXIC_GAS_DAMAGE 0.5
+#define MAX_TOXIC_GAS_DAMAGE 2.5
 
 // Pressure limits.
 /// This determins at what pressure the ultra-high pressure red icon is displayed. (This one is set as a constant)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adjusts the minimum toxic gas damage to 0.5
Adjusts the maximum toxic gas damage to 2.5
These values are calculated *per gas*, so this can be applied multiple times by mixing gasses. 

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Players only take a breath every four seconds, and if their breath fails they start taking breaths every second until they are back in good atmos or pass out from the damage. The caps in place allow for players to take so much damage so fast from breathing bad atmos that they die before they can even react to it in some cases. Breathing CO2 causes players to pass out MUCH faster than breathing nothing at all by being spaced. 

Lavaland killing miners that forgot their internals was the inspiration for this, because lavaland atmos is set up so that it deals 13 oxy damage per second. Oxy damage doesn't need crit to incapacitate players, and the damage is so fast that even if you try to run back to the door you won't make it in many cases, especially if you had just had your breath before going through the door. 

If the lavaland base is breached, players going through the gateway will die before they can get back into the station unless they came with internals already equipped and turned on. 

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->

This is how fast players pass out on lavaland since it was the inspiration for this PR anyway. This is more like the speed I'm used to passing out from bad atmos in most circumstances. 

![dreamseeker_cjMMzZ4YKw](https://github.com/user-attachments/assets/a01a4089-7cd5-4b21-86b0-ab478bdab9dd)


## Changelog
:cl:
tweak: Toxic gas damage has been capped to 2.5 damage per second per gas, down from 10 damage per second per gas. Players breathing toxic gasses will have about the same time to respond as those that are breathing nothing at all now. 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
