### PR TITLE
ASSERT() and trait helpers

### DIFF
--- a/beestation.dme
+++ b/beestation.dme
@@ -49,6 +49,7 @@
 #include "code\__DEFINES\armor.dm"
 #include "code\__DEFINES\art.dm"
 #include "code\__DEFINES\assemblies.dm"
+#include "code\__DEFINES\assert.dm"
 #include "code\__DEFINES\assets.dm"
 #include "code\__DEFINES\async.dm"
 #include "code\__DEFINES\atom_hud.dm"

--- a/beestation.dme
+++ b/beestation.dme
@@ -349,6 +349,7 @@
 #include "code\__HELPERS\test_helpers.dm"
 #include "code\__HELPERS\text.dm"
 #include "code\__HELPERS\time.dm"
+#include "code\__HELPERS\traits.dm"
 #include "code\__HELPERS\turfs.dm"
 #include "code\__HELPERS\type2type.dm"
 #include "code\__HELPERS\type_processing.dm"

--- a/code/__DEFINES/assert.dm
+++ b/code/__DEFINES/assert.dm
@@ -1,0 +1,13 @@
+#undef ASSERT
+
+/// Override BYOND's native ASSERT to optionally specify a message
+#define ASSERT(condition, message...) \
+	if (!(condition)) { \
+		CRASH(assertion_message(__FILE__, __LINE__, #condition, ##message)) \
+	}
+
+/proc/assertion_message(file, line, condition, message)
+	if (!isnull(message))
+		message = " - [message]"
+
+	return "[file]:[line]:Assertion failed: [condition][message]"

--- a/code/__DEFINES/traits/_traits.dm
+++ b/code/__DEFINES/traits/_traits.dm
@@ -298,6 +298,8 @@
 /// Checks if the mob has the specified trait from any source except from the ones specified
 /// Slightly slower than HAS_TRAIT and should be avoided when proc-overhead matters (roughly >1000 calls per second)
 #define HAS_TRAIT_NOT_FROM(target, trait, source) (target.status_traits && ____has_trait_not_from(target, trait, source))
+/// A simple helper for checking traits in a mob's mind
+#define HAS_MIND_TRAIT(target, trait) (HAS_TRAIT(target, trait) || (target.mind ? HAS_TRAIT(target.mind, trait) : FALSE))
 
 GLOBAL_DATUM_INIT(_trait_located, /datum/trait, null)
 

--- a/code/__HELPERS/traits.dm
+++ b/code/__HELPERS/traits.dm
@@ -1,0 +1,44 @@
+#define TRAIT_CALLBACK_ADD(target, trait, source) CALLBACK(GLOBAL_PROC, GLOBAL_PROC_REF(___TraitAdd), ##target, ##trait, ##source)
+#define TRAIT_CALLBACK_REMOVE(target, trait, source) CALLBACK(GLOBAL_PROC, GLOBAL_PROC_REF(___TraitRemove), ##target, ##trait, ##source)
+
+///DO NOT USE ___TraitAdd OR ___TraitRemove as a replacement for ADD_TRAIT / REMOVE_TRAIT defines. To be used explicitly for callback.
+/proc/___TraitAdd(target, trait, source)
+	if(!target || !trait || !source)
+		return
+
+	if(islist(target))
+		for(var/datum/listed_target in target)
+			ADD_TRAIT(listed_target, trait, source)
+		return
+
+	ASSERT(isdatum(target), "Invalid target used in TRAIT_CALLBACK_ADD! Expected a datum reference, got [target] instead.")
+
+	var/datum/datum_target = target
+	ADD_TRAIT(datum_target, trait, source)
+
+///DO NOT USE ___TraitAdd OR ___TraitRemove as a replacement for ADD_TRAIT / REMOVE_TRAIT defines. To be used explicitly for callback.
+/proc/___TraitRemove(target, trait, source)
+	if(!target || !trait || !source)
+		return
+
+	if(islist(target))
+		for(var/datum/listed_target in target)
+			REMOVE_TRAIT(listed_target, trait, source)
+		return
+
+	ASSERT(isdatum(target), "Invalid target used in TRAIT_CALLBACK_REMOVE! Expected a datum reference, got [target] instead.")
+
+	var/datum/datum_target = target
+	REMOVE_TRAIT(datum_target, trait, source)
+
+/// Proc that handles adding multiple traits to a target via a list. Must have a common source and target.
+/datum/proc/add_traits(list/list_of_traits, source)
+	ASSERT(islist(list_of_traits), "Invalid arguments passed to add_traits! Invoked on [src] with [list_of_traits], source being [source].")
+	for(var/trait in list_of_traits)
+		ADD_TRAIT(src, trait, source)
+
+/// Proc that handles removing multiple traits from a target via a list. Must have a common source and target.
+/datum/proc/remove_traits(list/list_of_traits, source)
+	ASSERT(islist(list_of_traits), "Invalid arguments passed to remove_traits! Invoked on [src] with [list_of_traits], source being [source].")
+	for(var/trait in list_of_traits)
+		REMOVE_TRAIT(src, trait, source)

--- a/code/game/objects/effects/anomalies/anomaly_hallucination.dm
+++ b/code/game/objects/effects/anomalies/anomaly_hallucination.dm
@@ -28,7 +28,7 @@
 /proc/hallucination_pulse(turf/location, range, strength = 50)
 	for(var/mob/living/carbon/human/near in view(location, range))
 		// If they are immune to hallucinations
-		if (HAS_TRAIT(near, TRAIT_MADNESS_IMMUNE) || (near.mind && HAS_TRAIT(near.mind, TRAIT_MADNESS_IMMUNE)))
+		if (HAS_MIND_TRAIT(near, TRAIT_MADNESS_IMMUNE))
 			continue
 
 		// Blind people don't get hallucinations

--- a/code/game/objects/items/food/donuts.dm
+++ b/code/game/objects/items/food/donuts.dm
@@ -52,7 +52,7 @@
 
 ///Override for checkliked in edible component, because all cops LOVE donuts
 /obj/item/food/donut/proc/check_liked(mob/living/carbon/human/H)
-	if(HAS_TRAIT(H.mind, TRAIT_LAW_ENFORCEMENT_METABOLISM) && !HAS_TRAIT(H, TRAIT_AGEUSIA))
+	if(HAS_MIND_TRAIT(H, TRAIT_LAW_ENFORCEMENT_METABOLISM))
 		return FOOD_LIKED
 
 //Regular, tasty donut.

--- a/code/game/objects/items/gift.dm
+++ b/code/game/objects/items/gift.dm
@@ -34,11 +34,11 @@ GLOBAL_LIST_EMPTY(possible_gifts)
 
 /obj/item/a_gift/examine(mob/M)
 	. = ..()
-	if((M.mind && HAS_TRAIT(M.mind, TRAIT_PRESENT_VISION)) || isobserver(M))
+	if(HAS_MIND_TRAIT(M, TRAIT_PRESENT_VISION) || isobserver(M))
 		. += span_notice("It contains \a [initial(contains_type.name)].")
 
 /obj/item/a_gift/attack_self(mob/M)
-	if(M.mind && HAS_TRAIT(M.mind, TRAIT_CANNOT_OPEN_PRESENTS))
+	if(HAS_MIND_TRAIT(M, TRAIT_CANNOT_OPEN_PRESENTS))
 		to_chat(M, span_warning("You're supposed to be spreading gifts, not opening them yourself!"))
 		return
 

--- a/code/game/objects/items/storage/backpack.dm
+++ b/code/game/objects/items/storage/backpack.dm
@@ -127,7 +127,7 @@
 	var/mob/user = get(loc, /mob)
 	if(!istype(user))
 		return
-	if(user.mind && HAS_TRAIT(user.mind, TRAIT_CANNOT_OPEN_PRESENTS))
+	if(HAS_MIND_TRAIT(user, TRAIT_CANNOT_OPEN_PRESENTS))
 		var/turf/floor = get_turf(src)
 		var/obj/item/thing = new /obj/item/a_gift/anything(floor)
 		if(!atom_storage.attempt_insert(src, thing, user, override = TRUE))

--- a/code/modules/antagonists/abductor/equipment/abduction_gear.dm
+++ b/code/modules/antagonists/abductor/equipment/abduction_gear.dm
@@ -180,16 +180,16 @@
 	righthand_file = 'icons/mob/inhands/antag/abductor_righthand.dmi'
 
 /obj/item/proc/AbductorCheck(mob/user)
-	if(HAS_TRAIT(user.mind, TRAIT_ABDUCTOR_TRAINING))
+	if(HAS_MIND_TRAIT(user, TRAIT_ABDUCTOR_TRAINING))
 		return TRUE
 	to_chat(user, span_warning("You can't figure out how this works!"))
 	return FALSE
 
 /obj/item/abductor/proc/ScientistCheck(mob/user)
-	if(!HAS_TRAIT(user.mind, TRAIT_ABDUCTOR_TRAINING))
+	if(HAS_MIND_TRAIT(user, TRAIT_ABDUCTOR_TRAINING))
 		to_chat(user, span_warning("You can't figure out how this works!"))
 		return FALSE
-	if(!HAS_TRAIT(user.mind, TRAIT_ABDUCTOR_SCIENTIST_TRAINING))
+	if(HAS_MIND_TRAIT(user, TRAIT_ABDUCTOR_SCIENTIST_TRAINING))
 		to_chat(user, span_warning("You're not trained to use this!"))
 		return FALSE
 	return TRUE

--- a/code/modules/antagonists/abductor/equipment/gland.dm
+++ b/code/modules/antagonists/abductor/equipment/gland.dm
@@ -29,7 +29,7 @@
 
 /obj/item/organ/heart/gland/examine(mob/user)
 	. = ..()
-	if(HAS_TRAIT(user.mind, TRAIT_ABDUCTOR_SCIENTIST_TRAINING) || isobserver(user))
+	if(HAS_MIND_TRAIT(user, TRAIT_ABDUCTOR_SCIENTIST_TRAINING) || isobserver(user))
 		. += span_notice("It is \a [true_name].")
 
 /obj/item/organ/heart/gland/proc/ownerCheck()

--- a/code/modules/antagonists/abductor/machinery/console.dm
+++ b/code/modules/antagonists/abductor/machinery/console.dm
@@ -50,13 +50,13 @@
 	. = ..()
 	if(.)
 		return
-	if(!HAS_TRAIT(user.mind, TRAIT_ABDUCTOR_TRAINING))
+	if(!HAS_MIND_TRAIT(user, TRAIT_ABDUCTOR_TRAINING))
 		to_chat(user, span_warning("You start mashing alien buttons at random!"))
 		if(do_after(user,100, target = src))
 			TeleporterSend()
 
 /obj/machinery/abductor/console/ui_status(mob/user)
-	if(!HAS_TRAIT(user.mind, TRAIT_ABDUCTOR_TRAINING) && !isobserver(user))
+	if(!HAS_MIND_TRAIT(user, TRAIT_ABDUCTOR_TRAINING) && !isobserver(user))
 		return UI_CLOSE
 	return ..()
 

--- a/code/modules/antagonists/nukeop/equipment/nuclearbomb.dm
+++ b/code/modules/antagonists/nukeop/equipment/nuclearbomb.dm
@@ -720,7 +720,7 @@ This is here to make the tiles around the station mininuke change when it's arme
 	if(!fake)
 		return
 
-	if(isobserver(user) || HAS_TRAIT(user.mind, TRAIT_DISK_VERIFIER))
+	if(isobserver(user) || HAS_MIND_TRAIT(user, TRAIT_DISK_VERIFIER))
 		. += span_warning("The serial numbers on [src] are incorrect.")
 
 /obj/item/disk/nuclear/attackby(obj/item/I, mob/living/user, params)

--- a/code/modules/mob/living/basic/basic.dm
+++ b/code/modules/mob/living/basic/basic.dm
@@ -171,7 +171,7 @@
 	. = ..()
 	if(stat != DEAD)
 		return
-	. += span_deadsay("Upon closer examination, [p_they()] appear[p_s()] to be [HAS_TRAIT(user.mind, TRAIT_NAIVE) ? "asleep" : "dead"].")
+	. += span_deadsay("Upon closer examination, [p_they()] appear[p_s()] to be [HAS_MIND_TRAIT(user, TRAIT_NAIVE) ? "asleep" : "dead"].")
 
 /mob/living/basic/proc/melee_attack(atom/target, list/modifiers)
 	face_atom(target)

--- a/code/modules/power/supermatter/supermatter.dm
+++ b/code/modules/power/supermatter/supermatter.dm
@@ -191,7 +191,7 @@ GLOBAL_DATUM(main_supermatter_engine, /obj/machinery/power/supermatter_crystal)
 	. = ..()
 	if(!user?.mind) // ghosts don't have mind
 		return .
-	var/immune = HAS_TRAIT(user, TRAIT_MADNESS_IMMUNE) || HAS_TRAIT(user.mind, TRAIT_MADNESS_IMMUNE)
+	var/immune = HAS_MIND_TRAIT(user, TRAIT_MADNESS_IMMUNE)
 	if (!isliving(user) && !immune && (get_dist(user, src) < HALLUCINATION_RANGE(power)))
 		. += span_danger("You get headaches just from looking at it.")
 
@@ -544,7 +544,7 @@ GLOBAL_DATUM(main_supermatter_engine, /obj/machinery/power/supermatter_crystal)
 			air_update_turf(FALSE, FALSE)
 
 	for(var/mob/living/carbon/human/l in viewers(HALLUCINATION_RANGE(power), src)) // If they can see it without mesons on.  Bad on them.
-		if(HAS_TRAIT(l, TRAIT_MADNESS_IMMUNE) || (l.mind && HAS_TRAIT(l.mind, TRAIT_MADNESS_IMMUNE)))
+		if(HAS_MIND_TRAIT(l, TRAIT_MADNESS_IMMUNE))
 			continue
 		var/D = sqrt(1 / max(1, get_dist(l, src)))
 		l.hallucination += power * config_hallucination_power * D

--- a/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
@@ -816,7 +816,7 @@
 /datum/reagent/consumable/ethanol/beepsky_smash/on_mob_metabolize(mob/living/carbon/M)
 	if(HAS_TRAIT(M, TRAIT_ALCOHOL_TOLERANCE))
 		metabolization_rate = 0.8
-	if(M.mind != null && !HAS_TRAIT(M.mind, TRAIT_LAW_ENFORCEMENT_METABOLISM))
+	if(!HAS_MIND_TRAIT(M, TRAIT_LAW_ENFORCEMENT_METABOLISM))
 		B = new()
 		M.gain_trauma(B, TRAUMA_RESILIENCE_ABSOLUTE)
 	ADD_TRAIT(M, TRAIT_NOBLOCK, type) //sorry sec, but you dont get a special stam heal to help with blocking
@@ -824,7 +824,7 @@
 
 /datum/reagent/consumable/ethanol/beepsky_smash/on_mob_life(mob/living/carbon/M, delta_time, times_fired)
 	M.Jitter(2)
-	if(M.mind != null && HAS_TRAIT(M.mind, TRAIT_LAW_ENFORCEMENT_METABOLISM))
+	if(HAS_MIND_TRAIT(M, TRAIT_LAW_ENFORCEMENT_METABOLISM))
 		M.adjustStaminaLoss(-10 * REM * delta_time, 0)
 		if(DT_PROB(10, delta_time))
 			new /datum/hallucination/items_other(M)
@@ -840,7 +840,7 @@
 	return ..()
 
 /datum/reagent/consumable/ethanol/beepsky_smash/overdose_start(mob/living/carbon/M)
-	if(M.mind != null && !HAS_TRAIT(M.mind, TRAIT_LAW_ENFORCEMENT_METABOLISM))
+	if(!HAS_MIND_TRAIT(M, TRAIT_LAW_ENFORCEMENT_METABOLISM))
 		M.gain_trauma(/datum/brain_trauma/mild/phobia/security, TRAUMA_RESILIENCE_BASIC)
 
 
@@ -1963,7 +1963,7 @@
 
 /datum/reagent/consumable/ethanol/quadruple_sec/on_mob_life(mob/living/carbon/M, delta_time, times_fired)
 	//Securidrink in line with the Screwdriver for engineers or Nothing for mimes
-	if(M.mind != null && HAS_TRAIT(M.mind, TRAIT_LAW_ENFORCEMENT_METABOLISM))
+	if(HAS_MIND_TRAIT(M, TRAIT_LAW_ENFORCEMENT_METABOLISM))
 		M.heal_bodypart_damage(0.5 * REM * delta_time, 0.5 * REM * delta_time)
 		M.adjust_nutrition(-1 * REM * delta_time)
 		. = TRUE
@@ -1987,7 +1987,7 @@
 
 /datum/reagent/consumable/ethanol/quintuple_sec/on_mob_life(mob/living/carbon/M, delta_time, times_fired)
 	//Securidrink in line with the Screwdriver for engineers or Nothing for mimes but STRONG..
-	if(M.mind != null && HAS_TRAIT(M.mind, TRAIT_LAW_ENFORCEMENT_METABOLISM))
+	if(HAS_MIND_TRAIT(M, TRAIT_LAW_ENFORCEMENT_METABOLISM))
 		M.heal_bodypart_damage(1 * REM * delta_time, 1 * REM * delta_time, 1 * REM * delta_time)
 		M.adjust_nutrition(-2 * REM * delta_time)
 		. = TRUE

--- a/code/modules/reagents/chemistry/reagents/drink_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drink_reagents.dm
@@ -876,7 +876,7 @@
 	M.adjustToxLoss(-0.5 * REM * delta_time, 0)
 	M.adjustOxyLoss(-0.5 * REM * delta_time, 0)
 	if(M.nutrition && (M.nutrition - 2 > 0))
-		if(M.mind && !HAS_TRAIT(M.mind, TRAIT_MEDICAL_METABOLISM)) //Drains the nutrition of the holder. Not medical staff though, since it's the Doctor's Delight!
+		if(!HAS_MIND_TRAIT(M, TRAIT_MEDICAL_METABOLISM)) //Drains the nutrition of the holder. Not medical staff though, since it's the Doctor's Delight!
 			M.adjust_nutrition(-2 * REM * delta_time)
 	..()
 	. = TRUE

--- a/code/modules/reagents/chemistry/reagents/food_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/food_reagents.dm
@@ -458,7 +458,7 @@
 	taste_description = "childhood whimsy"
 
 /datum/reagent/consumable/sprinkles/on_mob_life(mob/living/carbon/M, delta_time, times_fired)
-	if(M.mind && HAS_TRAIT(M.mind, TRAIT_LAW_ENFORCEMENT_METABOLISM))
+	if(HAS_MIND_TRAIT(M, TRAIT_LAW_ENFORCEMENT_METABOLISM))
 		M.heal_bodypart_damage(1 * REM * delta_time, 1 * REM * delta_time, 0)
 		. = TRUE
 	..()

--- a/code/modules/surgery/organs/tongue.dm
+++ b/code/modules/surgery/organs/tongue.dm
@@ -164,7 +164,7 @@
 
 /obj/item/organ/tongue/abductor/examine(mob/user)
 	. = ..()
-	if(HAS_TRAIT(user.mind, TRAIT_ABDUCTOR_TRAINING) || isobserver(user))
+	if(HAS_MIND_TRAIT(user, TRAIT_ABDUCTOR_TRAINING) || isobserver(user))
 		if(!mothership)
 			. += span_notice("It is not attuned to a specific mothership.")
 		else

--- a/code/modules/surgery/surgery.dm
+++ b/code/modules/surgery/surgery.dm
@@ -50,14 +50,14 @@
 	if(replaced_by == /datum/surgery)
 		return FALSE
 
-	if(HAS_TRAIT(user, TRAIT_SURGEON) || (!isnull(user.mind) && HAS_TRAIT(user.mind, TRAIT_SURGEON)))
+	if(HAS_MIND_TRAIT(user, TRAIT_SURGEON))
 		if(replaced_by)
 			return FALSE
 		else
 			return TRUE
 	//Grants the user innate access to all surgeries
 
-	if(!isnull(user.mind) && HAS_TRAIT(user.mind, TRAIT_ABDUCTOR_SURGEON))
+	if(HAS_MIND_TRAIT(user, TRAIT_ABDUCTOR_SURGEON))
 		if(replaced_by)
 			return FALSE
 		else if(!abductor_surgery_blacklist)


### PR DESCRIPTION
## About The Pull Request

Overrides byond's ASSERT() and adds trait helpers

- https://github.com/tgstation/tgstation/pull/73404
- https://github.com/tgstation/tgstation/pull/76548
- https://github.com/tgstation/tgstation/pull/74037

Before anyone notices, yes this pr adds the add_traits() and remove_traits() procs without actually having any use cases for them. BUT it seems every big PR I do I have to end up porting them, so... sooner or later they will be used.

## Why It's Good For The Game

makes porting things from /tg/ easier.

## Testing Photographs and Procedure

Honestly I don't think this needs testing evidence, but I'll add it tomorrow when I'm not busy.

## Changelog
:cl: mrmanlikesbt, Mothblocks, Bomberman66Dev, san7890
code: modifies the ASSERT() macro
code: adds trait helpers for easily adding a list of traits to something
/:cl:
