### PR TITLE
Completely removes triggerCameraAlarm() so players that disable cameras don't immediately alert AIs

### DIFF
--- a/code/game/machinery/camera/camera.dm
+++ b/code/game/machinery/camera/camera.dm
@@ -154,7 +154,6 @@ CREATION_TEST_IGNORE_SUBTYPES(/obj/machinery/camera)
 		toggle_cam(null, 0) //kick anyone viewing out and remove from the camera chunks
 	GLOB.cameranet.removeCamera(src)
 	GLOB.cameranet.cameras -= src
-	cancelCameraAlarm()
 	if(isarea(myarea))
 		LAZYREMOVE(myarea.cameras, src)
 	QDEL_NULL(alarm_manager)
@@ -217,14 +216,12 @@ CREATION_TEST_IGNORE_SUBTYPES(/obj/machinery/camera)
 
 /obj/machinery/camera/emp_reset()
 	..()
-	triggerCameraAlarm() //camera alarm triggers even if multiple EMPs are in effect.
 	if(emped == thisemp) //Only fix it if the camera hasn't been EMP'd again
 		network = previous_network
 		update_appearance()
 		if(can_use())
 			GLOB.cameranet.addCamera(src)
 		emped = 0 //Resets the consecutive EMP count
-		addtimer(CALLBACK(src, PROC_REF(cancelCameraAlarm)), 100)
 
 /obj/machinery/camera/ex_act(severity, target)
 	if(invuln)
@@ -413,7 +410,6 @@ CREATION_TEST_IGNORE_SUBTYPES(/obj/machinery/camera)
 		return
 	. = ..()
 	if(.)
-		triggerCameraAlarm()
 		toggle_cam(null, 0)
 
 /obj/machinery/camera/deconstruct(disassembled = TRUE)
@@ -472,8 +468,6 @@ CREATION_TEST_IGNORE_SUBTYPES(/obj/machinery/camera)
 	var/change_msg = "deactivates"
 	if(status)
 		change_msg = "reactivates"
-		triggerCameraAlarm()
-		addtimer(CALLBACK(src, PROC_REF(cancelCameraAlarm)), 100)
 	if(displaymessage)
 		if(user)
 			visible_message(span_danger("[user] [change_msg] [src]!"))
@@ -492,14 +486,6 @@ CREATION_TEST_IGNORE_SUBTYPES(/obj/machinery/camera)
 			O.unset_machine()
 			O.reset_perspective(null)
 			to_chat(O, "The screen bursts into static.")
-
-/obj/machinery/camera/proc/triggerCameraAlarm()
-	alarm_on = TRUE
-	alarm_manager.send_alarm(ALARM_CAMERA, src, src)
-
-/obj/machinery/camera/proc/cancelCameraAlarm()
-	alarm_on = FALSE
-	alarm_manager.clear_alarm(ALARM_CAMERA)
 
 /obj/machinery/camera/proc/can_use()
 	if(!status)

--- a/code/game/machinery/camera/camera.dm
+++ b/code/game/machinery/camera/camera.dm
@@ -33,8 +33,6 @@
 	var/view_range = 7
 	var/short_range = 2
 
-	var/alarm_on = FALSE
-	var/busy = FALSE
 	var/emped = FALSE  //Number of consecutive EMP's on this camera
 	var/in_use_lights = 0
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Removes the proc `triggerCameraAlarm()` which is called when cameras are disabled or turned back on from a disabled state. 

This is not the same proc used for motion sensor cameras, and that proc has not been touched. Cameras may be upgraded with motion sensors and those will still trip, though motion sensor cameras can also be disabled without sending an alert now. 

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

I asked with a ping to mentors in #questions what the best way to avoid an AI was to make sure I wasn't missing anything. I was the following advice:
* Cut the cameras (Immediately alerts AI)
* Buy a radio jammer (Repeatedly spams the AI with alerts)
* Radio silence
* Blow up the AI
* Hide in a plant
* Turn suit sensors off
* Buy the 1tc AI tracker
* Buy and use a chameleon projector

I think it's ridiculous that the best course of action for avoiding AI detection essentially boils down to minimize your radio presence and pray the AI doesn't decide to look your way without even knowing if they have or not (with exception to the two uplink options). Disabling cameras should not send an immediate and location named alert, it should be the go-to method of preventing yourself from being seen if you weren't already being watched, especially since most locations have multiple cameras and you can't hope to disable them all discreetly without being spotted after the first alert goes out. 

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

It's hard to demonstrate something not working anymore, but here's the best I've got. I'm playing as an AI in this screencap. 

<img width="809" height="144" alt="image" src="https://github.com/user-attachments/assets/ca0af0f7-caf9-46f8-8d84-37a7508db8b4" />

</details>

## Changelog
:cl:
del: Cameras no longer send alerts to AI except for motion cameras detecting motion. This means cameras can now be disabled, destroyed or hit with an EMP without the AI being immediately notified that cameras have been disabled in a specific location.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
