### PR TITLE
Replaces LOOC with private OOC

### DIFF
--- a/code/modules/client/verbs/looc.dm
+++ b/code/modules/client/verbs/looc.dm
@@ -2,9 +2,9 @@
 
 GLOBAL_VAR_INIT(looc_allowed, TRUE)
 
-AUTH_CLIENT_VERB(looc)
-	set name = "LOOC"
-	set desc = "Local OOC, can only be seen by the target which must be in view of the user."
+AUTH_CLIENT_VERB(private_ooc)
+	set name = "Private OOC"
+	set desc = "Private OOC, can only be seen by the target which must be in view of the user."
 	set category = "OOC"
 
 	if(GLOB.say_disabled)    //This is here to try to identify lag problems
@@ -20,6 +20,8 @@ AUTH_CLIENT_VERB(looc)
 		if (!target_mob.client)
 			continue
 		message_targets += target_mob
+
+
 
 	var/mob/living/target = tgui_input_list(
 		usr,

--- a/code/modules/client/verbs/looc.dm
+++ b/code/modules/client/verbs/looc.dm
@@ -21,8 +21,6 @@ AUTH_CLIENT_VERB(private_ooc)
 			continue
 		message_targets += target_mob
 
-
-
 	var/mob/living/target = tgui_input_list(
 		usr,
 		"Who would you like to contact?.",

--- a/code/modules/client/verbs/looc.dm
+++ b/code/modules/client/verbs/looc.dm
@@ -86,7 +86,8 @@ AUTH_CLIENT_VERB(looc)
 	var/list/targets = list()
 
 	to_chat(usr, span_looc("[span_prefix("LOOC:")] <EM>[span_name("[mob.name]")]:</EM> [span_message(msg)]"), avoid_highlighting = TRUE)
-	to_chat(target, span_looc("[span_prefix("LOOC:")] <EM>[span_name("[mob.name]")]:</EM> [span_message(msg)]"), avoid_highlighting = FALSE)
+	if (usr != target)
+		to_chat(target, span_looc("[span_prefix("LOOC:")] <EM>[span_name("[mob.name]")]:</EM> [span_message(msg)]"), avoid_highlighting = FALSE)
 
 	if(target.client.prefs.read_player_preference(/datum/preference/toggle/enable_runechat_looc))
 		targets |= target

--- a/code/modules/tgui_input/say_modal/speech.dm
+++ b/code/modules/tgui_input/say_modal/speech.dm
@@ -45,7 +45,7 @@
 			client.ooc(entry)
 			return TRUE
 		if(LOOC_CHANNEL)
-			client.looc(entry)
+			client.private_ooc(entry)
 		if(ASAY_CHANNEL)
 			if(client.holder)
 				client.cmd_admin_say(entry)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This will be a controversial PR, but I'll try to explain myself later on.

- LOOC now only sends to 1 person, who you select from a list when you try to use it.

I am kind of purposely making it a bit more annoying to use LOOC to try and discourage it's use in situations where it shouldn't be used. I am hoping that LOOC can be used to apologise or help other players out, but I want to push players away from using it as a first resort for any mistake that happens in the game, or to flame other players for their playstyle.

## Why It's Good For The Game

I have been seeing a few issues with LOOC:
- Players are using the LOOC to tell players that they don't like the way they are playing, which on one hand is okay, but in many cases it is getting toxic and making players feel heavy judgement and is pushing them away from the community. LOOC contributes to this problem since it is so easy to use that players are frequently using it for any situation.
- Players are using LOOC to have in-character conversations, and are using it for things that they shouldn't be using it.

In general players are getting scared by other players in the community, and LOOC is playing a big role in that trend, especially now that we have overhead LOOC.

I specifically do not want to revert LOOC overhead chat because it is actually quite good for helping new players.

## Testing Photographs and Procedure

<img width="451" height="416" alt="image" src="https://github.com/user-attachments/assets/481370d5-a2a5-4310-9478-204ecbda462c" />

<img width="426" height="212" alt="image" src="https://github.com/user-attachments/assets/86f648c9-d939-46e5-9fcc-faa00f086b3c" />

<img width="221" height="68" alt="image" src="https://github.com/user-attachments/assets/2036e033-a179-4e0e-884d-42d898bdb867" />

<img width="295" height="194" alt="image" src="https://github.com/user-attachments/assets/afa3dae8-90ac-4b5d-a1ac-50a6f5065d6b" />

## Changelog
:cl:
tweak: The LOOC verb has been removed and replacted with `private-ooc` which allows you to communicate with specific players.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
