### PR TITLE
Nooartrium fixes, code cleanup and polish

### DIFF
--- a/code/modules/reagents/chemistry/reagents/drug_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drug_reagents.dm
@@ -601,7 +601,7 @@
 
 	//If they don't have a functional heart or are so damaged the drug would stop working
 	var/obj/item/organ/heart/heart = affected_mob.get_organ_slot(ORGAN_SLOT_HEART)
-	if(!heart || (heart.organ_flags & ORGAN_FAILING) || affected_mob.health < -300)
+	if(!heart || (heart.organ_flags & ORGAN_FAILING) || affected_mob.health <= -300)
 		return
 
 	ADD_TRAIT(affected_mob, TRAIT_NOCRITDAMAGE, FROM_NOOARTRIUM)
@@ -635,7 +635,7 @@
 	var/obj/item/organ/heart/heart = affected_mob.get_organ_slot(ORGAN_SLOT_HEART)
 
 	//If the heart has totally failed, or their body has taken 100 damage past the point where full death normally occurs
-	if(!heart || (heart.organ_flags & ORGAN_FAILING) || affected_mob.health < -300)
+	if(!heart || (heart.organ_flags & ORGAN_FAILING) || affected_mob.health <= -300)
 		holder.remove_reagent(/datum/reagent/drug/nooartrium, 1000)
 		return
 
@@ -666,7 +666,7 @@
 		affected_mob.adjustOrganLoss(ORGAN_SLOT_HEART, max(current_cycle, 25))
 
 		//If the mob was pushed to their absolute limits, or the above spike caused organ failure, the heart explodes
-		if(affected_mob.health < -300 || heart.organ_flags & ORGAN_FAILING)
+		if(affected_mob.health <= -300 || heart.organ_flags & ORGAN_FAILING)
 			affected_mob.add_splatter_floor(get_turf(affected_mob))
 			qdel(heart)
 			affected_mob.visible_message(span_boldwarning("[affected_mob]'s heart explodes!"))

--- a/code/modules/reagents/chemistry/reagents/drug_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drug_reagents.dm
@@ -579,25 +579,38 @@
 	overdose_threshold = 25
 	color = "#280000"
 	self_consuming = TRUE //No pesky liver shenanigans
+	metabolization_rate = REAGENTS_METABOLISM
 	///If we brought someone back from the dead
 	var/back_from_the_dead = FALSE
-	var/consequences  = FALSE // This can't be healthy?
-	var/time_from_consumption = 0 // For tracking consequences
-
+	var/list/zombie_sounds = list(
+		'sound/hallucinations/growl1.ogg',
+		'sound/hallucinations/growl2.ogg',
+		'sound/hallucinations/growl3.ogg'
+	)
 
 /datum/reagent/drug/nooartrium/on_mob_add(mob/living/affected_mob)
+
+	//If they aren't a mob that this should affect
+	if(!ishuman(affected_mob))
+		return
+	var/mob/living/carbon/human/human_mob = affected_mob
+	if((human_mob.dna.species.reagent_tag & PROCESS_SYNTHETIC))
+		return
 	if(affected_mob.suiciding)
 		return
+
+	//If they don't have a functional heart or are so damaged the drug would stop working
 	var/obj/item/organ/heart/heart = affected_mob.get_organ_slot(ORGAN_SLOT_HEART)
-	if(!heart || heart.organ_flags & ORGAN_FAILING)
+	if(!heart || (heart.organ_flags & ORGAN_FAILING) || affected_mob.health < -300)
 		return
+
 	ADD_TRAIT(affected_mob, TRAIT_NOCRITDAMAGE, FROM_NOOARTRIUM)
 	ADD_TRAIT(affected_mob, TRAIT_NODEATH, FROM_NOOARTRIUM)
 	ADD_TRAIT(affected_mob, TRAIT_NOHARDCRIT, FROM_NOOARTRIUM)
 	ADD_TRAIT(affected_mob, TRAIT_NOSOFTCRIT, FROM_NOOARTRIUM)
 	ADD_TRAIT(affected_mob, TRAIT_STABLEHEART, FROM_NOOARTRIUM)
 	ADD_TRAIT(affected_mob, TRAIT_STUNRESISTANCE, FROM_NOOARTRIUM)
-	ADD_TRAIT(affected_mob, TRAIT_NOSTAMCRIT, FROM_NOOARTRIUM) // Moving corpses don't get tired
+	ADD_TRAIT(affected_mob, TRAIT_NOSTAMCRIT, FROM_NOOARTRIUM)
 	ADD_TRAIT(affected_mob, TRAIT_IGNOREDAMAGESLOWDOWN, FROM_NOOARTRIUM)
 	if(affected_mob.stat == DEAD)
 		back_from_the_dead = TRUE
@@ -607,8 +620,8 @@
 	REMOVE_TRAIT(affected_mob, TRAIT_KNOCKEDOUT, STAT_TRAIT)
 	REMOVE_TRAIT(affected_mob, TRAIT_KNOCKEDOUT, CRIT_HEALTH_TRAIT) // Normally updated using set_health() - we don't want to adjust health, and NOHARDCRIT blocks it being re-added, but not removed
 	REMOVE_TRAIT(affected_mob, TRAIT_KNOCKEDOUT, OXYLOSS_TRAIT) // Prevents knockout by oxyloss
-	affected_mob.set_resting(FALSE) // Please get up. No one wants a death throes juggernaut lying on the floor
 	affected_mob.SetAllImmobility(0)
+	playsound(affected_mob, 'sound/hallucinations/wail.ogg', 50, TRUE, 10)
 	if(!back_from_the_dead)
 		to_chat(affected_mob, span_userdanger("You feel your heart start beating with incredible strength!"))
 		return
@@ -619,43 +632,22 @@
 
 /datum/reagent/drug/nooartrium/on_mob_life(mob/living/carbon/affected_mob, delta_time, times_fired)
 	. = ..()
-	if (!consequences)
-		if (time_from_consumption > 180 SECONDS)
-			consequences = TRUE
-		else
-			time_from_consumption += delta_time SECONDS
-	REMOVE_TRAIT(affected_mob, TRAIT_KNOCKEDOUT, CRIT_HEALTH_TRAIT)
-	REMOVE_TRAIT(affected_mob, TRAIT_KNOCKEDOUT, OXYLOSS_TRAIT)
-	affected_mob.adjustOrganLoss(ORGAN_SLOT_HEART, (((affected_mob.getBruteLoss() + affected_mob.getFireLoss()) / 200) + 0.5)* delta_time/6)
 	var/obj/item/organ/heart/heart = affected_mob.get_organ_slot(ORGAN_SLOT_HEART)
-	if(!heart || heart.organ_flags & ORGAN_FAILING)
-		on_mob_delete(affected_mob)
-	else
-		heart.maxHealth -= 0.25 * delta_time/3
 
+	//If the heart has totally failed, or their body has taken 100 damage past the point where full death normally occurs
+	if(!heart || (heart.organ_flags & ORGAN_FAILING) || affected_mob.health < -300)
+		holder.remove_reagent(/datum/reagent/drug/nooartrium, 1000)
+		return
 
-/datum/reagent/drug/nooartrium/on_mob_delete(mob/living/carbon/affected_mob)
+	//After 15 cycles heart damage will overtake the only heart med we have, this exponential growth ensures the drug cannot keep going indefinitely
+	affected_mob.adjustOrganLoss(ORGAN_SLOT_HEART, (0.1 * current_cycle))
+
+	if(prob(15))
+		playsound(affected_mob, pick(zombie_sounds), 50, TRUE, 10)
+
+/datum/reagent/drug/nooartrium/on_mob_end_metabolize(mob/living/carbon/affected_mob)
 	. = ..()
-	var/obj/item/organ/heart/heart = affected_mob.get_organ_slot(ORGAN_SLOT_HEART)
-	remove_buffs(affected_mob)
-	if(affected_mob.health < -300 || !heart || heart.organ_flags & ORGAN_FAILING)
-		affected_mob.add_splatter_floor(get_turf(affected_mob))
-		qdel(heart)
-		affected_mob.visible_message(span_boldwarning("[affected_mob]'s heart explodes!"))
-	else if(consequences)
-		affected_mob.set_heartattack(TRUE)
-	time_from_consumption = 0 // Not sure if this is needed, not gonna risk it
-
-/datum/reagent/drug/nooartrium/overdose_start(mob/living/carbon/affected_mob)
-	. = ..()
-	to_chat(affected_mob, span_userdanger("You feel your heart tearing itself apart as it tries to beat stronger!"))
-	affected_mob.adjustOrganLoss(ORGAN_SLOT_HEART, 20)
-	affected_mob.SetParalyzed(6 SECONDS)
-	consequences = TRUE
-
-
-/datum/reagent/drug/nooartrium/proc/remove_buffs(mob/living/carbon/affected_mob)
-	to_chat(affected_mob, span_userdanger("You feel your heart grow calm."))
+	playsound(affected_mob, 'sound/hallucinations/far_noise.ogg', 50, TRUE, 10)
 	REMOVE_TRAIT(affected_mob, TRAIT_NOCRITDAMAGE, FROM_NOOARTRIUM)
 	REMOVE_TRAIT(affected_mob, TRAIT_NODEATH, FROM_NOOARTRIUM)
 	REMOVE_TRAIT(affected_mob, TRAIT_NOHARDCRIT, FROM_NOOARTRIUM)
@@ -665,3 +657,21 @@
 	REMOVE_TRAIT(affected_mob, TRAIT_NOSTAMCRIT, FROM_NOOARTRIUM)
 	REMOVE_TRAIT(affected_mob, TRAIT_IGNOREDAMAGESLOWDOWN, FROM_NOOARTRIUM)
 	affected_mob.update_sight()
+
+	//Make sure heart removal isn't the reason the drug stopped working
+	var/obj/item/organ/heart/heart = affected_mob.get_organ_slot(ORGAN_SLOT_HEART)
+	if(heart)
+
+		//A spike of heart damage proportional to the amount of time the drug was active.
+		affected_mob.adjustOrganLoss(ORGAN_SLOT_HEART, max(current_cycle, 25))
+
+		//If the mob was pushed to their absolute limits, or the above spike caused organ failure, the heart explodes
+		if(affected_mob.health < -300 || heart.organ_flags & ORGAN_FAILING)
+			affected_mob.add_splatter_floor(get_turf(affected_mob))
+			qdel(heart)
+			affected_mob.visible_message(span_boldwarning("[affected_mob]'s heart explodes!"))
+
+/datum/reagent/drug/nooartrium/overdose_start(mob/living/carbon/affected_mob)
+	. = ..()
+	to_chat(affected_mob, span_userdanger("You feel your heart tearing itself apart as it tries to beat stronger!"))
+	affected_mob.adjustOrganLoss(ORGAN_SLOT_HEART, 20)

--- a/code/modules/reagents/chemistry/recipes/drugs.dm
+++ b/code/modules/reagents/chemistry/recipes/drugs.dm
@@ -58,5 +58,5 @@
 	name = "Nooartrium"
 	results = list(/datum/reagent/drug/nooartrium = 1)
 	required_reagents = list(/datum/reagent/medicine/atropine = 1, /datum/reagent/medicine/morphine = 1, /datum/reagent/teslium = 1, /datum/reagent/medicine/tricordrazine =1)
-	required_temp = 575
+	required_temp = 470
 	reaction_tags = REACTION_TAG_DRUG


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

closes #13134

This PR primarily adds some polish and code cleanup to nooartrium, without affecting the balance of the drug in any notable way. 
* Adds a check for humans, and ensures the mob is not flagged for synthetic processing so that nooartrium can only affect organic mobs that have hearts
* Adds a check to ensure the affected mob is not *already* at -300 health when the reagent is applied because the reagent stops working when mobs have this much damage anyway
* Removes unnecessary variables `consequences` and `time_from_consumption`. Nooartrium's effects now scale with `current_cycle` instead. Nooartrium's effective use time should be largely unchanged.
* Nooartrium no longer reduces the maxhealth of the heart organ because this caused unforseen issues if the heart managed to reach 0 maxHealth. The above bullet point covers what the intended impact for this effect. 
* Greatly cleaned up and simplified the code for when nooartrium's effects end while keeping true to the original spirit of it. affected mob's heart still explodes if the heart failed due to the drug, or they were pushed to the health threshold of -300
* Added a spike in heart damage when the drug wears off to give a downside for using this as a strictly medicinal revival drug. (It is still a viable revival drug, but it has the intended downside of heart damage for doing so now)
* Mobs affected by Nooartrium now make zombie sounds - wailing when initially infected, and making a weakened wail when the reagent wears. Zombie growls occur at regular intervals while the drug is active as well. All of these make it easier for other players to recognize when someone is using nooartrium and also fit along with the drug's effects
* Reduces the temperature needed to craft Nooartrium to 470, just under the threshold by which teslium activates and shocks the person trying to make it instead of forcing players to rely on a bug to produce nooartrium. 

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Mostly bugs are bad. 

As for the other changes: I like nooartrium's current balance and think it's in a good spot overall but it wasn't communicated clearly when someone was under the effects of Nooartrium which could lead the drug feeling downright unfair in some cases. 

Code cleanup is something I meant to do after the original merge when I got so tired of arguing with the original author that I accepted it in a technically functional state with good balance. 

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->

https://github.com/user-attachments/assets/e0929f94-48d5-444b-801c-88bcb7b7a471

I only growled once here, but it's a 15% chance every time the drug ticks. 


## Changelog
:cl:
fix: Fixed nooartrium working in mobs it wasn't supposed to
tweak: Nooartrium now causes the affected mob to make a loud zombie wail when initially taking the drug, zombie growl periodically while the drug is active, and wail again (different, weaker one) when the drug's effects end.
tweak: Nooartrium now causes at least 25 heart damage when metabolization ends to give it a flavorful downside as a purely medical revival drug.
tweak: Nooartrium now only requires heating to 470K, just under teslium's activation point at 474. 
code: Cleaned up a lot of nooartrium code while trying to preserve all of the original balance aside from the above points regarding revival and sounds. 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
