### PR TITLE
Renames the proc applyOrganDamage() to apply_organ_damage()

### DIFF
--- a/code/datums/components/manual_blinking.dm
+++ b/code/datums/components/manual_blinking.dm
@@ -72,7 +72,7 @@
 			to_chat(C, span_userdanger("Your eyes begin to wither, you need to blink!"))
 			warn_dying = TRUE
 
-		E.applyOrganDamage(damage_rate * delta_time)
+		E.apply_organ_damage(damage_rate * delta_time)
 	else if(world.time > (last_blink + check_every))
 		if(!warn_grace)
 			to_chat(C, span_danger("You feel a need to blink!"))

--- a/code/datums/components/manual_breathing.dm
+++ b/code/datums/components/manual_breathing.dm
@@ -83,7 +83,7 @@
 			to_chat(C, span_userdanger("You begin to suffocate, you need to [next_text]!"))
 			warn_dying = TRUE
 
-		L.applyOrganDamage(damage_rate * delta_time)
+		L.apply_organ_damage(damage_rate * delta_time)
 		C.losebreath += 0.8
 	else if(world.time > (last_breath + check_every))
 		if(!warn_grace)

--- a/code/datums/diseases/advance/symptoms/organs.dm
+++ b/code/datums/diseases/advance/symptoms/organs.dm
@@ -104,7 +104,7 @@
 				M.set_blindness(0)
 				M.set_blurriness(0)
 			else if(eyes.damage > 0)
-				eyes.applyOrganDamage(-1)
+				eyes.apply_organ_damage(-1)
 		else
 			if(prob(base_message_chance) && M.stat != DEAD)
 				to_chat(M, span_notice("[pick("Your eyes feel great.","You feel like your eyes can focus more clearly.", "You don't feel the need to blink.","Your ears feel great.","Your healing feels more acute.")]"))

--- a/code/datums/diseases/advance/symptoms/vision.dm
+++ b/code/datums/diseases/advance/symptoms/vision.dm
@@ -65,10 +65,10 @@ Bonus
 				if(M.stat != DEAD)
 					to_chat(M, span_warning("<b>Your eyes burn!</b>"))
 				M.blur_eyes(10)
-				eyes.applyOrganDamage(1)
+				eyes.apply_organ_damage(1)
 			else
 				M.blur_eyes(20)
-				eyes.applyOrganDamage(5)
+				eyes.apply_organ_damage(5)
 				if(eyes.damage >= 10)
 					M.become_nearsighted(EYE_DAMAGE)
 				if(prob(eyes.damage - 10 + 1))
@@ -76,7 +76,7 @@ Bonus
 						if(!M.is_blind())
 							if(M.stat != DEAD)
 								to_chat(M, span_userdanger("You go blind!"))
-							eyes.applyOrganDamage(eyes.maxHealth)
+							eyes.apply_organ_damage(eyes.maxHealth)
 					else
 						M.visible_message(span_warning("[M]'s eyes fall out of their sockets!"), span_userdanger("Your eyes fall out of their sockets!"))
 						eyes.Remove(M)

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -925,7 +925,7 @@ GLOBAL_VAR_INIT(rpg_loot_items, FALSE)
 	if (!eyes)
 		return
 	M.adjust_blurriness(3)
-	eyes.applyOrganDamage(3)
+	eyes.apply_organ_damage(3)
 	if(eyes.damage >= 10)
 		M.adjust_blurriness(15)
 		if(M.stat != DEAD)

--- a/code/modules/antagonists/changeling/powers/headcrab.dm
+++ b/code/modules/antagonists/changeling/powers/headcrab.dm
@@ -33,7 +33,7 @@
 			to_chat(H, span_userdanger("You are blinded by a shower of blood!"))
 			H.Stun(20)
 			H.blur_eyes(20)
-			eyes?.applyOrganDamage(5)
+			eyes?.apply_organ_damage(5)
 			H.confused += 10
 		else if(issilicon(A))
 			var/mob/living/silicon/S = A

--- a/code/modules/clothing/glasses/_glasses.dm
+++ b/code/modules/clothing/glasses/_glasses.dm
@@ -71,7 +71,7 @@
 				H.flash_act(visual = 1)
 				H.adjust_blindness(3)
 				H.blur_eyes(5)
-				eyes.applyOrganDamage(5)
+				eyes.apply_organ_damage(5)
 
 /obj/item/clothing/glasses/meson
 	name = "optical meson scanner"

--- a/code/modules/food_and_drinks/kitchen_machinery/smartfridge.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/smartfridge.dm
@@ -727,7 +727,7 @@
 		var/obj/item/organ/O = organ
 		if(!istype(O))
 			return
-		O.applyOrganDamage(-repair_rate * delta_time)
+		O.apply_organ_damage(-repair_rate * delta_time)
 
 /obj/machinery/smartfridge/organ/Exited(atom/movable/gone, direction)
 	. = ..()

--- a/code/modules/holoparasite/abilities/major/healing.dm
+++ b/code/modules/holoparasite/abilities/major/healing.dm
@@ -160,7 +160,7 @@
 		target.restoreEars()
 		var/obj/item/organ/eyes/eyes = target.get_organ_slot(ORGAN_SLOT_EYES)
 		if(istype(eyes))
-			eyes.applyOrganDamage(-actual_heal_amt)
+			eyes.apply_organ_damage(-actual_heal_amt)
 		target.adjust_blindness(-actual_effect_heal_amt)
 		target.adjust_blurriness(-actual_effect_heal_amt)
 		target.adjust_disgust(-actual_effect_heal_amt)

--- a/code/modules/holoparasite/holoparasite_damage.dm
+++ b/code/modules/holoparasite/holoparasite_damage.dm
@@ -94,7 +94,7 @@
 		summoner.current.adjustCloneLoss(amount)
 		return
 	to_chat(summoner.current, span_dangerbold("You feel your mind strain as [color_name] takes damage!"))
-	brain.applyOrganDamage(amount, HOLOPARA_MAX_BRAIN_DAMAGE)
+	brain.apply_organ_damage(amount, HOLOPARA_MAX_BRAIN_DAMAGE)
 
 /**
  * A holoparasite does not sense through traditional methods, therefore it is immune to being flashed.

--- a/code/modules/holoparasite/holoparasite_holder.dm
+++ b/code/modules/holoparasite/holoparasite_holder.dm
@@ -207,11 +207,11 @@
 		if(!heart)
 			// damn you, heartless bastard!!
 			for(var/obj/item/organ/organ in new_body.internal_organs)
-				organ.applyOrganDamage(rand(20, 40), organ.maxHealth - 1)
+				organ.apply_organ_damage(rand(20, 40), organ.maxHealth - 1)
 		else
-			heart.applyOrganDamage(rand(20, 40), heart.maxHealth - 1)
+			heart.apply_organ_damage(rand(20, 40), heart.maxHealth - 1)
 	else
-		brain.applyOrganDamage(rand(20, 40), HOLOPARA_MAX_BRAIN_DAMAGE)
+		brain.apply_organ_damage(rand(20, 40), HOLOPARA_MAX_BRAIN_DAMAGE)
 	// straight to stamcrit with you!!
 	new_body.take_overall_damage(stamina = rand(new_body.maxHealth * 1.1, new_body.maxHealth * 1.5), updating_health = TRUE)
 	if(new_body.confused < 120)

--- a/code/modules/mob/living/carbon/alien/special/alien_embryo.dm
+++ b/code/modules/mob/living/carbon/alien/special/alien_embryo.dm
@@ -52,7 +52,7 @@
 /obj/item/organ/body_egg/alien_embryo/on_death()
 	. = ..()
 	if(!owner) // If we're out of the body, kill us and stop processing
-		applyOrganDamage(maxHealth)
+		apply_organ_damage(maxHealth)
 		STOP_PROCESSING(SSobj, src)
 
 /obj/item/organ/body_egg/alien_embryo/egg_process()

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -888,7 +888,7 @@ CREATION_TEST_IGNORE_SELF(/mob/living/carbon)
 			if(organ.organ_flags & ORGAN_SYNTHETIC)
 				continue
 
-			organ.applyOrganDamage(excess_healing * -1) //1 excess = 5 organ damage healed
+			organ.apply_organ_damage(excess_healing * -1) //1 excess = 5 organ damage healed
 
 	return ..()
 

--- a/code/modules/mob/living/carbon/carbon_defense.dm
+++ b/code/modules/mob/living/carbon/carbon_defense.dm
@@ -438,15 +438,15 @@
 		if (damage == 1)
 			to_chat(src, span_warning("Your eyes sting a little."))
 			if(prob(40))
-				eyes.applyOrganDamage(1)
+				eyes.apply_organ_damage(1)
 
 		else if (damage == 2)
 			to_chat(src, span_warning("Your eyes burn."))
-			eyes.applyOrganDamage(rand(2, 4))
+			eyes.apply_organ_damage(rand(2, 4))
 
 		else if( damage >= 3)
 			to_chat(src, span_warning("Your eyes itch and burn severely!"))
-			eyes.applyOrganDamage(rand(12, 16))
+			eyes.apply_organ_damage(rand(12, 16))
 
 		if(eyes.damage > 10)
 			adjust_blindness(damage)
@@ -461,7 +461,7 @@
 				else if(prob(eyes.damage - 25))
 					if(!is_blind())
 						to_chat(src, span_warning("You can't see anything!"))
-					eyes.applyOrganDamage(eyes.maxHealth)
+					eyes.apply_organ_damage(eyes.maxHealth)
 
 			else
 				to_chat(src, span_warning("Your eyes are really starting to hurt. This can't be good for you!"))

--- a/code/modules/mob/living/carbon/damage_procs.dm
+++ b/code/modules/mob/living/carbon/damage_procs.dm
@@ -138,7 +138,7 @@
 	if(O && !HAS_TRAIT(src, TRAIT_GODMODE))
 		if(required_status && O.status != required_status)
 			return FALSE
-		O.applyOrganDamage(amount, maximum)
+		O.apply_organ_damage(amount, maximum)
 
 /** setOrganLoss
   * inputs: slot (organ slot, like ORGAN_SLOT_HEART), amount(damage to be set to)

--- a/code/modules/mob/living/carbon/human/species_types/felinid.dm
+++ b/code/modules/mob/living/carbon/human/species_types/felinid.dm
@@ -63,7 +63,7 @@
 		if(prob(15))
 			if(locate(/obj/item/organ/stomach) in M.internal_organs)
 				var/obj/item/organ/stomach/cat_stomach = M.internal_organs_slot[ORGAN_SLOT_STOMACH]
-				cat_stomach.applyOrganDamage(15)
+				cat_stomach.apply_organ_damage(15)
 		return FALSE
 	return ..() //second part of this effect is handled elsewhere
 

--- a/code/modules/paperwork/paperplane.dm
+++ b/code/modules/paperwork/paperplane.dm
@@ -18,7 +18,7 @@
 	user.visible_message(span_suicide("[user] jams [src] in [user.p_their()] nose. It looks like [user.p_theyre()] trying to commit suicide!"))
 	user.adjust_blurriness(6)
 	if(eyes)
-		eyes.applyOrganDamage(rand(6,8))
+		eyes.apply_organ_damage(rand(6,8))
 	sleep(10)
 	return BRUTELOSS
 
@@ -71,6 +71,6 @@
 			return
 		visible_message(span_danger("\The [src] hits [H] in the eye!"))
 		H.adjust_blurriness(6)
-		eyes.applyOrganDamage(rand(6,8))
+		eyes.apply_organ_damage(rand(6,8))
 		H.Paralyze(40)
 		H.emote("scream")

--- a/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
@@ -50,7 +50,7 @@
 			affected_mob.client?.give_award(/datum/award/achievement/misc/drunk, affected_mob)
 		var/obj/item/organ/liver/liver = affected_mob.get_organ_slot(ORGAN_SLOT_LIVER)
 		if(istype(liver))
-			liver.applyOrganDamage(((max(sqrt(volume) * (boozepwr ** ALCOHOL_EXPONENT) * liver.alcohol_tolerance * delta_time, 0)) / 150))
+			liver.apply_organ_damage(((max(sqrt(volume) * (boozepwr ** ALCOHOL_EXPONENT) * liver.alcohol_tolerance * delta_time, 0)) / 150))
 
 /datum/reagent/consumable/ethanol/expose_obj(obj/exposed_obj, reac_volume)
 	. = ..()
@@ -230,7 +230,7 @@
 				affected_mob.adjustBruteLoss(15)
 		else
 			to_chat(affected_mob, span_userdanger("You scream in terror as you go blind!"))
-			eyes.applyOrganDamage(eyes.maxHealth)
+			eyes.apply_organ_damage(eyes.maxHealth)
 			affected_mob.emote("scream")
 
 	if(DT_PROB(1.5, delta_time))

--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -835,7 +835,7 @@
 	if(!eyes)
 		return
 
-	eyes.applyOrganDamage(-2 * REM * delta_time)
+	eyes.apply_organ_damage(-2 * REM * delta_time)
 	if(HAS_TRAIT_FROM(affected_mob, TRAIT_BLIND, EYE_DAMAGE))
 		if(DT_PROB(10, delta_time))
 			to_chat(affected_mob, span_warning("Your vision slowly returns..."))

--- a/code/modules/research/nanites/nanite_programs/protocol.dm
+++ b/code/modules/research/nanites/nanite_programs/protocol.dm
@@ -207,37 +207,37 @@
 		if(prob(10))
 			var/obj/item/organ/liver/liver = C.get_organ_slot(ORGAN_SLOT_LIVER)
 			if(liver)
-				liver.applyOrganDamage(0.6)
+				liver.apply_organ_damage(0.6)
 		current_stage++
 	if(nanites.nanite_volume > 750) //Extra volume spills out in other central organs
 		if(prob(10))
 			var/obj/item/organ/stomach/stomach = C.get_organ_slot(ORGAN_SLOT_STOMACH)
 			if(stomach)
-				stomach.applyOrganDamage(0.75)
+				stomach.apply_organ_damage(0.75)
 		if(prob(10))
 			var/obj/item/organ/lungs/lungs = C.get_organ_slot(ORGAN_SLOT_LUNGS)
 			if(lungs)
-				lungs.applyOrganDamage(0.75)
+				lungs.apply_organ_damage(0.75)
 		current_stage++
 	if(nanites.nanite_volume > 1000) //Extra volume spills out in more critical organs
 		if(prob(10))
 			var/obj/item/organ/heart/heart = C.get_organ_slot(ORGAN_SLOT_HEART)
 			if(heart)
-				heart.applyOrganDamage(0.75)
+				heart.apply_organ_damage(0.75)
 		if(prob(10))
 			var/obj/item/organ/brain/brain = C.get_organ_slot(ORGAN_SLOT_BRAIN)
 			if(brain)
-				brain.applyOrganDamage(0.75)
+				brain.apply_organ_damage(0.75)
 		current_stage++
 	if(nanites.nanite_volume > 1250) //Excess nanites start invading smaller organs for more space, including sensory organs
 		if(prob(13))
 			var/obj/item/organ/eyes/eyes = C.get_organ_slot(ORGAN_SLOT_EYES)
 			if(eyes)
-				eyes.applyOrganDamage(0.75)
+				eyes.apply_organ_damage(0.75)
 		if(prob(13))
 			var/obj/item/organ/ears/ears = C.get_organ_slot(ORGAN_SLOT_EARS)
 			if(ears)
-				ears.applyOrganDamage(0.75)
+				ears.apply_organ_damage(0.75)
 		current_stage++
 	if(nanites.nanite_volume > 1500) //Nanites start spilling into the bloodstream, causing toxicity
 		if(prob(15))

--- a/code/modules/surgery/advanced/lobotomy.dm
+++ b/code/modules/surgery/advanced/lobotomy.dm
@@ -88,7 +88,7 @@
 			span_notice("[user] successfully lobotomizes [target]!"),
 			span_notice("[user] completes the surgery on [target]'s brain."),
 		)
-		B.applyOrganDamage(80)
+		B.apply_organ_damage(80)
 		switch(rand(1,3))
 			if(1)
 				target.gain_trauma_type(BRAIN_TRAUMA_MILD, TRAUMA_RESILIENCE_MAGIC)

--- a/code/modules/surgery/organs/organ_internal.dm
+++ b/code/modules/surgery/organs/organ_internal.dm
@@ -191,7 +191,7 @@ INITIALIZE_IMMEDIATE(/obj/item/organ)
 /obj/item/organ/proc/on_death(delta_time, times_fired) //runs decay when outside of a person
 	if(organ_flags & (ORGAN_SYNTHETIC | ORGAN_FROZEN))
 		return
-	applyOrganDamage(decay_factor * maxHealth * delta_time)
+	apply_organ_damage(decay_factor * maxHealth * delta_time)
 
 /obj/item/organ/proc/on_life(delta_time, times_fired) //repair organ damage if the organ is not failing
 	SHOULD_CALL_PARENT(TRUE) //PASS YOUR ARGS FUCKER
@@ -203,7 +203,7 @@ INITIALIZE_IMMEDIATE(/obj/item/organ)
 	///Damage decrements again by a percent of its maxhealth, up to a total of 4 extra times depending on the owner's health
 	if(owner)
 		healing_amount += (owner.satiety > 0) ? (4 * healing_factor * owner.satiety / MAX_SATIETY) : 0
-	applyOrganDamage(-healing_amount * maxHealth * delta_time, damage) // pass current damage incase we are over cap
+	apply_organ_damage(-healing_amount * maxHealth * delta_time, damage) // pass current damage incase we are over cap
 
 /obj/item/organ/examine(mob/user)
 	. = ..()
@@ -259,7 +259,7 @@ INITIALIZE_IMMEDIATE(/obj/item/organ)
 	return //so we don't grant the organ's action to mobs who pick up the organ.
 
 ///Adjusts an organ's damage by the amount "d", up to a maximum amount, which is by default max damage
-/obj/item/organ/proc/applyOrganDamage(var/d, var/maximum = maxHealth)	//use for damaging effects
+/obj/item/organ/proc/apply_organ_damage(var/d, var/maximum = maxHealth)	//use for damaging effects
 	if(!d) //Micro-optimization.
 		return
 	if(maximum < damage)
@@ -272,7 +272,7 @@ INITIALIZE_IMMEDIATE(/obj/item/organ)
 
 ///SETS an organ's damage to the amount "d", and in doing so clears or sets the failing flag, good for when you have an effect that should fix an organ if broken
 /obj/item/organ/proc/set_organ_damage(var/d)	//use mostly for admin heals
-	applyOrganDamage(d - damage)
+	apply_organ_damage(d - damage)
 
 /** check_damage_thresholds
   * input: M (a mob, the owner of the organ we call the proc on)

--- a/code/modules/unit_tests/full_heal.dm
+++ b/code/modules/unit_tests/full_heal.dm
@@ -5,7 +5,7 @@
 	var/mob/living/carbon/human/dummy = allocate(/mob/living/carbon/human/consistent)
 
 	for(var/obj/item/organ/organ in dummy.internal_organs)
-		organ.applyOrganDamage(50)
+		organ.apply_organ_damage(50)
 
 	dummy.fully_heal(HEAL_ORGANS)
 


### PR DESCRIPTION
## About The Pull Request

Renames the proc `applyOrganDamage()` to `apply_organ_damage()`

## Why It's Good For The Game

Camelcase is icky, especially for proc names. 🤢 

Also, this is gonna make tg ports just that bit easier

## Testing Photographs and Procedure

<img width="1488" height="961" alt="image" src="https://github.com/user-attachments/assets/115e82ca-d9f4-46b0-96d6-46ff2cec6d32" />

It compiles, not much to say

## Changelog
:cl:
code: Renamed the applyOrganDamage() proc to apply_organ_damage()
/:cl:
