### PR TITLE
Fixes gun recharging

### DIFF
--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -175,9 +175,8 @@
 
 				// Defer to normal ranged attack
 				if (ranged_attack_result == SECONDARY_ATTACK_CALL_NORMAL)
-					if (!W.ranged_attack(A, src, params))
-						W.afterattack(A,src,0,params)
-					return
+					if (W.ranged_attack(A, src, params))
+						return
 
 				var/after_attack_secondary_result = W.afterattack_secondary(A, src, FALSE, params)
 

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -292,10 +292,28 @@
 				continue
 			O.emp_act(severity)
 
-/obj/item/gun/pre_attack(atom/A, mob/living/user, params)
+/obj/item/gun/attack_atom(obj/O, mob/living/user, params)
+	if (user.combat_mode || (flags_1 & ISWEAPON))
+		..()
+		return TRUE
+	return FALSE
+
+/obj/item/gun/attack_turf(turf/T, mob/living/user)
+	if (user.combat_mode || (flags_1 & ISWEAPON))
+		..()
+		return TRUE
+	return FALSE
+
+/obj/item/gun/attack(mob/M, mob/living/user)
+	if (user.combat_mode || (flags_1 & ISWEAPON))
+		..()
+		return TRUE
+	return FALSE
+
+/obj/item/gun/afterattack(atom/target, mob/user, proximity_flag, click_parameters)
 	. = ..()
 	// Cancel the attack chain if we fire
-	return . || pull_trigger(A, user, params, GUN_NOT_AIMED)
+	return . || pull_trigger(target, user, click_parameters, GUN_NOT_AIMED)
 
 /obj/item/gun/ranged_attack(atom/target, mob/living/user, params)
 	. = ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

- Fixes guns not being able to recharge properly due to attackby being skipped.

## Why It's Good For The Game

The code overrides attack_atom, attack_turf and attack because there is no other way to still have attackby called, since attackby calls these procs. If you want the ability to intercept attacks (like with rechargers) then it must be done this way. This should resolve any other future issues that come from things wanting to accept guns.

## Testing Photographs and Procedure

https://github.com/user-attachments/assets/e5d09e79-2abb-4c80-a03b-8767d598735e

## Changelog
:cl:
fix: Guns can now be recharged again.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
