### PR TITLE
Changeling Improvements and Soft-Rework (Drain)

### DIFF
--- a/code/datums/status_effects/buffs.dm
+++ b/code/datums/status_effects/buffs.dm
@@ -369,7 +369,6 @@
 
 /datum/status_effect/changeling
 	var/datum/antagonist/changeling/ling
-	var/chem_per_tick = 1
 
 /datum/status_effect/changeling/on_apply()
 	ling = IS_CHANGELING(owner)
@@ -378,10 +377,9 @@
 	return TRUE
 
 /datum/status_effect/changeling/tick()
-	if(ling.chem_charges < chem_per_tick)
+	if(ling.chem_charges <= 0)
 		qdel(src)
 		return FALSE
-	ling.chem_charges -= chem_per_tick
 	return TRUE
 
 //Changeling invisibility
@@ -427,7 +425,6 @@
 	id = "changelingmindshield"
 	alert_type = /atom/movable/screen/alert/status_effect/changeling_mindshield
 	tick_interval = 5 SECONDS
-	chem_per_tick = 1
 
 /datum/status_effect/changeling/mindshield/tick()
 	if(..() && owner.on_fire)

--- a/code/game/objects/items/devices/scanners/health_analyzer.dm
+++ b/code/game/objects/items/devices/scanners/health_analyzer.dm
@@ -118,13 +118,14 @@
 		if(advanced)
 			if(HAS_TRAIT_FROM(target, TRAIT_HUSK, BURN))
 				render_list += "<span class='alert ml-1'>Subject has been husked by severe burns.</span>\n"
-			else if (HAS_TRAIT_FROM(target, TRAIT_HUSK, CHANGELING_DRAIN))
-				render_list += "<span class='alert ml-1'>Subject has been husked by dessication.</span>\n"
 			else
 				render_list += "<span class='alert ml-1'>Subject has been husked by mysterious causes.</span>\n"
-
 		else
 			render_list += "<span class='alert ml-1'>Subject has been husked.</span>\n"
+
+	// Changeling Drain detection
+	if(HAS_TRAIT(target, CHANGELING_DRAIN))
+		render_list += "<span class='alert ml-1'>Subject has been drained by a foreign life form.</span>\n"
 
 	if(target.getStaminaLoss())
 		if(advanced)

--- a/code/modules/antagonists/changeling/cellular_emporium.dm
+++ b/code/modules/antagonists/changeling/cellular_emporium.dm
@@ -53,8 +53,6 @@
 		ability_data["dna_cost"] = dna_cost
 
 		var/can_purchase = TRUE
-		if(initial(ability_path.req_dna) > changeling.absorbed_count)
-			can_purchase = FALSE
 		if(dna_cost > genetic_points_remaining)
 			can_purchase = FALSE
 

--- a/code/modules/antagonists/changeling/cellular_emporium.dm
+++ b/code/modules/antagonists/changeling/cellular_emporium.dm
@@ -31,10 +31,10 @@
 /datum/cellular_emporium/ui_data(mob/user)
 	var/list/data = list()
 
-	data["can_readapt"] = changeling.can_respec
-
 	var/genetic_points_remaining = changeling.genetic_points
 	data["genetic_points_remaining"] = genetic_points_remaining
+
+	data["can_readapt"] = (genetic_points_remaining >= 4)
 
 	var/list/abilities = list()
 	for(var/datum/action/changeling/ability_path as anything in changeling.all_powers)
@@ -72,8 +72,7 @@
 
 	switch(action)
 		if("readapt")
-			if(changeling.can_respec)
-				changeling.readapt()
+			if(changeling.readapt())
 				. = TRUE
 		if("evolve")
 			var/sting_path = text2path(params["path"])

--- a/code/modules/antagonists/changeling/changeling.dm
+++ b/code/modules/antagonists/changeling/changeling.dm
@@ -404,6 +404,10 @@
 		if(verbose)
 			to_chat(user, span_warning("[target]'s DNA is ruined beyond usability!"))
 		return FALSE
+	if(HAS_TRAIT(target, CHANGELING_DRAIN))
+		if(verbose)
+			to_chat(user, span_warning("[target] has already been drained..."))
+		return FALSE
 	if(HAS_TRAIT(target, TRAIT_HUSK))
 		if(verbose)
 			to_chat(user, span_warning("[target]'s body is ruined beyond usability!"))

--- a/code/modules/antagonists/changeling/changeling.dm
+++ b/code/modules/antagonists/changeling/changeling.dm
@@ -32,7 +32,7 @@
 	/// The max chemical storage the changeling currently has.
 	var/total_chem_storage = 35
 	/// The chemical recharge rate per life tick.
-	var/chem_recharge_rate = 0.5
+	var/chem_recharge_rate = 0.3
 	/// Any additional modifiers triggered by changelings that modify the chem_recharge_rate.
 	var/chem_recharge_slowdown = 0
 	/// The range this ling can sting things.

--- a/code/modules/antagonists/changeling/changeling.dm
+++ b/code/modules/antagonists/changeling/changeling.dm
@@ -30,7 +30,7 @@
 	/// The number of chemicals the changeling currently has.
 	var/chem_charges = 20
 	/// The max chemical storage the changeling currently has.
-	var/total_chem_storage = 75
+	var/total_chem_storage = 35
 	/// The chemical recharge rate per life tick.
 	var/chem_recharge_rate = 0.5
 	/// Any additional modifiers triggered by changelings that modify the chem_recharge_rate.
@@ -40,9 +40,9 @@
 	/// Changeling name, what other lings see over the hivemind when talking.
 	var/changelingID = "Changeling"
 	/// The number of genetics points (to buy powers) this ling currently has.
-	var/genetic_points = 10
+	var/genetic_points = 2
 	/// The max number of genetics points (to buy powers) this ling can have..
-	var/total_genetic_points = 10
+	var/total_genetic_points = 100
 	/// List of all powers we start with.
 	var/list/innate_powers = list()
 	/// Associated list of all powers we have evolved / bought from the emporium. [path] = [instance of path]
@@ -50,8 +50,6 @@
 
 	/// The voice we're mimicing via the changeling voice ability.
 	var/mimicing = ""
-	/// Whether we can currently respec in the cellular emporium.
-	var/can_respec = FALSE
 
 	/// The currently active changeling sting.
 	var/datum/action/changeling/sting/chosen_sting
@@ -355,10 +353,10 @@
 		to_chat(owner.current, span_warning("We are too busy reforming ourselves to readapt right now!"))
 		return
 
-	if(can_respec)
-		to_chat(owner.current, span_notice("We have removed our evolutions from this form, and are now ready to readapt."))
+	if(genetic_points >= 4)
+		to_chat(owner.current, span_notice("We have removed our evolutions from this form for 1 genetic point."))
 		remove_changeling_powers()
-		can_respec = FALSE
+		genetic_points -= 1
 		SSblackbox.record_feedback("tally", "changeling_power_purchase", 1, "Readapt")
 		log_game("Genetic powers refunded by [owner.current.ckey]/[owner.current.name] the [owner.current.job], [genetic_points] GP remaining.")
 		return TRUE

--- a/code/modules/antagonists/changeling/changeling.dm
+++ b/code/modules/antagonists/changeling/changeling.dm
@@ -392,10 +392,6 @@
 		if(verbose)
 			to_chat(user, span_warning("[target] is not compatible with our biology."))
 		return FALSE
-	if(has_profile_with_dna(target.dna))
-		if(verbose)
-			to_chat(user, span_warning("We already have this DNA in storage!"))
-		return FALSE
 	if(HAS_TRAIT(target, TRAIT_NO_DNA_COPY))
 		if(verbose)
 			to_chat(user, span_warning("[target] is not compatible with our biology."))

--- a/code/modules/antagonists/changeling/changeling.dm
+++ b/code/modules/antagonists/changeling/changeling.dm
@@ -315,11 +315,7 @@
 		return FALSE
 
 	if(genetic_points < initial(sting_path.dna_cost))
-		to_chat(owner.current, span_warning("We have reached our capacity for abilities!"))
-		return FALSE
-
-	if(absorbed_count < initial(sting_path.req_dna))
-		to_chat(owner.current, span_warning("We lack the DNA to evolve this ability!"))
+		to_chat(owner.current, span_warning("We require [initial(sting_path.dna_cost)] genetic point\s to evolve this ability!"))
 		return FALSE
 
 	if(initial(sting_path.dna_cost) < 0)

--- a/code/modules/antagonists/changeling/changeling_power.dm
+++ b/code/modules/antagonists/changeling/changeling_power.dm
@@ -14,6 +14,7 @@
 	var/dna_cost = -1 //cost of the sting in dna points. 0 = auto-purchase (see changeling.dm), -1 = cannot be purchased
 	var/points_to_use = 0  //amount of genetic points needed to use this ability
 	var/req_human = 0 //if you need to be human to use this ability
+	var/recharge_slowdown = 0 // Chemical upkeep of ability in use
 	var/limb_sacrifice = FALSE // Sacrifices a limb and turns it into something else, can only be cast if ling has a limb obviously
 	var/ignores_fakedeath = FALSE // usable with the FAKEDEATH flag
 
