### PR TITLE
Removes handcuff RNG, Adds breaking your own wrists to escape

### DIFF
--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -437,7 +437,7 @@ GLOBAL_LIST_INIT(available_random_trauma_list, list(
 #define GRAB_PIXEL_SHIFT_AGGRESSIVE 12
 #define GRAB_PIXEL_SHIFT_NECK 16
 
-#define PULL_PRONE_SLOWDOWN 1.5
+#define PULL_PRONE_SLOWDOWN 4
 #define HUMAN_CARRY_SLOWDOWN 0.35
 
 #define SLEEP_CHECK_DEATH(X) sleep(X); if(QDELETED(src) || stat == DEAD) return;

--- a/code/_onclick/hud/alert.dm
+++ b/code/_onclick/hud/alert.dm
@@ -812,18 +812,26 @@ Recharging stations are available in robotics, the dormitory bathrooms, and the 
 
 /atom/movable/screen/alert/restrained/handcuffed
 	name = "Handcuffed"
-	desc = "You're handcuffed and can't act. If anyone drags you, you won't be able to move. Click the alert to free yourself."
+	desc = "You're handcuffed and can't act. If anyone drags you, you won't be able to move. Left-click the alert to free yourself over time. Right-click the alert if you're willing to severely injure yourself to break out immediately."
 
 /atom/movable/screen/alert/restrained/legcuffed
 	name = "Legcuffed"
 	desc = "You're legcuffed, which slows you down considerably. Click the alert to free yourself."
 
-/atom/movable/screen/alert/restrained/Click()
-	var/mob/living/L = usr
-	if(!istype(L) || !L.can_resist() || L != owner)
+/atom/movable/screen/alert/restrained/Click(location, control, params)
+	var/mob/living/living_mob = usr
+	if(!istype(living_mob) || !living_mob.can_resist() || living_mob != owner)
 		return
-	L.changeNext_move(CLICK_CD_RESIST)
-	return L.resist_restraints()
+
+	living_mob.changeNext_move(CLICK_CD_RESIST)
+
+	var/list/parameters = params2list(params)
+	if(LAZYACCESS(parameters, RIGHT_CLICK))
+		var/mob/living/carbon/human/human_mob = living_mob
+		if(ishuman(human_mob) && human_mob.handcuffed)
+			return human_mob.breakout_breaking_arms()
+
+	return living_mob.resist_restraints()
 
 /atom/movable/screen/alert/restrained/buckled/Click()
 	var/mob/living/L = usr

--- a/code/game/objects/items/stunbaton.dm
+++ b/code/game/objects/items/stunbaton.dm
@@ -23,7 +23,7 @@
 
 	var/obj/item/stock_parts/cell/cell
 	var/preload_cell_type //if not empty the baton starts with this type of cell
-	var/cell_hit_cost = 12.5 KILOWATT
+	var/cell_hit_cost = 1 KILOWATT
 	var/can_remove_cell = TRUE
 
 	var/turned_on = FALSE

--- a/code/game/objects/items/stunbaton.dm
+++ b/code/game/objects/items/stunbaton.dm
@@ -23,7 +23,7 @@
 
 	var/obj/item/stock_parts/cell/cell
 	var/preload_cell_type //if not empty the baton starts with this type of cell
-	var/cell_hit_cost = 1 KILOWATT
+	var/cell_hit_cost = 12.5 KILOWATT
 	var/can_remove_cell = TRUE
 
 	var/turned_on = FALSE

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -334,7 +334,7 @@ CREATION_TEST_IGNORE_SELF(/mob/living/carbon)
 		to_chat(src, span_notice("You attempt to wriggle your way out of [cuffs]..."))
 		while(do_after(src, 5 SECONDS, timed_action_flags = IGNORE_USER_LOC_CHANGE|IGNORE_HELD_ITEM, hidden = TRUE))
 			cuff_breakout_attempts++
-			if(cuff_breakout_attempts * 5 SECONDS >= breakouttime || (prob(cuff_breakout_attempts/4)))
+			if(cuff_breakout_attempts * 5 SECONDS >= breakouttime)
 				log_combat(src, src, "slipped out of [cuffs] after [cuff_breakout_attempts]/[breakouttime / (5 SECONDS)] attempts", important = FALSE)
 				. = clear_cuffs(cuffs, cuff_break)
 				break

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -331,7 +331,7 @@ CREATION_TEST_IGNORE_SELF(/mob/living/carbon)
 
 	else if(istype(cuffs, /obj/item/restraints/handcuffs))
 		to_chat(src, span_notice("You attempt to wriggle your way out of [cuffs]..."))
-		while(cuffs.item_flags & BEING_REMOVED)
+		while(cuffs.item_flags & BEING_REMOVED && handcuffed == cuffs)
 			cuff_breakout_attempts++ //We increment these first so that long-term progress is still made even if interrupted
 			if(!do_after(src, 5 SECONDS, timed_action_flags = IGNORE_USER_LOC_CHANGE|IGNORE_HELD_ITEM, hidden = TRUE))
 				break

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -330,16 +330,17 @@ CREATION_TEST_IGNORE_SELF(/mob/living/carbon)
 			to_chat(src, span_warning("You fail to break [cuffs]!"))
 
 	else if(istype(cuffs, /obj/item/restraints/handcuffs))
-
 		to_chat(src, span_notice("You attempt to wriggle your way out of [cuffs]..."))
-		while(do_after(src, 5 SECONDS, timed_action_flags = IGNORE_USER_LOC_CHANGE|IGNORE_HELD_ITEM, hidden = TRUE))
-			cuff_breakout_attempts++
+		while(cuffs.item_flags & BEING_REMOVED)
+			cuff_breakout_attempts++ //We increment these first so that long-term progress is still made even if interrupted
+			if(!do_after(src, 5 SECONDS, timed_action_flags = IGNORE_USER_LOC_CHANGE|IGNORE_HELD_ITEM, hidden = TRUE))
+				break
 			if(cuff_breakout_attempts * 5 SECONDS >= breakouttime)
 				log_combat(src, src, "slipped out of [cuffs] after [cuff_breakout_attempts]/[breakouttime / (5 SECONDS)] attempts", important = FALSE)
 				. = clear_cuffs(cuffs, cuff_break)
 				break
-			else if(prob(4))
-				visible_message(span_warning("[src] seems to be trying to wriggle out of [cuffs]!"))
+			else if(cuff_breakout_attempts % 10 == 0)
+				visible_message(span_warning("[src] seems to be trying to wriggle out of [cuffs]!")) //Ten second warning for zipties, three warnings for real cuffs
 
 	else
 		to_chat(src, span_notice("You attempt to remove [cuffs]... (This will take around [DisplayTimeText(breakouttime)]"))
@@ -347,7 +348,6 @@ CREATION_TEST_IGNORE_SELF(/mob/living/carbon)
 			. = clear_cuffs(cuffs, cuff_break)
 		else
 			to_chat(src, span_warning("You fail to remove [cuffs]!"))
-
 
 	cuffs.item_flags &= ~BEING_REMOVED
 

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -820,3 +820,19 @@
 	if(M.melee_damage != 0 && !HAS_TRAIT(M, TRAIT_PACIFISM) && check_shields(M, M.melee_damage, "the [M.name]", MELEE_ATTACK, M.armour_penetration))
 		return FALSE
 	return ..()
+
+/mob/living/carbon/human/proc/breakout_breaking_arms()
+	visible_message(span_warning("[src] is fighting [handcuffed] with every ounce of their strength!"))
+	if(!do_after(src, 5 SECONDS, timed_action_flags = IGNORE_USER_LOC_CHANGE|IGNORE_HELD_ITEM, hidden = TRUE))
+		return
+
+	playsound(src, 'sound/weapons/pierce_slow.ogg', 50, TRUE)
+
+	var/obj/item/bodypart/random_arm = pick(get_bodypart(BODY_ZONE_L_ARM), get_bodypart(BODY_ZONE_R_ARM))
+	if(HAS_TRAIT(src, TRAIT_EASYDISMEMBER) && !HAS_TRAIT(src, TRAIT_NODISMEMBER))
+		random_arm.dismember()
+		random_arm.receive_damage(20)
+		uncuff()
+	else
+		random_arm.receive_damage(50)
+		uncuff()

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -829,7 +829,7 @@
 	playsound(src, 'sound/weapons/pierce_slow.ogg', 50, TRUE)
 
 	var/obj/item/bodypart/random_arm = pick(get_bodypart(BODY_ZONE_L_ARM), get_bodypart(BODY_ZONE_R_ARM))
-	log_combat(src, src, "has forcibly broken their arm to escape [cuffs]", important = FALSE)
+	log_combat(src, src, "has forcibly broken their arm to escape [handcuffed]", important = FALSE)
 
 	if(HAS_TRAIT(src, TRAIT_EASYDISMEMBER) && !HAS_TRAIT(src, TRAIT_NODISMEMBER))
 		random_arm.dismember()

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -829,6 +829,8 @@
 	playsound(src, 'sound/weapons/pierce_slow.ogg', 50, TRUE)
 
 	var/obj/item/bodypart/random_arm = pick(get_bodypart(BODY_ZONE_L_ARM), get_bodypart(BODY_ZONE_R_ARM))
+	log_combat(src, src, "has forcibly broken their arm to escape [cuffs]", important = FALSE)
+
 	if(HAS_TRAIT(src, TRAIT_EASYDISMEMBER) && !HAS_TRAIT(src, TRAIT_NODISMEMBER))
 		random_arm.dismember()
 		random_arm.receive_damage(20)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

It's been a while since the handcuff changes and one of the predictions has proven to be true, so this is another take at solving the problem of handcuffs being indefinitely, hopefully with a little less of security feeling like they have to constantly stun everyone they cuff.

This PR:
* Removes the RNG breakout from cuffs so the combined breakout time must now equal or exceed the the rating on the cuffs - 1 minute for zipties, 3 minutes for proper cuffs. 
* Every fifty seconds an alert that you are attempting to break out will be sent. This is a ten second warning for zipties before they are broken, or a 30 second warning for cuffs the third time this message appears. 
* When attempting to break out, the counter increments **before** the five second bar fills up, so that if it is interrupted you still make some progress. This is to at least partially counteract chain stunning to indefinitely extend the duration of cuffs, but you do still have to succeed at the final five second attempt. This will not greatly affect breakout times, it's just to ensure that someone who is stunned as soon as they're upright or able to act again is able to make *some* progress between the stuns. 
* Dragging a prone (or stamcrit) player is now **much** slower. Fireman carry people to move them faster. fireman carry for instance.
* Players who are handcuffed now have the option of breaking (or dismembering) their own arm to escape the cuffs relatively quickly. Performing this action always sends an alert and will deal **50** damage to a random limb, or if the trait for easy dismemberment is present, just outright tear one of the limbs off. (Dismembering does less overall damage, a total of 35 if they reattach the limb (IPCs/Skeletons) or 15 if they don't or can't (oozelings))
* Fixes a small oversight where the looping attempts to break out would continue even if someone else removed the cuffs. 

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

**Handcuff RNG** - I still think this was good on paper, but it has left security in a state of constant paranoia and fear that their cuffs will break, heightening stress and causing them to take actions like chain-stunning in order to keep their prisoners in line. This is less fun for both parties and has returned to there being pretty much no chance of escape unless the officer runs out of juice.

**Dragging Slowdown** - Transporting someone more than a short distance now actually requires a free arm (or the patience of a saint) which limits the actions of the person who is moving them. I expect this will have an impact on both security and medical staff and will encourage a lot less bleeding out on the ground for patients being dragged as well as an additional push toward keeping officers from unnecessarily dragging prisoners around for an unwarranted amount of time or into unnecessary places.

**Breaking your own arms to free yourself** - This was suggested by @PowerfulBacon as a replacement option so that detained players always have at least one option for escape, while having a fairly extreme cost to them for using it. 50 damage is enough to completely disable one arm, and also leave them at about half health so get-away isn't terribly likely unless they were prepared to heal that damage quickly. For easy-delimb races this serves as a minor upside to an otherwise fairly debilitating racial downside, but while they take less damage they do start bleeding profusely as a result of tearing an arm off which can leave a trail for security to follow. 


<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

<img width="291" height="104" alt="image" src="https://github.com/user-attachments/assets/f485e7ba-6f3f-406e-937b-3a7bc7644dae" />


![dreamseeker_wG5Mpxb499](https://github.com/user-attachments/assets/9fcd009e-2a43-46d3-b104-ed79f181340e)
<img width="1099" height="971" alt="image" src="https://github.com/user-attachments/assets/ec33b12f-5bd3-461e-95aa-0f7dbd170263" />
<img width="581" height="102" alt="image" src="https://github.com/user-attachments/assets/d3f2c596-d192-4bf9-a861-425bde4cfc93" />

Comparison for dragging vs fireman carry:
![dreamseeker_5i8SSj0WUQ](https://github.com/user-attachments/assets/e30e8c3b-b392-410c-b73c-49c4db5ec928)
![dreamseeker_cCf6B0haYy](https://github.com/user-attachments/assets/2ba33425-a8a6-427f-bc56-44e3fa1b4f5e)

</details>

## Changelog
:cl:
balance: Handcuff RNG has been removed. It is no longer possible to randomly break out of cuffs sooner than the full timer, and messages about attempted escapes now happen every ten attempts
tweak: Dragging players which are prone (whether by choice or because they are unable to stand) is now much slower. Fireman carry or use roller bed or other similar item to move someone faster if they are unable or unwilling to stand. 
add: Handcuffed players may now severely injure one of their arms to break out of cuffs quickly, dealing 50 damage to a random arm or completely dismembering it if they are a race that is easily delimbed. Bear in mind that this option may not be wise to utilize depending on the circumstances you're in. 
fix: You now stop trying to break out of handcuffs if someone else removes them
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
