### PR TITLE
fixes ethereal colors

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/ethereal.dm
+++ b/code/modules/mob/living/carbon/human/species_types/ethereal.dm
@@ -100,11 +100,11 @@
 	. = ..()
 	if(!ethereal_light)
 		return
-	if(default_color != ethereal.dna.features["ethcolor"])
-		var/new_color = ethereal.dna.features["ethcolor"]
-		r1 = GETREDPART(new_color)
-		g1 = GETGREENPART(new_color)
-		b1 = GETBLUEPART(new_color)
+	var/dna_color = "#[ethereal.dna.features["ethcolor"]]"
+	if(default_color != dna_color)
+		r1 = GETREDPART(dna_color)
+		g1 = GETGREENPART(dna_color)
+		b1 = GETBLUEPART(dna_color)
 	if(ethereal.stat != DEAD && !EMPeffect)
 		var/healthpercent = max(ethereal.health, 0) / 100
 		if(!emageffect)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

the colors are decoded with macros that expect hex numbers to begin with a #, so the digits were shifted left

https://github.com/BeeStation/BeeStation-Hornet/blame/563ed65020b7298959f8f660b5da8ae32a58e9f7/code/modules/mob/living/carbon/human/species_types/ethereal.dm#L105

## Why It's Good For The Game

fixes #12926

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

https://github.com/user-attachments/assets/74f81d3e-0c4f-4d4b-b242-b7fa9d60bdfd

using game bar, couldn't be bothered to download capture software that could record the preference window so it's a verb proc call

i promise the tiny dummy is dark teal if you look closely, it used to be orange

<img width="725" height="374" alt="image" src="https://github.com/user-attachments/assets/f45a6161-4d88-4957-9151-b293e543a7f0" />

<img width="729" height="375" alt="image" src="https://github.com/user-attachments/assets/72ba4ca4-8099-46d0-a1ca-cd26877c9889" />

</details>

## Changelog
:cl: lord scrubling
fix: ethereal colors
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