@@ -68,7 +69,14 @@ the same goes for Remove(). if you override Remove(), call parent or else your p
 	// If the spell requires genetic points, deducts them here, check itself is done in ling_can_cast
 	if(points_to_use)
 		changeling.genetic_points -= points_to_use
+	if(recharge_slowdown)
+		changeling.chem_recharge_slowdown += recharge_slowdown
 	return FALSE
+
+/datum/action/changeling/proc/subtract_slowdown(mob/living/user)
+	if(recharge_slowdown)	// Just to be sure!
+		var/datum/antagonist/changeling/changeling = IS_CHANGELING(user)
+		changeling.chem_recharge_slowdown -= recharge_slowdown
 
 /datum/action/changeling/proc/sting_feedback(mob/living/user, mob/living/target)
 	return FALSE

--- a/code/modules/antagonists/changeling/changeling_power.dm
+++ b/code/modules/antagonists/changeling/changeling_power.dm
@@ -35,7 +35,7 @@ the same goes for Remove(). if you override Remove(), call parent or else your p
 	try_to_sting(user)
 
 /datum/action/changeling/proc/try_to_sting(mob/living/user, mob/living/target)
-	if(!can_sting(user, target))
+	if(!ling_can_cast(user, target))
 		return
 	var/datum/antagonist/changeling/changeling = user.mind.has_antag_datum(/datum/antagonist/changeling)
 	if(sting_action(user, target))
@@ -50,7 +50,7 @@ the same goes for Remove(). if you override Remove(), call parent or else your p
 	return FALSE
 
 //Fairly important to remember to return 1 on success >.<
-/datum/action/changeling/proc/can_sting(mob/living/user, mob/living/target)
+/datum/action/changeling/proc/ling_can_cast(mob/living/user, mob/living/target)
 	if (!is_available(user))
 		return FALSE
 	if(!ishuman(user) && !ismonkey(user)) //typecast everything from mob to carbon from this point onwards

--- a/code/modules/antagonists/changeling/changeling_power.dm
+++ b/code/modules/antagonists/changeling/changeling_power.dm
@@ -24,6 +24,15 @@ if you override it, MAKE SURE you call parent or it will not be usable
 the same goes for Remove(). if you override Remove(), call parent or else your power wont be removed on respec
 */
 
+/datum/action/changeling/New(master)
+	..()
+	if(recharge_slowdown)
+		helptext += "Maintaining consumes [recharge_slowdown] chemicals per second."
+	if(points_to_use)
+		helptext += "Requires [points_to_use] genetic point\s to activate."
+	if(req_human)
+		helptext += "Cannot be used in lesser form."
+
 /datum/action/changeling/proc/on_purchase(mob/user, is_respec)
 	if(!is_respec)
 		SSblackbox.record_feedback("tally", "changeling_power_purchase", 1, name)

--- a/code/modules/antagonists/changeling/changeling_power.dm
+++ b/code/modules/antagonists/changeling/changeling_power.dm
@@ -13,8 +13,8 @@
 	var/chemical_cost = 0 // negative chemical cost is for passive abilities (chemical glands)
 	var/dna_cost = -1 //cost of the sting in dna points. 0 = auto-purchase (see changeling.dm), -1 = cannot be purchased
 	var/points_to_use = 0  //amount of genetic points needed to use this ability
-	var/req_human = 0 //if you need to be human to use this ability
 	var/recharge_slowdown = 0 // Chemical upkeep of ability in use
+	var/req_human = FALSE //if you need to be human to use this ability
 	var/limb_sacrifice = FALSE // Sacrifices a limb and turns it into something else, can only be cast if ling has a limb obviously
 	var/ignores_fakedeath = FALSE // usable with the FAKEDEATH flag
 

--- a/code/modules/antagonists/changeling/changeling_power.dm
+++ b/code/modules/antagonists/changeling/changeling_power.dm
@@ -12,9 +12,8 @@
 	var/helptext = "" // Details
 	var/chemical_cost = 0 // negative chemical cost is for passive abilities (chemical glands)
 	var/dna_cost = -1 //cost of the sting in dna points. 0 = auto-purchase (see changeling.dm), -1 = cannot be purchased
-	var/req_dna = 0  //amount of dna needed to use this ability. Changelings always have atleast 1
+	var/points_to_use = 0  //amount of genetic points needed to use this ability
 	var/req_human = 0 //if you need to be human to use this ability
