### PR TITLE
Asimov Default-ish

### DIFF
--- a/code/controllers/configuration/entries/game_options.dm
+++ b/code/controllers/configuration/entries/game_options.dm
@@ -269,7 +269,8 @@
 
 /datum/config_entry/keyed_list/random_laws
 	key_mode = KEY_MODE_TEXT
-	value_mode = VALUE_MODE_FLAG
+	value_mode = VALUE_MODE_NUM
+	splitter = ","
 
 /datum/config_entry/keyed_list/law_weight
 	key_mode = KEY_MODE_TEXT

--- a/code/datums/ai_laws/ai_laws.dm
+++ b/code/datums/ai_laws/ai_laws.dm
@@ -60,16 +60,17 @@ GLOBAL_VAR(round_default_lawset)
 		if(CONFIG_CUSTOM)
 			return /datum/ai_laws/custom
 		if(CONFIG_RANDOM)
-			var/list/randlaws = list()
-			for(var/lpath in subtypesof(/datum/ai_laws))
-				var/datum/ai_laws/L = lpath
-				if(initial(L.id) in law_ids)
-					randlaws += lpath
 			var/datum/ai_laws/lawtype
-			if(length(randlaws))
-				lawtype = pick(randlaws)
-			else
-				lawtype = pick(subtypesof(/datum/ai_laws/default))
+			while(!lawtype && length(law_ids))
+				var/possible_id = pick_weight(law_ids)
+				lawtype = lawid_to_type(possible_id)
+				if(!lawtype)
+					law_ids -= possible_id
+					WARNING("Bad lawid in game_options.txt: [possible_id]")
+
+			if(!lawtype)
+				WARNING("No LAW_WEIGHT entries.")
+				lawtype = /datum/ai_laws/default/asimov
 
 			return lawtype
 		if(CONFIG_WEIGHTED)

--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -232,7 +232,7 @@ NEAR_DEATH_EXPERIENCE
 ## Set to 2 for "random", silicons will start with a random lawset picked from random laws specified below.
 ## Set to 3 for "weighted random", using values in "silicon_weights.txt", a law will be selected, with weights specified in that file.
 ## Set to 4 for "specified", silicons will start with an existing lawset. (If no specified lawset is identified, the AI will spawn with asimov.)
-DEFAULT_LAWS 2
+DEFAULT_LAWS 0
 
 ## RANDOM LAWS ##
 ## ------------------------------------------------------------------------------------------

--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -284,7 +284,7 @@ LAW_WEIGHT hippocratic,5
 LAW_WEIGHT liveandletlive,5
 LAW_WEIGHT peacekeeper,5
 LAW_WEIGHT ten_commandments,5
-LAW_WEIGHT nutimov,5^^
+LAW_WEIGHT nutimov,5
 
 ## Quirky laws. Shouldn't cause too much harm
 LAW_WEIGHT reporter,3

--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -229,10 +229,10 @@ NEAR_DEATH_EXPERIENCE
 ## This controls what the AI's laws are at the start of the round.
 ## Set to 0/commented out for "off", silicons will just start with Asimov.
 ## Set to 1 for "custom", silicons will start with the custom laws defined in silicon_laws.txt. (If silicon_laws.txt is empty, the AI will spawn with asimov and Custom boards will auto-delete.)
-## Set to 2 for "random", silicons will start with a random lawset picked from random laws specified below.
+## Set to 2 for "random", silicons will start with a random lawset picked from random laws specified below. Also weighted, for convenience.
 ## Set to 3 for "weighted random", using values in "silicon_weights.txt", a law will be selected, with weights specified in that file.
 ## Set to 4 for "specified", silicons will start with an existing lawset. (If no specified lawset is identified, the AI will spawn with asimov.)
-DEFAULT_LAWS 0
+DEFAULT_LAWS 2
 
 ## RANDOM LAWS ##
 ## ------------------------------------------------------------------------------------------
@@ -240,11 +240,11 @@ DEFAULT_LAWS 0
 ## See datums\ai_laws.dm for the full law lists
 
 ## standard-ish laws. These are fairly ok to run
-RANDOM_LAWS asimov
-RANDOM_LAWS asimovpp
-RANDOM_LAWS crewsimov
-RANDOM_LAWS corporate
-RANDOM_LAWS efficiency
+RANDOM_LAWS asimov,10
+RANDOM_LAWS corporate,3
+RANDOM_LAWS asimovpp,2
+RANDOM_LAWS efficiency,1
+#RANDOM_LAWS crewsimov
 
 ## Quirky laws. Shouldn't cause too much harm
 #RANDOM_LAWS hippocratic
@@ -284,7 +284,7 @@ LAW_WEIGHT hippocratic,5
 LAW_WEIGHT liveandletlive,5
 LAW_WEIGHT peacekeeper,5
 LAW_WEIGHT ten_commandments,5
-LAW_WEIGHT nutimov,5
+LAW_WEIGHT nutimov,5^^
 
 ## Quirky laws. Shouldn't cause too much harm
 LAW_WEIGHT reporter,3


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

With the push to make xeno races actually unique, I want to restore one of the more interesting unique benefits, Asimov laws for humans.

This adds optional weighting to random laws in case you don't want to full on go for the weighted thing, that has no way to exclude lawsets.

Kills crewsimov entirely.

Changes the weights as follows:
asimov,10
corporate,3
asimovpp,2
efficiency,1

See in testing evidence for a run of 20 rounds i went through noting down all the lawsets i got.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

I used to be an asimov hater and a crewsimov enjoyer. Now i see it for how it is. Crewsimov turns the AI into a slavering idiot that is unable to do anything interesting except for obey the crew.

Asimov offers just the right amount of people you have to obey vs people you can ignore, and is a cause for interesting conflict.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>

I restarted 20 times and noted down the lawsets:

- Asimov
- Asimov
- Corporate
- Asimov
- Hulkamania
- Asimov
- Corporate
- Asimov
- Asimov
- Asimov
- Asimov
- Asimov++
- Asimov
- Asimov
- Corporate
- Corporate
- Asimov
- Asimov
- Peacekeeper
- Corporate

So, 65% of rounds roughly on average are likely to be asimov-based.
</details>

## Changelog
:cl:
config: AI laws are now weighted, with asimov being vastly more likely than anything else.
config: Removes crewsimov from roundstart lawsets
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
