### PR TITLE
Patches mail spawn rate to actually spawn at intended rate (1/min at 5+ pop)

### DIFF
--- a/code/__DEFINES/economy.dm
+++ b/code/__DEFINES/economy.dm
@@ -66,7 +66,7 @@
 // this should use the same bitflag values in `\_DEFINES\jobs.dm` to match.
 // It's true that bitflags shouldn't be separated in two DEFINES if these are same, but just in case the system can be devided, it's remained separated.
 
-/// How much mail the Economy SS will create per minute, regardless of firing time.
+/// How much mail the Economy SS can create per minute, regardless of firing time.
 #define MAX_MAIL_PER_MINUTE 1
 /// Probability of using letters of envelope sprites on all letters.
 #define FULL_CRATE_LETTER_ODDS 70

--- a/code/controllers/subsystem/economy.dm
+++ b/code/controllers/subsystem/economy.dm
@@ -53,7 +53,7 @@ SUBSYSTEM_DEF(economy)
 		var/datum/bank_account/B = A
 		B.payday(1)
 	var/effective_mailcount = living_player_count()
-	mail_waiting = clamp(mail_waiting + clamp(effective_mailcount, 1, MAX_MAIL_PER_MINUTE), 0, MAX_MAIL_LIMIT)
+	mail_waiting = clamp(mail_waiting + clamp(effective_mailcount, 1, MAX_MAIL_PER_MINUTE * (wait / (1 MINUTES))), 0, MAX_MAIL_LIMIT)
 
 /datum/controller/subsystem/economy/proc/get_bank_account_by_id(target_id)
 	if(!length(bank_accounts))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

PR #12354 has removed junk mail, changed mail loot table and tweaked the mail spawn formula. However, while intending to spawn at least one mail per minute, nothing in the formula accounts for the fact that the economy subsystem (which is part of the mail generation) fires each 5 minutes. With this formula tweak, each 5 minutes a mail is created for every alive crewmember, up to 5 per 5 minutes (as apparently intended from the variable names).

Examples:
- at 1 pop, a mail spawns each 5 minutes -> with minimum mail level being 6, first mail crate can be expected to arrive 30 minutes in
- at 5 pop, 5 mails spawn each 5 minutes -> this means that the mail crate should arrive as soon as 10 minutes in
- any larger pop would result in same scenario as previously, because the current mail spawn rate is of 1 mail per minute

This leaves the minimum mail required for a mail crate to spawn **unchanged**.

## Why It's Good For The Game

This PR would make it so that mail spawns at the **intended** rate of at most 1 mail per minute. Previously, mail would appear too scarcely (1 per 5 minutes) and would not justify someone being dedicated to this bit.

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
Mail arrival was tested locally, while monitoring ``mail_waiting`` variable in economy subsystem. At one player, mail spawns at a rate of 1 each 5 minutes
Duplicating the ``players_list`` entry 10 times, mail spawn rate adjusted accordingly, while being capped to 5 mail
Screenshot includes first scenario described, the second remaining anecdotal evidence
<details>
<summary>Screenshots&Videos</summary>

<img width="1350" height="570" alt="image" src="https://github.com/user-attachments/assets/d4d23f50-5d75-4084-948e-b6a819689d48" />


</details>

## Changelog
:cl: Aramix
fix: mail now spawns at the intended rate (max 1/minute at 5+ pop, with crate still being limited to 6-12 mails)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
