### PR TITLE
MCR - Fixes 2 Modular Computer bugs (mb)

### DIFF
--- a/code/__DEFINES/devices.dm
+++ b/code/__DEFINES/devices.dm
@@ -4,7 +4,7 @@
 #define DISK_ATMOS (1<<1)
 #define DISK_MED (1<<2)
 #define DISK_CHEM (1<<3)
-#define DISK_MANIFEST (1<<4)
+#define DISK_SM (1<<4)
 #define DISK_NEWSCASTER (1<<5)
 #define DISK_SIGNAL	(1<<6)
 #define DISK_STATUS (1<<7)

--- a/code/__DEFINES/machines.dm
+++ b/code/__DEFINES/machines.dm
@@ -65,7 +65,7 @@
 #define MC_NET "NET"
 #define MC_PRINT "PRINT"
 #define MC_CELL "CELL"
-#define MC_CHARGE "CHARGE"
+#define MC_CHARGER "CHARGER"
 #define MC_AI "AI"
 #define MC_SENSORS "SENSORS"
 #define MC_SIGNALLER "SIGNALER"

--- a/code/modules/modular_computers/computers/item/computer.dm
+++ b/code/modules/modular_computers/computers/item/computer.dm
@@ -376,7 +376,7 @@ GLOBAL_LIST_EMPTY(TabletMessengers) // a list of all active messengers, similar 
 		return FALSE
 
 	// If we have a recharger, enable it automatically. Lets computer without a battery work.
-	var/obj/item/computer_hardware/recharger/recharger = all_components[MC_CHARGE]
+	var/obj/item/computer_hardware/recharger/recharger = all_components[MC_CHARGER]
 	if(recharger)
 		recharger.enabled = 1
 
@@ -479,7 +479,7 @@ GLOBAL_LIST_EMPTY(TabletMessengers) // a list of all active messengers, similar 
 	data["PC_theme_locked"] = theme_locked
 
 	var/obj/item/computer_hardware/battery/battery_module = all_components[MC_CELL]
-	var/obj/item/computer_hardware/recharger/recharger = all_components[MC_CHARGE]
+	var/obj/item/computer_hardware/recharger/recharger = all_components[MC_CHARGER]
 	var/obj/item/computer_hardware/hard_drive/drive = all_components[MC_HDD]
 
 	if(battery_module?.battery)
@@ -569,7 +569,7 @@ GLOBAL_LIST_EMPTY(TabletMessengers) // a list of all active messengers, similar 
 		to_chat(user, span_danger("\The [src]'s screen shows \"I/O ERROR - Unable to run program\" warning."))
 		return FALSE
 
-	if(!program.is_supported_by_hardware(user))
+	if(!program.is_supported_by_hardware(src, user))
 		return FALSE
 
 	// The program is already running. Resume it.

--- a/code/modules/modular_computers/computers/item/computer_power.dm
+++ b/code/modules/modular_computers/computers/item/computer_power.dm
@@ -3,7 +3,7 @@
 	if(check_power_override())
 		return TRUE
 
-	var/obj/item/computer_hardware/recharger/recharger = all_components[MC_CHARGE]
+	var/obj/item/computer_hardware/recharger/recharger = all_components[MC_CHARGER]
 
 	if(recharger && recharger.check_functionality())
 		if(recharger.use_power(amount))
@@ -75,7 +75,7 @@
 
 // Handles power-related things, such as battery interaction, recharging, shutdown when it's discharged
 /obj/item/modular_computer/proc/handle_power(delta_time)
-	var/obj/item/computer_hardware/recharger/recharger = all_components[MC_CHARGE]
+	var/obj/item/computer_hardware/recharger/recharger = all_components[MC_CHARGER]
 	if(recharger)
 		recharger.process(delta_time)
 

--- a/code/modules/modular_computers/computers/item/role_tablet_presets.dm
+++ b/code/modules/modular_computers/computers/item/role_tablet_presets.dm
@@ -170,6 +170,10 @@
 	default_disk = /obj/item/computer_hardware/hard_drive/role/ce
 	icon_state = "pda-ce"
 
+/obj/item/modular_computer/tablet/pda/preset/heads/chief_engineer/Initialize(mapload)
+	. = ..()
+	install_component(new /obj/item/computer_hardware/recharger/APC/pda)
+
 /obj/item/modular_computer/tablet/pda/preset/heads/chief_medical_officer
 	name = "chief medical officer PDA"
 	default_disk = /obj/item/computer_hardware/hard_drive/role/cmo
@@ -287,6 +291,10 @@
 	name = "atmospherics PDA"
 	default_disk = /obj/item/computer_hardware/hard_drive/role/atmos
 	icon_state = "pda-atmos"