-	var/req_absorbs = 0 //similar to req_dna, but only gained from absorbing, not DNA sting
 	var/ignores_fakedeath = FALSE // usable with the FAKEDEATH flag
 
 /*
@@ -63,8 +62,9 @@ the same goes for Remove(). if you override Remove(), call parent or else your p
 	if(c.chem_charges < chemical_cost)
 		to_chat(user, span_warning("We require at least [chemical_cost] unit\s of chemicals to do that!"))
 		return FALSE
-	if(c.absorbed_count < req_dna)
-		to_chat(user, span_warning("We require at least [req_dna] sample\s of compatible DNA."))
+	if(c.genetic_points < points_to_use)
+		user.balloon_alert(user, "Insuficient Genetic Points!", "#ffffff") // maybe change colour
+		to_chat(user, span_warning("We require at least [points_to_use] genetic point\s."))
 		return FALSE
 	if((HAS_TRAIT(user, TRAIT_DEATHCOMA)) && (!ignores_fakedeath))
 		to_chat(user, span_warning("We are incapacitated."))

--- a/code/modules/antagonists/changeling/powers/absorb.dm
+++ b/code/modules/antagonists/changeling/powers/absorb.dm
@@ -65,25 +65,26 @@
 	if(target.mind)
 		changeling.genetic_points += 1
 		changeling.total_chem_storage += 10
-		to_chat(owner, span_notice("We have drained [target] and gained 1 genetic point <span class='cfc_cyan'>Total</span>: <span class='cfc_green'>[changeling.genetic_points]</span>."))
+		to_chat(owner, span_notice("We have drained [target] and gained 1 genetic point. <span class='cfc_cyan'>Total</span>: <span class='cfc_green'>[changeling.genetic_points]</span>."))
 	else
-		if(total_chem_storage >= 50)
+		if(changeling.total_chem_storage >= 50)
 			to_chat(owner, span_notice("Absent-minded targets no longer sustain us... <span class='cfc_cyan'>Total</span>: <span class='cfc_green'>[changeling.genetic_points]</span>."))
 		else
 			changeling.genetic_points += 0.5
 			changeling.total_chem_storage += 5
-			to_chat(owner, span_notice("We have drained [target] and gained half a genetic point. Absent-minded targets are less... nutricious... <span class='cfc_cyan'>Total</span>: <span class='cfc_green'>[changeling.genetic_points]</span>."))
+			to_chat(owner, span_notice("We have drained [target] and gained 0.5 genetic point\s. Absent-minded targets are less... nutritious... <span class='cfc_cyan'>Total</span>: <span class='cfc_green'>[changeling.genetic_points]</span>."))
 
 	SSblackbox.record_feedback("nested tally", "changeling_powers", 1, list("Absorb DNA", "4"))
 	owner.visible_message(span_danger("[target] was drained!"))
 	to_chat(target, span_userdanger("You are drained by the changeling!"))
 
 	playsound(owner, 'sound/items/drink.ogg', 35, TRUE)
-	playsound(user, 'sound/effects/blobattack.ogg', 50)
-	playsound(user, 'sound/effects/splat.ogg', 50, TRUE)
+	playsound(owner, 'sound/effects/blobattack.ogg', 50)
+	playsound(owner, 'sound/effects/splat.ogg', 50, TRUE)
 	return TRUE
 
 /datum/action/changeling/absorbDNA/proc/absorb_ling_power(mob/living/carbon/human/target)
+	var/datum/antagonist/changeling/changeling = IS_CHANGELING(owner)
 	var/datum/antagonist/changeling/target_ling = IS_CHANGELING(target)
 	if(target_ling)//If the target was a changeling, suck out their extra juice and objective points!
 		to_chat(owner, span_boldnotice("[target] was one of us. We have absorbed their power."))
@@ -120,7 +121,7 @@
 				owner.visible_message(span_danger("[owner] stabs [target] with the proboscis!"), span_notice("We stab [target] with the proboscis."))
 				to_chat(target, span_userdanger("You feel a sharp stabbing pain!"))
 				playsound(owner, 'sound/creatures/venus_trap_hit.ogg', 40)
-				playsound(get_turf(C), 'sound/weapons/slice.ogg', 50, 1)
+				playsound(target, 'sound/weapons/slice.ogg', 50)
 				target.take_overall_damage(40)
 
 		SSblackbox.record_feedback("nested tally", "changeling_powers", 1, list("Absorb DNA", "[absorbing_iteration]"))

--- a/code/modules/antagonists/changeling/powers/absorb.dm
+++ b/code/modules/antagonists/changeling/powers/absorb.dm
@@ -24,7 +24,7 @@
 	var/datum/antagonist/changeling/changeling = IS_CHANGELING(owner)
 	return changeling.can_absorb_dna(target)
 
-/datum/action/changeling/absorbDNA/sting_action(mob/owner)
+/datum/action/changeling/absorbDNA/sting_action(mob/living/carbon/owner)
 	SHOULD_CALL_PARENT(FALSE)
 
 	var/datum/antagonist/changeling/changeling = IS_CHANGELING(owner)
@@ -51,7 +51,7 @@
 	if(target.stat != DEAD)
 		target.investigate_log("has died from being changeling absorbed.", INVESTIGATE_DEATHS)
 
-	switch(total_chem_storage)
+	switch(changeling.total_chem_storage)
 		if(35 to 45)
 			target.soft_drain()
 		if(46 to 70)	// Third drain on a normal person will cause this.
@@ -61,7 +61,7 @@
 
 	// Changeling gains chems, 50 more than cap.
 	changeling.adjust_chemicals(100, changeling.total_chem_storage + 50)
-	changeling.blood_volume += 300	// We drain blood because its cool and useful!
+	owner.blood_volume += 300	// We drain blood because its cool and useful!
 	if(target.mind)
 		changeling.genetic_points += 1
 		changeling.total_chem_storage += 10

--- a/code/modules/antagonists/changeling/powers/absorb.dm
+++ b/code/modules/antagonists/changeling/powers/absorb.dm
@@ -44,7 +44,7 @@
 	owner.copy_languages(target, LANGUAGE_ABSORB)
 
 	if(target.mind && owner.mind)//if the victim and owner have minds
-		absorb_memories(target)
+		absorb_ling_power(target)
 
 	is_absorbing = FALSE
 
@@ -80,63 +80,7 @@
 	playsound(owner, 'sound/surgery/organ2.ogg', 50)
 	return TRUE
 
-/datum/action/changeling/absorbDNA/proc/absorb_memories(mob/living/carbon/human/target)
-	var/datum/mind/suckedbrain = target.mind
-	owner.mind.memory += "<BR><b>We've absorbed [target]'s memories into our own...</b><BR>[suckedbrain.memory]<BR>"
-	for(var/A in suckedbrain.antag_datums)
-		var/datum/antagonist/antag_types = A
-		var/list/all_objectives = antag_types.objectives.Copy()
-		if(antag_types.antag_memory)
-			owner.mind.memory += "[antag_types.antag_memory]<BR>"
-		if(LAZYLEN(all_objectives))
-			owner.mind.memory += "<B>Objectives:</B>"
-			var/obj_count = 1
-			for(var/O in all_objectives)
-				var/datum/objective/objective = O
-				owner.mind.memory += "<br><B>Objective #[obj_count++]</B>: [objective.explanation_text]"
-				var/list/datum/mind/other_owners = objective.get_owners() - suckedbrain
-				if(other_owners.len)
-					owner.mind.memory += "<ul>"
-					for(var/mind in other_owners)
-						var/datum/mind/M = mind
-						owner.mind.memory += "<li>Conspirator: [M.name]</li>"
-					owner.mind.memory += "</ul>"
-	owner.mind.memory += "<b>That's all [target] had.</b><BR>"
-	owner.memory() //I can read your mind, kekeke. Output all their notes.
-
-	//Some of target's recent speech, so the changeling can attempt to imitate them better.
-	//Recent as opposed to all because rounds tend to have a LOT of text.
-
-	var/list/recent_speech = list()
-	var/list/say_log = list()
-	var/log_source = target.logging
-	for(var/log_type in log_source)
-		var/nlog_type = text2num(log_type)
-		if(nlog_type & LOG_SAY)
-			var/list/reversed = log_source[log_type]
-			if(islist(reversed))
-				say_log = reverse_range(reversed.Copy())
-				break
-
-	if(LAZYLEN(say_log) > LING_ABSORB_RECENT_SPEECH)
-		recent_speech = say_log.Copy(say_log.len-LING_ABSORB_RECENT_SPEECH+1,0) //0 so len-LING_ARS+1 to end of list
-	else
-		for(var/spoken_memory in say_log)
-			if(recent_speech.len >= LING_ABSORB_RECENT_SPEECH)
-				break
-			recent_speech[spoken_memory] = say_log[spoken_memory]
-
-	var/datum/antagonist/changeling/changeling = IS_CHANGELING(owner)
-	if(recent_speech.len && changeling)
-		changeling.antag_memory += "<B>Some of [target]'s speech patterns, we should study these to better impersonate [target.p_them()]!</B><br>"
-		to_chat(owner, span_boldnotice("Some of [target]'s speech patterns, we should study these to better impersonate [target.p_them()]!"))
-		for(var/spoken_memory in recent_speech)
-			changeling.antag_memory += "\"[recent_speech[spoken_memory]]\"<br>"
-			to_chat(owner, span_notice("\"[recent_speech[spoken_memory]]\""))
-		changeling.antag_memory += "<B>We have no more knowledge of [target]'s speech patterns.</B><br>"
-		to_chat(owner, span_boldnotice("We have no more knowledge of [target]'s speech patterns."))
-
-
+/datum/action/changeling/absorbDNA/proc/absorb_ling_power(mob/living/carbon/human/target)
 	var/datum/antagonist/changeling/target_ling = IS_CHANGELING(target)
 	if(target_ling)//If the target was a changeling, suck out their extra juice and objective points!
 		to_chat(owner, span_boldnotice("[target] was one of us. We have absorbed their power."))

--- a/code/modules/antagonists/changeling/powers/absorb.dm
+++ b/code/modules/antagonists/changeling/powers/absorb.dm
@@ -8,7 +8,7 @@
 	///if we're currently absorbing, used for sanity
 	var/is_absorbing = FALSE
 
-/datum/action/changeling/absorbDNA/can_sting(mob/living/carbon/user)
+/datum/action/changeling/absorbDNA/ling_can_cast(mob/living/carbon/user)
 	if(!..())
 		return
 

--- a/code/modules/antagonists/changeling/powers/absorb.dm
+++ b/code/modules/antagonists/changeling/powers/absorb.dm
@@ -34,20 +34,6 @@
 	if(!attempt_absorb(target))
 		return
 
-	changeling.adjust_chemicals(10)
-	changeling.total_chem_storage += 5
-	if(target.mind)
-		changeling.genetic_points += 1
-		to_chat(owner, span_notice("We have drained [target] and gained 1 genetic point <span class='cfc_cyan'>Total</span>: <span class='cfc_green'>[changeling.genetic_points]</span>."))
-	else
-		changeling.genetic_points += 0.5
-		to_chat(owner, span_notice("We have drained [target] and gained half genetic point. Absent-minded targets are less... nutricious... <span class='cfc_cyan'>Total</span>: <span class='cfc_green'>[changeling.genetic_points]</span>."))
-
-	SSblackbox.record_feedback("nested tally", "changeling_powers", 1, list("Absorb DNA", "4"))
-	owner.balloon_alert_to_viewers("<font color='#ff0040'>SLURP!</font>")
-	owner.visible_message(span_danger("[target] was drained!"))
-	to_chat(target, span_userdanger("You are drained by the changeling!"))
-
 	if(!changeling.has_profile_with_dna(target.dna))
 		changeling.add_new_profile(target)
 
@@ -65,10 +51,33 @@
 	if(target.stat != DEAD)
 		target.investigate_log("has died from being changeling absorbed.", INVESTIGATE_DEATHS)
 
+	switch(total_chem_storage)
+		if(35 to 45)
+			target.soft_drain()
+		if(46 to 70)	// Third drain on a normal person will cause this.
+			target.changeling_drain()
+		if(71 to INFINITY)
+			target.master_drain()
+
+	// Changeling gains chems, 50 more than cap.
+	changeling.adjust_chemicals(100, changeling.total_chem_storage + 50)
+	changeling.blood_volume += 300	// We drain blood because its cool and useful!
+	if(target.mind)
+		changeling.genetic_points += 1
+		changeling.total_chem_storage += 10
+		to_chat(owner, span_notice("We have drained [target] and gained 1 genetic point <span class='cfc_cyan'>Total</span>: <span class='cfc_green'>[changeling.genetic_points]</span>."))
+	else
+		changeling.genetic_points += 0.5
+		changeling.total_chem_storage += 5
+		to_chat(owner, span_notice("We have drained [target] and gained half a genetic point. Absent-minded targets are less... nutricious... <span class='cfc_cyan'>Total</span>: <span class='cfc_green'>[changeling.genetic_points]</span>."))
+
+	SSblackbox.record_feedback("nested tally", "changeling_powers", 1, list("Absorb DNA", "4"))
+	owner.balloon_alert_to_viewers("<font color='#ff0040'>SLURP!</font>")
+	owner.visible_message(span_danger("[target] was drained!"))
+	to_chat(target, span_userdanger("You are drained by the changeling!"))
+
 	playsound(owner, 'sound/items/drink.ogg', 35, TRUE)
 	playsound(owner, 'sound/surgery/organ2.ogg', 50)
-	target.death(FALSE)
-	target.Drain()
 	return TRUE
 
 /datum/action/changeling/absorbDNA/proc/absorb_memories(mob/living/carbon/human/target)

--- a/code/modules/antagonists/changeling/powers/absorb.dm
+++ b/code/modules/antagonists/changeling/powers/absorb.dm
@@ -67,17 +67,20 @@
 		changeling.total_chem_storage += 10
 		to_chat(owner, span_notice("We have drained [target] and gained 1 genetic point <span class='cfc_cyan'>Total</span>: <span class='cfc_green'>[changeling.genetic_points]</span>."))
 	else
-		changeling.genetic_points += 0.5
-		changeling.total_chem_storage += 5
-		to_chat(owner, span_notice("We have drained [target] and gained half a genetic point. Absent-minded targets are less... nutricious... <span class='cfc_cyan'>Total</span>: <span class='cfc_green'>[changeling.genetic_points]</span>."))
+		if(total_chem_storage >= 50)
+			to_chat(owner, span_notice("Absent-minded targets no longer sustain us... <span class='cfc_cyan'>Total</span>: <span class='cfc_green'>[changeling.genetic_points]</span>."))
+		else
+			changeling.genetic_points += 0.5
+			changeling.total_chem_storage += 5
+			to_chat(owner, span_notice("We have drained [target] and gained half a genetic point. Absent-minded targets are less... nutricious... <span class='cfc_cyan'>Total</span>: <span class='cfc_green'>[changeling.genetic_points]</span>."))
 
 	SSblackbox.record_feedback("nested tally", "changeling_powers", 1, list("Absorb DNA", "4"))
-	owner.balloon_alert_to_viewers("<font color='#ff0040'>SLURP!</font>")
 	owner.visible_message(span_danger("[target] was drained!"))
 	to_chat(target, span_userdanger("You are drained by the changeling!"))
 
 	playsound(owner, 'sound/items/drink.ogg', 35, TRUE)
-	playsound(owner, 'sound/surgery/organ2.ogg', 50)
+	playsound(user, 'sound/effects/blobattack.ogg', 50)
+	playsound(user, 'sound/effects/splat.ogg', 50, TRUE)
 	return TRUE
 
 /datum/action/changeling/absorbDNA/proc/absorb_ling_power(mob/living/carbon/human/target)
@@ -116,11 +119,12 @@
 			if(3)
 				owner.visible_message(span_danger("[owner] stabs [target] with the proboscis!"), span_notice("We stab [target] with the proboscis."))
 				to_chat(target, span_userdanger("You feel a sharp stabbing pain!"))
-				playsound(owner, 'sound/creatures/venus_trap_hit.ogg', 30)
+				playsound(owner, 'sound/creatures/venus_trap_hit.ogg', 40)
+				playsound(get_turf(C), 'sound/weapons/slice.ogg', 50, 1)
 				target.take_overall_damage(40)
 
 		SSblackbox.record_feedback("nested tally", "changeling_powers", 1, list("Absorb DNA", "[absorbing_iteration]"))
-		if(!do_after(owner, 2 SECONDS, target))
+		if(!do_after(owner, 3 SECONDS, target))
 			owner.balloon_alert(owner, "interrupted!")
 			is_absorbing = FALSE
 			return FALSE

--- a/code/modules/antagonists/changeling/powers/adrenaline.dm
+++ b/code/modules/antagonists/changeling/powers/adrenaline.dm
@@ -5,7 +5,7 @@
 	button_icon_state = "adrenaline"
 	chemical_cost = 20
 	dna_cost = 2
-	req_human = 1
+	req_human = TRUE
 	check_flags = AB_CHECK_DEAD
 
 //Recover from stuns.

--- a/code/modules/antagonists/changeling/powers/chameleon_skin.dm
+++ b/code/modules/antagonists/changeling/powers/chameleon_skin.dm
@@ -5,10 +5,10 @@
 	button_icon_state = "chameleon_skin"
 	dna_cost = 2
 	chemical_cost = 1
-	req_human = 1
+	req_human = TRUE
 
 /datum/action/changeling/refractive_chitin/sting_action(mob/living/user)
-	var/mob/living/carbon/human/H = user //SHOULD always be human, because req_human = 1
+	var/mob/living/carbon/human/H = user //SHOULD always be human, because req_human = TRUE
 	if(!istype(H)) // req_human could be done in can_sting stuff.
 		return
 	..()

--- a/code/modules/antagonists/changeling/powers/fakedeath.dm
+++ b/code/modules/antagonists/changeling/powers/fakedeath.dm
@@ -3,7 +3,7 @@
 	desc = "We fall into a stasis, allowing us to regenerate and trick our enemies. Costs 15 chemicals."
 	button_icon_state = "fake_death"
 	chemical_cost = 15
-	dna_cost = 0
+	dna_cost = 2
 	req_dna = 1
 	check_flags = NONE
 	ignores_fakedeath = TRUE

--- a/code/modules/antagonists/changeling/powers/fakedeath.dm
+++ b/code/modules/antagonists/changeling/powers/fakedeath.dm
@@ -65,7 +65,7 @@
 	chemical_cost = 0
 	revive_ready = TRUE
 
-/datum/action/changeling/fakedeath/can_sting(mob/living/user)
+/datum/action/changeling/fakedeath/ling_can_cast(mob/living/user)
 	if(HAS_TRAIT(user, TRAIT_HUSK))
 		to_chat(user, span_warning("This body is too damaged to revive!."))
 		return

--- a/code/modules/antagonists/changeling/powers/fakedeath.dm
+++ b/code/modules/antagonists/changeling/powers/fakedeath.dm
@@ -4,7 +4,7 @@
 	button_icon_state = "fake_death"
 	chemical_cost = 15
 	dna_cost = 2
-	req_dna = 1
+	points_to_use = 1
 	check_flags = NONE
 	ignores_fakedeath = TRUE
 	var/revive_ready = FALSE

--- a/code/modules/antagonists/changeling/powers/headcrab.dm
+++ b/code/modules/antagonists/changeling/powers/headcrab.dm
@@ -4,7 +4,7 @@
 	helptext = "We will be placed in control of a small, fragile creature. We may attack a corpse like this to plant an egg which will slowly mature into a new form for us. Cannot be used while being absorbed by another changeling."
 	button_icon_state = "last_resort"
 	chemical_cost = 20
-	dna_cost = 0
+	dna_cost = 1
 	req_human = 1
 	check_flags = NONE
 	ignores_fakedeath = TRUE

--- a/code/modules/antagonists/changeling/powers/headcrab.dm
+++ b/code/modules/antagonists/changeling/powers/headcrab.dm
@@ -5,7 +5,7 @@
 	button_icon_state = "last_resort"
 	chemical_cost = 20
 	dna_cost = 1
-	req_human = 1
+	req_human = TRUE
 	check_flags = NONE
 	ignores_fakedeath = TRUE
 

--- a/code/modules/antagonists/changeling/powers/humanform.dm
+++ b/code/modules/antagonists/changeling/powers/humanform.dm
@@ -3,7 +3,7 @@
 	desc = "We change into a human. Costs 10 chemicals."
 	button_icon_state = "human_form"
 	chemical_cost = 10
-	req_dna = 1
+	points_to_use = 1
 
 //Transform into a human.
 /datum/action/changeling/humanform/sting_action(mob/living/carbon/user)

--- a/code/modules/antagonists/changeling/powers/humanform.dm
+++ b/code/modules/antagonists/changeling/powers/humanform.dm
@@ -3,7 +3,6 @@
 	desc = "We change into a human. Costs 10 chemicals."
 	button_icon_state = "human_form"
 	chemical_cost = 10
-	points_to_use = 1
 
 //Transform into a human.
 /datum/action/changeling/humanform/sting_action(mob/living/carbon/user)

--- a/code/modules/antagonists/changeling/powers/lesserform.dm
+++ b/code/modules/antagonists/changeling/powers/lesserform.dm
@@ -5,7 +5,7 @@
 	button_icon_state = "lesser_form"
 	chemical_cost = 20
 	dna_cost = 1
-	req_human = 1
+	req_human = TRUE
 
 //Transform into a monkey.
 /datum/action/changeling/lesserform/sting_action(mob/living/carbon/human/user)

--- a/code/modules/antagonists/changeling/powers/mimic_voice.dm
+++ b/code/modules/antagonists/changeling/powers/mimic_voice.dm
@@ -4,6 +4,7 @@
 	button_icon_state = "mimic_voice"
 	helptext = "Will turn your voice into the name that you enter."
 	chemical_cost = 0
+	recharge_slowdown = 0.2
 	dna_cost = 1
 	req_human = 1
 
@@ -27,7 +28,6 @@
 /datum/action/changeling/mimicvoice/Remove(mob/user)
 	var/datum/antagonist/changeling/changeling = user.mind.has_antag_datum(/datum/antagonist/changeling)
 	if(changeling?.mimicing)
-		changeling.chem_recharge_slowdown = max(0, changeling.chem_recharge_slowdown - 0.25)
 		changeling.mimicing = ""
 		to_chat(user, span_notice("Our vocal glands return to their original position."))
 	. = ..()

--- a/code/modules/antagonists/changeling/powers/mimic_voice.dm
+++ b/code/modules/antagonists/changeling/powers/mimic_voice.dm
@@ -1,6 +1,6 @@
 /datum/action/changeling/mimicvoice
 	name = "Mimic Voice"
-	desc = "We shape our vocal glands to sound like a desired voice. Maintaining this power slows chemical production."
+	desc = "We shape our vocal glands to sound like a desired voice."
 	button_icon_state = "mimic_voice"
 	helptext = "Will turn your voice into the name that you enter."
 	chemical_cost = 0

--- a/code/modules/antagonists/changeling/powers/mimic_voice.dm
+++ b/code/modules/antagonists/changeling/powers/mimic_voice.dm
@@ -6,7 +6,7 @@
 	chemical_cost = 0
 	recharge_slowdown = 0.2
 	dna_cost = 1
-	req_human = 1
+	req_human = TRUE
 
 // Fake Voice
 /datum/action/changeling/mimicvoice/sting_action(mob/user)

--- a/code/modules/antagonists/changeling/powers/mutations.dm
+++ b/code/modules/antagonists/changeling/powers/mutations.dm
@@ -138,7 +138,7 @@
 	desc = "We reform one of our arms into a deadly blade. Costs 20 chemicals."
 	helptext = "We may retract our armblade in the same manner as we form it."
 	button_icon_state = "armblade"
-	chemical_cost = 20
+	chemical_cost = 5
 	recharge_slowdown = 0.2
 	dna_cost = 2
 	weapon_type = /obj/item/melee/arm_blade
@@ -476,7 +476,7 @@ CREATION_TEST_IGNORE_SUBTYPES(/obj/item/gun/magic/tentacle)
 	desc = "We turn our skin into tough chitin to protect us from damage. Costs 20 chemicals."
 	helptext = "The armor provides decent protection against projectiles and some protection against melee attacks."
 	button_icon_state = "chitinous_armor"
-	chemical_cost = 20
+	chemical_cost = 10
 	dna_cost = 2
 	recharge_slowdown = 0.2
 

--- a/code/modules/antagonists/changeling/powers/mutations.dm
+++ b/code/modules/antagonists/changeling/powers/mutations.dm
@@ -141,7 +141,6 @@
 	chemical_cost = 20
 	recharge_slowdown = 0.2
 	dna_cost = 2
-	req_human = 1
 	weapon_type = /obj/item/melee/arm_blade
 	weapon_name_simple = "blade"
 
@@ -156,7 +155,6 @@
 	item_flags = NEEDS_PERMIT | ABSTRACT | DROPDEL | ISWEAPON
 	w_class = WEIGHT_CLASS_HUGE
 	force = 30
-	throwforce = 0 //Just to be on the safe side
 	throw_range = 0
 	throw_speed = 0
 	block_flags = BLOCKING_ACTIVE | BLOCKING_NASTY
@@ -211,7 +209,6 @@ CREATION_TEST_IGNORE_SUBTYPES(/obj/item/melee/arm_blade)
 	button_icon_state = "tentacle"
 	chemical_cost = 10
 	dna_cost = 2
-	req_human = 1
 	weapon_type = /obj/item/gun/magic/tentacle
 	weapon_name_simple = "tentacle"
 	silent = TRUE
@@ -387,8 +384,6 @@ CREATION_TEST_IGNORE_SUBTYPES(/obj/item/gun/magic/tentacle)
 	button_icon_state = "organic_suit"
 	chemical_cost = 20
 	dna_cost = 1
-	req_human = 1
-
 	suit_type = /obj/item/clothing/suit/space/changeling
 	helmet_type = /obj/item/clothing/head/helmet/space/changeling
 	suit_name_simple = "flesh shell"
@@ -483,7 +478,6 @@ CREATION_TEST_IGNORE_SUBTYPES(/obj/item/gun/magic/tentacle)
 	button_icon_state = "chitinous_armor"
 	chemical_cost = 20
 	dna_cost = 2
-	req_human = 1
 	recharge_slowdown = 0.2
 
 	suit_type = /obj/item/clothing/suit/armor/changeling

--- a/code/modules/antagonists/changeling/powers/mutations.dm
+++ b/code/modules/antagonists/changeling/powers/mutations.dm
@@ -136,7 +136,7 @@
 /datum/action/changeling/weapon/arm_blade
 	name = "Arm Blade"
 	desc = "We reform one of our arms into a deadly blade. Costs 20 chemicals."
-	helptext = "We may retract our armblade in the same manner as we form it. Cannot be used while in lesser form."
+	helptext = "We may retract our armblade in the same manner as we form it."
 	button_icon_state = "armblade"
 	chemical_cost = 20
 	recharge_slowdown = 0.2
@@ -207,8 +207,7 @@ CREATION_TEST_IGNORE_SUBTYPES(/obj/item/melee/arm_blade)
 	desc = "We ready a tentacle to grab items or victims with. Costs 10 chemicals."
 	helptext = "We can use it once to retrieve a distant item. If used on living creatures, the effect depends on our combat mode: \
 	In our neutral stance, we will simply drag them closer; if we try to shove, we will grab whatever they're holding in their active hand instead of them; \
-	in our combat stance, we will put the victim in our hold after catching them, and we will pull them in and stab them if we're also holding a sharp weapon. \
-	Cannot be used while in lesser form."
+	in our combat stance, we will put the victim in our hold after catching them, and we will pull them in and stab them if we're also holding a sharp weapon."
 	button_icon_state = "tentacle"
 	chemical_cost = 10
 	dna_cost = 2
@@ -384,7 +383,7 @@ CREATION_TEST_IGNORE_SUBTYPES(/obj/item/gun/magic/tentacle)
 /datum/action/changeling/suit/organic_space_suit
 	name = "Organic Space Suit"
 	desc = "We grow an organic suit to protect ourselves from space exposure and is lightly armoured. Costs 20 chemicals."
-	helptext = "We must constantly repair our form to make it armored and space-proof, reducing chemical production while we are protected. Cannot be used in Lesser Form."
+	helptext = "We must constantly repair our form to make it armored and space-proof."
 	button_icon_state = "organic_suit"
 	chemical_cost = 20
 	dna_cost = 1
@@ -480,7 +479,7 @@ CREATION_TEST_IGNORE_SUBTYPES(/obj/item/gun/magic/tentacle)
 /datum/action/changeling/suit/armor
 	name = "Chitinous Armor"
 	desc = "We turn our skin into tough chitin to protect us from damage. Costs 20 chemicals."
-	helptext = "Upkeep of the armor slows our rate of chemical production. The armor provides decent protection against projectiles and some protection against melee attacks. Cannot be used in lesser form."
+	helptext = "The armor provides decent protection against projectiles and some protection against melee attacks."
 	button_icon_state = "chitinous_armor"
 	chemical_cost = 20
 	dna_cost = 2

--- a/code/modules/antagonists/changeling/powers/mutations.dm
+++ b/code/modules/antagonists/changeling/powers/mutations.dm
@@ -17,6 +17,7 @@
 	chemical_cost = 1000
 	dna_cost = -1
 
+	req_human = TRUE
 	var/silent = FALSE
 	var/weapon_type
 	var/weapon_name_simple
@@ -73,6 +74,7 @@
 	helptext = "Yell at Miauw and/or Perakp"
 	chemical_cost = 1000
 	dna_cost = -1
+	req_human = TRUE
 
 	var/helmet_type = /obj/item
 	var/suit_type = /obj/item

--- a/code/modules/antagonists/changeling/powers/mutations.dm
+++ b/code/modules/antagonists/changeling/powers/mutations.dm
@@ -34,6 +34,7 @@
 			playsound(user, 'sound/effects/blobattack.ogg', 30, 1)
 			user.visible_message(span_warning("With a sickening crunch, [user] reforms [user.p_their()] [weapon_name_simple] into an arm!"), span_notice("We assimilate the [weapon_name_simple] back into our body."), span_italics("You hear organic matter ripping and tearing!"))
 		user.update_inv_hands()
+		subtract_slowdown(user)
 		return 1
 
 /datum/action/changeling/weapon/sting_action(mob/living/carbon/user)
@@ -77,7 +78,6 @@
 	var/suit_type = /obj/item
 	var/suit_name_simple = "    "
 	var/helmet_name_simple = "     "
-	var/recharge_slowdown = 0
 	var/blood_on_castoff = 0
 
 /datum/action/changeling/suit/try_to_sting(mob/user, mob/target)
@@ -104,7 +104,7 @@
 			H.add_splatter_floor()
 			playsound(H.loc, 'sound/effects/splat.ogg', 50, 1) //So real sounds
 
-		changeling.chem_recharge_slowdown -= recharge_slowdown
+		subtract_slowdown(user)
 		return 1
 
 /datum/action/changeling/suit/Remove(mob/user)
@@ -124,9 +124,6 @@
 
 	user.equip_to_slot_if_possible(new suit_type(user), ITEM_SLOT_OCLOTHING, 1, 1, 1)
 	user.equip_to_slot_if_possible(new helmet_type(user), ITEM_SLOT_HEAD, 1, 1, 1)
-
-	var/datum/antagonist/changeling/changeling = user.mind.has_antag_datum(/datum/antagonist/changeling)
-	changeling.chem_recharge_slowdown += recharge_slowdown
 	return TRUE
 
 
@@ -140,6 +137,7 @@
 	helptext = "We may retract our armblade in the same manner as we form it. Cannot be used while in lesser form."
 	button_icon_state = "armblade"
 	chemical_cost = 20
+	recharge_slowdown = 0.2
 	dna_cost = 2
 	req_human = 1
 	weapon_type = /obj/item/melee/arm_blade
@@ -394,7 +392,7 @@ CREATION_TEST_IGNORE_SUBTYPES(/obj/item/gun/magic/tentacle)
 	helmet_type = /obj/item/clothing/head/helmet/space/changeling
 	suit_name_simple = "flesh shell"
 	helmet_name_simple = "space helmet"
-	recharge_slowdown = 0.25
+	recharge_slowdown = 0.2
 	blood_on_castoff = 1
 
 /obj/item/clothing/suit/space/changeling
@@ -485,7 +483,7 @@ CREATION_TEST_IGNORE_SUBTYPES(/obj/item/gun/magic/tentacle)
 	chemical_cost = 20
 	dna_cost = 2
 	req_human = 1
-	recharge_slowdown = 0.125
+	recharge_slowdown = 0.2
 
 	suit_type = /obj/item/clothing/suit/armor/changeling
 	helmet_type = /obj/item/clothing/head/helmet/changeling

--- a/code/modules/antagonists/changeling/powers/organic_mindshield.dm
+++ b/code/modules/antagonists/changeling/powers/organic_mindshield.dm
@@ -4,6 +4,7 @@
 	button_icon_state = "mindshield"
 	helptext = "Will cause you to appear to have a mindshield on security HUDs. Maintaining uses 1 chemical every 3 seconds. Does not work while on fire."
 	chemical_cost = 0
+	recharge_slowdown = 0.1
 	dna_cost = 1
 	req_human = 1
 

--- a/code/modules/antagonists/changeling/powers/organic_mindshield.dm
+++ b/code/modules/antagonists/changeling/powers/organic_mindshield.dm
@@ -2,7 +2,7 @@
 	name = "Organic Mindshield"
 	desc = "We emit a constant frequency matching that of a mindshield, fooling security HUDs into thinking we are mindshielded."
 	button_icon_state = "mindshield"
-	helptext = "Will cause you to appear to have a mindshield on security HUDs. Maintaining uses 1 chemical every 3 seconds. Does not work while on fire."
+	helptext = "Will cause you to appear to have a mindshield on security HUDs. Does not work while on fire."
 	chemical_cost = 0
 	recharge_slowdown = 0.1
 	dna_cost = 1

--- a/code/modules/antagonists/changeling/powers/organic_mindshield.dm
+++ b/code/modules/antagonists/changeling/powers/organic_mindshield.dm
@@ -6,7 +6,7 @@
 	chemical_cost = 0
 	recharge_slowdown = 0.1
 	dna_cost = 1
-	req_human = 1
+	req_human = TRUE
 
 /datum/action/changeling/organic_mindshield/sting_action(mob/living/user)
 	..()

--- a/code/modules/antagonists/changeling/powers/regenerate.dm
+++ b/code/modules/antagonists/changeling/powers/regenerate.dm
@@ -44,30 +44,12 @@
 	dna_cost = 2
 	req_human = TRUE
 	check_flags = NONE
+	limb_sacrifice = TRUE
 	ignores_fakedeath = TRUE
 
 /datum/action/changeling/limbsnake/sting_action(mob/user)
 	..()
 	var/mob/living/carbon/C = user
-	var/list/parts = list()
-	for(var/Zim in C.bodyparts)
-		var/obj/item/bodypart/BP = Zim
-		if(BP.body_part != HEAD && BP.body_part != CHEST && IS_ORGANIC_LIMB(BP))
-			if(BP.dismemberable)
-				parts += BP
-	if(!LAZYLEN(parts))
-		to_chat(user, span_notice("We don't have any limbs to detach."))
-		return
-	//limb related actions
-	var/obj/item/bodypart/BP = pick(parts)
-	for(var/obj/item/bodypart/Gir in parts)
-		if(Gir.body_part == ARM_RIGHT || Gir.body_part == ARM_LEFT)	//arms first, so they can mitigate the damage with the Armblade ability too, and it's not entirely reliant on regenerate
-			BP = Gir
-	//text message
-	C.visible_message(span_warning("[user]'s [BP] detaches itself and takes the form of a snake!"),
-			span_userdanger("Our [BP] forms into a horrifying snake and heads towards our attackers!"))
-	BP.dismember()
-	BP.Destroy()
 	//Deploy limbsnake
 	var/mob/living/snek = new /mob/living/simple_animal/hostile/poison/limbsnake(get_turf(user))
 	//assign faction

--- a/code/modules/antagonists/changeling/powers/shriek.dm
+++ b/code/modules/antagonists/changeling/powers/shriek.dm
@@ -5,7 +5,7 @@
 	button_icon_state = "resonant_shriek"
 	chemical_cost = 30
 	dna_cost = 2
-	req_human = 1
+	req_human = TRUE
 
 //A flashy ability, good for crowd control and sowing chaos.
 /datum/action/changeling/resonant_shriek/sting_action(mob/user)

--- a/code/modules/antagonists/changeling/powers/strained_muscles.dm
+++ b/code/modules/antagonists/changeling/powers/strained_muscles.dm
@@ -8,7 +8,7 @@
 	button_icon_state = "strained_muscles"
 	chemical_cost = 0
 	dna_cost = 1
-	req_human = 1
+	req_human = TRUE
 	var/stacks = 0 //Increments every 5 seconds; damage increases over time
 	toggleable = TRUE
 

--- a/code/modules/antagonists/changeling/powers/teratoma.dm
+++ b/code/modules/antagonists/changeling/powers/teratoma.dm
@@ -22,17 +22,18 @@
 	return FALSE		//create_teratoma() handles the chemicals anyway so there is no reason to take them again
 
 /datum/action/changeling/teratoma/proc/create_teratoma(mob/living/carbon/human/user)
-	if (!istype(user))
+	var/datum/antagonist/changeling/changeling = IS_CHANGELING(owner)
+	if(!istype(user))
 		return FALSE
-	if (!user.dna)
-		to_chat(user, span_warning("Our current form has insufficient genetic material to create a Teratoma."))
+	if(!changeling.genetic_points)
+		to_chat(user, span_warning("Our current form has insufficient genetic points to create a Teratoma."))
 		return FALSE
 	var/terratoma_count = 0
-	for (var/mob/living/carbon/monkey/tumor/teratoma in GLOB.mob_living_list)
-		if (teratoma.creator_key != user.key || teratoma.stat == DEAD)
+	for(var/mob/living/carbon/monkey/tumor/teratoma in GLOB.mob_living_list)
+		if(teratoma.creator_key != user.key || teratoma.stat == DEAD)
 			continue
 		terratoma_count ++
-	if (terratoma_count >= MAX_TERATOMA)
+	if(terratoma_count >= MAX_TERATOMA)
 		to_chat(user, span_warning("You don't have enough energy to birth a teratoma..."))
 		return FALSE
 	var/datum/antagonist/changeling/c = user.mind.has_antag_datum(/datum/antagonist/changeling)
@@ -63,6 +64,7 @@
 	if (terratoma_count >= MAX_TERATOMA)
 		to_chat(user, span_warning("You don't have enough energy to birth a teratoma..."))
 		return FALSE
+	changeling.genetic_points -= 1
 	var/mob/living/carbon/monkey/tumor/T = new /mob/living/carbon/monkey/tumor(A)
 	// Copies the DNA, so that you can find who caused it while causing some chaos
 	T.dna.copy_dna(user.dna)

--- a/code/modules/antagonists/changeling/powers/teratoma.dm
+++ b/code/modules/antagonists/changeling/powers/teratoma.dm
@@ -3,7 +3,7 @@
 /datum/action/changeling/teratoma
 	name = "Birth Teratoma"
 	desc = "Our form divides, creating an egg that will soon hatch into a living tumor, fixated on causing mayhem"
-	helptext = "The tumor will not be loyal to us or our cause. Costs 1 genetic point"
+	helptext = "The tumor will not be loyal to us or our cause."
 	button_icon_state = "spread_infestation"
 	points_to_use = 1
 	chemical_cost = 30

--- a/code/modules/antagonists/changeling/powers/teratoma.dm
+++ b/code/modules/antagonists/changeling/powers/teratoma.dm
@@ -45,7 +45,8 @@
 	)
 	if(!candidate) //if we got at least one candidate, they're teratoma now
 		to_chat(usr, span_warning("You fail at creating a tumor. Perhaps you should try again later?"))
-		c.chem_charges += chemical_cost				//If it fails we want to refund the chemicals
+		c.chem_charges += chemical_cost		//If it fails we want to refund the chemicals and genetic points
+		c.genetic_points += points_to_use
 		return FALSE
 	// Rerun preconditions after sleeping
 	if (!user.dna)

--- a/code/modules/antagonists/changeling/powers/teratoma.dm
+++ b/code/modules/antagonists/changeling/powers/teratoma.dm
@@ -3,9 +3,10 @@
 /datum/action/changeling/teratoma
 	name = "Birth Teratoma"
 	desc = "Our form divides, creating an egg that will soon hatch into a living tumor, fixated on causing mayhem"
-	helptext = "The tumor will not be loyal to us or our cause. Costs two changeling absorptions"
+	helptext = "The tumor will not be loyal to us or our cause. Costs 1 genetic point"
 	button_icon_state = "spread_infestation"
-	chemical_cost = 60
+	points_to_use = 1
+	chemical_cost = 30
 	dna_cost = 2
 	req_human = TRUE
 
@@ -24,9 +25,6 @@
 /datum/action/changeling/teratoma/proc/create_teratoma(mob/living/carbon/human/user)
 	var/datum/antagonist/changeling/changeling = IS_CHANGELING(owner)
 	if(!istype(user))
-		return FALSE
-	if(!changeling.genetic_points)
-		to_chat(user, span_warning("Our current form has insufficient genetic points to create a Teratoma."))
 		return FALSE
 	var/terratoma_count = 0
 	for(var/mob/living/carbon/monkey/tumor/teratoma in GLOB.mob_living_list)
@@ -64,7 +62,6 @@
 	if (terratoma_count >= MAX_TERATOMA)
 		to_chat(user, span_warning("You don't have enough energy to birth a teratoma..."))
 		return FALSE
-	changeling.genetic_points -= 1
 	var/mob/living/carbon/monkey/tumor/T = new /mob/living/carbon/monkey/tumor(A)
 	// Copies the DNA, so that you can find who caused it while causing some chaos
 	T.dna.copy_dna(user.dna)

--- a/code/modules/antagonists/changeling/powers/teratoma.dm
+++ b/code/modules/antagonists/changeling/powers/teratoma.dm
@@ -23,7 +23,6 @@
 	return FALSE		//create_teratoma() handles the chemicals anyway so there is no reason to take them again
 
 /datum/action/changeling/teratoma/proc/create_teratoma(mob/living/carbon/human/user)
-	var/datum/antagonist/changeling/changeling = IS_CHANGELING(owner)
 	if(!istype(user))
 		return FALSE
 	var/terratoma_count = 0

--- a/code/modules/antagonists/changeling/powers/tiny_prick.dm
+++ b/code/modules/antagonists/changeling/powers/tiny_prick.dm
@@ -35,7 +35,7 @@
 		if(changeling?.chosen_sting)
 			changeling.chosen_sting.unset_sting(src)
 
-/datum/action/changeling/sting/can_sting(mob/user, mob/target)
+/datum/action/changeling/sting/ling_can_cast(mob/user, mob/target)
 	if(!..())
 		return
 	var/datum/antagonist/changeling/changeling = user.mind.has_antag_datum(/datum/antagonist/changeling)
@@ -87,7 +87,7 @@
 		return
 	return ..()
 
-/datum/action/changeling/sting/transformation/can_sting(mob/user, mob/living/carbon/target)
+/datum/action/changeling/sting/transformation/ling_can_cast(mob/user, mob/living/carbon/target)
 	if(!..())
 		return
 	if(!iscarbon(target) || HAS_TRAIT(target, TRAIT_HUSK) || HAS_TRAIT(target, TRAIT_NO_TRANSFORMATION_STING))
@@ -127,7 +127,7 @@
 	force = 5 //Basically as strong as a punch
 	fake = TRUE
 
-/datum/action/changeling/sting/false_armblade/can_sting(mob/user, mob/target)
+/datum/action/changeling/sting/false_armblade/ling_can_cast(mob/user, mob/target)
 	if(!..())
 		return
 	if(isliving(target))
@@ -178,7 +178,7 @@
 	dna_cost = 0
 	stealthy = TRUE
 
-/datum/action/changeling/sting/extract_dna/can_sting(mob/user, mob/target)
+/datum/action/changeling/sting/extract_dna/ling_can_cast(mob/user, mob/target)
 	if(..())
 		var/datum/antagonist/changeling/changeling = user.mind.has_antag_datum(/datum/antagonist/changeling)
 		return changeling.can_absorb_dna(target)

--- a/code/modules/antagonists/changeling/powers/tiny_prick.dm
+++ b/code/modules/antagonists/changeling/powers/tiny_prick.dm
@@ -175,7 +175,7 @@
 	helptext = "Will give you the DNA of your target, allowing you to transform into them."
 	button_icon_state = "sting_extract"
 	chemical_cost = 25
-	dna_cost = 0
+	dna_cost = 1
 	stealthy = TRUE
 
 /datum/action/changeling/sting/extract_dna/ling_can_cast(mob/user, mob/target)

--- a/code/modules/antagonists/changeling/powers/transform.dm
+++ b/code/modules/antagonists/changeling/powers/transform.dm
@@ -4,7 +4,7 @@
 	button_icon_state = "transform"
 	chemical_cost = 5
 	dna_cost = 0
-	req_dna = 1
+	points_to_use = 1
 	req_human = 1
 
 /obj/item/clothing/glasses/changeling

--- a/code/modules/antagonists/changeling/powers/transform.dm
+++ b/code/modules/antagonists/changeling/powers/transform.dm
@@ -4,7 +4,7 @@
 	button_icon_state = "transform"
 	chemical_cost = 5
 	dna_cost = 0
-	req_human = 1
+	req_human = TRUE
 
 /obj/item/clothing/glasses/changeling
 	name = "flesh"

--- a/code/modules/antagonists/changeling/powers/transform.dm
+++ b/code/modules/antagonists/changeling/powers/transform.dm
@@ -4,7 +4,6 @@
 	button_icon_state = "transform"
 	chemical_cost = 5
 	dna_cost = 0
-	points_to_use = 1
 	req_human = 1
 
 /obj/item/clothing/glasses/changeling

--- a/code/modules/awaymissions/corpse.dm
+++ b/code/modules/awaymissions/corpse.dm
@@ -182,7 +182,7 @@ CREATION_TEST_IGNORE_SELF(/obj/effect/mob_spawn)
 	if(mob_species)
 		H.set_species(mob_species)
 	if(husk)
-		H.Drain()
+		H.changeling_drain()	// What? Why is changeling drain here? (Renaming it)
 	else //Because for some reason I can't track down, things are getting turned into husks even if husk = false. It's in some damage proc somewhere.
 		H.cure_husk()
 	H.underwear = "Nude"

--- a/code/modules/mob/living/carbon/human/death.dm
+++ b/code/modules/mob/living/carbon/human/death.dm
@@ -112,8 +112,8 @@
 	set_species(/datum/species/skeleton)
 	return TRUE
 
-
-/mob/living/carbon/proc/Drain()
+/mob/living/carbon/proc/changeling_drain()
+	// We removed death at this point, because they will surelly die by having no blood... its more immersive!
 	// Drain is used only for health analizer
 	// Geneless is sort of a super power? You become imune to genetic mutations so...
 	ADD_TRAIT(src, TRAIT_GENELESS, CHANGELING_DRAIN)
@@ -122,6 +122,18 @@
 	adjust_bodytemperature(-200)
 	reagents.add_reagent(/datum/reagent/consumable/frostoil, 20)
 	return TRUE
+
+/mob/living/carbon/proc/soft_drain()
+	ADD_TRAIT(src, TRAIT_GENELESS, CHANGELING_DRAIN)
+	blood_volume -= 300
+	// Lowers their temperature with frost-oil but doesnt kill them
+	reagents.add_reagent(/datum/reagent/consumable/frostoil, 5)
+	return TRUE
+
+/mob/living/carbon/proc/master_drain()
+	changeling_drain()
+	death()
+	makeSkeleton()
 
 /mob/living/carbon/proc/makeUncloneable()
 	ADD_TRAIT(src, TRAIT_BADDNA, MADE_UNCLONEABLE)

--- a/code/modules/mob/living/carbon/human/death.dm
+++ b/code/modules/mob/living/carbon/human/death.dm
@@ -137,7 +137,7 @@
 	death()
 	make_uncloneable()
 	spawn_gibs(FALSE)
-	target.balloon_alert_to_viewers("<font color='#ff0040'>SLURP</font>")
+	balloon_alert_to_viewers("<font color='#ff0040'>SLURP</font>")
 	if(istype(src, /mob/living/carbon/human))
 		var/mob/living/carbon/human/H = src
 		H.makeSkeleton()

--- a/code/modules/mob/living/carbon/human/death.dm
+++ b/code/modules/mob/living/carbon/human/death.dm
@@ -114,9 +114,13 @@
 
 
 /mob/living/carbon/proc/Drain()
-	become_husk(CHANGELING_DRAIN)
-	ADD_TRAIT(src, TRAIT_BADDNA, CHANGELING_DRAIN)
+	// Drain is used only for health analizer
+	// Geneless is sort of a super power? You become imune to genetic mutations so...
+	ADD_TRAIT(src, TRAIT_GENELESS, CHANGELING_DRAIN)
 	blood_volume = 0
+	// Lowers their temperature and keeps it low when they are revived by frostoil.
+	adjust_bodytemperature(-200)
+	reagents.add_reagent(/datum/reagent/consumable/frostoil, 20)
 	return TRUE
 
 /mob/living/carbon/proc/makeUncloneable()

--- a/code/modules/mob/living/carbon/human/death.dm
+++ b/code/modules/mob/living/carbon/human/death.dm
@@ -112,6 +112,13 @@
 	set_species(/datum/species/skeleton)
 	return TRUE
 
+/mob/living/carbon/proc/soft_drain()
+	ADD_TRAIT(src, TRAIT_GENELESS, CHANGELING_DRAIN)
+	blood_volume -= 300
+	// Lowers their temperature with frost-oil but doesnt kill them
+	reagents.add_reagent(/datum/reagent/consumable/frostoil, 5)
+	return TRUE
+
 /mob/living/carbon/proc/changeling_drain()
 	// We removed death at this point, because they will surelly die by having no blood... its more immersive!
 	// Drain is used only for health analizer
@@ -123,21 +130,14 @@
 	reagents.add_reagent(/datum/reagent/consumable/frostoil, 20)
 	return TRUE
 
-/mob/living/carbon/proc/soft_drain()
-	ADD_TRAIT(src, TRAIT_GENELESS, CHANGELING_DRAIN)
-	blood_volume -= 300
-	// Lowers their temperature with frost-oil but doesnt kill them
-	reagents.add_reagent(/datum/reagent/consumable/frostoil, 5)
-	return TRUE
-
 /mob/living/carbon/proc/master_drain()
 	changeling_drain()
 	death()
+	make_uncloneable()
 	if(istype(src, /mob/living/carbon/human))
 		var/mob/living/carbon/human/H = src
 		H.makeSkeleton()
 
-/mob/living/carbon/proc/makeUncloneable()
+/mob/living/carbon/proc/make_uncloneable()
 	ADD_TRAIT(src, TRAIT_BADDNA, MADE_UNCLONEABLE)
-	blood_volume = 0
 	return TRUE

--- a/code/modules/mob/living/carbon/human/death.dm
+++ b/code/modules/mob/living/carbon/human/death.dm
@@ -133,7 +133,9 @@
 /mob/living/carbon/proc/master_drain()
 	changeling_drain()
 	death()
-	makeSkeleton()
+	if(istype(src, /mob/living/carbon/human))
+		var/mob/living/carbon/human/H = src
+		H.makeSkeleton()
 
 /mob/living/carbon/proc/makeUncloneable()
 	ADD_TRAIT(src, TRAIT_BADDNA, MADE_UNCLONEABLE)

--- a/code/modules/mob/living/carbon/human/death.dm
+++ b/code/modules/mob/living/carbon/human/death.dm
@@ -125,8 +125,10 @@
 	// Geneless is sort of a super power? You become imune to genetic mutations so...
 	ADD_TRAIT(src, TRAIT_GENELESS, CHANGELING_DRAIN)
 	blood_volume = 0
+	new /obj/effect/decal/cleanable/blood(get_turf(src))
 	// Lowers their temperature and keeps it low when they are revived by frostoil.
 	adjust_bodytemperature(-200)
+	balloon_alert_to_viewers("<font color='#ff8080'>Blood is spilled...</font>")
 	reagents.add_reagent(/datum/reagent/consumable/frostoil, 20)
 	return TRUE
 
@@ -134,9 +136,13 @@
 	changeling_drain()
 	death()
 	make_uncloneable()
+	spawn_gibs(FALSE)
+	target.balloon_alert_to_viewers("<font color='#ff0040'>SLURP</font>")
 	if(istype(src, /mob/living/carbon/human))
 		var/mob/living/carbon/human/H = src
 		H.makeSkeleton()
+	else	// If they are not human what are they?
+		gib()
 
 /mob/living/carbon/proc/make_uncloneable()
 	ADD_TRAIT(src, TRAIT_BADDNA, MADE_UNCLONEABLE)

--- a/html/antagtips/changeling.html
+++ b/html/antagtips/changeling.html
@@ -3,11 +3,11 @@
 	<h1>You are a Changeling!</h1>
 	<img src="changeling.gif"/>
 	<p>You are a Changeling, a shapeshifting alien assuming the form of a crewmember on Space Station 13.</p>
-	<p>The goal of many changelings is to acquire 5-7 DNA strains. To do this, it must take ANY human, living or dead, and acquire their DNA.</p>
-	<p><img src="sting_extract.png"/>Use the <b>DNA Extraction Sting</b> and sting a target to stealthily steal their DNA. This will count towards your objective.</p>
-	<p><img src="absorb.png"/>Alternatively, you can <b>absorb</b> humans to drain their DNA. Have them in an aggressive grab and click the absorb button on the top left of the screen.</p>
-	<p><img src="emporium.gif"/>Use the <b>Cellular Emporium</b> to acquire special abilities which will help you achieve your objectives.</p>
-	<p>Absorbing a human will allow you to <b>readapt</b> and purchase different abilities.</p>
+	<p>The goal of many changelings is to acquire 5-7 DNA strains. To do this, it must take ANY person, living or dead, and acquire their DNA.</p>
+	<p><img src="sting_extract.png"/>Use the <b>DNA Extraction Sting</b> and sting a target to stealthily steal their DNA. This will count towards your objective but not grant genetic points.</p>
+	<p><img src="absorb.png"/>Alternatively, you can <b>absorb</b> people to drain their DNA. This increases your genetic points and maximum chemical storage. Grab them and click the absorb button on the top left of the screen.</p>
+	<p><img src="emporium.gif"/>Use the <b>Cellular Emporium</b> to acquire special abilities with genetic points which will help you achieve your objectives.</p>
+	<p>Having more than 4 genetic points will allow you to <b>readapt</b> and purchase different abilities, at the cost of 1 genetic point.</p>
 	<p><img src="tentacle.png"/>Work together with the other changelings to complete your objectives, but be cautious. Other changelings could have an objective to absorb you.</p>
 	<p>For further information visit <b>https://wiki.beestation13.com/view/Changeling</b></p>
 	</center>


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

## This is a WIP currently under change!

Changeling drain is in a tough spot.
It takes really long to do, it husks the target beyond any revival.
There is social pressure NOT to drain because of how violent it is to the victim for no reward what so ever.

This PR aims to fix that and turn Changeling into a real monster.
One that starts off containable, maybe even friendly.

But as they drain and become stronger they will feel a necessity to prey on living people.

### Drain, the core changeling mechanic

Draining is much faster, rewards the changeling with genetic points and max chemical storage.
But it is also audible and has some alerts for it!

Changelings drain also replenishes blood, chemicals, (planned to make the changeling be healed also).

## WIP TIERS

Changelings start off weak with only 2 genetic points.

They can absorb people, humanized monkeys, even simple mobs.

But as they become stronger easy prey become non nutricious.

Tiers make draining more dangerous against humans.

(Im still considering if drain reward for simplemobs and mindless targets should be locked to a specific number or Tier)

<details>
<summary>TIER 1 - Corgi Eater</summary>

In tier one changelings get rewarded for draining anything from simple mobs to normal players.

This is the Spore bacteria stage.

As you may understand station pets are not as DNA rich as a human body, so they give very little reward in comparison.

Draining mobs will cause a very big mess!

Drain at this stage should be almost un-noticeable if preformed on a human body.
</details>

<details>
<summary>TIER 2 - Clone Eater</summary>

At this point simple mods stop rewarding you with max chemicals and genetic points and you must move on to real bodies... even if they are clones or humanified monkeys!

However mindless bodies are worth half of what bodies with minds are worth!

Pictured, difference between a humanified monkey and an SSD person (has a mind)
<img width="786" height="102" alt="image" src="https://github.com/user-attachments/assets/2d38c674-0f76-45e5-99e9-a4e0d1a699b4" />
<img width="476" height="96" alt="image" src="https://github.com/user-attachments/assets/a8aa477d-fc41-4c11-a1ae-d7c8d8923d72" />

But, the drain at this stage is still not lethal. But it hurts!
It will drain 300 units of blood
It will add the drained trait visible in health analizers.
Draining targets that were already drained causes draining to become 1 tier more dangerous.
It will add a little bit of frost oil just to make them cold.

https://github.com/user-attachments/assets/cf425b3e-a5f8-4cf6-923b-c240c0bbf010
</details>
<details>
<summary>TIER 3 - People Eater</summary>

At this point mindless bodies no longer offer nutrition... (They still replenish food, blood and chemicals thought)

<img width="387" height="70" alt="image" src="https://github.com/user-attachments/assets/743f4836-c8a9-4bcf-acf6-026973693708" />

You must move onto real people...

Sting at this point becomes lethal...
It kills the target by draining all blood and freezing the body completely.
Its not instantaneous for flavour!

https://github.com/user-attachments/assets/f7e52973-99c2-4d4d-98a8-343c54bc8cd7
</details>

<details>
<summary>TIER 4 - Monster</summary>

At this point you are so strong you must completely drain your victims to be satisfied...

Drain will do what it did before but now it causes sudden death, skeletonification and unclonability.
This is meant to make the target unrevivable by using mechanics players already know instead of arbitrary vars or traits inexplicably stopping revival.

https://github.com/user-attachments/assets/b75d552c-dbbe-4d65-8914-dbe4c13c4f9c
</details>

### Small changes to make scaling work!

Changeling starts at max power and they can respec on demand.

Which means robust changeling players essentially have all perks. This is a bit... too much...

I decided to make Changeling much less powerful at roundstart.
It now NEEDS to drain in order to become stronger.

However, they can in theory become stronger than they were before, since the maximum is no longer 10 genetic points.
This is offset by the drain requirement and respec now consuming a genetic point.

Some abilities had their costs reworked for this purpose.

## Why It's Good For The Game

Changelings have the fame of cleaning house from roundstart.
The absorb ability is too punishing for victims and offers no actual reward to the changeling, which makes it go mostly unused.

So, right now... it feels a little void.

This attempt to fix that and make changeling cooler and needing to ACT.

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

Will add later.

</details>

## Changelog
:cl:
tweak: Makes changelings hella cool?
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
