### PR TITLE
Add recipe for quantum hair dye

### DIFF
--- a/code/modules/reagents/chemistry/recipes/others.dm
+++ b/code/modules/reagents/chemistry/recipes/others.dm
@@ -694,6 +694,12 @@
 	required_reagents = list(/datum/reagent/stable_plasma = 1, /datum/reagent/uranium/radium = 1, /datum/reagent/drug/space_drugs = 1, /datum/reagent/medicine/cryoxadone = 1, /datum/reagent/consumable/triple_citrus = 1)
 	reaction_tags = REACTION_TAG_OTHER
 
+/datum/chemical_reaction/hair_dye
+	name = /datum/reagent/hair_dye
+	results = list(/datum/reagent/hair_dye = 5)
+	required_reagents = list(/datum/reagent/colorful_reagent = 1, /datum/reagent/drug/space_drugs = 1, /datum/reagent/uranium/radium = 1)
+	reaction_tags = REACTION_TAG_OTHER
+
 /datum/chemical_reaction/life
 	name = "Life"
 	required_reagents = list(/datum/reagent/medicine/strange_reagent = 1, /datum/reagent/medicine/synthflesh = 1, /datum/reagent/blood = 1)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Add a recipe to create quantum hair dye to match what's already in the wiki.

## Why It's Good For The Game

Quantum hair dye is an item that can show up on the bounty list and the wiki shows a recipe to make it. It's bad for a chemist's experience to spend a portion of their shift trying to work towards this bounty item only to be confused why it can't be created for some reason in the end.

## Testing Photographs and Procedure
<details>
<summary>Screenshot showing it work</summary>

**Search "hair" in the chem dispenser. Note that a recipe appears now.**
<img width="805" height="322" alt="Hair dye recipe" src="https://github.com/user-attachments/assets/1dc29539-ee67-43e7-af02-fd0582c9d56f" />

</details>

## Changelog
:cl:
fix: Add previously missing hair dye receipe
/:cl:
