### PR TITLE
Actually Fixes Loadouts - (For real this time)

### DIFF
--- a/code/modules/jobs/job_types/_job.dm
+++ b/code/modules/jobs/job_types/_job.dm
@@ -329,7 +329,8 @@
 						if(old_bag)
 							for(var/obj/item/item in old_bag.contents)
 								item.forceMove(new_bag)
-							H.doUnEquip(old_bag, newloc = H.drop_location(), invdrop = FALSE, silent = TRUE)
+							H.doUnEquip(old_bag, newloc = null, invdrop = FALSE, silent = TRUE)
+							qdel(old_bag)
 							if(H.equip_to_slot_or_del(new_bag, G.slot))
 								if(M.client)
 									to_chat(M, span_notice("Equipping you with [G.display_name]!"))
@@ -346,7 +347,7 @@
 								spawned_box.forceMove(current_bag)	// Gets put in the backpack
 								if(M.client)
 									to_chat(M, span_notice("A box with your standard equipment was placed in your [current_bag.name]!"))
-							if(isplasmaman(H) && G.slot == ITEM_SLOT_HEAD || G.slot == ITEM_SLOT_ICLOTHING)
+							if(isplasmaman(H) && (G.slot == ITEM_SLOT_HEAD || G.slot == ITEM_SLOT_ICLOTHING))
 								new_item.forceMove(spawned_box)	// iF THEY'RE PLASMAMAN PUT IT IN THE BOX INSTEAD
 								if(M.client)
 									to_chat(M, span_notice("Storing your [G.display_name] inside a box in your [current_bag.name]!"))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Third time is the charm.

While doing the previous 2 PRs I had not tested on characters after picking a job preference.

Now it works.



Before:

<img width="226" height="563" alt="image" src="https://github.com/user-attachments/assets/a369eafe-68f7-42b9-aac1-87a04693db3a" />


After:

<img width="207" height="564" alt="image" src="https://github.com/user-attachments/assets/6017669c-edff-4fcd-973c-271952dbb32c" />


Ingame:

<img width="784" height="594" alt="image" src="https://github.com/user-attachments/assets/f55cd931-6212-4ea9-af2a-4d42852b7fa6" />


## Why It's Good For The Game

The feature was poorly implemented by me due to a small testing oversight.

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

Up there.

</details>

## Changelog
:cl:
fix: Finally actually fixes loadouts and loadout replacements
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
