### PR TITLE
Deputy vendor lowpop machine

### DIFF
--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -18240,6 +18240,7 @@
 /obj/structure/sign/departments/minsky/security/security{
 	pixel_y = 32
 	},
+/obj/machinery/vending/deputy,
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
 "dVL" = (

--- a/_maps/map_files/CardinalStation/CardinalStation.dmm
+++ b/_maps/map_files/CardinalStation/CardinalStation.dmm
@@ -39088,6 +39088,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/machinery/vending/deputy,
 /turf/open/floor/iron,
 /area/hallway/upper/primary/starboard)
 "hUX" = (

--- a/_maps/map_files/CorgStation/CorgStation.dmm
+++ b/_maps/map_files/CorgStation/CorgStation.dmm
@@ -56067,6 +56067,11 @@
 /obj/effect/turf_decal/tile/blue,
 /turf/open/floor/iron/dark,
 /area/bridge)
+"slc" = (
+/obj/effect/turf_decal/tile/blue/fourcorners/contrasted,
+/obj/machinery/vending/deputy,
+/turf/open/floor/iron,
+/area/hallway/primary/fore)
 "sle" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-8"
@@ -109697,7 +109702,7 @@ bgr
 uGg
 qJy
 shJ
-ryd
+slc
 pJQ
 onZ
 wza

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -79139,6 +79139,7 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
+/obj/machinery/vending/deputy,
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
 "toc" = (

--- a/_maps/map_files/EchoStation/EchoStation.dmm
+++ b/_maps/map_files/EchoStation/EchoStation.dmm
@@ -29589,6 +29589,7 @@
 	alpha = 180;
 	dir = 1
 	},
+/obj/machinery/vending/deputy,
 /turf/open/floor/iron/dark/side{
 	dir = 4
 	},

--- a/_maps/map_files/FlandStation/FlandStation.dmm
+++ b/_maps/map_files/FlandStation/FlandStation.dmm
@@ -67603,6 +67603,15 @@
 	broken = 1
 	},
 /area/maintenance/starboard/aft)
+"rsu" = (
+/obj/effect/turf_decal/guideline/guideline_mid/purple,
+/obj/effect/turf_decal/guideline/guideline_out/yellow,
+/obj/effect/turf_decal/guideline/guideline_in/blue,
+/obj/machinery/vending/deputy,
+/turf/open/floor/iron/dark/corner{
+	dir = 4
+	},
+/area/hallway/primary/central)
 "rsv" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/firealarm/directional/south,
@@ -129086,7 +129095,7 @@ bQm
 sIS
 bZm
 gAI
-rOy
+rsu
 rfa
 fXI
 cnM

--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -27323,6 +27323,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/neutral/opposingcorners,
+/obj/machinery/vending/deputy,
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
 "gTo" = (

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -38333,6 +38333,7 @@
 	light_color = "#e8eaff"
 	},
 /obj/effect/turf_decal/tile/red,
