### PR TITLE
Fixes Aux Base Construction Computer

### DIFF
--- a/code/game/objects/items/RCD.dm
+++ b/code/game/objects/items/RCD.dm
@@ -396,16 +396,20 @@ GLOBAL_VAR_INIT(icon_holographic_window, init_holographic_window())
 	//Not scaling these down to button size because they look horrible then, instead just bumping up radius.
 	return MA
 
-/obj/item/construction/rcd/proc/change_computer_dir(mob/user)
+/obj/item/construction/rcd/proc/change_computer_dir(mob/user, atom/anchor = null, require_near = TRUE)
 	if(!user)
 		return
+
+	if(!anchor)
+		anchor=src
+
 	var/list/computer_dirs = list(
 		"NORTH" = image(icon = 'icons/hud/radials/radial_generic.dmi', icon_state = "cnorth"),
 		"EAST" = image(icon = 'icons/hud/radials/radial_generic.dmi', icon_state = "ceast"),
 		"SOUTH" = image(icon = 'icons/hud/radials/radial_generic.dmi', icon_state = "csouth"),
 		"WEST" = image(icon = 'icons/hud/radials/radial_generic.dmi', icon_state = "cwest")
 		)
-	var/computerdirs = show_radial_menu(user, src, computer_dirs, custom_check = CALLBACK(src, PROC_REF(check_menu), user), require_near = TRUE, tooltips = TRUE)
+	var/computerdirs = show_radial_menu(user, anchor, computer_dirs, custom_check = CALLBACK(src, PROC_REF(check_menu), user), require_near = require_near, tooltips = TRUE)
 	if(!check_menu(user))
 		return
 	switch(computerdirs)

--- a/code/game/objects/items/RCD.dm
+++ b/code/game/objects/items/RCD.dm
@@ -396,12 +396,9 @@ GLOBAL_VAR_INIT(icon_holographic_window, init_holographic_window())
 	//Not scaling these down to button size because they look horrible then, instead just bumping up radius.
 	return MA
 
-/obj/item/construction/rcd/proc/change_computer_dir(mob/user, atom/anchor = null, require_near = TRUE)
+/obj/item/construction/rcd/proc/change_computer_dir(mob/user, atom/anchor = src, require_near = TRUE)
 	if(!user)
 		return
