### PR TITLE
Fixed Box Station Atmos External Airlocks

### DIFF
--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -25993,16 +25993,6 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
-"haj" = (
-/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
-	cycle_id = "atmos_external"
-	},
-/obj/machinery/door/airlock/external{
-	name = "Atmospherics External Airlock";
-	req_one_access = "24, 13"
-	},
-/turf/open/floor/plating,
-/area/maintenance/aft)
 "haz" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer4{
 	dir = 8
@@ -105832,10 +105822,10 @@ ccB
 cbH
 bLK
 aaf
-haj
+way
 ctl
 ctl
-haj
+way
 ixA
 aoV
 aaf
@@ -106348,7 +106338,7 @@ bLK
 gXs
 oSu
 oSu
-haj
+way
 oSu
 lTm
 cnb


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

### Closes #13073

Atmos techs were unable to open these doors.
Now they can.

https://github.com/user-attachments/assets/d64dbeb3-7fb2-4769-bd7a-2017e6144d41


## Why It's Good For The Game

This was probably not intended. These silly locks are always a problem every time an atmos technician plays on box.

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

Up there

</details>

## Changelog
:cl:
fix: Fixed Atmospheric external airlock access in Box Station
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
