### PR TITLE
Removes a stray decal on BoxStation

### DIFF
--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -4211,9 +4211,6 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
 /obj/machinery/stasis{
 	dir = 4
 	},
@@ -4223,6 +4220,9 @@
 	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 4
 	},
 /turf/open/floor/iron/grid,
 /area/medical/patients_rooms)
@@ -10820,9 +10820,6 @@
 	},
 /obj/effect/turf_decal/tile/blue/opposingcorners,
 /obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/siding/blue{
 	dir = 4
 	},
 /turf/open/floor/iron/white,
@@ -23737,9 +23734,6 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
 /obj/effect/turf_decal/tile/white/opposingcorners,
 /obj/effect/turf_decal/tile/white{
 	dir = 4
@@ -23749,6 +23743,9 @@
 	},
 /obj/machinery/stasis{
 	dir = 1
+	},
+/obj/structure/window/reinforced{
+	dir = 8
 	},
 /turf/open/floor/iron/grid,
 /area/medical/patients_rooms)
@@ -41916,9 +41913,6 @@
 /turf/open/floor/prison,
 /area/security/prison)
 "nly" = (
-/obj/structure/window/reinforced{
-	dir = 8
-	},
 /obj/effect/turf_decal/tile/white,
 /obj/effect/turf_decal/tile/blue/opposingcorners{
 	dir = 1
@@ -41928,6 +41922,9 @@
 	},
 /obj/machinery/computer/operating{
 	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 8
 	},
 /turf/open/floor/iron/grid,
 /area/medical/patients_rooms)
@@ -57056,9 +57053,6 @@
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "taf" = (
-/obj/structure/window/reinforced{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/white,
 /obj/effect/turf_decal/tile/blue/half/contrasted{
 	dir = 1
@@ -57068,6 +57062,9 @@
 	},
 /obj/structure/bed/roller,
 /obj/item/bedsheet/medical,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
 /turf/open/floor/iron/grid,
 /area/medical/patients_rooms)
 "tam" = (


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

There was a random decal I did not remove on BoxStation medbay

<img width="352" height="224" alt="image" src="https://github.com/user-attachments/assets/157ef53f-e07d-4013-97bd-dab8c592542e" />

## Changelog
:cl:
del: Removed a stray decal on BoxStation
/:cl:
