### PR TITLE
Fixes lavaboat not accepting oar

### DIFF
--- a/code/modules/vehicles/lavaboat.dm
+++ b/code/modules/vehicles/lavaboat.dm
@@ -10,6 +10,7 @@
 	icon_state_preview = "boat"
 	resistance_flags = LAVA_PROOF | FIRE_PROOF
 	can_buckle = TRUE
+	key_type = /obj/item/oar
 
 /obj/vehicle/ridden/lavaboat/add_riding_element()
 	AddElement(/datum/element/ridable, /datum/component/riding/vehicle/lavaboat)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Closes #13236

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Bug bad

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->

![dreamseeker_tZaXwWTfzb](https://github.com/user-attachments/assets/89a3a3dc-682f-40e0-99d1-47df9c18dbaf)

![dreamseeker_CiKz05Dx4x](https://github.com/user-attachments/assets/185b1012-6ec8-4f01-bec6-b8a0b1984b0e)

## Changelog
:cl:
fix: Goliath lava boats now work again by properly accepting the oar they need to function
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
