### PR TITLE
Fixes anomalies giving a renamed generic core and the threadripper modsuit overlay showing while unselected

### DIFF
--- a/code/game/objects/effects/anomalies/_anomalies.dm
+++ b/code/game/objects/effects/anomalies/_anomalies.dm
@@ -33,7 +33,7 @@ CREATION_TEST_IGNORE_SUBTYPES(/obj/effect/anomaly)
 	START_PROCESSING(SSobj, src)
 	impact_area = get_area(src)
 
-	anomaly_core = new(src)
+	anomaly_core = new anomaly_core(src)
 	anomaly_core.name = "[name] core"
 	anomaly_core.code = rand(1,100)
 	anomaly_core.anomaly_type = type

--- a/code/modules/mod/modules/modules_medical.dm
+++ b/code/modules/mod/modules/modules_medical.dm
@@ -283,7 +283,7 @@
 	use_power_cost = DEFAULT_CHARGE_DRAIN
 	incompatible_modules = list(/obj/item/mod/module/thread_ripper)
 	cooldown_time = 1.5 SECONDS
-	overlay_state_inactive = "module_threadripper"
+	overlay_state_active = "module_threadripper"
 	required_slots = list(ITEM_SLOT_GLOVES)
 	/// An associated list of ripped clothing and the body part covering slots they covered before
 	var/list/ripped_clothing = list()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

fixes #13220
Anomalies would always spawn a generic blue core before. The core in the issue's video is a blue gravitational anomaly, which are green when admin spawned
fixes #13224
The threadripper modsuit overlay only shows when active

## Why It's Good For The Game

Cores use their respective sprites now and can be type checked

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

https://github.com/user-attachments/assets/b4e69416-4c8d-4499-a944-af3bed032814

https://github.com/user-attachments/assets/4bcb5dd8-ab76-48ef-b285-8e2cd615d507

</details>

## Changelog
:cl: lord scrubling
fix: Anomaly cores are no longer all blue
fix: Cores from diffused anomalies fit in anomaly modsuit modules
fix: The threadripper modsuit module is no longer visible even when not selected
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
