### PR TITLE
Gives changelings most languages

### DIFF
--- a/code/__DEFINES/language.dm
+++ b/code/__DEFINES/language.dm
@@ -61,6 +61,7 @@
 #define LANGUAGE_HOLOPARA "holoparasite"
 #define LANGUAGE_BABEL "babel"
 #define LANGUAGE_VAMPIRE "vampire"
+#define LANGUAGE_CHANGELING "changeling"
 
 // Language flags. Used in granting and removing languages.
 /// This language can be spoken.

--- a/code/modules/antagonists/changeling/changeling.dm
+++ b/code/modules/antagonists/changeling/changeling.dm
@@ -13,7 +13,7 @@
 	hijack_speed = 0.5
 	/// Whether to give this changeling objectives or not
 	give_objectives = TRUE
-	/// Weather we assign objectives which compete with other lings
+	/// Whether we assign objectives which compete with other lings
 	var/competitive_objectives = FALSE
 
 	// Changeling Stuff.
@@ -66,7 +66,7 @@
 	/// Static list of possible ids. Initialized into the greek alphabet the first time it is used
 	var/static/list/possible_changeling_IDs
 
-	/// Satic list of what each slot associated with (in regard to changeling flesh items).
+	/// Static list of what each slot associated with (in regard to changeling flesh items).
 	var/static/list/slot2type = list(
 		"head" = /obj/item/clothing/head/changeling,
 		"wear_mask" = /obj/item/clothing/mask/changeling,
@@ -85,6 +85,23 @@
 
 	///	Keeps track of the currently selected profile.
 	var/datum/changeling_profile/current_profile
+
+	/// A list of languages granted to changelings
+	var/static/list/granted_languages = list(
+		/datum/language/apidite,
+		/datum/language/buzzwords,
+		/datum/language/calcic,
+		/datum/language/common,
+		/datum/language/uncommon,
+		/datum/language/draconic,
+		/datum/language/moffic,
+		/datum/language/monkey,
+		/datum/language/slime,
+		/datum/language/sonus,
+		/datum/language/sylvan,
+		/datum/language/terrum,
+		/datum/language/voltaic,
+	)
 
 /datum/antagonist/changeling/New()
 	. = ..()
@@ -110,7 +127,9 @@
 	handle_clown_mutation(owner.current, "You have evolved beyond your clownish nature, allowing you to wield weapons without harming yourself.")
 	owner.current.get_language_holder().omnitongue = TRUE
 	owner.current.playsound_local(get_turf(owner.current), 'sound/ambience/antag/ling_aler.ogg', 100, FALSE, pressure_affected = FALSE, use_reverb = FALSE)
-	owner.current.grant_all_languages(ALL, TRUE, LANGUAGE_CHANGELING)
+
+	for(var/datum/language/language as anything in granted_languages)
+		owner.current.grant_language(language, source = LANGUAGE_CHANGELING)
 	return ..()
 
 /datum/antagonist/changeling/apply_innate_effects(mob/living/mob_override)

--- a/code/modules/antagonists/changeling/changeling.dm
+++ b/code/modules/antagonists/changeling/changeling.dm
@@ -110,6 +110,7 @@
 	handle_clown_mutation(owner.current, "You have evolved beyond your clownish nature, allowing you to wield weapons without harming yourself.")
 	owner.current.get_language_holder().omnitongue = TRUE
 	owner.current.playsound_local(get_turf(owner.current), 'sound/ambience/antag/ling_aler.ogg', 100, FALSE, pressure_affected = FALSE, use_reverb = FALSE)
+	owner.current.grant_all_languages(ALL, TRUE, LANGUAGE_CHANGELING)
 	return ..()
 
 /datum/antagonist/changeling/apply_innate_effects(mob/living/mob_override)
@@ -159,6 +160,7 @@
 
 /datum/antagonist/changeling/on_removal()
 	remove_changeling_powers(include_innate = TRUE)
+	owner.current.remove_all_languages(LANGUAGE_CHANGELING, TRUE)
 	if(!iscarbon(owner.current))
 		return
 	var/mob/living/carbon/carbon_owner = owner.current


### PR DESCRIPTION
## About The Pull Request

Changelings are granted the ability to speak any "normal" language. Basically every language excluding antagonist and exotic ones.

Here is the full list of languages:
- Apidite, from apids
- Buzzwords, from flypeople
- Calcic, from plasmamen and skeletons
- Galactic Common
- Galactic Uncommon
- Draconic, from the lizards
- Moffic, from the weird things
- Chimpanzee, from... monkies
- I can't be bothered to write out their sources anymore
- Slime
- Sonus
- Sylvan
- Terrum
- Voltaic

## Why It's Good For The Game

Changelings are masters of deception, they take on many forms, can copy a person's DNA and transform into them. Them being able to speak _most_ languages makes sense and allows for (even if its not many) extra role-play opportunities

## Testing Photographs and Procedure

https://github.com/user-attachments/assets/d9bac5e2-1eb3-481a-bac1-d04c378b8efc

## Changelog
:cl:
add: Changelings can speak most languages now
/:cl:
