### PR TITLE
Fixes & Refactors playtime tracking

### DIFF
--- a/code/controllers/subsystem/blackbox.dm
+++ b/code/controllers/subsystem/blackbox.dm
@@ -35,7 +35,7 @@ SUBSYSTEM_DEF(blackbox)
 
 	if(CONFIG_GET(flag/use_exp_tracking))
 		if((triggertime < 0) || (world.time > (triggertime +3000)))	//subsystem fires once at roundstart then once every 10 minutes. a 5 min check skips the first fire. The <0 is midnight rollover check
-			update_exp(10,FALSE)
+			update_exp(10)
 
 /datum/controller/subsystem/blackbox/proc/CheckPlayerCount()
 	set waitfor = FALSE

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -48,15 +48,6 @@
 			return
 		cmd_show_exp_panel(M.client)
 
-	else if(href_list["toggleexempt"])
-		if(!check_rights(R_ADMIN))
-			return
-		var/client/C = locate(href_list["toggleexempt"]) in GLOB.clients
-		if(!C)
-			to_chat(usr, span_danger("ERROR: Client not found."))
-			return
-		toggle_exempt_status(C)
-
 	else if(href_list["forceevent"])
 		if(!check_rights(R_FUN))
 			return

--- a/code/modules/jobs/job_exp.dm
+++ b/code/modules/jobs/job_exp.dm
@@ -74,13 +74,13 @@ GLOBAL_PROTECT(exp_to_update)
 	else
 		return "0h"
 
-/datum/controller/subsystem/blackbox/proc/update_exp(mins, ann = FALSE)
+/datum/controller/subsystem/blackbox/proc/update_exp(mins)
 	if(!SSdbcore.Connect())
 		return -1
 	for(var/client/L in GLOB.clients)
 		if(L.is_afk())
 			continue
-		L.update_exp_list(mins,ann)
+		L.update_exp_list(mins)
 
 /datum/controller/subsystem/blackbox/proc/update_exp_db()
 	set waitfor = FALSE
@@ -143,60 +143,50 @@ GLOBAL_PROTECT(exp_to_update)
 	qdel(flag_update)
 
 
-/client/proc/update_exp_list(minutes, announce_changes = FALSE)
+/**
+ * Tallies up the exp for the playtime tracking and adds it to the global update list.
+ *
+ * For a client mob of [/mob/dead/observer], it adds EXP_TYPE_GHOST.
+ *
+ * For a client mob of [/mob/living], it grabs the exp list from a mob proc call.
+ * Being dead but still in your body will tally time towards your /mob/living roles instead of ghost roles.
+ * If /mob/living returns an empty list, uses "Unknown" instead.
+ *
+ * For anything else, it doesn't update anything.
+ *
+ * Arguments:
+ * * minutes - The number of minutes to add to the playtime tally.
+ */
+/client/proc/update_exp_list(minutes)
 	if(!CONFIG_GET(flag/use_exp_tracking))
 		return -1
 	if(!SSdbcore.Connect())
 		return -1
 	if (!isnum_safe(minutes))
 		return -1
+
 	var/list/play_records = list()
 
