### PR TITLE
Fixes plasmamen not receiving a helmet and internals after being captured/released

### DIFF
--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -1467,8 +1467,9 @@ GLOBAL_LIST_EMPTY(features_by_species)
 	if(!outfit_important_for_life)
 		return
 
-	outfit_important_for_life= new()
-	outfit_important_for_life.equip(human_to_equip)
+	var/datum/outfit/outfit = new outfit_important_for_life()
+	outfit.equip(human_to_equip)
+	qdel(outfit)
 
 ////////
 //LIFE//

--- a/code/modules/mob/living/carbon/human/species_types/plasmamen.dm
+++ b/code/modules/mob/living/carbon/human/species_types/plasmamen.dm
@@ -110,7 +110,7 @@
 			H.open_internals(H.get_item_for_held_index(2))
 
 /datum/species/plasmaman/give_important_for_life(mob/living/carbon/human/human_to_equip)
-	..()
+	. = ..()
 	human_to_equip.open_internals(human_to_equip.get_item_for_held_index(2))
 
 /datum/species/plasmaman/qualifies_for_rank(rank, list/features)

--- a/code/modules/mob/living/carbon/human/species_types/plasmamen.dm
+++ b/code/modules/mob/living/carbon/human/species_types/plasmamen.dm
@@ -109,6 +109,10 @@
 			H.equip_to_slot(new helmet, ITEM_SLOT_HEAD)
 			H.open_internals(H.get_item_for_held_index(2))
 
+/datum/species/plasmaman/give_important_for_life(mob/living/carbon/human/human_to_equip)
+	..()
+	human_to_equip.open_internals(human_to_equip.get_item_for_held_index(2))
+
 /datum/species/plasmaman/qualifies_for_rank(rank, list/features)
 	if(rank in SSdepartment.get_jobs_by_dept_id(DEPT_NAME_SECURITY))
 		return 0


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

give_important_for_life is called when being captured and released
https://github.com/BeeStation/BeeStation-Hornet/blob/743b433646d3a90f5e1d5a887c5a76a8fed7361c/code/modules/antagonists/ninja/energy_net_nets.dm#L123
give_important_for_life would create a new outfit without a type which would be "Naked", leading to plasmamen getting no helmet nor internals when being sent and returned

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

plasmamen no longer have to pray they are released near an emergency or fire closet so that they can get a pressure proof helmet and epinephrine/vacuum pen to live until they run back to where their stuff was

getting captured is no longer a qte either

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

https://github.com/user-attachments/assets/7d051084-0b9e-4ca2-8653-95e39a647b81

</details>

## Changelog
:cl: lord scrubling
fix: plasmamen receive a helmet and internals after being captured
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
