### PR TITLE
Xenomorph stun is now stamina based + fixes acid runtime

### DIFF
--- a/code/game/objects/obj_defense.dm
+++ b/code/game/objects/obj_defense.dm
@@ -116,9 +116,9 @@ GLOBAL_DATUM_INIT(acid_overlay, /mutable_appearance, mutable_appearance('icons/e
 /obj/proc/acid_processing()
 	. = 1
 	if(!(resistance_flags & ACID_PROOF))
-		for(var/armour_value in get_armor_rating())
-			if(armour_value != ACID && armour_value != FIRE)
-				set_armor(get_armor().generate_new_with_modifiers(list(0 - round(sqrt(acid_level)*0.1))))
+		var/acid_armor = get_armor_rating(ACID)
+		if(!acid_armor)
+			set_armor(set_armor(/datum/armor/none))
 		if(prob(33))
 			playsound(loc, 'sound/items/welder.ogg', 150, 1)
 		take_damage(min(1 + round(sqrt(acid_level)*0.3), 300), BURN, ACID, 0)

--- a/code/game/objects/obj_defense.dm
+++ b/code/game/objects/obj_defense.dm
@@ -116,9 +116,6 @@ GLOBAL_DATUM_INIT(acid_overlay, /mutable_appearance, mutable_appearance('icons/e
 /obj/proc/acid_processing()
 	. = 1
 	if(!(resistance_flags & ACID_PROOF))
-		var/acid_armor = get_armor_rating(ACID)
-		if(!acid_armor)
-			set_armor(set_armor(/datum/armor/none))
 		if(prob(33))
 			playsound(loc, 'sound/items/welder.ogg', 150, 1)
 		take_damage(min(1 + round(sqrt(acid_level)*0.3), 300), BURN, ACID, 0)

--- a/code/modules/mob/living/carbon/alien/humanoid/alien_powers.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/alien_powers.dm
@@ -190,7 +190,7 @@ Doesn't work on other aliens/AI.*/
 	name = "Corrosive Acid"
 	desc = "Drench an object in acid, destroying it over time."
 	button_icon_state = "alien_acid"
-	plasma_cost = 200
+	plasma_cost = 50
 
 /datum/action/alien/acid/corrosion/set_click_ability(mob/on_who)
 	. = ..()
@@ -216,7 +216,11 @@ Doesn't work on other aliens/AI.*/
 	return ..()
 
 /datum/action/alien/acid/corrosion/on_activate(mob/user, atom/target)
-	if(!target.acid_act(200, 1000))
+	if(iscarbon(target))
+		//This is blocked by virtually any clothing which is destroyed if possible, but will still do 60 damage without any.
+		target.acid_act(50, 50)
+
+	else if(!target.acid_act(200, 1000))
 		to_chat(owner, ("<span class='noticealien'>You cannot dissolve this object.</span>"))
 		return FALSE
 

--- a/code/modules/mob/living/carbon/alien/humanoid/caste/hunter.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/caste/hunter.dm
@@ -73,7 +73,9 @@
 					blocked = TRUE
 			if(!blocked)
 				L.visible_message(span_danger("[src] pounces on [L]!"), span_userdanger("[src] pounces on you!"))
-				L.Paralyze(100)
+				var/obj/item/bodypart/chest = L.get_bodypart(BODY_ZONE_CHEST)
+				var/armor_block = L.run_armor_check(chest, MELEE, "", "")
+				L.apply_damage(110, STAMINA, chest, armor_block)
 				sleep(0.2 SECONDS)//Runtime prevention (infinite bump() calls on hulks)
 				step_towards(src, L)
 			else

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -268,13 +268,12 @@
 			to_chat(user, span_danger("You disarm [src]!"))
 		else
 			playsound(loc, 'sound/weapons/pierce.ogg', 25, TRUE, -1)
-			Knockdown(20)
 			log_combat(user, src, "tackled")
 			var/obj/item/bodypart/affecting = get_bodypart(ran_zone(user.get_combat_bodyzone(src)))
 			if(!affecting)
 				affecting = get_bodypart(BODY_ZONE_CHEST)
 			var/armor_block = run_armor_check(affecting, MELEE,"","",10)
-			apply_damage(30, STAMINA, affecting, armor_block)
+			apply_damage(45, STAMINA, affecting, armor_block)
 			visible_message(span_danger("[user] tackles [src] down!"), \
 					span_userdanger("[user] tackles you down!"), span_hear("You hear aggressive shuffling followed by a loud thud!"), null, user)
 			to_chat(user, span_danger("You tackle [src] down!"))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

* Fixes an oversight in Xeno acid which allows it to be used at full power against mobs, dealing acid damage equivalent to *checks notes* 5000 units of fluorosulfuric acid when spat at them. It now only sprays 50 units of acid which is 20% stronger than fluorosulfuric when used on carbons. 
* Decreases cost of acid spit to 50 so it can be used more offensively given the newly balanced numbers, instead of only being a very expensive way to very slowly destroy some walls. 
* Changes the hunter tackle to deal 110 stamina damage instead of being a hardcoded stun so that stamina armor (such as riot) resists the stun, but it will still generally stun immediately or at least put most targets very close to stamcrit.
* All Xenomorph disarms deal 45 stamina damage now, up from 30
* Removed an armor check from acid_processing() proc which was both unnecessary and causing runtimes due to bad args


<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

When you are hit with the equivalent of *checks notes again* **5000 UNITS** of fluorosulfuric acid it more or less guarantees the near immediate destruction of anything that wasn't totally acid proof. Second use of ability on the now naked person causes 360 combined damage instantly. 

Tackle should utilize stamina damage so it respects armor flags, but the "instant takedown" has been mostly preserved. 

Increasing stamina damage of the shove was a suggestion by bacon both to compensate for the removal of the stun and because stun armor will make it do almost nothing. 

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>

Here is the tackle
![dreamseeker_9wb8Exi5Xf](https://github.com/user-attachments/assets/b6cbcf80-10e0-4947-892f-e906e2e90d42)

This is the spit against some basic equipment that isn't meant to take acid now. It does 60 damage if the target has nothing left to protect them from direct acid contact, and 0 damage if they do. The clown took 0 damage in this gif. 
![dreamseeker_uyrEP33uL1](https://github.com/user-attachments/assets/66372b69-e4e6-4836-ac0d-ebc2967a5e43)

</details>

## Changelog
:cl:
tweak: Xenomorph hunter leap attack now does 110 stamina damage instead of being hardcoded as a 10 second stun. This means armor will potentially mitigate this to less than an immediate takedown
tweak: All xenomorphs now do slightly more stamina damage with right click attack
fix: Xenomorph acid no longer instantly annihilates mobs, but has had its cost reduced to 50. This ability was not previously intended to work on mobs at all, so consider this turning a bug into a feature officially. 
fix: Removed an armor check from acid_processing() proc which was both unnecessary and causing runtimes due to bad args
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