-	if(isliving(mob))
-		if(mob.stat != DEAD)
-			var/rolefound = FALSE
-			play_records[EXP_TYPE_LIVING] += minutes
-
-			process_ten_minute_living()
-
-			if(announce_changes)
-				to_chat(src,span_notice("You got: [minutes] Living EXP!"))
-			if(mob.mind.assigned_role)
-				for(var/job in SSjob.name_occupations)
-					if(mob.mind.assigned_role == job)
-						rolefound = TRUE
-						play_records[job] += minutes
-						if(announce_changes)
-							to_chat(src,span_notice("You got: [minutes] [job] EXP!"))
-				if(!rolefound)
-					for(var/role in GLOB.exp_specialmap[EXP_TYPE_SPECIAL])
-						if(mob.mind.assigned_role == role)
-							rolefound = TRUE
-							play_records[role] += minutes
-							if(announce_changes)
-								to_chat(mob,span_notice("You got: [minutes] [role] EXP!"))
-				if(mob.mind.special_role && !(mob.mind.datum_flags & DF_VAR_EDITED))
-					var/trackedrole = mob.mind.special_role
-					play_records[trackedrole] += minutes
-					if(announce_changes)
-						to_chat(src,span_notice("You got: [minutes] [trackedrole] EXP!"))
-			if(!rolefound)
-				play_records["Unknown"] += minutes
+	if(isobserver(mob))
+		play_records[EXP_TYPE_GHOST] = minutes
+	else if(isliving(mob))
+		var/mob/living/living_mob = mob
+		var/list/mob_exp_list = living_mob.get_exp_list(minutes)
+		if(!length(mob_exp_list))
+			play_records["Unknown"] = minutes
 		else
-			if(holder && !holder.deadmined)
-				play_records[EXP_TYPE_ADMIN] += minutes
-				if(announce_changes)
-					to_chat(src,span_notice("You got: [minutes] Admin EXP!"))
-			else
-				play_records[EXP_TYPE_GHOST] += minutes
-				if(announce_changes)
-					to_chat(src,span_notice("You got: [minutes] Ghost EXP!"))
-	else if(isobserver(mob))
-		play_records[EXP_TYPE_GHOST] += minutes
-		if(announce_changes)
-			to_chat(src,span_notice("You got: [minutes] Ghost EXP!"))
-	else if(minutes)	//Let "refresh" checks go through
+			play_records |= mob_exp_list
+
+		play_records[EXP_TYPE_LIVING] = minutes
+
+		process_ten_minute_living()
+
+	// Lobby surfing? /mob/dead/new_player? Not worth any exp!
+	else
 		return
+
+	if(holder && !holder.deadmined && holder.check_for_rights(R_BAN))
+		play_records[EXP_TYPE_ADMIN] = minutes
 
 	for(var/jtype in play_records)
 		var/jvalue = play_records[jtype]
@@ -211,7 +201,6 @@ GLOBAL_PROTECT(exp_to_update)
 			"minutes" = jvalue)))
 		prefs.exp[jtype] += jvalue
 	addtimer(CALLBACK(SSblackbox, TYPE_PROC_REF(/datum/controller/subsystem/blackbox, update_exp_db)),20,TIMER_OVERRIDE|TIMER_UNIQUE)
-
 
 //ALWAYS call this at beginning to any proc touching player flags, or your database admin will probably be mad
 /client/proc/set_db_player_flags()

--- a/code/modules/jobs/job_report.dm
+++ b/code/modules/jobs/job_report.dm
@@ -17,6 +17,13 @@
 		ui = new(user, src, "TrackedPlaytime")
 		ui.open()
 
+/datum/job_report_menu/ui_data(mob/user)
+	var/list/data = list()
+
+	data["exemptStatus"] = (owner.prefs?.db_flags & DB_FLAG_EXEMPT)
+
+	return data
+
 /datum/job_report_menu/ui_static_data()
 	if (!CONFIG_GET(flag/use_exp_tracking))
 		return list("failReason" = JOB_REPORT_MENU_FAIL_REASON_TRACKING_DISABLED)
@@ -46,8 +53,39 @@
 
 	data["livingTime"] = play_records[EXP_TYPE_LIVING]
 	data["ghostTime"] = play_records[EXP_TYPE_GHOST]
+	data["adminTime"] = play_records[EXP_TYPE_ADMIN] ? play_records[EXP_TYPE_ADMIN] : 0
+
+	data["isAdmin"] = check_rights(R_ADMIN, show_msg = FALSE)
 
 	return data