+
+/obj/item/modular_computer/tablet/pda/preset/atmospheric_technician/Initialize(mapload)
+	. = ..()
+	install_component(new /obj/item/computer_hardware/recharger/APC/pda)
 
 /obj/item/modular_computer/tablet/pda/preset/chemist
 	name = "chemist PDA"

--- a/code/modules/modular_computers/computers/machinery/modular_console.dm
+++ b/code/modules/modular_computers/computers/machinery/modular_console.dm
@@ -24,7 +24,7 @@
 	// User-built consoles start as empty frames.
 	var/obj/item/computer_hardware/hard_drive/hard_drive = cpu.all_components[MC_HDD]
 	var/obj/item/computer_hardware/hard_drive/network_card = cpu.all_components[MC_NET]
-	var/obj/item/computer_hardware/hard_drive/recharger = cpu.all_components[MC_CHARGE]
+	var/obj/item/computer_hardware/hard_drive/recharger = cpu.all_components[MC_CHARGER]
 	qdel(recharger)
 	qdel(network_card)
 	qdel(hard_drive)

--- a/code/modules/modular_computers/file_system/program.dm
+++ b/code/modules/modular_computers/file_system/program.dm
@@ -110,15 +110,17 @@
  * Checks for hardware incompatibilities.
  * If the current computer doesn't have the hardware matching hardware equipment an error will display and the program wont start.
  * Arguments:
+ * * to_check - The computer being checked, this does not use the computer var due to cases where the program doesn't exist yet in any computer but needs to be checked against yours.
  * * user - The mob that started the program
+ * * loud - Are we making a sound and displaying balloon alert?
  **/
-/datum/computer_file/program/proc/is_supported_by_hardware(mob/living/user, loud = TRUE)
+/datum/computer_file/program/proc/is_supported_by_hardware(obj/item/modular_computer/to_check, mob/user, loud = TRUE)
 	if(!hardware_requirement)
 		return TRUE
-	if(!computer?.get_modular_computer_part(hardware_requirement))
+	if(!to_check?.get_modular_computer_part(hardware_requirement))
 		if(loud)	// Else fail silently
-			computer.balloon_alert(user, "<font color='#d80000'>ERROR:</font> Required hardware type :: <font color='#e65bc3'>[hardware_requirement]</font> not found!")
-			playsound(computer, 'sound/machines/defib_failed.ogg', 25, TRUE)
+			to_check.balloon_alert(user, "<font color='#d80000'>ERROR:</font> Required hardware type :: <font color='#e65bc3'>[hardware_requirement]</font> not found!")
+			playsound(to_check, 'sound/machines/defib_failed.ogg', 25, TRUE)
 		return FALSE
 	return TRUE
 
@@ -183,7 +185,7 @@
  **/
 /datum/computer_file/program/proc/on_start(mob/living/user)
 	SHOULD_CALL_PARENT(TRUE)
-	if(is_supported_by_hardware(user, 1))
+	if(is_supported_by_hardware(computer, user, 1))
 		if(requires_ntnet && network_destination)
 			var/obj/item/computer_hardware/network_card/network_card = computer.all_components[MC_NET]
 			generate_network_log("Connection opened to [network_destination].", network_card) // Probably should be cut

--- a/code/modules/modular_computers/file_system/programs/antagonist/revelation.dm
+++ b/code/modules/modular_computers/file_system/programs/antagonist/revelation.dm
@@ -32,7 +32,7 @@
 		computer.update_icon()
 		var/obj/item/computer_hardware/hard_drive/hard_drive = computer.all_components[MC_HDD]
 		var/obj/item/computer_hardware/battery/battery_module = computer.all_components[MC_CELL]
-		var/obj/item/computer_hardware/recharger/recharger = computer.all_components[MC_CHARGE]
+		var/obj/item/computer_hardware/recharger/recharger = computer.all_components[MC_CHARGER]
 		qdel(hard_drive)
 		computer.take_damage(25, BRUTE, 0, 0)
 		if(battery_module && prob(25))

--- a/code/modules/modular_computers/file_system/programs/ntdownloader.dm
+++ b/code/modules/modular_computers/file_system/programs/ntdownloader.dm
@@ -172,7 +172,7 @@
 			"installed" = !!hard_drive.find_file_by_name(P.filename),
 			"size" = P.size,
 			"access" = emagged && P.available_on_syndinet ? TRUE : P.can_download(user, access = access),
-			"compatible" = P.is_supported_by_hardware(user, loud = FALSE),
+			"compatible" = P.is_supported_by_hardware(computer, user, loud = FALSE),
 			"requiredhardware" = P.hardware_requirement,
 			"verifiedsource" = P.available_on_ntnet,
 		))

--- a/code/modules/modular_computers/file_system/programs/powermonitor.dm
+++ b/code/modules/modular_computers/file_system/programs/powermonitor.dm
@@ -12,7 +12,7 @@
 	size = 8
 	tgui_id = "NtosPowerMonitor"
 	program_icon = "plug"
-	hardware_requirement = MC_CHARGE
+	hardware_requirement = MC_CHARGER
 
 	var/has_alert = 0
 	var/obj/structure/cable/attached_wire

--- a/code/modules/modular_computers/hardware/battery_module.dm
+++ b/code/modules/modular_computers/hardware/battery_module.dm
@@ -16,7 +16,7 @@ CREATION_TEST_IGNORE_SUBTYPES(/obj/item/computer_hardware/battery)
 /obj/item/computer_hardware/battery/on_remove(obj/item/modular_computer/remove_from, mob/user)
 	if(!holder)
 		return ..()
-	var/obj/item/computer_hardware/recharger/recharger = holder.all_components[MC_CHARGE]
+	var/obj/item/computer_hardware/recharger/recharger = holder.all_components[MC_CHARGER]
 	if(!recharger)	// We need to shutdown the computer if the battery is removed and theres nothing to give it power
 		remove_from.shutdown_computer()
 	return ..()

--- a/code/modules/modular_computers/hardware/portable_disks/job_disk.dm
+++ b/code/modules/modular_computers/hardware/portable_disks/job_disk.dm
@@ -30,15 +30,16 @@
 		return
 	if(disk_flags & DISK_POWER)
 		progs_to_store += new /datum/computer_file/program/power_monitor(src)
-		progs_to_store += new /datum/computer_file/program/supermatter_monitor(src)
 		progs_to_store += new /datum/computer_file/program/alarm_monitor(src)
 
-	if(disk_flags & DISK_NETWORK)	//Put this higher up so players see it easier and try to interact with it
-		progs_to_store += new /datum/computer_file/program/ntnetmonitor(src)
+	if(disk_flags & DISK_SM)
+		progs_to_store += new /datum/computer_file/program/supermatter_monitor(src)
 
 	if(disk_flags & DISK_ATMOS)
 		progs_to_store += new /datum/computer_file/program/atmosscan(src)
-		progs_to_store += new /datum/computer_file/program/alarm_monitor(src)
+
+	if(disk_flags & DISK_NETWORK)	//Put this higher up so players see it easier and try to interact with it
+		progs_to_store += new /datum/computer_file/program/ntnetmonitor(src)
 
 	if(disk_flags & DISK_SEC)
 		progs_to_store += new /datum/computer_file/program/records/security(src)
@@ -109,12 +110,12 @@
 	name = "\improper Power-ON disk"
 	desc = "Engineers ignoring station power-draw since 2400."
 	icon_state = "cart-engie"
-	disk_flags = DISK_POWER
+	disk_flags = DISK_POWER | DISK_SM
 
 /obj/item/computer_hardware/hard_drive/role/atmos
 	name = "\improper BreatheDeep disk"
 	icon_state = "cart-atmos"
-	disk_flags = DISK_ATMOS | DISK_ROBOS
+	disk_flags = DISK_ATMOS | DISK_ROBOS | DISK_POWER
 
 /obj/item/computer_hardware/hard_drive/role/medical
 	name = "\improper Med-U disk"
@@ -129,17 +130,17 @@
 /obj/item/computer_hardware/hard_drive/role/brig_physician
 	name = "\improper R.O.B.U.S.T. MED-U disk"
 	icon_state = "cart-brigphys"
-	disk_flags = DISK_MANIFEST | DISK_MED | DISK_ROBOS
+	disk_flags = DISK_MED | DISK_ROBOS
 
 /obj/item/computer_hardware/hard_drive/role/security
 	name = "\improper R.O.B.U.S.T. disk"
 	icon_state = "cart-sec"
-	disk_flags = DISK_SEC | DISK_MANIFEST | DISK_ROBOS
+	disk_flags = DISK_SEC | DISK_ROBOS
 
 /obj/item/computer_hardware/hard_drive/role/detective
 	name = "\improper D.E.T.E.C.T. disk"
 	icon_state = "cart-det"
-	disk_flags = DISK_MED | DISK_SEC | DISK_MANIFEST | DISK_ROBOS | DISK_CHEM
+	disk_flags = DISK_MED | DISK_SEC | DISK_ROBOS | DISK_CHEM
 
 /obj/item/computer_hardware/hard_drive/role/janitor
 	name = "\improper CustodiPRO disk"
@@ -192,32 +193,32 @@
 /obj/item/computer_hardware/hard_drive/role/head
 	name = "\improper Easy-Record DELUXE disk"
 	icon_state = "cart-val"
-	disk_flags = DISK_MANIFEST | DISK_STATUS | DISK_BUDGET
+	disk_flags = DISK_STATUS | DISK_BUDGET
 
 /obj/item/computer_hardware/hard_drive/role/hop
 	name = "\improper HumanResources9001 disk"
 	icon_state = "cart-hop"
