### PR TITLE
Cleans up ranged clicks, fixes guns not shooting adjacent tiles and slowing down while worn

### DIFF
--- a/_maps/_basemap.dm
+++ b/_maps/_basemap.dm
@@ -1,4 +1,4 @@
-// #define LOWMEMORYMODE //uncomment this to load centcom and runtime station and thats it.
+#define LOWMEMORYMODE //uncomment this to load centcom and runtime station and thats it.
 // #define QUICKSTART // uncomment this to start the round immidiately when ready and automatically spawn players with debug outfit
 
 // uncomment this for a map you need to use

--- a/_maps/_basemap.dm
+++ b/_maps/_basemap.dm
@@ -1,4 +1,4 @@
-#define LOWMEMORYMODE //uncomment this to load centcom and runtime station and thats it.
+// #define LOWMEMORYMODE //uncomment this to load centcom and runtime station and thats it.
 // #define QUICKSTART // uncomment this to start the round immidiately when ready and automatically spawn players with debug outfit
 
 // uncomment this for a map you need to use

--- a/_maps/holodeck/debug/guns.dmm
+++ b/_maps/holodeck/debug/guns.dmm
@@ -1,0 +1,401 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"a" = (
+/turf/open/indestructible,
+/area/template_noop)
+"b" = (
+/obj/structure/table,
+/obj/item/gun/magic/staff/healing,
+/turf/open/indestructible,
+/area/template_noop)
+"c" = (
+/obj/structure/table,
+/obj/item/gun/ballistic/shotgun/automatic/bulldog/unrestricted,
+/turf/open/indestructible,
+/area/template_noop)
+"e" = (
+/obj/item/storage/box/firingpins,
+/turf/open/indestructible,
+/area/template_noop)
+"f" = (
+/obj/structure/table,
+/obj/item/gun/energy/e_gun,
+/turf/open/indestructible,
+/area/template_noop)
+"h" = (
+/obj/structure/table,
+/turf/open/indestructible,
+/area/template_noop)
+"i" = (
+/obj/structure/table,
+/obj/item/gun/medbeam,
+/turf/open/indestructible,
+/area/template_noop)
+"k" = (
+/obj/structure/table,
+/obj/item/gun/ballistic/automatic/l6_saw/toy/unrestricted/riot,
+/obj/item/gun/ballistic/automatic/c20r/unrestricted,
+/turf/open/indestructible,
+/area/template_noop)
+"l" = (
+/obj/item/ammo_box/a762,
+/obj/item/ammo_box/a762,
+/obj/item/ammo_box/a762,
+/obj/item/ammo_box/a762,
+/obj/item/ammo_box/a762,
+/obj/item/ammo_box/a762,
+/obj/item/ammo_box/a762,
+/obj/item/ammo_box/a762,
+/obj/item/ammo_box/a762,
+/obj/item/ammo_box/a762,
+/obj/item/ammo_box/a762,
+/obj/item/ammo_box/a762,
+/turf/open/indestructible,
+/area/template_noop)
+"n" = (
+/obj/item/ammo_box/foambox,
+/obj/item/ammo_box/foambox,
+/obj/item/ammo_box/foambox,
+/turf/open/indestructible,
+/area/template_noop)
+"o" = (
+/turf/closed/indestructible/riveted,
+/area/template_noop)
+"p" = (
+/obj/structure/table,
+/obj/item/gun/ballistic/shotgun/hook,
+/turf/open/indestructible,
+/area/template_noop)
+"q" = (
+/obj/structure/table,
+/obj/item/ammo_casing/caseless/rocket,
+/obj/item/ammo_casing/caseless/rocket,
+/obj/item/ammo_casing/caseless/rocket,
+/obj/item/ammo_casing/caseless/rocket,
+/obj/item/ammo_casing/caseless/rocket,
+/obj/item/ammo_casing/caseless/rocket,
+/obj/item/ammo_casing/caseless/rocket,
+/obj/item/ammo_casing/caseless/rocket,
+/obj/item/ammo_casing/caseless/rocket,
+/obj/item/ammo_casing/caseless/rocket,
+/obj/item/ammo_casing/caseless/rocket,
+/obj/item/ammo_casing/caseless/rocket,
+/obj/item/ammo_casing/caseless/rocket,
+/turf/open/indestructible,
+/area/template_noop)
+"s" = (
+/obj/structure/table,
+/obj/item/gun/ballistic/rifle,
+/turf/open/indestructible,
+/area/template_noop)
+"t" = (
+/obj/structure/table,
+/obj/item/gun/ballistic/bow,
+/turf/open/indestructible,
+/area/template_noop)
+"u" = (
+/obj/item/ammo_box/sniper,
+/turf/open/indestructible,
+/area/template_noop)
+"v" = (
+/obj/structure/table,
+/obj/item/gun/energy/pulse/carbine,
+/turf/open/indestructible,
+/area/template_noop)
+"w" = (
+/obj/item/storage/box/breacherslug,
+/obj/item/storage/box/breacherslug,
+/obj/item/storage/box/breacherslug,
+/obj/item/storage/box/breacherslug,
+/obj/item/storage/box/breacherslug,
+/turf/open/indestructible,
+/area/template_noop)
+"x" = (
+/obj/structure/table,
+/obj/item/gun/ballistic/rocketlauncher/unrestricted,
+/turf/open/indestructible,
+/area/template_noop)
+"y" = (
+/obj/structure/table,
+/obj/item/gun/energy/beam_rifle,
+/turf/open/indestructible,
+/area/template_noop)
+"A" = (
+/obj/item/storage/box/lethalshot,
+/obj/item/storage/box/lethalshot,
+/obj/item/storage/box/lethalshot,
+/obj/item/storage/box/lethalshot,
+/obj/item/storage/box/lethalshot,
+/obj/item/storage/box/lethalshot,
+/obj/item/storage/box/lethalshot,
+/obj/item/storage/box/lethalshot,
+/turf/open/indestructible,
+/area/template_noop)
+"B" = (
+/obj/structure/table,
+/obj/item/gun/energy/laser/captain,
+/turf/open/indestructible,
+/area/template_noop)
+"C" = (
+/obj/item/storage/box/beanbag,
+/obj/item/storage/box/beanbag,
+/obj/item/storage/box/beanbag,
+/obj/item/storage/box/beanbag,
+/obj/item/storage/box/beanbag,
+/turf/open/indestructible,
+/area/template_noop)
+"E" = (
+/obj/structure/table,
+/obj/item/gun/magic/wand/resurrection/debug,
+/turf/open/indestructible,
+/area/template_noop)
+"J" = (
+/obj/structure/table,
+/obj/item/gun/ballistic/sniper_rifle,
+/turf/open/indestructible,
+/area/template_noop)
+"L" = (
+/obj/structure/table,
+/obj/item/gun/energy/disabler,
+/turf/open/indestructible,
+/area/template_noop)
+"M" = (
+/obj/machinery/recharger,
+/turf/open/indestructible,
+/area/template_noop)
+"N" = (
+/mob/living/carbon/human,
+/turf/open/indestructible,
+/area/template_noop)
+"O" = (
+/obj/structure/table,
+/obj/item/gun/energy/recharge/ebow,
+/turf/open/indestructible,
+/area/template_noop)
+"P" = (
+/obj/item/ammo_box/a40mm,
+/obj/item/ammo_box/a40mm,
+/obj/item/ammo_box/a40mm,
+/obj/item/ammo_box/a40mm,
+/turf/open/indestructible,
+/area/template_noop)
+"S" = (
+/obj/item/ammo_casing/caseless/arrow,
+/obj/item/ammo_casing/caseless/arrow,
+/obj/item/ammo_casing/caseless/arrow,
+/obj/item/ammo_casing/caseless/arrow,
+/obj/item/ammo_casing/caseless/arrow,
+/obj/item/ammo_casing/caseless/arrow,
+/obj/item/ammo_casing/caseless/arrow,
+/obj/item/ammo_casing/caseless/arrow,
+/obj/item/ammo_casing/caseless/arrow,
+/obj/item/ammo_casing/caseless/arrow,
+/obj/item/ammo_casing/caseless/arrow,
+/obj/item/ammo_casing/caseless/arrow,
+/obj/item/ammo_casing/caseless/arrow,
+/obj/item/ammo_casing/caseless/arrow,
+/obj/item/ammo_casing/caseless/arrow,
+/obj/item/ammo_casing/caseless/arrow,
+/obj/item/ammo_casing/caseless/arrow,
+/obj/item/ammo_casing/caseless/arrow,
+/turf/open/indestructible,
+/area/template_noop)
+"T" = (
+/obj/structure/table,
+/obj/item/gun/magic/hook,
+/turf/open/indestructible,
+/area/template_noop)
+"U" = (
+/obj/structure/table,
+/obj/item/gun/ballistic/automatic/m90/unrestricted,
+/turf/open/indestructible,
+/area/template_noop)
+"V" = (
+/obj/item/ammo_box/foambox/riot,
+/obj/item/ammo_box/foambox/riot,
+/obj/item/ammo_box/foambox/riot,
+/turf/open/indestructible,
+/area/template_noop)
+"W" = (
+/obj/structure/table,
+/obj/item/gun/energy/temperature/pin,
+/turf/open/indestructible,
+/area/template_noop)
+"X" = (
+/obj/structure/table,
+/obj/item/gun/energy/taser,
+/turf/open/indestructible,
+/area/template_noop)
+"Z" = (
+/obj/structure/table,
+/obj/item/gun/energy/xray,
+/turf/open/indestructible,
+/area/template_noop)
+
+(1,1,1) = {"
+o
+o
+o
+o
+o
+a
+a
+a
+a
+V
+n
+a
+"}
+(2,1,1) = {"
+o
+N
+a
+a
+a
+a
+x
+q
+a
+k
+h
+a
+"}
+(3,1,1) = {"
+o
+N
+a
+a
+M
+a
+a
+a
+a
+a
+a
+a
+"}
+(4,1,1) = {"
+o
+N
+a
+a
+a
+a
+i
+h
+a
+Z
+X
+M
+"}
+(5,1,1) = {"
+o
+N
+a
+a
+M
+a
+a
+a
+a
+a
+a
+a
+"}
+(6,1,1) = {"
+o
+N
+a
+a
+a
+a
+E
+b
+a
+W
+v
+M
+"}
+(7,1,1) = {"
+o
+N
+a
+a
+M
+a
+a
+a
+a
+a
+a
+a
+"}
+(8,1,1) = {"
+o
+N
+a
+a
+a
+a
+T
+t
+S
+O
+B
+M
+"}
+(9,1,1) = {"
+o
+N
+a
+a
+M
+a
+a
+a
+a
+a
+a
+a
+"}
+(10,1,1) = {"
+o
+N
+a
+a
+a
+l
+s
+c
+C
+f
+U
+P
+"}
+(11,1,1) = {"
+o
+N
+a
+a
+M
+a
+a
+a
+w
+a
+e
+a
+"}
+(12,1,1) = {"
+o
+o
+o
+o
+o
+u
+J
+p
+A
+y
+L
+M
+"}

--- a/code/__DEFINES/dcs/signals/signals_obj/signals_item/signals_itemattack.dm
+++ b/code/__DEFINES/dcs/signals/signals_obj/signals_item/signals_itemattack.dm
@@ -13,8 +13,19 @@
 #define COMSIG_ITEM_ATTACK_SELF_SECONDARY "item_attack_self_secondary"
 ///from base of obj/item/attack_atom(): (/obj, /mob)
 #define COMSIG_ITEM_ATTACK_OBJ "item_attack_obj"
+///from base of obj/item/pre_ranged_attack(): (atom/target, mob/user, params)
+#define COMSIG_ITEM_RANGED_ATTACK "item_pre_ranged_attack"
+	//COMPONENT_CANCEL_ATTACK_CHAIN
+	//COMPONENT_SKIP_ATTACK
 ///from base of obj/item/pre_attack(): (atom/target, mob/user, params)
 #define COMSIG_ITEM_PRE_ATTACK "item_pre_attack"
+	//COMPONENT_CANCEL_ATTACK_CHAIN
+	//COMPONENT_SKIP_ATTACK
+/// From base of [/obj/item/proc/pre_ranged_attack_secondary()]: (atom/target, mob/user, params)
+#define COMSIG_ITEM_RANGED_ATTACK_SECONDARY "item_pre_ranged_attack_secondary"
+	// COMPONENT_SECONDARY_CANCEL_ATTACK_CHAIN
+	// COMPONENT_SECONDARY_CONTINUE_ATTACK_CHAIN
+	// COMPONENT_SECONDARY_CALL_NORMAL_ATTACK_CHAIN
 /// From base of [/obj/item/proc/pre_attack_secondary()]: (atom/target, mob/user, params)
 #define COMSIG_ITEM_PRE_ATTACK_SECONDARY "item_pre_attack_secondary"
 	#define COMPONENT_SECONDARY_CANCEL_ATTACK_CHAIN (1<<0)

--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -170,12 +170,22 @@
 	else
 		if(W)
 			if(LAZYACCESS(modifiers, RIGHT_CLICK))
+				// Try the ranged attack first
+				var/ranged_attack_result = W.ranged_attack_secondary(A, src, params)
+
+				// Defer to normal ranged attack
+				if (ranged_attack_result == SECONDARY_ATTACK_CALL_NORMAL)
+					if (!W.ranged_attack(A, src, params))
+						W.afterattack(A,src,0,params)
+					return
+
 				var/after_attack_secondary_result = W.afterattack_secondary(A, src, FALSE, params)
 
 				if(after_attack_secondary_result == SECONDARY_ATTACK_CALL_NORMAL)
 					W.afterattack(A, src, FALSE, params)
 			else
-				W.afterattack(A,src,0,params)
+				if (!W.ranged_attack(A, src, params))
+					W.afterattack(A,src,0,params)
 		else
 			if(LAZYACCESS(modifiers, RIGHT_CLICK))
 				ranged_secondary_attack(A, modifiers)

--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -74,6 +74,21 @@
 		return TRUE
 
 /**
+ * Called before an attack is performed when the user is clicking on an object
+ * at range. After attack is called with the proximity flag set to false if
+ * this does not abort the attack chain.
+ *
+ * Arguments:
+ * * atom/target - The atom about to be hit
+ * * mob/living/user - The mob doing the htting
+ * * params - click params such as alt/shift etc
+ */
+/obj/item/proc/ranged_attack(atom/target, mob/living/user, params)
+	if(SEND_SIGNAL(src, COMSIG_ITEM_RANGED_ATTACK, target, user, params) & COMPONENT_CANCEL_ATTACK_CHAIN)
+		return TRUE
+	return FALSE //return TRUE to avoid calling attackby after this proc does stuff
+
+/**
   * Called on the item before it hits something
   *
   * Arguments:
@@ -87,6 +102,26 @@
 	if(SEND_SIGNAL(src, COMSIG_ITEM_PRE_ATTACK, A, user, params) & COMPONENT_CANCEL_ATTACK_CHAIN)
 		return TRUE
 	return FALSE //return TRUE to avoid calling attackby after this proc does stuff
+
+/**
+ * Called before an attack is performed when the user is clicking on an object
+ * at range.
+ *
+ * Arguments:
+ * * atom/target - The atom about to be hit
+ * * mob/living/user - The mob doing the htting
+ * * params - click params such as alt/shift etc
+ */
+/obj/item/proc/ranged_attack_secondary(atom/target, mob/living/user, params)
+	var/signal_result = SEND_SIGNAL(src, COMSIG_ITEM_RANGED_ATTACK_SECONDARY, target, user, params)
+
+	if(signal_result & COMPONENT_SECONDARY_CANCEL_ATTACK_CHAIN)
+		return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
+
+	if(signal_result & COMPONENT_SECONDARY_CONTINUE_ATTACK_CHAIN)
+		return SECONDARY_ATTACK_CONTINUE_CHAIN
+
+	return SECONDARY_ATTACK_CALL_NORMAL
 
 /**
  * Called on the item before it hits something, when right clicking.

--- a/code/datums/ai/monkey/monkey_behaviors.dm
+++ b/code/datums/ai/monkey/monkey_behaviors.dm
@@ -203,7 +203,7 @@
 		var/can_shoot = gun?.can_shoot() || FALSE
 		if(gun && controller.blackboard[BB_MONKEY_GUN_WORKED] && prob(95))
 			// We attempt to attack even if we can't shoot so we get the effects of pulling the trigger
-			gun.afterattack(real_target, living_pawn, FALSE)
+			gun.pull_trigger(real_target, living_pawn)
 			controller.set_blackboard_key(BB_MONKEY_GUN_WORKED, can_shoot ? TRUE : prob(80)) // Only 20% likely to notice it didn't work
 			if(can_shoot)
 				controller.set_blackboard_key(BB_MONKEY_GUN_NEURONS_ACTIVATED, TRUE)

--- a/code/datums/components/aiming.dm
+++ b/code/datums/components/aiming.dm
@@ -295,9 +295,9 @@ AIMING_DROP_WEAPON means they selected the "drop your weapon" command
 	if(istype(parent, /obj/item/gun)) // If we have a gun, shoot it at the target
 		var/obj/item/gun/G = parent
 		if(holding_at_gunpoint)
-			G.afterattack(target, user, null, null, GUN_AIMED_POINTBLANK)
+			G.pull_trigger(target, user, null, GUN_AIMED_POINTBLANK)
 		else
-			G.afterattack(target, user, null, null, GUN_AIMED)
+			G.pull_trigger(target, user, null, GUN_AIMED)
 		stop_aiming()
 		return TRUE
 	if(isitem(parent)) // Otherwise, just wave it at them

--- a/code/modules/antagonists/clock_cult/items/clockwork_weapon.dm
+++ b/code/modules/antagonists/clock_cult/items/clockwork_weapon.dm
@@ -5,13 +5,12 @@
 	lefthand_file = 'icons/mob/inhands/antag/clockwork_lefthand.dmi';
 	righthand_file = 'icons/mob/inhands/antag/clockwork_righthand.dmi'
 	worn_icon_state = "baguette"
-	item_flags = ABSTRACT
+	item_flags = ABSTRACT | ISWEAPON
 	block_flags = BLOCKING_NASTY | BLOCKING_ACTIVE
 	block_level = 1	//God blocking is actual aids to deal with, I am sorry for putting this here
 	block_upgrade_walk = TRUE
 	w_class = WEIGHT_CLASS_BULKY
 	slot_flags = ITEM_SLOT_BACK
-	item_flags = ISWEAPON
 	throwforce = 20
 	throw_speed = 4
 	armour_penetration = 10

--- a/code/modules/holodeck/holodeck_map_template_debug.dm
+++ b/code/modules/holodeck/holodeck_map_template_debug.dm
@@ -43,3 +43,8 @@
 	name = "Holodeck - Syndicates"
 	template_id = "debug-syndicates"
 	mappath = "_maps/holodeck/debug/syndicates.dmm"
+
+/datum/map_template/holodeck/debug/guns
+	name = "Holodeck - Guns"
+	template_id = "debug-guns"
+	mappath = "_maps/holodeck/debug/guns.dmm"

--- a/code/modules/projectiles/autofire.dm
+++ b/code/modules/projectiles/autofire.dm
@@ -98,7 +98,7 @@ Everything else should be handled for you. Good luck soldier.
 			G.attack(autofire_target, L)
 			next_process = world.time + CLICK_CD_MELEE
 			return
-	G.afterattack(autofire_target,L)
+	G.pull_trigger(autofire_target,L)
 
 /datum/component/full_auto/ClearFromParent()
 	. = ..()

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -10,7 +10,7 @@
 	worn_icon_state = "gun"
 	flags_1 =  CONDUCT_1
 	slot_flags = ITEM_SLOT_BELT
-	item_flags = SLOWS_WHILE_IN_HAND | NO_WORN_SLOWDOWN | ISWEAPON | NEEDS_PERMIT
+	item_flags = SLOWS_WHILE_IN_HAND | NO_WORN_SLOWDOWN | NEEDS_PERMIT
 	custom_materials = list(/datum/material/iron=2000)
 	w_class = WEIGHT_CLASS_LARGE
 	throwforce = 5
@@ -305,8 +305,6 @@
 	if(flag) //It's adjacent, is the user, or is on the user's person
 		if(target in user.contents) //can't shoot stuff inside us.
 			return
-		if(!ismob(target) || user.combat_mode) //melee attack
-			return
 		if(target == user && !user.is_zone_selected(BODY_ZONE_PRECISE_MOUTH)) //so we can't shoot ourselves (unless mouth selected)
 			return
 	add_fingerprint(user)
@@ -494,7 +492,7 @@
 	if(user.combat_mode) //Flogging
 		if(bayonet)
 			M.attackby(bayonet, user)
-			return
+			return TRUE
 		else
 			return ..()
 	return
@@ -503,7 +501,7 @@
 	if(user.combat_mode)
 		if(bayonet)
 			O.attackby(bayonet, user)
-			return
+			return TRUE
 	return ..()
 
 /obj/item/gun/attackby(obj/item/I, mob/living/user, params)

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -10,14 +10,13 @@
 	worn_icon_state = "gun"
 	flags_1 =  CONDUCT_1
 	slot_flags = ITEM_SLOT_BELT
-	item_flags = SLOWS_WHILE_IN_HAND | NO_WORN_SLOWDOWN
+	item_flags = SLOWS_WHILE_IN_HAND | NO_WORN_SLOWDOWN | ISWEAPON | NEEDS_PERMIT
 	custom_materials = list(/datum/material/iron=2000)
 	w_class = WEIGHT_CLASS_LARGE
 	throwforce = 5
 	throw_speed = 3
 	throw_range = 5
 	force = 5
-	item_flags = NEEDS_PERMIT || ISWEAPON
 	attack_verb_continuous = list("strikes", "hits", "bashes")
 	attack_verb_simple = list("strike", "hit", "bash")
 	max_integrity = 500

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -292,48 +292,57 @@
 				continue
 			O.emp_act(severity)
 
-/obj/item/gun/afterattack(atom/target, mob/living/user, flag, params, aimed)
+/obj/item/gun/pre_attack(atom/A, mob/living/user, params)
 	. = ..()
-	return pull_trigger(target, user, flag, params, aimed)
+	// Cancel the attack chain if we fire
+	return . || pull_trigger(A, user, params, GUN_NOT_AIMED)
+
+/obj/item/gun/ranged_attack(atom/target, mob/living/user, params)
+	. = ..()
+	// Cancel the attack chain if we fire
+	return . || pull_trigger(target, user, params, GUN_NOT_AIMED)
 
 /// Represents the user pulling the trigger while aiming at the target
-/obj/item/gun/proc/pull_trigger(atom/target, mob/living/user, flag, params, aimed)
+/obj/item/gun/proc/pull_trigger(atom/target, mob/living/user, params = null, aimed = GUN_NOT_AIMED)
 	if(QDELETED(target))
-		return
+		return TRUE
 	if(firing_burst)
-		return
+		return TRUE
+	if(target in user.contents) //can't shoot stuff inside us.
+		return FALSE
+	var/flag = user.Adjacent(target, TRUE)
 	if(flag) //It's adjacent, is the user, or is on the user's person
-		if(target in user.contents) //can't shoot stuff inside us.
-			return
+		if (!isturf(target) && (user.combat_mode || (item_flags & ISWEAPON)))
+			return FALSE
 		if(target == user && !user.is_zone_selected(BODY_ZONE_PRECISE_MOUTH)) //so we can't shoot ourselves (unless mouth selected)
-			return
+			return FALSE
 	add_fingerprint(user)
 
 	if(istype(user))//Check if the user can use the gun, if the user isn't alive(turrets) assume it can.
 		var/mob/living/L = user
 		if(!can_trigger_gun(L))
-			return
+			return FALSE
 
 	if(flag)
 		var/mob/living/living_target = target
 		if (!user.client || user.client.prefs.read_player_preference(/datum/preference/choiced/zone_select) == PREFERENCE_BODYZONE_INTENT)
 			if(user.is_zone_selected(BODY_ZONE_PRECISE_MOUTH))
 				handle_suicide(user, target, params)
-				return
+				return TRUE
 		// On simplified mode, contextually determine if we want to suicide them
 		// If the target is ourselves, they are buckled, restrained or lying down then suicide them
 		else if(user.is_zone_selected(BODY_ZONE_HEAD) && istype(living_target) && (user == target || HAS_TRAIT(living_target, TRAIT_HANDS_BLOCKED) || living_target.buckled || living_target.IsUnconscious()))
 			handle_suicide(user, target, params)
-			return
+			return TRUE
 
 	// Play the clicking sound if we can't shoot
 	if(!can_shoot())
 		shoot_with_empty_chamber(user)
-		return
+		return FALSE
 
 	// Not ready to fire
 	if (ranged_cooldown>world.time)
-		return
+		return FALSE
 
 	//Exclude lasertag guns from the TRAIT_CLUMSY check.
 	if(clumsy_check)
@@ -352,17 +361,18 @@
 					var/shot_leg = pick(BODY_ZONE_L_LEG, BODY_ZONE_R_LEG)
 					process_fire(user, user, FALSE, params, shot_leg)
 					user.dropItemToGround(src, TRUE)
-				return
+				return TRUE
 
 	if(weapon_weight == WEAPON_HEAVY && !is_wielded)
 		balloon_alert(user, "You need both hands free to fire [src]!")
-		return
+		return FALSE
 
 	var/zone_override = null
 	if(aimed == GUN_AIMED_POINTBLANK)
 		zone_override = BODY_ZONE_HEAD //Shooting while pressed against someone's temple
 
 	process_fire(target, user, TRUE, params, zone_override, aimed)
+	return TRUE
 
 /obj/item/gun/can_trigger_gun(mob/living/user)
 	. = ..()
@@ -492,7 +502,7 @@
 	if(user.combat_mode) //Flogging
 		if(bayonet)
 			M.attackby(bayonet, user)
-			return TRUE
+			return
 		else
 			return ..()
 	return
@@ -501,7 +511,7 @@
 	if(user.combat_mode)
 		if(bayonet)
 			O.attackby(bayonet, user)
-			return TRUE
+			return
 	return ..()
 
 /obj/item/gun/attackby(obj/item/I, mob/living/user, params)
@@ -517,6 +527,8 @@
 		balloon_alert(user, "You attach [K] to [src].")
 		bayonet = K
 		update_appearance()
+		// Become a weapon when we gain a bayonet
+		item_flags |= ISWEAPON
 	else
 		return ..()
 

--- a/code/modules/projectiles/guns/ballistic/automatic.dm
+++ b/code/modules/projectiles/guns/ballistic/automatic.dm
@@ -143,8 +143,12 @@
 	underbarrel = new /obj/item/gun/ballistic/revolver/grenadelauncher/unrestricted(src)
 	update_icon()
 
-/obj/item/gun/ballistic/automatic/m90/afterattack_secondary(atom/target, mob/living/user, flag, params)
-	underbarrel.afterattack(target, user, flag, params)
+/obj/item/gun/ballistic/automatic/m90/ranged_attack_secondary(atom/target, mob/living/user, params)
+	underbarrel.pull_trigger(target, user, params)
+	return SECONDARY_ATTACK_CONTINUE_CHAIN
+
+/obj/item/gun/ballistic/automatic/m90/pre_attack_secondary(atom/target, mob/living/user, params)
+	underbarrel.pull_trigger(target, user, params)
 	return SECONDARY_ATTACK_CONTINUE_CHAIN
 
 /obj/item/gun/ballistic/automatic/m90/attackby(obj/item/A, mob/user, params)
@@ -256,8 +260,7 @@
 	. = ..()
 	. += "l6_door_[cover_open ? "open" : "closed"]"
 
-
-/obj/item/gun/ballistic/automatic/l6_saw/afterattack(atom/target as mob|obj|turf, mob/living/user as mob|obj, flag, params)
+/obj/item/gun/ballistic/automatic/l6_saw/pull_trigger(atom/target, mob/living/user, flag, params, aimed)
 	if(cover_open)
 		to_chat(user, span_warning("[src]'s cover is open! Close it before firing!"))
 		return

--- a/code/modules/projectiles/guns/ballistic/bow.dm
+++ b/code/modules/projectiles/guns/ballistic/bow.dm
@@ -12,7 +12,7 @@
 	load_sound = null
 	fire_sound = 'sound/weapons/bowfire.ogg'
 	slot_flags = ITEM_SLOT_BACK
-	item_flags = NEEDS_PERMIT
+	item_flags = SLOWS_WHILE_IN_HAND | NO_WORN_SLOWDOWN | NEEDS_PERMIT
 	casing_ejector = FALSE
 	internal_magazine = TRUE
 	pin = null

--- a/code/modules/projectiles/guns/ballistic/launchers.dm
+++ b/code/modules/projectiles/guns/ballistic/launchers.dm
@@ -67,7 +67,7 @@
 /obj/item/gun/ballistic/rocketlauncher/unrestricted
 	pin = /obj/item/firing_pin
 
-/obj/item/gun/ballistic/rocketlauncher/afterattack()
+/obj/item/gun/ballistic/rocketlauncher/after_live_shot_fired(mob/living/user, pointblank, atom/pbtarget, message)
 	. = ..()
 	magazine.get_round(FALSE) //Hack to clear the mag after it's fired
 

--- a/code/modules/projectiles/guns/ballistic/rifle.dm
+++ b/code/modules/projectiles/guns/ballistic/rifle.dm
@@ -79,7 +79,7 @@
 	item_state = "arcane_barrage"
 	slot_flags = null
 	can_bayonet = FALSE
-	item_flags = NEEDS_PERMIT | DROPDEL | ABSTRACT | NOBLUDGEON
+	item_flags = NEEDS_PERMIT | DROPDEL | ABSTRACT | NOBLUDGEON | SLOWS_WHILE_IN_HAND | NO_WORN_SLOWDOWN
 	flags_1 = NONE
 	trigger_guard = TRIGGER_GUARD_ALLOW_ALL
 

--- a/code/modules/projectiles/guns/ballistic/shotgun.dm
+++ b/code/modules/projectiles/guns/ballistic/shotgun.dm
@@ -364,8 +364,12 @@
 	. = ..()
 	. += "<span class='notice'>Right-click to shoot the hook.</span>"
 
-/obj/item/gun/ballistic/shotgun/hook/afterattack_secondary(atom/target, mob/user, proximity_flag, click_parameters)
-	hook.afterattack(target, user, proximity_flag, click_parameters)
+/obj/item/gun/ballistic/shotgun/hook/ranged_attack_secondary(atom/target, mob/living/user, params)
+	hook.pull_trigger(target, user, params)
+	return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
+
+/obj/item/gun/ballistic/shotgun/hook/pre_attack_secondary(atom/target, mob/living/user, params)
+	hook.pull_trigger(target, user, params)
 	return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
 
 ///Lever action shotgun, formerly on thefactory.dm

--- a/code/modules/projectiles/guns/energy/laser_gatling.dm
+++ b/code/modules/projectiles/guns/energy/laser_gatling.dm
@@ -185,7 +185,7 @@
 	if(heating)
 		current_heat += 2
 
-/obj/item/gun/energy/minigun/afterattack(atom/target, mob/living/user, flag, params)
+/obj/item/gun/energy/minigun/pull_trigger(atom/target, mob/living/user, params, aimed)
 	if(!ammo_pack || ammo_pack.loc != user)
 		to_chat(user, span_warning("You need the backpack power source to fire the gun!"))
 	. = ..()

--- a/code/modules/projectiles/guns/magic/wand.dm
+++ b/code/modules/projectiles/guns/magic/wand.dm
@@ -30,7 +30,7 @@
 		return
 	..()
 
-/obj/item/gun/magic/wand/afterattack(atom/target, mob/living/user)
+/obj/item/gun/magic/wand/pull_trigger(atom/target, mob/living/user, params, aimed)
 	if(!charges)
 		shoot_with_empty_chamber(user)
 		return

--- a/code/modules/projectiles/guns/misc/beam_rifle.dm
+++ b/code/modules/projectiles/guns/misc/beam_rifle.dm
@@ -291,25 +291,19 @@
 	process_aim()
 	if(aiming_time_left <= aiming_time_fire_threshold && check_user())
 		sync_ammo()
-		afterattack(object, M, FALSE, params, passthrough = TRUE)
+		pull_trigger(object, M, params, passthrough = TRUE)
 	stop_aiming()
 	QDEL_LIST(current_tracers)
 	return ..()
 
-/obj/item/gun/energy/beam_rifle/afterattack(atom/target, mob/living/user, flag, params, passthrough = FALSE)
-	if(flag) //It's adjacent, is the user, or is on the user's person
-		if(target in user.contents) //can't shoot stuff inside us.
-			return
-		if(!ismob(target) || user.combat_mode) //melee attack
-			return
-		if(target == user && !user.is_zone_selected(BODY_ZONE_PRECISE_MOUTH)) //so we can't shoot ourselves (unless mouth selected)
-			return
+/obj/item/gun/energy/beam_rifle/pull_trigger(atom/target, mob/living/user, params, aimed, passthrough = FALSE)
 	if(!passthrough && (aiming_time > aiming_time_fire_threshold))
-		return
+		return FALSE
 	if(lastfire > world.time + delay)
-		return
+		return FALSE
 	lastfire = world.time
-	. = ..()
+	if (!..())
+		return FALSE
 	stop_aiming()
 
 /obj/item/gun/energy/beam_rifle/proc/sync_ammo()

--- a/code/modules/projectiles/guns/misc/blastcannon.dm
+++ b/code/modules/projectiles/guns/misc/blastcannon.dm
@@ -87,7 +87,7 @@
 		return 0
 	return ((pressure - TANK_FRAGMENT_PRESSURE) / TANK_FRAGMENT_SCALE)
 
-/obj/item/gun/blastcannon/afterattack(atom/target, mob/user, flag, params)
+/obj/item/gun/blastcannon/pull_trigger(atom/target, mob/living/user, params, aimed)
 	if((!bomb && bombcheck) || (!target) || (get_dist(get_turf(target), get_turf(user)) <= 2))
 		return ..()
 	var/power = bomb? calculate_bomb() : debug_power


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Changes:
- Adds a new ranged_attack proc, which is called before afterattack only if the click was ranged.
- Cleans up gun code by using this new proc, rather than after attack (which resulted in cases of hitting and shooting at the same time)

fixes #12099
fixes #13154

Tweaks:
- Full auto will never be able to attack items.
- Pulling the trigger happens before attacking, meaning you cannot shoot and attack at the same time.
- Whether or not to melee attack is not determined by either combat mode or the is weapon flag.
- When attaching a bayonet to a gun, it will be able to melee attack adjacent targets in combat mode but will shoot in non-combat mode; matching the standard behaviours. If the gun has no ammo, or is incapable of firing then it will attack targets even in help mode.

## Why It's Good For The Game

Fixes various bugs

## Testing Photographs and Procedure


https://github.com/user-attachments/assets/f0a3c346-df8e-4705-8a79-d8fcaa0a3107



## Changelog
:cl:
fix: Fixes guns slowing down while worn on the belt.
fix: Fixes guns not being able to shoot if you click on a tile adjacent to you.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