+
+/datum/job_report_menu/ui_act(action, list/params, datum/tgui/ui, datum/ui_state/state)
+	. = ..()
+	if(.)
+		return
+
+	switch(action)
+		if("toggle_exempt")
+			if(!check_rights(R_ADMIN))
+				message_admins("[ADMIN_LOOKUPFLW(usr)] attempted to toggle job playtime exempt status without admin rights.")
+				log_admin("[ADMIN_LOOKUPFLW(usr)] attempted to toggle job playtime exempt status without admin rights.")
+				to_chat(usr, span_danger("ERROR: Insufficient admin rights."))
+				return TRUE
+
+			var/datum/admins/viewer_admin_datum = GLOB.admin_datums[usr.ckey]
+
+			if(!viewer_admin_datum)
+				message_admins("[ADMIN_LOOKUPFLW(usr)] attempted to toggle job playtime exempt status without admin datum for their ckey.")
+				log_admin("[ADMIN_LOOKUPFLW(usr)] attempted to toggle job playtime exempt status without admin datum for their ckey.")
+				to_chat(usr, span_danger("ERROR: Insufficient admin rights."))
+				return TRUE
+
+			if(QDELETED(owner))
+				to_chat(usr, span_danger("ERROR: Client not found."))
+				return TRUE
+
+			viewer_admin_datum.toggle_exempt_status(owner)
+			return TRUE
 
 #undef JOB_REPORT_MENU_FAIL_REASON_TRACKING_DISABLED
 #undef JOB_REPORT_MENU_FAIL_REASON_NO_RECORDS

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1042,6 +1042,12 @@
 	src.apply_damage(power, BRUTE, def_zone = pick(BODY_ZONE_PRECISE_R_FOOT, BODY_ZONE_PRECISE_L_FOOT))
 	src.Paralyze(10 * power)
 
+/mob/living/carbon/human/get_exp_list(minutes)
+	. = ..()
+
+	if(mind.assigned_role in SSjob.name_occupations)
+		.[mind.assigned_role] = minutes
+
 /mob/living/carbon/human/monkeybrain
 	ai_controller = /datum/ai_controller/monkey
 

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1984,6 +1984,23 @@
 		return style.harm_act(src, target)
 	return style.help_act(src, target)
 
+/**
+ * Returns an assoc list of assignments and minutes for updating a client's exp time in the databse.
+ *
+ * Arguments:
+ * * minutes - The number of minutes to allocate to each valid role.
+ */
+/mob/living/proc/get_exp_list(minutes)
+	var/list/exp_list = list()
+
+	if(mind && mind.special_role && !(mind.datum_flags & DF_VAR_EDITED))
+		exp_list[mind.special_role] = minutes
+
+	if(mind.assigned_role in GLOB.exp_specialmap[EXP_TYPE_SPECIAL])
+		exp_list[mind.assigned_role] = minutes
+
+	return exp_list
+
 /// Actually does the shapeshift
 /mob/living/proc/do_shapeshift(shapeshift_type = /mob/living/basic/pet/dog/corgi)
 	// Spawn the new mob

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -1103,6 +1103,13 @@ CREATION_TEST_IGNORE_SUBTYPES(/mob/living/silicon/ai/spawned)
 /mob/living/silicon/on_handsblocked_end()
 	return // AIs have no hands
 
+/mob/living/silicon/ai/get_exp_list(minutes)
+	. = ..()
+
+	var/datum/job/ai/ai_job_ref = SSjob.GetJobType(/datum/job/ai)
+
+	.[ai_job_ref.title] = minutes
+
 /mob/living/silicon/ai/verb/change_photo_camera_radius()
 	set category = "AI Commands"
 	set name = "Adjust Camera Zoom"

--- a/code/modules/mob/living/silicon/silicon.dm
+++ b/code/modules/mob/living/silicon/silicon.dm
@@ -494,6 +494,13 @@
 	if(program)
 		program.force_full_update()
 
+/mob/living/silicon/robot/get_exp_list(minutes)
+	. = ..()
+
+	var/datum/job/cyborg/cyborg_job_ref = SSjob.GetJobType(/datum/job/cyborg)
+
+	.[cyborg_job_ref.title] = minutes
+
 /// Same as the normal character name replacement, but updates the contents of the modular interface.
 /mob/living/silicon/fully_replace_character_name(oldname, newname)
 	. = ..()