-	disk_flags = DISK_MANIFEST | DISK_STATUS | DISK_JANI | DISK_SEC | DISK_NEWSCASTER | DISK_CARGO | DISK_SILO_LOG | DISK_ROBOS | DISK_BUDGET | DISK_HOP
+	disk_flags = DISK_STATUS | DISK_JANI | DISK_SEC | DISK_NEWSCASTER | DISK_CARGO | DISK_SILO_LOG | DISK_ROBOS | DISK_BUDGET | DISK_HOP
 
 /obj/item/computer_hardware/hard_drive/role/hos
 	name = "\improper R.O.B.U.S.T. DELUXE disk"
 	icon_state = "cart-hos"
-	disk_flags = DISK_MANIFEST | DISK_STATUS | DISK_SEC | DISK_ROBOS | DISK_BUDGET
+	disk_flags = DISK_STATUS | DISK_SEC | DISK_ROBOS | DISK_BUDGET
 
 /obj/item/computer_hardware/hard_drive/role/ce
 	name = "\improper Power-On DELUXE disk"
 	icon_state = "cart-ce"
-	disk_flags = DISK_POWER | DISK_ATMOS | DISK_MANIFEST | DISK_STATUS | DISK_ROBOS | DISK_BUDGET
+	disk_flags = DISK_POWER | DISK_ATMOS | DISK_SM | DISK_STATUS | DISK_ROBOS | DISK_BUDGET
 
 /obj/item/computer_hardware/hard_drive/role/cmo
 	name = "\improper Med-U DELUXE disk"
 	icon_state = "cart-cmo"
-	disk_flags = DISK_MANIFEST | DISK_STATUS | DISK_MED | DISK_CHEM | DISK_ROBOS | DISK_BUDGET
+	disk_flags = DISK_STATUS | DISK_MED | DISK_CHEM | DISK_ROBOS | DISK_BUDGET
 
 /obj/item/computer_hardware/hard_drive/role/rd
 	name = "\improper Signal Ace DELUXE disk"
 	icon_state = "cart-rd"
-	disk_flags = DISK_NETWORK | DISK_ATMOS | DISK_MANIFEST | DISK_STATUS | DISK_CHEM | DISK_ROBOS | DISK_BUDGET | DISK_SIGNAL
+	disk_flags = DISK_NETWORK | DISK_ATMOS | DISK_STATUS | DISK_CHEM | DISK_ROBOS | DISK_BUDGET | DISK_SIGNAL
 
 /obj/item/computer_hardware/hard_drive/role/captain
 	name = "\improper Value-PAK disk"

--- a/code/modules/modular_computers/hardware/recharger.dm
+++ b/code/modules/modular_computers/hardware/recharger.dm
@@ -2,7 +2,7 @@
 	critical = 1
 	enabled = 1
 	var/charge_rate = 100
-	device_type = MC_CHARGE
+	device_type = MC_CHARGER
 
 /obj/item/computer_hardware/recharger/proc/use_power(amount, charging = 0)
 	if(charging)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Firstly:

When I made a fix for downloading apps in #13091 I forgot the check compatibility proc wouldn't work as expected since those programs didn't exist yet in the players device.

So what was meant to be a helpful way to tell players what they won't be able to download due to hardware constraints was actually stopping them from downloading any programs with hardware requirement.

That has been fixed:

<img width="596" height="599" alt="image" src="https://github.com/user-attachments/assets/459a020b-e02f-42e6-beac-109af4ddb0a9" />
<img width="599" height="601" alt="image" src="https://github.com/user-attachments/assets/31ef9b3a-43fa-4924-a9e6-84329baa2e91" />


Secondly:

This is both a fix for CE and a QOL for atmos.

CE and Atmos PDAs will now start with a recharger installed to ensure they can use the power monitor program.

The component was renamed to "charger" instead of "charge" to be more informative to players.

Atmos roledisks were also given the power monitor program.
Atmos don't get engineering access even if there's no engineering.
Checking Power is something they should be doing if engineering is absent or unable.

<img width="389" height="168" alt="image" src="https://github.com/user-attachments/assets/e7cefccc-2b9b-43a6-95fa-77c87dede9bf" />

## Why It's Good For The Game

Bug fixes and small QOL!

No biggie but very important!!

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

Up there.

</details>

## Changelog
:cl:
fix: Fixed a bug stopping players from downloading programs that had a hardware requirement
tweak: CE and Atmos PDAs start with a micro area recharger for compatibility with the Power Monitor app.
tweak: Atmos role disk was given the Power Monitor app.
refactor: Refactored my own ass code to ensure this bug doesn't happen ever again.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
