### PR TITLE
powermonitor graph line fix

### DIFF
--- a/tgui/packages/tgui/interfaces/PowerMonitor.jsx
+++ b/tgui/packages/tgui/interfaces/PowerMonitor.jsx
@@ -70,7 +70,7 @@ export const PowerMonitorContent = (props) => {
           </Section>
         </Flex.Item>
         <Flex.Item grow={1}>
-          <Section position="relative" height="100%">
+          <Section fill position="relative" height="100%">
             <Chart.Line
               fillPositionedParent
               data={supplyData}


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

as described by bacon:
Horizontal flex
Flex item set to grow, so contains the whole thing
Section inside doesn't fill it's parents width, it only expands so it's children can fit inside of it
Child is a line which has no size

so i added fill to the item.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
having a working game is nice, actually.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

<img width="587" height="166" alt="image" src="https://github.com/user-attachments/assets/0ba5e261-856c-4b4e-bddd-58c450b3824d" />

</details>

## Changelog
:cl:
fix: fixed the power monitor graph
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
