### PR TITLE
MCR - Fixes Computer Program Downloading + QOL

### DIFF
--- a/code/modules/modular_computers/file_system/program.dm
+++ b/code/modules/modular_computers/file_system/program.dm
@@ -2,8 +2,6 @@
 /datum/computer_file/program
 	filetype = "PRG"
 	filename = "UnknownProgram"				// File name. FILE NAME MUST BE UNIQUE IF YOU WANT THE PROGRAM TO BE DOWNLOADABLE FROM NTNET!
-	/// List of required accesses to *run* the program.
-	var/list/required_access = list()
 	/// List of required access to download or file host the program
 	var/list/transfer_access = list()
 	var/program_state = PROGRAM_STATE_KILLED// PROGRAM_STATE_KILLED or PROGRAM_STATE_BACKGROUND or PROGRAM_STATE_ACTIVE - specifies whether this program is running.
@@ -61,7 +59,6 @@
 
 /datum/computer_file/program/clone()
 	var/datum/computer_file/program/temp = ..()
-	temp.required_access = required_access
 	temp.filedesc = filedesc
 	temp.program_icon_state = program_icon_state
 	temp.requires_ntnet = requires_ntnet
@@ -140,28 +137,21 @@
   *NT Software Hub is checking available software), a list can be given to be used instead.
   *Arguments:
   *user is a ref of the mob using the device.
-  *loud is a bool deciding if this proc should use to_chats
   *access_to_check is an access level that will be checked against the ID
-  *transfer, if TRUE and access_to_check is null, will tell this proc to use the program's transfer_access in place of access_to_check
   *access can contain a list of access numbers to check against. If access is not empty, it will be used istead of checking any inserted ID.
 */
 
-/datum/computer_file/program/proc/can_run(mob/user, loud = FALSE, access_to_check, transfer = FALSE, var/list/access)
+/datum/computer_file/program/proc/can_download(mob/user, loud = FALSE, access_to_check, var/list/access)
 	if(issilicon(user))
 		return TRUE
 
 	if(IsAdminGhost(user))
 		return TRUE
 
-	if(!transfer && computer && (computer.obj_flags & EMAGGED))	//emags can bypass the execution locks but not the download ones.
+	if(computer && (computer.obj_flags & EMAGGED))	//emags can bypass download access requirements
 		return TRUE
 
-	// Defaults to required_access
-	if(!access_to_check)
-		if(transfer && transfer_access)
-			access_to_check = transfer_access
-		else
-			access_to_check = required_access
+	access_to_check = transfer_access
 	if(!islist(access_to_check))
 		access_to_check = list(access_to_check)
 	if(!length(access_to_check)) // No required_access, allow it.
@@ -173,20 +163,14 @@
 		if(computer)
 			card_slot = computer.all_components[MC_CARD]
 			access_card = card_slot?.GetID()
-
 		if(!access_card)
-			if(loud)
-				computer.balloon_alert_to_viewers("RFID Error - Unable to scan ID")
-				to_chat(user, span_danger("\The [computer] flashes an \"RFID Error - Unable to scan ID\" warning."))
 			return FALSE
+
 		access = access_card.GetAccess()
 
 	for(var/singular_access in access_to_check)
 		if(singular_access in access)//For loop checks every individual access entry in the access list. If the user's ID has access to any entry, then we're good.
 			return TRUE
-	if(loud)
-		computer.balloon_alert_to_viewers("Access Denied")
-		to_chat(user, span_danger("\The [computer] flashes an \"Access Denied\" warning."))
 	return FALSE
 
 /**
@@ -199,7 +183,7 @@
  **/
 /datum/computer_file/program/proc/on_start(mob/living/user)
 	SHOULD_CALL_PARENT(TRUE)
-	if(can_run(user, 1))
+	if(is_supported_by_hardware(user, 1))
 		if(requires_ntnet && network_destination)
 			var/obj/item/computer_hardware/network_card/network_card = computer.all_components[MC_NET]
 			generate_network_log("Connection opened to [network_destination].", network_card) // Probably should be cut

--- a/code/modules/modular_computers/file_system/programs/ntdownloader.dm
+++ b/code/modules/modular_computers/file_system/programs/ntdownloader.dm
@@ -171,7 +171,9 @@
 			"category" = P.category,
 			"installed" = !!hard_drive.find_file_by_name(P.filename),
 			"size" = P.size,
-			"access" = emagged && P.available_on_syndinet ? TRUE : P.can_run(user,transfer = 1, access = access),
+			"access" = emagged && P.available_on_syndinet ? TRUE : P.can_download(user, access = access),
+			"compatible" = P.is_supported_by_hardware(user, loud = FALSE),
+			"requiredhardware" = P.hardware_requirement,
 			"verifiedsource" = P.available_on_ntnet,
 		))
 

--- a/code/modules/modular_computers/file_system/programs/ntnrc_client.dm
+++ b/code/modules/modular_computers/file_system/programs/ntnrc_client.dm
@@ -105,7 +105,7 @@
 				channel?.add_client(src)
 				return TRUE
 			var/mob/living/user = usr
-			if(can_run(user, TRUE, ACCESS_NETWORK))
+			if(can_admin(user))
 				for(var/C in SSnetworks.station_network.chat_channels)
 					var/datum/ntnet_conversation/chan = C
 					chan.remove_client(src)
@@ -219,8 +219,20 @@
 
 /datum/computer_file/program/chatclient/ui_static_data(mob/user)
 	var/list/data = list()
-	data["can_admin"] = can_run(user, FALSE, ACCESS_NETWORK)
+	data["can_admin"] = can_admin(user)
 	return data
+
+/// Checks for RD server access in Id cards for admin purposes
+/datum/computer_file/program/chatclient/proc/can_admin(mob/user)
+	var/obj/item/computer_hardware/card_slot/card_slot = computer.all_components[MC_CARD]
+	if(!card_slot)
+		return FALSE
+	var/obj/item/card/id/id_card = card_slot.stored_card
+	if(!id_card)
+		return FALSE
+	if(ACCESS_RD_SERVER in id_card.access)
+		return TRUE
+	return FALSE
 
 /datum/computer_file/program/chatclient/ui_data(mob/user)
 	if(!SSnetworks.station_network || !SSnetworks.station_network.chat_channels)

--- a/code/modules/modular_computers/hardware/portable_disks/job_disk.dm
+++ b/code/modules/modular_computers/hardware/portable_disks/job_disk.dm
@@ -81,7 +81,6 @@
 		progs_to_store += new /datum/computer_file/program/job_management(src)
 
 	for (var/datum/computer_file/program/prog in progs_to_store)
-		prog.required_access = list()
 		prog.transfer_access = list()
 		store_file(prog)
 

--- a/tgui/packages/tgui/interfaces/NtosNetDownloader.tsx
+++ b/tgui/packages/tgui/interfaces/NtosNetDownloader.tsx
@@ -31,6 +31,7 @@ type ProgramData = {
   compatible: BooleanLike;
   size: number;
   access: BooleanLike;
+  requiredhardware: string;
   verifiedsource: BooleanLike;
 };
 
@@ -55,10 +56,10 @@ export const NtosNetDownloader = (props) => {
   const search = createSearch<ProgramData>(searchItem, (program) => program.filedesc);
   let items =
     searchItem.length > 0
-      ? // If we have a query, search everything for it.
-      filter(programs, search)
-      : // Otherwise, show respective programs for the category.
-      filter(programs, (program) => program.category === selectedCategory);
+      ? filter(programs, search)
+      : selectedCategory === 'All'
+        ? programs
+        : filter(programs, (program) => program.category === selectedCategory);
   // This sorts all programs in the lists by name and compatibility
   items = sortBy(
     items,
@@ -174,7 +175,7 @@ const Program = (props) => {
                   program.installed
                     ? 'Installed'
                     : !program.compatible
-                      ? 'Incompatible'
+                      ? `Missing ${program.requiredhardware}`
                       : !program.access
                         ? id_inserted
                           ? 'No Access'


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

### Closes #13075

Programs can be downloaded again.

(No ID inserted)
<img width="603" height="600" alt="image" src="https://github.com/user-attachments/assets/e5b44bec-726e-4656-8eb0-c735579554d5" />


I added a visual queue for when the program is not supported.

(Full access ID inserted)
<img width="599" height="599" alt="image" src="https://github.com/user-attachments/assets/ad30a20d-76f7-4897-b5b4-6c5e06606401" />


Fixed "all" category not displaying any programs at all.

<img width="597" height="596" alt="image" src="https://github.com/user-attachments/assets/e6b14b45-a648-4644-8ebd-9cd8a95b5ee3" />


Also, emagged computers can now transfer any program they wish, mind you most programs have their own authentication method, mainly card modification.

## Why It's Good For The Game

It's bug fixes and QOL.

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

Up there.

</details>

## Changelog
:cl:
fix: Fixed computer program downloading
fix: The "All" category in the program downloader app now properly displays all programs
tweak: Hardware required for running a program will now be displayed if they are missing in the program downloader.
tweak: Emagged computers can now bypass access requirements on program downloads.
refactor: Refactored can_run into can_download since programs authenticate access on their own.

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
