### PR TITLE
Add support for dynamic midround bitflags

### DIFF
--- a/code/__DEFINES/dynamic.dm
+++ b/code/__DEFINES/dynamic.dm
@@ -9,11 +9,11 @@
 #define DYNAMIC_CATEGORY_LATEJOIN "Latejoin"
 
 /// For relatively small antagonists (Sleeper Agent, Obsessed, Fugitives, etc.)
-#define DYNAMIC_MIDROUND_LIGHT "Light"
+#define DYNAMIC_MIDROUND_LIGHT (1 << 0)
 /// For round disruptive antagonists (Abductors, Malf AI, Slaughter Demon, etc.)
-#define DYNAMIC_MIDROUND_MEDIUM "Medium"
+#define DYNAMIC_MIDROUND_MEDIUM (1 << 1)
 /// For round ending antagonists (Wizard, Lone Operative, Blob, etc.)
-#define DYNAMIC_MIDROUND_HEAVY "Heavy"
+#define DYNAMIC_MIDROUND_HEAVY (1 << 2)
 
 /// Only one ruleset with this flag will be picked
 #define HIGH_IMPACT_RULESET (1<<0)

--- a/code/controllers/subsystem/dynamic/dynamic.dm
+++ b/code/controllers/subsystem/dynamic/dynamic.dm
@@ -612,7 +612,7 @@ SUBSYSTEM_DEF(dynamic)
 			if(DYNAMIC_MIDROUND_MEDIUM)
 				new_severity = DYNAMIC_MIDROUND_LIGHT
 
-		log_dynamic("MIDROUND: FAIL: Tried to roll a [severity_flag_to_text(severity)] midround but there are no possible rulesets.")
+		log_dynamic("MIDROUND: FAIL: Tried to roll a [severity_flag_to_text(forced_severity)] midround but there are no possible rulesets.")
 
 		if(!isnull(new_severity))
 			choose_midround_ruleset(new_severity)

--- a/code/controllers/subsystem/dynamic/dynamic.dm
+++ b/code/controllers/subsystem/dynamic/dynamic.dm
@@ -577,7 +577,7 @@ SUBSYSTEM_DEF(dynamic)
 	// Get possible rulesets
 	var/list/possible_rulesets = list()
 	for(var/datum/dynamic_ruleset/midround/ruleset in midround_configured_rulesets)
-		if(ruleset.severity != severity)
+		if(!(ruleset.severity & severity))
 			continue
 
 		if(check_is_ruleset_blocked(ruleset, midround_executed_rulesets))
@@ -593,7 +593,7 @@ SUBSYSTEM_DEF(dynamic)
 		possible_rulesets[ruleset] = ruleset.weight
 
 	if(!length(possible_rulesets))
-		log_dynamic("MIDROUND: FAIL: Tried to roll a [severity] midround but there are no possible rulesets.")
+		log_dynamic("MIDROUND: FAIL: Tried to roll a [severity_flag_to_text(severity)] midround but there are no possible rulesets.")
 		return
 
 	// Pick ruleset and log
@@ -775,3 +775,13 @@ SUBSYSTEM_DEF(dynamic)
 
 	WARNING("Something has gone terribly wrong. /datum/controller/subsystem/dynamic/antag_pick() failed to select a candidate. Falling back to pick()")
 	return pick(candidates)
+
+/datum/controller/subsystem/dynamic/proc/severity_flag_to_text(flag)
+	var/texts = list()
+	if (flag & DYNAMIC_MIDROUND_LIGHT)
+		texts += "LIGHT"
+	if (flag & DYNAMIC_MIDROUND_MEDIUM)
+		texts += "MEDIUM"
+	if (flag & DYNAMIC_MIDROUND_HEAVY)
+		texts += "HEAVY"
+	return jointext(texts, " | ")

--- a/code/controllers/subsystem/dynamic/dynamic_rulesets_midround.dm
+++ b/code/controllers/subsystem/dynamic/dynamic_rulesets_midround.dm
@@ -23,7 +23,7 @@
 
 /datum/dynamic_ruleset/midround/pirates
 	name = "Space Pirates"
-	severity = DYNAMIC_MIDROUND_MEDIUM
+	severity = DYNAMIC_MIDROUND_MEDIUM | DYNAMIC_MIDROUND_HEAVY
 	points_cost = 40
 	flags = CANNOT_REPEAT
 

--- a/code/controllers/subsystem/dynamic/dynamic_rulesets_midround_ghost.dm
+++ b/code/controllers/subsystem/dynamic/dynamic_rulesets_midround_ghost.dm
@@ -196,7 +196,7 @@
 	severity = DYNAMIC_MIDROUND_HEAVY
 	antag_datum = /datum/antagonist/blob
 	points_cost = 50
-	minimum_players_required = 20
+	minimum_players_required = 13
 	weight = 4
 	use_spawn_locations = FALSE
 	flags = CANNOT_REPEAT
@@ -267,7 +267,7 @@
 	antag_datum = /datum/antagonist/space_dragon
 	points_cost = 40
 	weight = 4
-	minimum_players_required = 13
+	minimum_players_required = 10
 	flags = CANNOT_REPEAT
 
 /datum/dynamic_ruleset/midround/ghost/space_dragon/get_poll_icon()

--- a/code/controllers/subsystem/dynamic/dynamic_rulesets_midround_ghost.dm
+++ b/code/controllers/subsystem/dynamic/dynamic_rulesets_midround_ghost.dm
@@ -292,7 +292,7 @@
 
 /datum/dynamic_ruleset/midround/ghost/ninja
 	name = "Space Ninja"
-	severity = DYNAMIC_MIDROUND_MEDIUM
+	severity = DYNAMIC_MIDROUND_MEDIUM | DYNAMIC_MIDROUND_HEAVY
 	antag_datum = /datum/antagonist/ninja
 	points_cost = 40
 	weight = 6
@@ -321,7 +321,7 @@
 
 /datum/dynamic_ruleset/midround/ghost/nightmare
 	name = "Nightmare"
-	severity = DYNAMIC_MIDROUND_MEDIUM
+	severity = DYNAMIC_MIDROUND_LIGHT | DYNAMIC_MIDROUND_MEDIUM
 	antag_datum = /datum/antagonist/nightmare
 	points_cost = 30
 	weight = 6
@@ -413,7 +413,7 @@
 
 /datum/dynamic_ruleset/midround/ghost/revenant
 	name = "Revenant"
-	severity = DYNAMIC_MIDROUND_MEDIUM
+	severity = DYNAMIC_MIDROUND_LIGHT | DYNAMIC_MIDROUND_MEDIUM
 	antag_datum = /datum/antagonist/revenant
 	points_cost = 30
 	weight = 6
@@ -458,7 +458,7 @@
 
 /datum/dynamic_ruleset/midround/ghost/spiders
 	name = "Spider Infestation"
-	severity = DYNAMIC_MIDROUND_MEDIUM
+	severity = DYNAMIC_MIDROUND_MEDIUM | DYNAMIC_MIDROUND_HEAVY
 	antag_datum = /datum/antagonist/spider
 	drafted_players_amount = 3
 	points_cost = 40
@@ -516,7 +516,7 @@
 
 /datum/dynamic_ruleset/midround/ghost/swarmer
 	name = "Swarmer"
-	severity = DYNAMIC_MIDROUND_MEDIUM
+	severity = DYNAMIC_MIDROUND_MEDIUM | DYNAMIC_MIDROUND_HEAVY
 	antag_datum = /datum/antagonist/swarmer
 	points_cost = 40
 	weight = 4

--- a/code/controllers/subsystem/dynamic/dynamic_rulesets_midround_ghost.dm
+++ b/code/controllers/subsystem/dynamic/dynamic_rulesets_midround_ghost.dm
@@ -296,7 +296,7 @@
 	severity = DYNAMIC_MIDROUND_MEDIUM | DYNAMIC_MIDROUND_HEAVY
 	antag_datum = /datum/antagonist/ninja
 	points_cost = 40
-	weight = 6
+	weight = 4
 	flags = CANNOT_REPEAT
 
 /datum/dynamic_ruleset/midround/ghost/ninja/get_poll_icon()
@@ -325,7 +325,7 @@
 	severity = DYNAMIC_MIDROUND_LIGHT | DYNAMIC_MIDROUND_MEDIUM
 	antag_datum = /datum/antagonist/nightmare
 	points_cost = 40
-	weight = 6
+	weight = 4
 
 /datum/dynamic_ruleset/midround/ghost/nightmare/get_poll_icon()
 	return /obj/item/light_eater
@@ -359,7 +359,7 @@
 	antag_datum = /datum/antagonist/abductor/agent
 	drafted_players_amount = 2
 	points_cost = 30
-	weight = 6
+	weight = 4
 	use_spawn_locations = FALSE
 
 	var/has_made_leader = FALSE
@@ -391,7 +391,7 @@
 	severity = DYNAMIC_MIDROUND_MEDIUM
 	antag_datum = /datum/antagonist/abductor/scientist/solo
 	points_cost = 30
-	weight = 6
+	weight = 4
 	use_spawn_locations = FALSE
 
 	var/datum/team/abductor_team/team
@@ -417,7 +417,7 @@
 	severity = DYNAMIC_MIDROUND_LIGHT | DYNAMIC_MIDROUND_MEDIUM
 	antag_datum = /datum/antagonist/revenant
 	points_cost = 30
-	weight = 6
+	weight = 4
 
 /datum/dynamic_ruleset/midround/ghost/revenant/get_poll_icon()
 	return /mob/living/simple_animal/revenant

--- a/code/controllers/subsystem/dynamic/dynamic_rulesets_midround_ghost.dm
+++ b/code/controllers/subsystem/dynamic/dynamic_rulesets_midround_ghost.dm
@@ -134,7 +134,7 @@
 	severity = DYNAMIC_MIDROUND_HEAVY
 	antag_datum = /datum/antagonist/wizard
 	points_cost = 50
-	weight = 2
+	weight = 4
 
 /datum/dynamic_ruleset/midround/ghost/wizard/get_poll_icon()
 	return /obj/item/clothing/head/wizard
@@ -162,7 +162,7 @@
 	drafted_players_amount = 3
 	points_cost = 50
 	minimum_players_required = 20
-	weight = 1
+	weight = 4
 	use_spawn_locations = FALSE
 	flags = CANNOT_REPEAT
 
@@ -197,7 +197,7 @@
 	antag_datum = /datum/antagonist/blob
 	points_cost = 50
 	minimum_players_required = 20
-	weight = 6
+	weight = 4
 	use_spawn_locations = FALSE
 	flags = CANNOT_REPEAT
 
@@ -266,7 +266,7 @@
 	severity = DYNAMIC_MIDROUND_HEAVY
 	antag_datum = /datum/antagonist/space_dragon
 	points_cost = 40
-	weight = 5
+	weight = 4
 	flags = CANNOT_REPEAT
 
 /datum/dynamic_ruleset/midround/ghost/space_dragon/get_poll_icon()

--- a/code/controllers/subsystem/dynamic/dynamic_rulesets_midround_living.dm
+++ b/code/controllers/subsystem/dynamic/dynamic_rulesets_midround_living.dm
@@ -137,7 +137,7 @@
 
 /datum/dynamic_ruleset/midround/living/obsessed
 	name = "Obsessed"
-	severity = DYNAMIC_MIDROUND_LIGHT
+	severity = DYNAMIC_MIDROUND_LIGHT | DYNAMIC_MIDROUND_MEDIUM
 	antag_datum = /datum/antagonist/obsessed
 	role_preference = /datum/role_preference/midround/obsessed
 	weight = 4

--- a/code/modules/unit_tests/dynamic_ruleset_sanity.dm
+++ b/code/modules/unit_tests/dynamic_ruleset_sanity.dm
@@ -35,7 +35,7 @@
 
 		// Severity
 		var/severity = initial(ruleset.severity)
-		if(!(severity in list(DYNAMIC_MIDROUND_LIGHT, DYNAMIC_MIDROUND_MEDIUM, DYNAMIC_MIDROUND_HEAVY)))
+		if(!severity)
 			TEST_FAIL("[ruleset] has an invalid severity!")
 
 	// Latejoin


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Converts the dynamic midround severity level into bitflags, so that we can have rulesets in multiple categories.

## Why It's Good For The Game

We are encoutering an issue where only wizard is available in the heavy category at low-pop. I want to put off disabling it for low-pops as that will lead us into the spiral of disabling everything since it becomes so common due to the lack of alternatives, which would lead us back to the same problem that old dynamic had. Instead, allowing rulesets to have multiple severities means that we can diversify the pool of rulesets that trigger late into a round and increases the configurability of dynamic.

## Testing Photographs and Procedure

<img width="340" height="106" alt="image" src="https://github.com/user-attachments/assets/0b4e84a5-e7f4-4dd2-89bf-3c0976106fe2" />

<img width="312" height="140" alt="image" src="https://github.com/user-attachments/assets/4e1b3194-c3b6-4b5e-9086-c8db88d9203a" />

<img width="672" height="127" alt="image" src="https://github.com/user-attachments/assets/e7543c5d-7934-44bd-b854-23562c49f46f" />

<img width="886" height="340" alt="image" src="https://github.com/user-attachments/assets/98c47c1e-0afb-4ccb-aca2-8652377d88b8" />

<img width="1188" height="300" alt="image" src="https://github.com/user-attachments/assets/54cddc29-13ca-4b30-9cb9-5b57d19f3b16" />

<img width="269" height="299" alt="image" src="https://github.com/user-attachments/assets/de176ebf-3436-470a-a5d1-47d5d61086e4" />

## Changelog
:cl:
tweak: Dynamic midround rulesets can now have multiple severities, meaning that it is not limited to only wizards during round ends at low-pops.
tweak: Lowers the min pop required for dragon and blob to spawn.
tweak: All dynamic midround rulesets are equally weighted.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