+/obj/machinery/vending/deputy,
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
 "juU" = (

--- a/_maps/map_files/RadStation/RadStation.dmm
+++ b/_maps/map_files/RadStation/RadStation.dmm
@@ -5664,6 +5664,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
+/obj/machinery/vending/deputy,
 /turf/open/floor/iron,
 /area/security/main)
 "bPo" = (

--- a/beestation.dme
+++ b/beestation.dme
@@ -4484,6 +4484,7 @@
 #include "code\modules\vending\clothesmate.dm"
 #include "code\modules\vending\coffee.dm"
 #include "code\modules\vending\cola.dm"
+#include "code\modules\vending\deputy.dm"
 #include "code\modules\vending\drinnerware.dm"
 #include "code\modules\vending\engineering.dm"
 #include "code\modules\vending\engivend.dm"

--- a/code/game/objects/effects/spawners/vending.dm
+++ b/code/game/objects/effects/spawners/vending.dm
@@ -36,8 +36,9 @@
 
 /obj/effect/spawner/deputy_vend
 	name = "Deputy vendor"
-	icon_state = "secdrobe-broken"
 	desc = "Spawns a deputy vendor if the station is lowpop."
+	icon = 'icons/obj/vending.dmi'
+	icon_state = "secdrobe-broken"
 
 /obj/effect/spawner/deputy_vend/Initialize(mapload)
 	. = ..()

--- a/code/game/objects/effects/spawners/vending.dm
+++ b/code/game/objects/effects/spawners/vending.dm
@@ -33,3 +33,23 @@
 	vend.extended_inventory = hacked
 
 	return INITIALIZE_HINT_QDEL
+
+/obj/effect/spawner/deputy_vend
+	name = "Deputy vendor"
+	icon_state = "secdrobe-broken"
+	desc = "Spawns a deputy vendor if the station is lowpop."
+
+/obj/effect/spawner/deputy_vend/Initialize(mapload)
+	. = ..()
+	if (!mapload)
+		new /obj/machinery/vending/deputy(loc)
+		return INITIALIZE_HINT_QDEL
+	if (!SSticker.current_state >= GAME_STATE_PLAYING)
+		check_spawn()
+		return
+	SSticker.OnRoundstart(CALLBACK(src, PROC_REF(check_spawn)))
+
+/obj/effect/spawner/deputy_vend/proc/check_spawn()
+	if ((SSjob.is_job_empty(JOB_NAME_SECURITYOFFICER) && SSjob.is_job_empty(JOB_NAME_HEADOFSECURITY) && SSjob.initial_players_to_assign < LOWPOP_JOB_LIMIT) || SSjob.initial_players_to_assign < MINPOP_JOB_LIMIT)
+		new /obj/machinery/vending/deputy(loc)
+	qdel(src)

--- a/code/game/objects/items/storage/backpack.dm
+++ b/code/game/objects/items/storage/backpack.dm
@@ -595,6 +595,7 @@
 	new /obj/item/clothing/shoes/sneakers/black(src)
 	new /obj/item/storage/belt/security/deputy(src)
 	new /obj/item/clothing/accessory/armband/deputy(src)
+	new /obj/item/card/id/pass/deputy(src)
 
 /obj/item/storage/backpack/duffelbag/engineering
 	name = "industrial duffel bag"

--- a/code/modules/jobs/job_types/_job.dm
+++ b/code/modules/jobs/job_types/_job.dm
@@ -499,11 +499,6 @@
 		if (SSjob.is_job_empty(JOB_NAME_CAPTAIN))
 			. |= ACCESS_HEADS
 			. |= ACCESS_KEYCARD_AUTH
-		// Access to security basics (get captain for guns)
-		if (SSjob.is_job_empty(JOB_NAME_SECURITYOFFICER))
-			. |= list(
-				ACCESS_SECURITY, ACCESS_BRIG, ACCESS_SEC_DOORS
-			)
 		// Access to science
 		if (SSjob.is_job_empty(JOB_NAME_SCIENTIST))
 			. |= list(

--- a/code/modules/vending/deputy.dm
+++ b/code/modules/vending/deputy.dm
@@ -1,0 +1,24 @@
+/obj/machinery/vending/deputy
+	name = "\improper DepVend"
+	desc = "A machine that dispenses the equipment required to join security voluntarily. Used on stations with skeleton crews as all crew are forced to collectively maintain the station."
+	product_ads = "Free weapons!;Time to kill your collegues!;You always wanted to do this!;Your weapons are right here.;Come and declare military law!;Your friends are your enemies!;To test for a changeling, kill them and see if they survive!;Everyone is a syndicate if they don't follow orders."
+	icon_state = "sec"
+	icon_deny = "sec-deny"
+	light_mask = "sec-light-mask"
+	vend_reply = "Thank you for your service!"
+	req_access = list()
+	// The deputisation kit
+	products = list(/obj/item/storage/backpack/duffelbag/sec/deputy = 4)
+	// Things that could be useful to antags
+	contraband = list(/obj/item/clothing/glasses/sunglasses/advanced = 2)
+	// Things that could be useful for crew protection
+	premium = list(/obj/item/clothing/head/helmet = 4,
+				   /obj/item/clothing/suit/armor/vest = 4)
+	refill_canister = /obj/item/vending_refill/deputy
+	default_price = 450
+	extra_price = 700
+	dept_req_for_free = NONE
+
+/obj/item/vending_refill/deputy
+	machine_name = "DepVend"
+	icon_state = "refill_sec"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds in the deputy vendor for lowpops, removes inherent access to the security department.

## Why It's Good For The Game

The current process of self-deputisation is not clear, which causes 2 issues:
- Players are not following this option out of fear of a report.
- Players who are reporting players who do this due to a disconnect between the player perception and intended process.

## Testing Photographs and Procedure

<img width="533" height="696" alt="image" src="https://github.com/user-attachments/assets/07728b25-1c2c-436c-b4ec-ef8b5996f25e" />

<img width="443" height="647" alt="image" src="https://github.com/user-attachments/assets/ec27b7b5-e330-420c-a6a9-f74f801015a1" />


Note the pre-existing bug where it shows as free when you are an assistant despite having a cost.

</details>

## Changelog
:cl:
tweak: Players on lowpop no longer spawn with security access if no security are present.
add: Added a new machine on lowpop which dispenses security deputy kits for 450 credits.
add: The deputy duffel bag now comes with a deputy access upgrade card.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