-
-	if(!anchor)
-		anchor=src
 
 	var/list/computer_dirs = list(
 		"NORTH" = image(icon = 'icons/hud/radials/radial_generic.dmi', icon_state = "cnorth"),
@@ -422,12 +419,9 @@ GLOBAL_VAR_INIT(icon_holographic_window, init_holographic_window())
 		if("WEST")
 			computer_dir = 8
 
-/obj/item/construction/rcd/proc/change_airlock_setting(mob/user, atom/anchor = null, require_near = TRUE)
+/obj/item/construction/rcd/proc/change_airlock_setting(mob/user, atom/anchor = src, require_near = TRUE)
 	if(!user)
 		return
-
-	if(!anchor)
-		anchor=src
 
 	var/list/solid_or_glass_choices = list(
 		"Solid" = get_airlock_image(/obj/machinery/door/airlock),

--- a/code/game/objects/items/RCD.dm
+++ b/code/game/objects/items/RCD.dm
@@ -418,9 +418,12 @@ GLOBAL_VAR_INIT(icon_holographic_window, init_holographic_window())
 		if("WEST")
 			computer_dir = 8
 
-/obj/item/construction/rcd/proc/change_airlock_setting(mob/user)
+/obj/item/construction/rcd/proc/change_airlock_setting(mob/user, atom/anchor = null, require_near = TRUE)
 	if(!user)
 		return
+
+	if(!anchor)
+		anchor=src
 
 	var/list/solid_or_glass_choices = list(
 		"Solid" = get_airlock_image(/obj/machinery/door/airlock),
@@ -466,13 +469,13 @@ GLOBAL_VAR_INIT(icon_holographic_window, init_holographic_window())
 		"External Maintenance" = get_airlock_image(/obj/machinery/door/airlock/maintenance/external/glass)
 	)
 
-	var/airlockcat = show_radial_menu(user, src, solid_or_glass_choices, custom_check = CALLBACK(src, PROC_REF(check_menu), user), require_near = TRUE, tooltips = TRUE)
+	var/airlockcat = show_radial_menu(user, anchor, solid_or_glass_choices, custom_check = CALLBACK(src, PROC_REF(check_menu), user), require_near = require_near, tooltips = TRUE)
 	if(!check_menu(user))
 		return
 	switch(airlockcat)
 		if("Solid")
 			if(advanced_airlock_setting == 1)
-				var/airlockpaint = show_radial_menu(user, src, solid_choices, radius = 42, custom_check = CALLBACK(src, PROC_REF(check_menu), user), require_near = TRUE, tooltips = TRUE)
+				var/airlockpaint = show_radial_menu(user, anchor, solid_choices, radius = 42, custom_check = CALLBACK(src, PROC_REF(check_menu), user), require_near = require_near, tooltips = TRUE)
 				if(!check_menu(user))
 					return
 				switch(airlockpaint)
@@ -517,7 +520,7 @@ GLOBAL_VAR_INIT(icon_holographic_window, init_holographic_window())
 
 		if("Glass")
 			if(advanced_airlock_setting == 1)
-				var/airlockpaint = show_radial_menu(user, src , glass_choices, radius = 42, custom_check = CALLBACK(src, PROC_REF(check_menu), user), require_near = TRUE, tooltips = TRUE)
+				var/airlockpaint = show_radial_menu(user, anchor, glass_choices, radius = 42, custom_check = CALLBACK(src, PROC_REF(check_menu), user), require_near = require_near, tooltips = TRUE)
 				if(!check_menu(user))
 					return
 				switch(airlockpaint)

--- a/code/modules/mining/aux_base_camera.dm
+++ b/code/modules/mining/aux_base_camera.dm
@@ -200,8 +200,10 @@
 	var/list/buildlist = list("Walls and Floors" = RCD_FLOORWALL,"Airlocks" = RCD_AIRLOCK,"Deconstruction" = RCD_DECONSTRUCT,"Windows and Grilles" = RCD_WINDOWGRILLE, "Machine Frames"= RCD_MACHINE, "Computer Frames"=RCD_COMPUTER)
 	var/buildmode = tgui_input_list(owner, "Set construction mode.", "Base Console", buildlist,  timeout = 0 )
 	if(buildmode)
-	B.RCD.mode = buildlist[buildmode]
-	to_chat(owner, "Build mode is now [buildmode].")
+		B.RCD.mode = buildlist[buildmode]
+		to_chat(owner, "Build mode is now [buildmode].")
+		if(B.RCD.mode == RCD_COMPUTER)//Bring up the menu to change computer direction
+			B.RCD.change_computer_dir(owner, remote_eye, FALSE)
 
 /datum/action/innate/aux_base/airlock_type
 	name = "Select Airlock Type"

--- a/code/modules/mining/aux_base_camera.dm
+++ b/code/modules/mining/aux_base_camera.dm
@@ -65,6 +65,7 @@
 	if(mapload) //Map spawned consoles have a filled RCD and stocked special structures
 		RCD.matter = RCD.max_matter
 		RCD.mode = RCD_FLOORWALL //Initialize To Floor And Wall Mode
+		RCD.upgrade = RCD_UPGRADE_FRAMES //Fancy Frames
 		fans_remaining = 4
 		turret_stock = 4
 
@@ -196,8 +197,9 @@
 	if(..())
 		return
 
-	var/list/buildlist = list("Walls and Floors" = RCD_FLOORWALL,"Airlocks" = RCD_AIRLOCK,"Deconstruction" = RCD_DECONSTRUCT,"Windows and Grilles" = RCD_WINDOWGRILLE)
+	var/list/buildlist = list("Walls and Floors" = RCD_FLOORWALL,"Airlocks" = RCD_AIRLOCK,"Deconstruction" = RCD_DECONSTRUCT,"Windows and Grilles" = RCD_WINDOWGRILLE, "Machine Frames"= RCD_MACHINE, "Computer Frames"=RCD_COMPUTER)
 	var/buildmode = tgui_input_list(owner, "Set construction mode.", "Base Console", buildlist,  timeout = 0 )
+	if(buildmode)
 	B.RCD.mode = buildlist[buildmode]
 	to_chat(owner, "Build mode is now [buildmode].")
 
@@ -209,7 +211,7 @@
 	if(..())
 		return
 
-	B.RCD.change_airlock_setting()
+	B.RCD.change_airlock_setting(owner,remote_eye, FALSE)
 
 
 /datum/action/innate/aux_base/window_type

--- a/code/modules/mining/aux_base_camera.dm
+++ b/code/modules/mining/aux_base_camera.dm
@@ -64,6 +64,7 @@
 	. = ..()
 	if(mapload) //Map spawned consoles have a filled RCD and stocked special structures
 		RCD.matter = RCD.max_matter
+		RCD.mode = RCD_FLOORWALL //Initialize To Floor And Wall Mode
 		fans_remaining = 4
 		turret_stock = 4
 
@@ -184,7 +185,7 @@
 			rcd_target = S //If we don't break out of this loop we'll get the last placed thing
 
 	owner.changeNext_move(CLICK_CD_RANGE)
-	B.RCD.afterattack(rcd_target, owner, TRUE) //Activate the RCD and force it to work remotely!
+	B.RCD.rcd_create(rcd_target, owner) //Activate the RCD and force it to work remotely!
 	playsound(target_turf, 'sound/items/deconstruct.ogg', 60, 1)
 
 /datum/action/innate/aux_base/switch_mode
@@ -195,7 +196,7 @@
 	if(..())
 		return
 
-	var/list/buildlist = list("Walls and Floors" = 1,"Airlocks" = 2,"Deconstruction" = 3,"Windows and Grilles" = 4)
+	var/list/buildlist = list("Walls and Floors" = RCD_FLOORWALL,"Airlocks" = RCD_AIRLOCK,"Deconstruction" = RCD_DECONSTRUCT,"Windows and Grilles" = RCD_WINDOWGRILLE)
 	var/buildmode = tgui_input_list(owner, "Set construction mode.", "Base Console", buildlist,  timeout = 0 )
 	B.RCD.mode = buildlist[buildmode]
 	to_chat(owner, "Build mode is now [buildmode].")
@@ -218,7 +219,7 @@
 /datum/action/innate/aux_base/window_type/on_activate()
 	if(..())
 		return
-	B.RCD.toggle_window_glass()
+	B.RCD.toggle_window_glass(owner)
 
 /datum/action/innate/aux_base/place_fan
 	name = "Place Tiny Fan"

--- a/code/modules/mining/aux_base_camera.dm
+++ b/code/modules/mining/aux_base_camera.dm
@@ -196,7 +196,7 @@
 		return
 
 	var/list/buildlist = list("Walls and Floors" = 1,"Airlocks" = 2,"Deconstruction" = 3,"Windows and Grilles" = 4)
-	var/buildmode = tgui_input_list("Set construction mode.", "Base Console", buildlist)
+	var/buildmode = tgui_input_list(owner, "Set construction mode.", "Base Console", buildlist,  timeout = 0 )
 	B.RCD.mode = buildlist[buildmode]
 	to_chat(owner, "Build mode is now [buildmode].")
 


### PR DESCRIPTION
## About The Pull Request

RCD improvements had broken the aux base construction computer. This restores that functionality, and adds the ability to make machine and computer frames.

## Why It's Good For The Game

Working features are good.
Fixes #11536 Fixes #11428 Fixes #10456 (Most of these say that it was fixed, but testing on live shows that it is still broken.)

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>
<img width="1098" height="1087" alt="all types" src="https://github.com/user-attachments/assets/1923f6ac-18fd-4fae-a2c4-db900e3f4990" />

Airlock Selection:
<img width="545" height="421" alt="airlock Selection" src="https://github.com/user-attachments/assets/826ec2a1-3520-4387-825d-5c43f0b3028b" />

Materials run out and reloading:
<img width="411" height="59" alt="reloading" src="https://github.com/user-attachments/assets/0573c318-23de-4c62-9ff0-9731f8f5b7ff" />


RCD Menu Still Works
<img width="465" height="386" alt="rcd works main menu" src="https://github.com/user-attachments/assets/eb735a1b-554d-47a0-88c1-483ac86c3323" />
<img width="407" height="434" alt="rcd menu works" src="https://github.com/user-attachments/assets/625724bd-5d1a-4225-937a-6de533b640a7" />
RCD menu closes when thrown:
<img width="368" height="428" alt="menu closes when thrown" src="https://github.com/user-attachments/assets/fb303f46-2297-44e6-aaaf-c632a3ed09b9" />

</details>

## Changelog
:cl:
fix: Central Command has repaired your station's Auxiliary Base Construction Computer.
add: Auxiliary Base Construction Computer can now construct machine frames and computer frames.
/:cl:

