### PR TITLE
Fixes an incredibly stupid mistake I made making vampires unstoppable

### DIFF
--- a/code/modules/antagonists/vampire/clans/_clan.dm
+++ b/code/modules/antagonists/vampire/clans/_clan.dm
@@ -84,7 +84,7 @@
 	favorite_vassal.grant_power(new /datum/action/vampire/targeted/brawn)
 
 /datum/vampire_clan/proc/spend_rank(mob/living/carbon/carbon_vassal)
-	if(vampiredatum.vampire_level_unspent <= 0)
+	if(QDELETED(vampiredatum.owner?.current) || vampiredatum.vampire_level_unspent <= 0)
 		return
 
 	// Generate radial menu

--- a/code/modules/antagonists/vampire/clans/_clan.dm
+++ b/code/modules/antagonists/vampire/clans/_clan.dm
@@ -84,6 +84,9 @@
 	favorite_vassal.grant_power(new /datum/action/vampire/targeted/brawn)
 
 /datum/vampire_clan/proc/spend_rank(mob/living/carbon/carbon_vassal)
+	if(vampiredatum.vampire_level_unspent <= 0)
+		return
+
 	// Generate radial menu
 	var/list/options = list()
 	var/list/radial_display = list()


### PR DESCRIPTION
## About The Pull Request

In #13189 when was culling a lot of useless and repetitive code, I accidentally removed an important check for seeing if the vampire actually has enough unspent levels to rank up. I didn't notice this in my testing because I would always give myself a ton of ranks for ease of debugging.

## Why It's Good For The Game

this literally makes vampires unstoppable

## Testing Photographs and Procedure

https://github.com/user-attachments/assets/ada13d48-9686-4d3c-abd1-567b82ab2e89

## Changelog
:cl:
fix: fixed vampires being able to level up an infinite amount of times
/:cl:
