### PR TITLE
Maybe fixes skin v2

### DIFF
--- a/code/modules/client/preferences/entries/player/fullscreen.dm
+++ b/code/modules/client/preferences/entries/player/fullscreen.dm
@@ -50,7 +50,7 @@
 		if(client.fully_created)
 			INVOKE_ASYNC(client, PROC_REF(fix_mapsize), client)
 		else
-			addtimer(CALLBACK(client, PROC_REF(fix_mapsize), client), 1 SECONDS)
+			addtimer(CALLBACK(src, PROC_REF(fix_mapsize), client), 1 SECONDS)
 
 /datum/preference/toggle/fullscreen/proc/fix_mapsize(client/client)
 	var/windowsize = winget(client, "split", "size")

--- a/code/modules/client/preferences/entries/player/fullscreen.dm
+++ b/code/modules/client/preferences/entries/player/fullscreen.dm
@@ -53,7 +53,9 @@
 			addtimer(CALLBACK(src, PROC_REF(fix_mapsize), client), 1 SECONDS)
 
 /datum/preference/toggle/fullscreen/proc/fix_mapsize(client/client)
-	var/windowsize = winget(client, "split", "size")
+ 	if (!client)
+ 		return
+ 	var/windowsize = winget(client, "split", "size")
 	if (!client || !windowsize)
 		return
 	var/split = findtext(windowsize, "x")

--- a/code/modules/client/preferences/entries/player/fullscreen.dm
+++ b/code/modules/client/preferences/entries/player/fullscreen.dm
@@ -48,9 +48,9 @@
 			winset(client, "status_bar", "is-visible=false")
 
 		if(client.fully_created)
-			INVOKE_ASYNC(client, TYPE_PROC_REF(/client, fit_viewport))
+			INVOKE_ASYNC(client, PROC_REF(fix_mapsize), client)
 		else
-			addtimer(CALLBACK(client, TYPE_PROC_REF(/client, fit_viewport), 1 SECONDS))
+			addtimer(CALLBACK(client, PROC_REF(fix_mapsize), client), 1 SECONDS)
 
 /datum/preference/toggle/fullscreen/proc/fix_mapsize(client/client)
 	var/windowsize = winget(client, "split", "size")

--- a/interface/skin.dmf
+++ b/interface/skin.dmf
@@ -83,7 +83,7 @@ window "mainwindow"
 		anchor2 = 100,100
 		background-color = none
 		is-default = true
-		saved-params = "pos;size;is-minimized;is-maximized"
+		saved-params = "is-minimized;is-maximized"
 		icon = 'icons\\ss13_64.png'
 		macro = "default"
 		menu = "menu"
@@ -147,7 +147,7 @@ window "mapwindow"
 		anchor1 = 0,0
 		anchor2 = 100,100
 		background-color = none
-		saved-params = "pos;size;is-minimized;is-maximized"
+		saved-params = "is-minimized;is-maximized"
 		is-pane = true
 		outer-size = 656x538
 		inner-size = 640x499
@@ -183,7 +183,7 @@ window "infowindow"
 		anchor1 = none
 		anchor2 = none
 		background-color = none
-		saved-params = "pos;size;is-minimized;is-maximized"
+		saved-params = "is-minimized;is-maximized"
 		is-pane = true
 		outer-size = 656x538
 		inner-size = 640x499
@@ -287,7 +287,7 @@ window "outputwindow"
 		anchor1 = none
 		anchor2 = none
 		background-color = none
-		saved-params = "pos;size;is-minimized;is-maximized"
+		saved-params = "is-minimized;is-maximized"
 		is-pane = true
 		outer-size = 656x1017
 		inner-size = 640x979

--- a/interface/skin.dmf
+++ b/interface/skin.dmf
@@ -352,7 +352,7 @@ window "output_legacy"
 		anchor1 = -1,-1
 		anchor2 = -1,-1
 		background-color = none
-		saved-params = "pos;size;is-minimized;is-maximized"
+		saved-params = "is-minimized;is-maximized"
 		is-pane = true
 	elem "output"
 		type = OUTPUT
@@ -371,7 +371,7 @@ window "output_browser"
 		anchor1 = -1,-1
 		anchor2 = -1,-1
 		background-color = none
-		saved-params = "pos;size;is-minimized;is-maximized"
+		saved-params = "is-minimized;is-maximized"
 		is-pane = true
 	elem "browseroutput"
 		type = BROWSER


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Okay new information:
- Probably caused by #12888
- Possibly caused by the game resizing during lobby screen

## Why It's Good For The Game

I think the issue is caused by saving the size, when the game reloads it loads the saved chat size which is of course, wrong. There is no reason you would want to save the chat height, because it isn't adjustable and it doesn't pop out of the game.

## Testing Photographs and Procedure

<img width="1914" height="1007" alt="image" src="https://github.com/user-attachments/assets/01f56e82-efc2-48f0-a1e7-510ddc53dde1" />

It worked for 1 round

## Changelog
:cl:
fix: Fixes the chat going off the side of the game screen
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
