### PR TITLE
More OOC data

### DIFF
--- a/code/__HELPERS/roundend.dm
+++ b/code/__HELPERS/roundend.dm
@@ -815,9 +815,10 @@ GLOBAL_VAR(survivor_report) //! Contains shared survivor report for roundend rep
 	discordmsg += "Server: [CONFIG_GET(string/servername)]\n"
 	discordmsg += "Round Number: [GLOB.round_id]\n"
 	discordmsg += "Duration: [DisplayTimeText(world.time - SSticker.round_start_time)]\n"
-	discordmsg += "Players: [GLOB.player_list.len]\n"
+	discordmsg += "Players: [GLOB.player_list.len] (Total: [GLOB.connected_ckeys.len])\n"
 	discordmsg += "Survivors: [survivors]\n"
 	discordmsg += "Escapees: [escapees]\n"
+	discordmsg += "Total Crew: [GLOB.joined_player_list.len] (Roundstart: [SSjob.initial_players_to_assign])\n"
 	discordmsg += "Integrity: [integrity]\n"
 
 	// Roundstart

--- a/code/__HELPERS/roundend.dm
+++ b/code/__HELPERS/roundend.dm
@@ -815,7 +815,7 @@ GLOBAL_VAR(survivor_report) //! Contains shared survivor report for roundend rep
 	discordmsg += "Server: [CONFIG_GET(string/servername)]\n"
 	discordmsg += "Round Number: [GLOB.round_id]\n"
 	discordmsg += "Duration: [DisplayTimeText(world.time - SSticker.round_start_time)]\n"
-	discordmsg += "Players: [GLOB.player_list.len] (Total: [GLOB.total_connected_ckeys.len])\n"
+	discordmsg += "Players: [GLOB.player_list.len] (Total: [GLOB.unique_connected_keys.len])\n"
 	discordmsg += "Survivors: [survivors]\n"
 	discordmsg += "Escapees: [escapees]\n"
 	discordmsg += "Total Crew: [GLOB.joined_player_list.len] (Roundstart: [SSjob.initial_players_to_assign])\n"

--- a/code/__HELPERS/roundend.dm
+++ b/code/__HELPERS/roundend.dm
@@ -815,7 +815,7 @@ GLOBAL_VAR(survivor_report) //! Contains shared survivor report for roundend rep
 	discordmsg += "Server: [CONFIG_GET(string/servername)]\n"
 	discordmsg += "Round Number: [GLOB.round_id]\n"
 	discordmsg += "Duration: [DisplayTimeText(world.time - SSticker.round_start_time)]\n"
-	discordmsg += "Players: [GLOB.player_list.len] (Total: [GLOB.connected_ckeys.len])\n"
+	discordmsg += "Players: [GLOB.player_list.len] (Total: [GLOB.total_connected_ckeys.len])\n"
 	discordmsg += "Survivors: [survivors]\n"
 	discordmsg += "Escapees: [escapees]\n"
 	discordmsg += "Total Crew: [GLOB.joined_player_list.len] (Roundstart: [SSjob.initial_players_to_assign])\n"

--- a/code/_globalvars/lists/mobs.dm
+++ b/code/_globalvars/lists/mobs.dm
@@ -19,6 +19,7 @@ GLOBAL_LIST_INIT(dangerous_turfs, typecacheof(list(
 //Since it didn't really belong in any other category, I'm putting this here
 //This is for procs to replace all the goddamn 'in world's that are chilling around the code
 
+GLOBAL_LIST_EMPTY(connected_ckeys)			//All connected ckeys
 GLOBAL_LIST_EMPTY(player_list)				//all mobs **with clients attached**.
 GLOBAL_LIST_EMPTY(mob_list)					//all mobs, including clientless
 GLOBAL_LIST_EMPTY(mob_directory)			//mob_id -> mob

--- a/code/_globalvars/lists/mobs.dm
+++ b/code/_globalvars/lists/mobs.dm
@@ -19,7 +19,7 @@ GLOBAL_LIST_INIT(dangerous_turfs, typecacheof(list(
 //Since it didn't really belong in any other category, I'm putting this here
 //This is for procs to replace all the goddamn 'in world's that are chilling around the code
 
-GLOBAL_LIST_EMPTY(connected_ckeys)			//All connected ckeys
+GLOBAL_LIST_EMPTY(total_connected_ckeys)	//All ckeys that have connected at any point in the game
 GLOBAL_LIST_EMPTY(player_list)				//all mobs **with clients attached**.
 GLOBAL_LIST_EMPTY(mob_list)					//all mobs, including clientless
 GLOBAL_LIST_EMPTY(mob_directory)			//mob_id -> mob

--- a/code/_globalvars/lists/mobs.dm
+++ b/code/_globalvars/lists/mobs.dm
@@ -19,7 +19,6 @@ GLOBAL_LIST_INIT(dangerous_turfs, typecacheof(list(
 //Since it didn't really belong in any other category, I'm putting this here
 //This is for procs to replace all the goddamn 'in world's that are chilling around the code
 
-GLOBAL_LIST_EMPTY(total_connected_ckeys)	//All ckeys that have connected at any point in the game
 GLOBAL_LIST_EMPTY(player_list)				//all mobs **with clients attached**.
 GLOBAL_LIST_EMPTY(mob_list)					//all mobs, including clientless
 GLOBAL_LIST_EMPTY(mob_directory)			//mob_id -> mob
@@ -44,6 +43,7 @@ GLOBAL_LIST_EMPTY(all_mimites)				//all mimites and their subtypes
 GLOBAL_LIST_EMPTY(bots_list)
 GLOBAL_LIST_EMPTY(ai_eyes)
 GLOBAL_LIST_EMPTY(suit_sensors_list) 		//all people with suit sensors on
+GLOBAL_LIST_EMPTY(unique_connected_keys)	//All ckeys that have connected at any point in the game
 
 GLOBAL_LIST_EMPTY(language_datum_instances)
 GLOBAL_LIST_EMPTY(all_languages)

--- a/code/modules/client/login/client_login.dm
+++ b/code/modules/client/login/client_login.dm
@@ -114,6 +114,7 @@
 	if(first_run)
 		GLOB.clients_unsafe += src
 	GLOB.directory[ckey] = src
+	GLOB.connected_ckeys |= ckey
 	if(authenticated)
 		GLOB.clients += src
 

--- a/code/modules/client/login/client_login.dm
+++ b/code/modules/client/login/client_login.dm
@@ -114,7 +114,7 @@
 	if(first_run)
 		GLOB.clients_unsafe += src
 	GLOB.directory[ckey] = src
-	GLOB.connected_ckeys |= ckey
+	GLOB.total_connected_ckeys |= ckey
 	if(authenticated)
 		GLOB.clients += src
 

--- a/code/modules/client/login/client_login.dm
+++ b/code/modules/client/login/client_login.dm
@@ -114,7 +114,7 @@
 	if(first_run)
 		GLOB.clients_unsafe += src
 	GLOB.directory[ckey] = src
-	GLOB.total_connected_ckeys |= ckey
+	GLOB.unique_connected_keys |= ckey
 	if(authenticated)
 		GLOB.clients += src
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Includes more information in the #OOC readout.

- Total number of players who joined, including players who joined roundstart.
- Total number of clients who connected throughout the round.

## Why It's Good For The Game

A little bit more information makes it useful to see which direction the rounds are trending. This information is very useful for when inspecting how dynamic rounds have been going, and it provides a little bit more context at a glance for past rounds.

## Testing Photographs and Procedure

![Screenshot_20250831_181706_Discord.jpg](https://github.com/user-attachments/assets/26f91142-adc8-4fd4-bd97-2ad98e3e2d66)



## Changelog
:cl:
tweak: Includes players who joined, players who joined roundstart, and total client connections in the #ooc information of a round
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