--- a/tgui/packages/tgui/interfaces/TrackedPlaytime.jsx
+++ b/tgui/packages/tgui/interfaces/TrackedPlaytime.jsx
@@ -1,7 +1,7 @@
 import { sortBy } from 'common/collections';
 
 import { useBackend } from '../backend';
-import { Box, Flex, ProgressBar, Section, Table } from '../components';
+import { Box, Button, Flex, ProgressBar, Section, Table } from '../components';
 import { Window } from '../layouts';
 
 const JOB_REPORT_MENU_FAIL_REASON_TRACKING_DISABLED = 1;
@@ -11,7 +11,15 @@ const sortByPlaytime = (array) => sortBy(array, ([_, playtime]) => -playtime);
 
 const PlaytimeSection = (props) => {
   const { playtimes, removedJobs } = props;
-  const sortedPlaytimes = sortByPlaytime(Object.entries(playtimes));
+
+  const sortedPlaytimes = sortByPlaytime(Object.entries(playtimes)).filter(
+    (entry) => entry[1],
+  );
+
+  if (!sortedPlaytimes.length) {
+    return 'No recorded playtime hours for this section.';
+  }
+
   const mostPlayed = sortedPlaytimes[0][1];
   return (
     <Table>
@@ -52,14 +60,17 @@ const PlaytimeSection = (props) => {
 };
 
 export const TrackedPlaytime = (props) => {
-  const { data } = useBackend();
+  const { act, data } = useBackend();
   const {
     failReason,
     jobPlaytimes = {},
     jobRemovedPlaytimes = {},
     specialPlaytimes,
+    exemptStatus,
+    isAdmin,
     livingTime,
     ghostTime,
+    adminTime,
   } = data;
   return (
     <Window title="Tracked Playtime" width={550} height={650}>
@@ -77,10 +88,23 @@ export const TrackedPlaytime = (props) => {
                 playtimes={{
                   Ghost: ghostTime,
                   Living: livingTime,
+                  Admin: adminTime,
                 }}
               />
             </Section>
-            <Section title="Jobs">
+            <Section
+              title="Jobs"
+              buttons={
+                !!isAdmin && (
+                  <Button.Checkbox
+                    checked={!!exemptStatus}
+                    onClick={() => act('toggle_exempt')}
+                  >
+                    Job Playtime Exempt
+                  </Button.Checkbox>
+                )
+              }
+            >
               <PlaytimeSection
                 playtimes={{ ...jobPlaytimes, ...jobRemovedPlaytimes }}
                 removedJobs={Object.keys(jobRemovedPlaytimes)}


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

closes #7294 

Technically a recoup of https://github.com/BeeStation/BeeStation-Hornet/pull/7302

This PR readds a button that lets admins exempt playtime tracking in roles.

Additionally, this PR adds proper tracking to time spent adminning, rather than aggregating it with ghost time.

<details>
<summary>Attributions</summary>

- https://github.com/tgstation/tgstation/pull/56799 
- https://github.com/tgstation/tgstation/pull/56951 
- https://github.com/tgstation/tgstation/pull/57443 
- https://github.com/tgstation/tgstation/pull/58186

</details>

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Fixes old bug, makes time tracking better

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

<img width="1673" height="946" alt="Screenshot 2025-08-25 142635" src="https://github.com/user-attachments/assets/4f1e4faa-ffc9-4783-aa69-bff1e90b95ec" />


</details>

## Changelog
:cl: rkz, Timberpoes
admin: Re-added the button to the player playtime panel that lets admins toggle a player's job playtime exemption status.
refactor: Rewrite the way we handle which roles get assigned with playtime tracking.
fix: Players who get MMI'd and put into borgs or AIs mid-shift now gain job playtime tracking towards Silicon roles instead.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
