### PR TITLE
Fixes gas analyzer's barometer

### DIFF
--- a/code/controllers/subsystem/weather.dm
+++ b/code/controllers/subsystem/weather.dm
@@ -25,7 +25,6 @@ SUBSYSTEM_DEF(weather)
 		run_weather(our_event, list(text2num(z)))
 		eligible_zlevels -= z
 		var/randTime = rand(3000, 6000)
-		addtimer(CALLBACK(src, PROC_REF(make_eligible), z, possible_weather), randTime + initial(our_event.weather_duration_upper), TIMER_UNIQUE) //Around 5-10 minutes between weathers
 		next_hit_by_zlevel["[z]"] = addtimer(CALLBACK(src, PROC_REF(make_eligible), z, possible_weather), randTime + initial(our_event.weather_duration_upper), TIMER_UNIQUE|TIMER_STOPPABLE) //Around 5-10 minutes between weathers
 
 

--- a/code/game/objects/items/devices/scanners/gas_analyzer.dm
+++ b/code/game/objects/items/devices/scanners/gas_analyzer.dm
@@ -60,7 +60,7 @@
 
 	for(var/V in SSweather.processing)
 		var/datum/weather/W = V
-		if(W.barometer_predictable && (T.z in W.impacted_z_levels) && !(W.stage == END_STAGE)) //remove the area check or figure something out
+		if(W.barometer_predictable && (T.z in W.impacted_z_levels) && !(W.stage == END_STAGE))
 			ongoing_weather = W
 			break
 

--- a/code/game/objects/items/devices/scanners/gas_analyzer.dm
+++ b/code/game/objects/items/devices/scanners/gas_analyzer.dm
@@ -39,7 +39,7 @@
 /obj/item/analyzer/AltClick(mob/user) //Barometer output for measuring when the next storm happens
 	..()
 
-	if(user.canUseTopic(src, BE_CLOSE))
+	if(!user.canUseTopic(src, BE_CLOSE))
 		return
 
 	if(cooldown)
@@ -60,7 +60,7 @@
 
 	for(var/V in SSweather.processing)
 		var/datum/weather/W = V
-		if(W.barometer_predictable && (T.z in W.impacted_z_levels) && W.area_type == user_area.type && !(W.stage == END_STAGE))
+		if(W.barometer_predictable && (T.z in W.impacted_z_levels) && !(W.stage == END_STAGE)) //remove the area check or figure something out
 			ongoing_weather = W
 			break
 


### PR DESCRIPTION
## About The Pull Request
Fixes the if check that returns every time it shouldn't return
Removes duplicate timer that shouldn't exist
Removes area type check since it's now broken(the type of all weather is now just 'area/' instead of the specific lavaland area type) and since it seems to be covered by the z level check anyway.

Closes https://github.com/BeeStation/BeeStation-Hornet/issues/12195
## Why It's Good For The Game
Unbreaks feature

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>

<img width="799" height="359" alt="dreamseeker_dfO9XFk5vR" src="https://github.com/user-attachments/assets/f4ea9901-5678-4041-9022-aad1b289c94e" />

<summary>Screenshots&Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>

## Changelog
:cl:
fix: Gas analyzer's barometer function works again (Alt-Click the gas analyzer on lavaland to use the barometer function)

/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
