### PR TITLE
[FIX] Inducer Crates

### DIFF
--- a/code/game/objects/items/inducer.dm
+++ b/code/game/objects/items/inducer.dm
@@ -205,10 +205,10 @@
 	transfer_coef = 1
 	opened = TRUE
 
-/obj/item/inducer/sci/with_cell()
-	cell_type = /obj/item/stock_parts/cell/high
-	opened = FALSE
-
 /obj/item/inducer/sci/Initialize(mapload)
 	. = ..()
 	update_icon()
+
+/obj/item/inducer/sci/with_cell
+	cell_type = /obj/item/stock_parts/cell/high
+	opened = FALSE

--- a/code/game/objects/items/inducer.dm
+++ b/code/game/objects/items/inducer.dm
@@ -9,7 +9,7 @@
 	force = 7
 	var/transfer_coef = 2
 	var/opened = FALSE
-	var/cell_type = /obj/item/stock_parts/cell/high
+	var/cell_type = /obj/item/stock_parts/cell/high/plus
 	var/obj/item/stock_parts/cell/cell
 	var/recharging = FALSE
 
@@ -204,6 +204,10 @@
 	cell_type = null
 	transfer_coef = 1
 	opened = TRUE
+
+/obj/item/inducer/sci/with_cell()
+	cell_type = /obj/item/stock_parts/cell/high
+	opened = FALSE
 
 /obj/item/inducer/sci/Initialize(mapload)
 	. = ..()

--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -1082,17 +1082,13 @@
 	crate_name = "space shelter crate"
 	crate_type = /obj/structure/closet/crate/engineering/electrical
 
-/obj/item/stock_parts/cell/inducer_supply
-	maxcharge = 5000
-	charge = 5000
-
 /datum/supply_pack/engineering/inducers
 	name = "NT-100 Heavy-Duty Inducers Crate"
 	desc = "No rechargers? No problem, with the NT-100 EPI, you can recharge any standard cell-based equipment anytime, anywhere, twice faster than consumer alternatives! Contains two Engineering inducers."
 	cost = 2000
 	max_supply = 3
-	contains = list(/obj/item/inducer {cell_type = /obj/item/stock_parts/cell/high; opened = 0}, /obj/item/inducer {cell_type = /obj/item/stock_parts/cell/inducer_supply; opened = 0}) //FALSE doesn't work in modified type paths apparently.
-	crate_name = "inducer crate"
+	contains = list(/obj/item/inducer, /obj/item/inducer)
+	crate_name = "industrial inducer crate"
 	crate_type = /obj/structure/closet/crate/engineering/electrical
 
 /datum/supply_pack/engineering/pacman
@@ -2043,8 +2039,8 @@
 	desc = "No rechargers? No problem, with the NT-50 EPI, you can recharge any standard cell-based equipment anytime, anywhere! Contains two Science inducers."
 	cost = 1000
 	max_supply = 3
-	contains = list(/obj/item/inducer/sci {cell_type = /obj/item/stock_parts/cell/inducer_supply; opened = 0}, /obj/item/inducer/sci {cell_type = /obj/item/stock_parts/cell/inducer_supply; opened = 0}) //FALSE doesn't work in modified type paths apparently.
-	crate_name = "inducer crate"
+	contains = list(/obj/item/inducer/sci/with_cell, /obj/item/inducer/sci/with_cell)
+	crate_name = "science inducer crate"
 
 /datum/supply_pack/science/rped
 	name = "RPED crate"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Closes #13242

This PR fixes inducer crates being empty, caused by https://github.com/BeeStation/BeeStation-Hornet/pull/10906

This PR also makes the default cell for engineering inducer a tiny bit better (just to force more of a difference between science and industrial)


Industrial crate inducer and the battery it comes with (game fucked me and gave me only one)
<img width="229" height="268" alt="image" src="https://github.com/user-attachments/assets/7f16859b-f14b-4481-9d14-8d6e5cfdee6f" />


## Why It's Good For The Game

Bug Fix

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>


</details>

## Changelog
:cl:
fix: Inducer crates are no longer empty
code: Created a subtype of science inducer that starts with a standard cell
code: Deleted yet another cell type that was, this time, hidden away in crate code
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
