### PR TITLE
Fixes two oversights in the effort to remove keys from antag reports

### DIFF
--- a/code/datums/candidate_poll.dm
+++ b/code/datums/candidate_poll.dm
@@ -134,4 +134,4 @@
 	for(var/mob/chosen in chosen_candidates)
 		var/client/chosen_client = chosen.client
 		for(var/mob/poll_recipient as anything in poll_recipients)
-			to_chat(poll_recipient, span_ooc("[isobserver(poll_recipient) ? FOLLOW_LINK(poll_recipient, chosen_client.mob) : null][span_warning(" [full_capitalize(role)] Poll: ")][key_name(chosen_client, include_name = FALSE)] was selected."))
+			to_chat(poll_recipient, span_ooc("[isobserver(poll_recipient) ? FOLLOW_LINK(poll_recipient, chosen_client.mob) : null][span_warning(" [full_capitalize(role)] Poll: ")]Player was selected."))

--- a/code/modules/antagonists/holoparasite/holoparasite_team.dm
+++ b/code/modules/antagonists/holoparasite/holoparasite_team.dm
@@ -34,7 +34,7 @@
 	return {"
 		<div class="section">
 			<div class="section-title">
-				<b>[holopara_mind.display_key()]</b> was <b>[holoparasite.color_name]</b>, the <b>[holoparasite.theme.name]</b><br>
+				<b>[holoparasite.color_name]</b>, the <b>[holoparasite.theme.name]</b><br>
 			</div>
 			<div class="section-rest">
 				<div class="section-content">

--- a/code/modules/antagonists/traitor/datum_traitor.dm
+++ b/code/modules/antagonists/traitor/datum_traitor.dm
@@ -200,7 +200,7 @@
 		/// Special case for reinforcements, we want to show their ckey and name on round end.
 		if (istype(contractor_purchase, /datum/contractor_item/contractor_partner))
 			var/datum/contractor_item/contractor_partner/partner = contractor_purchase
-			contractor_support_unit += "<br><b>[partner.partner_mind.display_key()]</b> played <b>[partner.partner_mind.current.name]</b>, their contractor support unit."
+			contractor_support_unit += "<br><b>[partner.partner_mind.current.name]</b>, their contractor support unit."
 
 	if (contractor_hub.purchased_items.len)
 		result += "<br>(used [total_spent_rep] Rep) "


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This removes ckeys from the round end reports for holoparasites and contractor support agents.
Removes ckey from the poll result sent to dead chat as well. I didn't entirely remove this alert because it's nice to know when a decision was made and that you weren't the one chosen. 

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

They were intended to be removed in an earlier PR, but I overlooked them.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->

<img width="1191" height="685" alt="image" src="https://github.com/user-attachments/assets/914e3982-f79f-4cce-8537-8acf51c84dce" />


## Changelog
:cl:
fix: fixed holoparasites and contractor agents still showing player keys on round-end reports
tweak: Antagonist ckey is no longer reported to deadchat.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
