### PR TITLE
Fixes PDAs dropping parts on Qdel

### DIFF
--- a/code/__DEFINES/machines.dm
+++ b/code/__DEFINES/machines.dm
@@ -72,6 +72,9 @@
 #define MC_IDENTIFY "IDENTIFY"
 #define MC_CAMERA "CAMERA"
 
+//Chance Defines
+#define MC_PART_DROP_CHANCE 50
+
 //Trojan defines
 #define BREACHER "BREACHER"
 #define SLEDGE "SLEDGE"

--- a/code/modules/modular_computers/computers/item/computer.dm
+++ b/code/modules/modular_computers/computers/item/computer.dm
@@ -144,16 +144,6 @@ GLOBAL_LIST_EMPTY(TabletMessengers) // a list of all active messengers, similar 
 /obj/item/modular_computer/Destroy()
 	kill_program(forced = TRUE)
 	STOP_PROCESSING(SSobj, src)
-	var/obj/item/computer_hardware/card_slot/card_slot = all_components[MC_CARD]
-	if(card_slot)
-		if(card_slot.stored_card)
-			card_slot.RemoveID()
-	for(var/port in all_components)
-		var/obj/item/computer_hardware/component = all_components[port]
-		if(prob(50))
-			uninstall_component(component)	// Lets not just delete all components like that
-		else
-			qdel(component)
 	all_components?.Cut()
 	if(istype(stored_pai_card))
 		qdel(stored_pai_card)

--- a/code/modules/modular_computers/computers/item/computer_damage.dm
+++ b/code/modules/modular_computers/computers/item/computer_damage.dm
@@ -23,7 +23,7 @@
 		new /obj/item/stack/sheet/iron(newloc, round(steel_sheet_cost/2))
 		for(var/port in all_components)
 			var/obj/item/computer_hardware/component = all_components[port]
-			if(prob(50))
+			if(prob(MC_PART_DROP_CHANCE))
 				uninstall_component(component)	// Lets not just delete all components like that
 			else
 				qdel(component)

--- a/code/modules/modular_computers/computers/item/computer_damage.dm
+++ b/code/modules/modular_computers/computers/item/computer_damage.dm
@@ -21,13 +21,11 @@
 		physical.visible_message("\The [src] breaks apart!")
 		var/turf/newloc = get_turf(src)
 		new /obj/item/stack/sheet/iron(newloc, round(steel_sheet_cost/2))
-		for(var/C in all_components)
-			var/obj/item/computer_hardware/H = all_components[C]
-			if(QDELETED(H))
-				continue
-			uninstall_component(H)
-			H.forceMove(newloc)
-			if(prob(25))
-				H.take_damage(rand(10,30), BRUTE, 0, 0)
+		for(var/port in all_components)
+			var/obj/item/computer_hardware/component = all_components[port]
+			if(prob(50))
+				uninstall_component(component)	// Lets not just delete all components like that
+			else
+				qdel(component)
 	relay_qdel()
 	qdel(src)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Solene shitcode moment.

I wasn't aware there were 3 DIFFERENT PROCS FOR MODULAR COMPUTER DESTRUCTION/DELETION.

Parts wont drop on qdel anymore.
(Still drop normally upon destruction)

<img width="703" height="593" alt="image" src="https://github.com/user-attachments/assets/20365bea-975d-43ba-83de-f140c971c959" />
 
 Youll have to believe I gibbed and deleted a mob with a PDA. Because I then went to test if PDAs would still drop parts upon normal destruction. Happy to say they do.

## Why It's Good For The Game

Fixes a bug that trolls admins sometimes.

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

Up there.

</details>

## Changelog
:cl:
fix: Fixes a bug causing qdeled modular computers to drop parts
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
