### PR TITLE
Adds extinguishers to various atmos suit storage slots and fixes firefighting foam

### DIFF
--- a/code/game/objects/effects/effect_system/effects_foam.dm
+++ b/code/game/objects/effects/effect_system/effects_foam.dm
@@ -42,7 +42,7 @@
 
 	var/turf/open/T = get_turf(src)
 	var/obj/effect/hotspot/hotspot = (locate(/obj/effect/hotspot) in T)
-	if(hotspot && istype(T) && T.air)
+	if(hotspot && T.air)
 		qdel(hotspot)
 		var/datum/gas_mixture/G = T.air
 		var/plas_amt = min(30,GET_MOLES(/datum/gas/plasma, G)) //Absorb some plasma

--- a/code/game/objects/items/extinguisher.dm
+++ b/code/game/objects/items/extinguisher.dm
@@ -60,7 +60,6 @@
 	tanktype = /obj/structure/reagent_dispensers/foamtank
 	sprite_name = "foam_extinguisher"
 	precision = TRUE
-	w_class = WEIGHT_CLASS_NORMAL
 
 /obj/item/extinguisher/suicide_act(mob/living/carbon/user)
 	if (!safety && (reagents.total_volume >= 1))

--- a/code/game/objects/items/extinguisher.dm
+++ b/code/game/objects/items/extinguisher.dm
@@ -60,6 +60,7 @@
 	tanktype = /obj/structure/reagent_dispensers/foamtank
 	sprite_name = "foam_extinguisher"
 	precision = TRUE
+	w_class = WEIGHT_CLASS_NORMAL
 
 /obj/item/extinguisher/suicide_act(mob/living/carbon/user)
 	if (!safety && (reagents.total_volume >= 1))

--- a/code/modules/clothing/spacesuits/hardsuit.dm
+++ b/code/modules/clothing/spacesuits/hardsuit.dm
@@ -365,6 +365,8 @@
 	armor_type = /datum/armor/engine_atmos
 	heat_protection = HEAD												//Uncomment to enable firesuit protection
 	max_heat_protection_temperature = FIRE_IMMUNITY_MAX_TEMP_PROTECT
+	allowed = list(/obj/item/flashlight, /obj/item/tank/internals, /obj/item/t_scanner,
+		/obj/item/construction/rcd, /obj/item/pipe_dispenser, /obj/item/extinguisher)
 
 
 /datum/armor/engine_atmos

--- a/code/modules/clothing/spacesuits/hardsuit.dm
+++ b/code/modules/clothing/spacesuits/hardsuit.dm
@@ -365,8 +365,6 @@
 	armor_type = /datum/armor/engine_atmos
 	heat_protection = HEAD												//Uncomment to enable firesuit protection
 	max_heat_protection_temperature = FIRE_IMMUNITY_MAX_TEMP_PROTECT
-	allowed = list(/obj/item/flashlight, /obj/item/tank/internals, /obj/item/t_scanner,
-		/obj/item/construction/rcd, /obj/item/pipe_dispenser, /obj/item/extinguisher)
 
 
 /datum/armor/engine_atmos
@@ -391,6 +389,8 @@
 	heat_protection = CHEST|GROIN|LEGS|FEET|ARMS|HANDS					//Uncomment to enable firesuit protection
 	max_heat_protection_temperature = FIRE_IMMUNITY_MAX_TEMP_PROTECT
 	helmettype = /obj/item/clothing/head/helmet/space/hardsuit/engine/atmos
+	allowed = list(/obj/item/flashlight, /obj/item/tank/internals, /obj/item/t_scanner,
+		/obj/item/construction/rcd, /obj/item/pipe_dispenser, /obj/item/extinguisher)
 
 
 	//Chief Engineer's hardsuit

--- a/code/modules/clothing/suits/wintercoats.dm
+++ b/code/modules/clothing/suits/wintercoats.dm
@@ -416,6 +416,7 @@
 	icon_state = "coatatmos"
 	item_state = "coatatmos"
 	hoodtype = /obj/item/clothing/head/hooded/winterhood/engineering/atmos
+	allowed = list(/obj/item/flashlight, /obj/item/tank/internals/emergency_oxygen, /obj/item/tank/internals/plasmaman, /obj/item/t_scanner, /obj/item/construction/rcd, /obj/item/pipe_dispenser, /obj/item/toy, /obj/item/storage/fancy/cigarettes, /obj/item/lighter, /obj/item/extinguisher)
 
 /obj/item/clothing/head/hooded/winterhood/engineering/atmos
 	icon_state = "winterhood_atmos"

--- a/code/modules/mod/mod_theme.dm
+++ b/code/modules/mod/mod_theme.dm
@@ -318,6 +318,7 @@
 		/obj/item/t_scanner,
 		/obj/item/construction/rcd,
 		/obj/item/pipe_dispenser,
+		/obj/item/extinguisher,
 	)
 	variants = list(
 		"atmospheric" = list(

--- a/code/modules/reagents/chemistry/reagents/pyrotechnic_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/pyrotechnic_reagents.dm
@@ -322,7 +322,7 @@
 	if(reac_volume >= 1)
 		var/obj/effect/particle_effect/foam/firefighting/foam = locate(/obj/effect/particle_effect/foam) in exposed_turf
 		if(!foam)
-			foam = new(foam)
+			foam = new(exposed_turf)
 		else if(istype(foam))
 			foam.lifetime = initial(foam.lifetime) //reduce object churn a little bit when using smoke by keeping existing foam alive a bit longer
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
- atmos clothing has had extinguishers added to their suit storage slot
- advanced extinguishers behaved like normal extinguishers without their foam because they weren't being initialized with a loc properly which can be blamed back to #13094
https://github.com/BeeStation/BeeStation-Hornet/blame/abcac06bdc768c44733c2058acbedebd53d9d27b/code/modules/reagents/chemistry/reagents/pyrotechnic_reagents.dm#L325
## Why It's Good For The Game
hopefully will encourage their use more
## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

https://github.com/user-attachments/assets/f019f208-7b41-4d68-8c7b-88090469c41b

https://github.com/user-attachments/assets/b47763be-6d0b-4f6d-bbdc-dca62b730b13

</details>

## Changelog
:cl: lord scrubling
add: atmos hardsuits, winter coats, and modsuits can carry extinguishers in their exo slot
fix: firefighting foam now works
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
