### PR TITLE
Bubblegum no longer ends his dashes early

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/megafauna/bubblegum.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/bubblegum.dm
@@ -195,14 +195,13 @@ Difficulty: Hard
 	while(charging)
 		SLEEP_CHECK_DEATH(1)
 
-/mob/living/simple_animal/hostile/megafauna/bubblegum/proc/charge_end(datum/source)
+/mob/living/simple_animal/hostile/megafauna/bubblegum/proc/charge_end(datum/move_loop/source)
 	SIGNAL_HANDLER
-	var/datum/move_loop/loop = source
-	if(!QDELETED(loop))
+	if(!QDELETED(source))
 		SSmove_manager.stop_looping(src) // cancel the movement
 	try_bloodattack()
 	charging = FALSE
-	UnregisterSignal(loop, list(COMSIG_MOVELOOP_REACHED_TARGET, COMSIG_QDELETING))
+	UnregisterSignal(source, list(COMSIG_MOVELOOP_REACHED_TARGET, COMSIG_QDELETING))
 
 /mob/living/simple_animal/hostile/megafauna/bubblegum/proc/get_mobs_on_blood()
 	var/list/targets = ListTargets()

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/bubblegum.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/bubblegum.dm
@@ -185,12 +185,13 @@ Difficulty: Hard
 	SLEEP_CHECK_DEATH(delay)
 	revving_charge = FALSE
 	var/movespeed = 0.7
-	var/datum/move_loop/loop = SSmove_manager.move_towards(src, T, movespeed, timeout = get_dist(src, T) - movespeed)
+	var/time_to_hit = min(get_dist(src, T), 50) * movespeed
+	var/datum/move_loop/loop = SSmove_manager.home_onto(src, T, movespeed, timeout = time_to_hit + 1, extra_info = T)
 	if(!loop)
 		return
 	RegisterSignal(loop, COMSIG_MOVELOOP_REACHED_TARGET, PROC_REF(charge_end))
-	RegisterSignal(loop, COMSIG_QDELETING, PROC_REF(charge_end))
-	//Wait until we're done
+	RegisterSignal(loop, COMSIG_QDELETING, PROC_REF(charge_end)) // When loop times out
+	// Wait until we're done
 	while(charging)
 		SLEEP_CHECK_DEATH(1)
 

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/bubblegum.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/bubblegum.dm
@@ -185,7 +185,8 @@ Difficulty: Hard
 	SLEEP_CHECK_DEATH(delay)
 	revving_charge = FALSE
 	var/movespeed = 0.7
-	var/time_to_hit = min(get_dist(src, T), 50) * movespeed
+	var/max_range
+	var/time_to_hit = min(get_dist(src, T), max_range) * movespeed
 	var/datum/move_loop/loop = SSmove_manager.home_onto(src, T, movespeed, timeout = time_to_hit + 1, extra_info = T)
 	if(!loop)
 		return

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/bubblegum.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/bubblegum.dm
@@ -185,7 +185,7 @@ Difficulty: Hard
 	SLEEP_CHECK_DEATH(delay)
 	revving_charge = FALSE
 	var/movespeed = 0.7
-	var/max_range
+	var/max_range = 50
 	var/time_to_hit = min(get_dist(src, T), max_range) * movespeed
 	var/datum/move_loop/loop = SSmove_manager.home_onto(src, T, movespeed, timeout = time_to_hit + 1, extra_info = T)
 	if(!loop)

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/bubblegum.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/bubblegum.dm
@@ -190,8 +190,7 @@ Difficulty: Hard
 	var/datum/move_loop/loop = SSmove_manager.home_onto(src, T, movespeed, timeout = time_to_hit + 1, extra_info = T)
 	if(!loop)
 		return
-	RegisterSignal(loop, COMSIG_MOVELOOP_REACHED_TARGET, PROC_REF(charge_end))
-	RegisterSignal(loop, COMSIG_QDELETING, PROC_REF(charge_end)) // When loop times out
+	RegisterSignals(loop, list(COMSIG_MOVELOOP_REACHED_TARGET, COMSIG_QDELETING), PROC_REF(charge_end))
 	// Wait until we're done
 	while(charging)
 		SLEEP_CHECK_DEATH(1)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Title.
Prior to this bubblegum would end his dash several tiles before reaching his target rune

move_towards() has been replaced with home_onto() because it more accurately travels to its target

Previously the movement loop duration was controlled by `SLEEP_CHECK_DEATH(get_dist(src, T) * movespeed)` which consistently ended the dash shorter than it's supposed to be ended
Now the dash is  ended via signals by bubblegum reaching his target or in the case where he can't reach it for whatever reason it's ended by `timeout = time_to_hit + 1`(The timing on this still is not perfect but it seems to end when bubblegum is inside his 3x3 target rune and i'm out of ideas)

Also gives his dashes a max range of 50


## Why It's Good For The Game

Bubblegum is supposed to be hard

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

Removed because it contained my CID.


Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>

## Changelog
:cl:
fix: Bubblegum no longer ends his dashes earlier than he should
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
