### PR TITLE
Adds oxygen candles to engineering and adjusts their tator values

### DIFF
--- a/code/game/objects/items/storage/boxes.dm
+++ b/code/game/objects/items/storage/boxes.dm
@@ -856,6 +856,15 @@
 	for(var/i in 1 to 7)
 		new/obj/item/grenade/chem_grenade/smart_metal_foam(src)
 
+/obj/item/storage/box/oxycandle
+	name = "box of oxygen candles"
+	desc = "Used to repressurize areas during power emergencies."
+	illustration = "grenade"
+
+/obj/item/storage/box/oxycandle/PopulateContents()
+	for(var/i in 1 to 7)
+		new/obj/item/flashlight/oxycandle(src)
+
 /obj/item/storage/box/hug
 	name = "box of hugs"
 	desc = "A special box for sensitive people."

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -1368,8 +1368,8 @@ GLOBAL_LIST_INIT(illegal_tech_blacklist, typecacheof(list(
 	desc = "This modified oxygen candle is delivered fresh directly off the conveyor at one of our signature warcrime factories. \
 			Pull the tab and watch in glee as a solid quarter of the station becomes uninhabitable."
 	item = /obj/item/flashlight/oxycandle/hellfire
-	player_minimum = 8
-	cost = 2
+	player_minimum = 15
+	cost = 4
 
 //Support and Mechs
 /datum/uplink_item/support

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -1368,8 +1368,8 @@ GLOBAL_LIST_INIT(illegal_tech_blacklist, typecacheof(list(
 	desc = "This modified oxygen candle is delivered fresh directly off the conveyor at one of our signature warcrime factories. \
 			Pull the tab and watch in glee as a solid quarter of the station becomes uninhabitable."
 	item = /obj/item/flashlight/oxycandle/hellfire
-	player_minimum = 15
-	cost = 10
+	player_minimum = 8
+	cost = 2
 
 //Support and Mechs
 /datum/uplink_item/support

--- a/code/modules/vending/engivend.dm
+++ b/code/modules/vending/engivend.dm
@@ -15,10 +15,12 @@
 					/obj/item/electronics/airalarm = 10,
 					/obj/item/electronics/firealarm = 10,
 					/obj/item/electronics/firelock = 10,
+					/obj/item/flashlight/oxycandle = 10,
 					/obj/item/storage/bag/construction = 3)
 	contraband = list(/obj/item/stock_parts/cell/potato = 3)
 	premium = list(/obj/item/storage/belt/utility = 3,
-				   /obj/item/storage/box/smart_metal_foam = 1)
+				   /obj/item/storage/box/smart_metal_foam = 3,
+				   /obj/item/storage/box/oxycandle = 3)
 	refill_canister = /obj/item/vending_refill/engivend
 	default_price = 20
 	extra_price = 50


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

adds 10 oxygen candles to the vendor, and 3 boxes of 7. Like the smartfoam grenades.

Also i went way overboard with their cost, I don't know what the fuck i was smoking.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

woopsie!

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

<img width="622" height="309" alt="image" src="https://github.com/user-attachments/assets/0553c725-3e97-415b-9da5-efd07446d47f" />

</details>

## Changelog
:cl:
add: Engineering now has oxycandles in the engie-vend
tweak: Hellfire candles are now cheaper.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
