### PR TITLE
Fixes improper smartfridge overlay

### DIFF
--- a/code/modules/food_and_drinks/kitchen_machinery/smartfridge.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/smartfridge.dm
@@ -231,7 +231,7 @@
 		icon_state += "-broken"
 	return ..()
 
-/// Returns the number of items visible in the fridge. Faster than subtracting 2 lists
+/// Returns the number of items visible in the fridge.
 /obj/machinery/smartfridge/proc/visible_items()
 	return length(contents) - length(component_parts) // Exclude circuitboard and matter bin
 

--- a/code/modules/food_and_drinks/kitchen_machinery/smartfridge.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/smartfridge.dm
@@ -233,7 +233,7 @@
 
 /// Returns the number of items visible in the fridge. Faster than subtracting 2 lists
 /obj/machinery/smartfridge/proc/visible_items()
-	return contents.len - 1 // Exclude circuitboard
+	return length(contents) - length(component_parts) // Exclude circuitboard and matter bin
 
 /obj/machinery/smartfridge/update_overlays()
 	. = ..()


### PR DESCRIPTION
## About The Pull Request

The previous code took the length of the smartfridge's contents and subtracted it by one (to account for the circuit board) to calculate the amount of items in the fridge. Problem is that all of the component parts are also in contents, including the matter bin.

The solution I've put in place is less hardcody and actually displays the overlay correctly.

## Why It's Good For The Game

closes #13213

## Testing Photographs and Procedure

<img width="610" height="605" alt="image" src="https://github.com/user-attachments/assets/9f981e08-fdae-49e4-90dc-83f9e9dec014" />

<img width="520" height="599" alt="image" src="https://github.com/user-attachments/assets/6b4ef6c3-c4c1-4e5e-9049-72e0f06cfc40" />


## Changelog
:cl:
fix: Fixed the item overlay on smartfridges displaying even when there are no items inside.
/:cl:
