### PR TITLE
Fixes advanced atmos resin foam being killed prematurely in high heat

### DIFF
--- a/code/game/objects/effects/effect_system/effects_foam.dm
+++ b/code/game/objects/effects/effect_system/effects_foam.dm
@@ -87,7 +87,7 @@
 	name = "resin foam"
 	metal = RESIN_FOAM
 
-/obj/effect/particle_effect/foam/metal/chainreact_resin
+/obj/effect/particle_effect/foam/metal/resin/chainreact
 	name = "self-destruct resin foam"
 	metal = RESIN_FOAM_CHAINREACT
 	lifetime = 20

--- a/code/game/objects/items/tanks/watertank.dm
+++ b/code/game/objects/items/tanks/watertank.dm
@@ -528,7 +528,7 @@
 					return
 			if(resin_synthesis_cooldown < max_foam)
 				if(toggled)
-					var/obj/effect/particle_effect/foam/metal/chainreact_resin/foam = new (get_turf(target))
+					var/obj/effect/particle_effect/foam/metal/resin/chainreact/foam = new (get_turf(target))
 					foam.amount = 0
 				else
 					var/obj/effect/particle_effect/foam/metal/resin/foam = new (get_turf(target))
@@ -585,10 +585,10 @@
 	anchored = TRUE
 
 /obj/effect/resin_container/chainreact/Smoke()
-	if(locate(/obj/effect/particle_effect/foam/metal/chainreact_resin) in get_turf(src) || locate(/obj/effect/particle_effect/foam/metal/resin) in get_turf(src))
+	if(locate(/obj/effect/particle_effect/foam/metal/resin) in get_turf(src))
 		qdel(src)
 		return
-	var/obj/effect/particle_effect/foam/metal/chainreact_resin/S = new /obj/effect/particle_effect/foam/metal/chainreact_resin(get_turf(loc))
+	var/obj/effect/particle_effect/foam/metal/resin/chainreact/S = new(get_turf(loc))
 	S.amount = smoke_amount
 	playsound(src,'sound/effects/bamf.ogg',100,1)
 	qdel(src)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

resin used to stop spreading early when the air is above 470K
this behavior was removed in #12452, however advanced resin was seemingly overlooked when asked to limit it to just atmos resin due to it not being a subtype
> Theres no reason for the other foams to not be affected by the high heat. If you are fixing the firefighting foam, limit your changes to that.

## Why It's Good For The Game

advanced resin should be as good as normal resin at cleaning up hot gases
it should also inherit any potential future behavior added to normal resin

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

https://github.com/user-attachments/assets/2831f86b-05b7-442f-b996-9d1af1323d4f

</details>

## Changelog
:cl: lord scrubling
fix: advanced atmos resin is no longer killed early when spreading in hot air
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
