### PR TITLE
Modsuit Medical and Storage Fix

### DIFF
--- a/code/modules/mod/mod_theme.dm
+++ b/code/modules/mod/mod_theme.dm
@@ -652,6 +652,7 @@
 		/obj/item/storage/pill_bottle,
 		/obj/item/storage/bag/chemistry,
 		/obj/item/storage/bag/bio,
+		/obj/item/storage/firstaid,
 	)
 	variants = list(
 		"medical" = list(
@@ -764,6 +765,7 @@
 		/obj/item/storage/bag/chemistry,
 		/obj/item/storage/bag/bio,
 		/obj/item/melee/classic_baton/police/telescopic,
+		/obj/item/storage/firstaid,
 	)
 	variants = list(
 		"rescue" = list(

--- a/code/modules/mod/modules/modules_general.dm
+++ b/code/modules/mod/modules/modules_general.dm
@@ -61,6 +61,7 @@
 	icon_state = "storage_large"
 	max_combined_w_class = 21
 	max_items = 14
+	max_w_class = WEIGHT_CLASS_LARGE
 
 /obj/item/mod/module/storage/syndicate
 	name = "MOD syndicate storage module"
@@ -70,6 +71,7 @@
 	icon_state = "storage_syndi"
 	max_combined_w_class = 30
 	max_items = 21
+	max_w_class = WEIGHT_CLASS_LARGE
 
 /obj/item/mod/module/storage/belt
 	name = "MOD case storage module"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Lets medical actually fit their primary storage bags in the modsuit outerwear while also letting extended storage module/syndicate storage module fit large objects, like regular backpacks already can

## Why It's Good For The Game

Fixes minor code inconsistencies

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

<img width="786" height="412" alt="image" src="https://github.com/user-attachments/assets/219ad685-5570-48be-8f44-35336b069d6c" />

<img width="469" height="115" alt="image" src="https://github.com/user-attachments/assets/71f96014-a8f7-4530-954d-9e0c14cbeac9" />

</details>

## Changelog
:cl: Isaac
fix: Medical modsuits can now fit first aid kits
fix: You can now fit large items in extended capacity/syndicate storage modules
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
