### PR TITLE
Loadout replaces starting gear

### DIFF
--- a/code/modules/jobs/job_types/_job.dm
+++ b/code/modules/jobs/job_types/_job.dm
@@ -334,9 +334,11 @@
 							if(!spawned_box && !on_dummy)	//Spawn the box only if theres something being unequiped.
 								var/obj/item/storage/current_bag = H.get_item_by_slot(ITEM_SLOT_BACK)
 
-								spawned_box = new /obj/item/storage/box/suitbox(current_bag)
+								spawned_box = new /obj/item/storage/box
 								spawned_box.name = "compression box of standard gear"
-								H.put_in_hands(spawned_box)	// Not putting it in the bagpack for obvious reasons
+								spawned_box.forceMove(current_bag)	// Gets put in the backpack
+								if(M.client)
+									to_chat(M, span_notice("A box with your standard equipment was placed in your [current_bag.name]!"))
 							H.doUnEquip(o, newloc = spawned_box ? spawned_box : H.drop_location(), invdrop = FALSE, silent = TRUE)
 
 						if(H.equip_to_slot_or_del(new_item, G.slot))

--- a/code/modules/jobs/job_types/_job.dm
+++ b/code/modules/jobs/job_types/_job.dm
@@ -314,17 +314,32 @@
 					continue
 
 				if(G.slot)
-					var/obj/o
-					if(on_dummy) // remove the old item
-						o = H.get_item_by_slot(G.slot)
-						H.doUnEquip(H.get_item_by_slot(G.slot), newloc = H.drop_location(), invdrop = FALSE, silent = TRUE)
-					if(H.equip_to_slot_or_del(G.spawn_item(H, skirt_pref = jumpsuit_style), G.slot))
-						if(M.client)
-							to_chat(M, span_notice("Equipping you with [G.display_name]!"))
-						if(on_dummy && o)
-							qdel(o)
+					if(G.slot == ITEM_SLOT_BACK)
+						var/obj/item/storage/new_bag = G.spawn_item(H, skirt_pref = jumpsuit_style)
+						var/obj/item/storage/old_bag = H.get_item_by_slot(ITEM_SLOT_BACK)
+						if(old_bag)
+							for(var/obj/item/item in old_bag.contents)
+								item.forceMove(new_bag)
+							H.doUnEquip(old_bag, newloc = H.drop_location(), invdrop = FALSE, silent = TRUE)
+							if(H.equip_to_slot_or_del(new_bag, G.slot))
+								if(M.client)
+									to_chat(M, span_notice("Equipping you with [G.display_name]!"))
 					else
-						gear_leftovers += G
+						var/obj/item/new_item = G.spawn_item(H, skirt_pref = jumpsuit_style)
+
+						// Unequip only if we're about to equip something in that slot
+						var/obj/o = H.get_item_by_slot(G.slot)
+						if(o)
+							H.doUnEquip(o, newloc = H.drop_location(), invdrop = FALSE, silent = TRUE)
+
+						if(H.equip_to_slot_or_del(new_item, G.slot))
+							if(M.client)
+								to_chat(M, span_notice("Equipping you with [G.display_name]!"))
+
+						else
+							// If slot was blocked, or item couldn't be equipped, push to leftovers
+							gear_leftovers += G
+							qdel(new_item) // prevent duplicate spawns
 				else
 					gear_leftovers += G
 

--- a/code/modules/jobs/job_types/_job.dm
+++ b/code/modules/jobs/job_types/_job.dm
@@ -286,6 +286,7 @@
 /proc/apply_loadout_to_mob(mob/living/carbon/human/H, mob/M, client/preference_source, on_dummy = FALSE)
 	var/mob/living/carbon/human/human = H
 	var/list/gear_leftovers = list()
+	var/obj/item/storage/spawned_box
 	var/jumpsuit_style = preference_source.prefs.read_character_preference(/datum/preference/choiced/jumpsuit_style)
 	if(preference_source && LAZYLEN(preference_source.prefs.equipped_gear))
 		for(var/gear in preference_source.prefs.equipped_gear)
@@ -330,7 +331,13 @@
 						// Unequip only if we're about to equip something in that slot
 						var/obj/o = H.get_item_by_slot(G.slot)
 						if(o)
-							H.doUnEquip(o, newloc = H.drop_location(), invdrop = FALSE, silent = TRUE)
+							if(!spawned_box && !on_dummy)	//Spawn the box only if theres something being unequiped.
+								var/obj/item/storage/current_bag = H.get_item_by_slot(ITEM_SLOT_BACK)
+
+								spawned_box = new /obj/item/storage/box/suitbox(current_bag)
+								spawned_box.name = "compression box of standard gear"
+								H.put_in_hands(spawned_box)	// Not putting it in the bagpack for obvious reasons
+							H.doUnEquip(o, newloc = spawned_box ? spawned_box : H.drop_location(), invdrop = FALSE, silent = TRUE)
 
 						if(H.equip_to_slot_or_del(new_item, G.slot))
 							if(M.client)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

### Made with the help of @Rukofamicom by scavenging some code from: #8591

Ever since I joined the game I was plagued with a simple thing:

Having to full strip myself round start just to equip the items I bought with my hard earned bee coins.

This is no longer an issue.

Gear you equipped will now replace your job's gear:

<img width="767" height="299" alt="image" src="https://github.com/user-attachments/assets/274d5162-9642-47b4-8d13-0eb82ec5b4fe" />

I could only test this with donator items in local.


Your job gear will now be put in a box to ensure you're not losing anything:
(It will be stored inside your backpack!)

<img width="750" height="280" alt="image" src="https://github.com/user-attachments/assets/302b3df9-a571-4fbb-a146-b86cb7e0bb67" />
<img width="759" height="278" alt="image" src="https://github.com/user-attachments/assets/27b502f2-7528-4758-ac86-bde8f20d6735" />
<img width="684" height="148" alt="image" src="https://github.com/user-attachments/assets/4afcefa5-51f8-4c54-b717-8bc1b5bb59ff" />


The box doesn't spawn unless it's necessary:

<img width="753" height="301" alt="image" src="https://github.com/user-attachments/assets/90357120-984e-49e5-baff-3a7084ae42d6" />


A nice little added bonus of this that I just now discovered is that now your character will display its loadout properly in character creation!

Before:
<img width="232" height="396" alt="image" src="https://github.com/user-attachments/assets/9076c08f-776b-4a1f-9c30-671ed66ed4d9" />

After:
<img width="211" height="277" alt="image" src="https://github.com/user-attachments/assets/d6306458-f680-4537-a8e1-12a55d236b9a" />


Neat!!

This PR also fixes an issue causing some loadout items to be duplicated.


## Why It's Good For The Game

Equipping gear and then not having it be equipped doesn't seem intentional.

I like to work on these little polish/QOL things.

It will save players about 10 seconds of their round... and not litter the arrivals shuttle....

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

<img width="277" height="86" alt="image" src="https://github.com/user-attachments/assets/c4fbe3c3-49e5-4bab-8fdb-fcc3bda6f084" />

</details>

## Changelog
:cl: Solene and Rukofamicom
tweak: Loadout items now will be equipped on your character on spawn, replacing standard job equipment (which will spawn in a box instead).
fix: Fixed duplication of loadout items on spawn.
fix: Loadout's will now display properly on the character panel
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
