### PR TITLE
Lethals box fix

### DIFF
--- a/code/game/objects/items/storage/boxes.dm
+++ b/code/game/objects/items/storage/boxes.dm
@@ -923,6 +923,7 @@
 /obj/item/storage/box/lethalshot
 	name = "box of lethal shotgun shots"
 	desc = "A standard box full of lethal shots, designed for riot shotguns."
+	icon_state = "lethalshot_box"
 	illustration = null
 
 /obj/item/storage/box/lethalshot/PopulateContents()

--- a/code/modules/projectiles/ammunition/ballistic/shotgun.dm
+++ b/code/modules/projectiles/ammunition/ballistic/shotgun.dm
@@ -11,7 +11,7 @@
 
 /obj/item/ammo_casing/shotgun/beanbag
 	name = "beanbag slug"
-	desc = "A gold-tipped beanbag slug for riot control."
+	desc = "A less-lethal beanbag slug for riot control."
 	icon_state = "bshell"
 	high_power = FALSE
 	custom_materials = list(/datum/material/iron=4000, /datum/material/copper=2000)
@@ -70,7 +70,7 @@
 
 /obj/item/ammo_casing/shotgun/rubbershot
 	name = "rubber shot"
-	desc = "A bronze-tipped shotgun casing filled with densely-packed rubber balls, used to incapacitate crowds from a distance."
+	desc = "A gold-tipped shotgun casing filled with densely-packed rubber balls, used to incapacitate crowds from a distance."
 	icon_state = "bshell"
 	high_power = FALSE
 	projectile_type = /obj/projectile/bullet/pellet/shotgun_rubbershot


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes the lethals ammo box to use @Bieyes beautiful new art and not the plain box art.
Also changed the description of some shells to better reflect the material that is used in their creation.

## Why It's Good For The Game

Good art good, good readability of box type good

## Testing Photographs and Procedure


<img width="389" height="374" alt="image" src="https://github.com/user-attachments/assets/2e682395-a9c1-44ac-8594-68ba955a2994" />


## Changelog
:cl:
fix: Fixes the lethals ammo box to use @Bieyes beautiful new art and not the plain box art.
/:cl:
