### PR TITLE
Renames cybernetic stomachs to be less misleading

### DIFF
--- a/code/modules/surgery/organs/stomach.dm
+++ b/code/modules/surgery/organs/stomach.dm
@@ -193,14 +193,14 @@
 	to_chat(owner, span_notice("You absorb some of the shock into your body!"))
 
 /obj/item/organ/stomach/cybernetic
-	name = "basic cybernetic stomach"
+	name = "cybernetic stomach"
 	icon_state = "stomach-c"
 	desc = "A basic device designed to mimic the functions of a human stomach"
 	organ_flags = ORGAN_SYNTHETIC
 	maxHealth = STANDARD_ORGAN_THRESHOLD * 0.5
 
 /obj/item/organ/stomach/cybernetic/upgraded
-	name = "cybernetic stomach"
+	name = "advanced cybernetic stomach"
 	icon_state = "stomach-c-u"
 	desc = "An electronic device designed to mimic the functions of a human stomach. Handles disgusting food a bit better."
 	maxHealth = 1.5 * STANDARD_ORGAN_THRESHOLD


### PR DESCRIPTION
## About The Pull Request

Renames the un-upgraded "basic cybernetic stomach" to "cybernetic stomach" and the upgraded "cybernetic stomach" to "advanced cybernetic stomach". 

Closes #12831.

## Why It's Good For The Game

Avoids confusion by fixing the inconsistency between the names of the cybernetic stomachs when printing.

## Testing Photographs and Procedure
<details>
<summary>Screenshots&Videos</summary>

<img width="769" height="174" alt="oldstomach" src="https://github.com/user-attachments/assets/2bf986f9-6832-408d-bcfa-a2377bf7c3db" />

Old cybernetic stomach names

<img width="781" height="174" alt="stomachchange" src="https://github.com/user-attachments/assets/4c288364-e73d-4000-a9cc-edb7aea40c19" />

New cybernetic stomach names

</details>

## Changelog
:cl:
tweak: renamed cybernetic stomachs
/:cl: