### PR TITLE
Updates changelog theme

### DIFF
--- a/tgui/packages/tgui/interfaces/Changelog.tsx
+++ b/tgui/packages/tgui/interfaces/Changelog.tsx
@@ -363,7 +363,7 @@ export class Changelog extends Component {
         ));
 
     return (
-      <Window title="Changelog" width={testmerges?.length ? 1000 : 675} height={650}>
+      <Window title="Changelog" theme="admin" width={testmerges?.length ? 1000 : 675} height={650}>
         <Window.Content scrollable>
           <Header dropdown={dateDropdown} />
           <Stack>

--- a/tgui/packages/tgui/styles/themes/admin.scss
+++ b/tgui/packages/tgui/styles/themes/admin.scss
@@ -42,7 +42,7 @@ $generic: hsl(252, 9.3%, 31.6%);
 
   .Layout__content {
     background-image: url('../../assets/bg-beestation.svg');
-    background-size: 70% 100%;
+    background-size: 80% 90%;
     background-position: center;
     background-repeat: no-repeat;
   }


### PR DESCRIPTION
## About The Pull Request

The changelog now uses the admin theme instead of the default Nanotrasen theme

## Why It's Good For The Game

closes #12966

## Testing Photographs and Procedure

<img width="729" height="684" alt="image" src="https://github.com/user-attachments/assets/bfb108c0-80d7-4de6-b4b4-444120f1fdfc" />

## Changelog
:cl:
tweak: the changelog uses the bee theme now
/:cl:
