### PR TITLE
Fixes improper fancychat size after reconnects (v3?)

### DIFF
--- a/interface/skin.dmf
+++ b/interface/skin.dmf
@@ -376,7 +376,7 @@ window "output_browser"
 	elem "browseroutput"
 		type = BROWSER
 		pos = 0,0
-		size = 640x940
+		size = 0x940
 		anchor1 = 0,0
 		anchor2 = 100,100
 		background-color = none

--- a/tgui/packages/tgui-panel/index.tsx
+++ b/tgui/packages/tgui-panel/index.tsx
@@ -82,8 +82,6 @@ const setupApp = () => {
     left: 'output_browser',
   });
 
-  based_winset();
-
   // Enable hot module reloading
   if (module.hot) {
     setupHotReloading();
@@ -95,13 +93,6 @@ const setupApp = () => {
       }
     );
   }
-};
-
-const based_winset = async (based_on_what = 'output') => {
-  const winget_output = await Byond.winget(based_on_what);
-  Byond.winset('browseroutput', {
-    'size': winget_output['size'],
-  });
 };
 
 setupApp();


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This PR represents another attempt (following #13105) at fixing fancychat
The problematic element was identified by @PowerfulBacon to be ``browseroutput``, and I can confirm that the parent element: ``legacy-output-selector``, is properly resized.
What is done here is to figure that since #12888, the ``based_winset`` function, used when initializing tgui-panel, does not longer help properly resize the fancychat (contained by ``browseroutput``) (though TG does it, it also likely doesn't mix 15x15 and 17x15 lobby formats).
This function was removed, and its role replaced with setting the width of ``browseroutput`` to 0, which according to DM reference, auto-resizes the skin element to occupy the remaining space. 

## Why It's Good For The Game

Removes a mild but repetitive annoyance of players when fancychat would get resized, such as after a server reboot

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
although not exhaustively tested, seems to work with and without fullscreen, as well as with both 515 and 516 byond versions
successful results upon using replication steps provided in comments of previous PR
<details>
<summary>Screenshots&Videos</summary>

example of test run with chat that would otherwise shorten
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/b2ff496f-9e70-4b40-b8f5-1cef402df81a" />
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/71baa339-8475-42d8-a920-f521095acfb6" />
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/e0b1fef9-246b-45a8-ad46-a34f18ac6ec4" />
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/20a9e169-0f48-4837-9ac8-44fce087a750" />
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/f18ca639-8e15-4861-93f8-318cd909d974" />


</details>

## Changelog
:cl: Aramix
fix: fancychat now auto-resizes to occupy the remaining space properly, especially after reconnects
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
