### PR TITLE
Rewards Ready players with Beecoins

### DIFF
--- a/code/__DEFINES/metacoin.dm
+++ b/code/__DEFINES/metacoin.dm
@@ -8,3 +8,5 @@
 #define METACOIN_NOTSURVIVE_REWARD       10
 /// Rewarded when you are alive and active for 10 minutes
 #define METACOIN_TENMINUTELIVING_REWARD  4
+/// Rewarded when you started the round ready
+#define METACOIN_READY_UP_REWARD  100

--- a/code/__DEFINES/metacoin.dm
+++ b/code/__DEFINES/metacoin.dm
@@ -9,4 +9,4 @@
 /// Rewarded when you are alive and active for 10 minutes
 #define METACOIN_TENMINUTELIVING_REWARD  4
 /// Rewarded when you started the round ready
-#define METACOIN_READY_UP_REWARD  100
+#define METACOIN_READY_UP_REWARD  40

--- a/code/controllers/subsystem/job.dm
+++ b/code/controllers/subsystem/job.dm
@@ -185,7 +185,7 @@ SUBSYSTEM_DEF(job)
 		unassigned -= player
 		job.current_positions++
 		if(!latejoin)
-			player.client.inc_metabalance(METACOIN_READY_UP_REWARD, reason = "Thanks for readying up!")
+			player.client.inc_metabalance(METACOIN_READY_UP_REWARD, reason = "Joined the station as a roundstart crew member.")
 		JobDebug("Player: [player] is now Rank: [rank], JCP:[job.current_positions], JPL:[position_limit]. Group size: [job.count_players_in_group()]")
 		return TRUE
 	JobDebug("AR has failed, Player: [player], Rank: [rank]")

--- a/code/controllers/subsystem/job.dm
+++ b/code/controllers/subsystem/job.dm
@@ -177,13 +177,15 @@ SUBSYSTEM_DEF(job)
 			return FALSE
 		var/position_limit = job.get_spawn_position_count()
 		// Unassign our previous job, to prevent double counts
-		if (player.mind.assigned_role)
+		if(player.mind.assigned_role)
 			var/datum/job/current_job = SSjob.GetJob(player.mind.assigned_role)
 			current_job.current_positions--
 			player.mind.assigned_role = null
 		player.mind.assigned_role = rank
 		unassigned -= player
 		job.current_positions++
+		if(!latejoin)
+			player.client.inc_metabalance(METACOIN_READY_UP_REWARD, reason = "Thanks for readying up!")
 		JobDebug("Player: [player] is now Rank: [rank], JCP:[job.current_positions], JPL:[position_limit]. Group size: [job.count_players_in_group()]")
 		return TRUE
 	JobDebug("AR has failed, Player: [player], Rank: [rank]")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Requested by Bacon and other people.
<img width="420" height="111" alt="image" src="https://github.com/user-attachments/assets/55a679ae-2549-4d45-94ff-3b0ecc26b0ca" />


Now when you ready up for a round, whatever your role may be you'll get 40 beecoins.

<img width="784" height="243" alt="image" src="https://github.com/user-attachments/assets/e16f18d0-25d2-4346-b06b-89865c376462" />



This does NOT apply to late joins!!


My only concern is if people gonna ready up, then cryo instant.
I don't know how to stop that.
Maybe we should try letting players know they get beecoins by just PLAYING and this should not be silent:

<img width="483" height="61" alt="image" src="https://github.com/user-attachments/assets/11286e0c-e277-483d-9c68-39a51dc7017d" />


## Why It's Good For The Game

People readying up is good for the server. Now they have less of a reason to skip it for whatever reason.

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>

## Changelog
:cl:
add: You now get 40 beecoins at roundstart after readying up.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
