### PR TITLE
Fixes some small mistakes on MetaStation

### DIFF
--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -2216,7 +2216,7 @@
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "avs" = (
-/obj/structure/reagent_dispensers/watertank,
+/obj/machinery/modular_fabricator/autolathe,
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "avN" = (
@@ -12981,6 +12981,10 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
 /turf/open/floor/iron/dark,
 /area/aisat)
+"bWI" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/maintenance/starboard)
 "bXm" = (
 /obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
 	dir = 4
@@ -57693,9 +57697,6 @@
 	},
 /turf/open/floor/iron/dark/smooth_large,
 /area/security/execution/education)
-"qvo" = (
-/turf/open/floor/plating,
-/area/space/nearstation)
 "qvu" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -75911,7 +75912,7 @@
 /obj/structure/closet/firecloset,
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
-/area/space/nearstation)
+/area/maintenance/starboard)
 "wGx" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/command{
@@ -124678,10 +124679,10 @@ sSP
 uaT
 pzQ
 axY
-bKK
-qRl
-qRl
-qvo
+atm
+bWI
+bWI
+apc
 wGs
 bhT
 vcq
@@ -124937,9 +124938,9 @@ yhu
 noP
 eVI
 dgj
-qRl
-qRl
-bKK
+bWI
+bWI
+atm
 bhT
 bhT
 duM

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -40697,6 +40697,9 @@
 	pixel_y = -32
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/hallway/secondary/service)
 "kEM" = (
@@ -45122,9 +45125,6 @@
 /obj/effect/spawner/lootdrop/grille_or_trash,
 /turf/open/floor/iron,
 /area/maintenance/aft)
-"mlj" = (
-/turf/closed/wall/r_wall,
-/area/space)
 "mlo" = (
 /obj/machinery/status_display/ai{
 	pixel_y = 32
@@ -125494,10 +125494,10 @@ aaf
 aaf
 aaf
 aaf
-htU
-mlj
-mlj
-mlj
+aaf
+bKK
+bKK
+bKK
 aaf
 aaf
 aaf

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -9358,8 +9358,7 @@
 /area/ai_monitored/turret_protected/aisat_interior)
 "bsc" = (
 /obj/machinery/door/airlock{
-	name = "Service Hall";
-	req_access_txt = "35"
+	name = "Service Hall"
 	},
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -34799,7 +34798,7 @@
 "iCu" = (
 /obj/effect/turf_decal/tile/dark,
 /obj/effect/turf_decal/bot,
-/obj/machinery/modular_computer/console/preset/civilian{
+/obj/machinery/computer/rdconsole/production{
 	dir = 8
 	},
 /turf/open/floor/iron,
@@ -35918,7 +35917,7 @@
 /area/hallway/primary/aft)
 "iUu" = (
 /obj/machinery/door/airlock/public/glass{
-	name = "Kitchen";
+	name = "Auxiliary Tool Storage";
 	req_access_txt = "12"
 	},
 /obj/effect/landmark/event_spawn,
@@ -46540,16 +46539,13 @@
 /turf/open/floor/wood,
 /area/library)
 "mHY" = (
-/obj/structure/table/glass,
 /obj/effect/turf_decal/trimline/yellow/filled/warning{
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 4
 	},
-/obj/item/candydispenser/engineering{
-	pixel_y = 11
-	},
+/obj/machinery/modular_computer/console/preset/civilian,
 /turf/open/floor/iron,
 /area/engine/break_room)
 "mIf" = (
@@ -79549,6 +79545,10 @@
 	},
 /obj/effect/turf_decal/tile/yellow/anticorner/contrasted{
 	dir = 1
+	},
+/obj/structure/table/glass,
+/obj/item/candydispenser/engineering{
+	pixel_y = 11
 	},
 /turf/open/floor/iron,
 /area/engine/break_room)


### PR DESCRIPTION
## About The Pull Request

closes #13331

The door to Auxiliary Tool Storage was named "Kitchen" before

<img width="537" height="415" alt="image" src="https://github.com/user-attachments/assets/1eec5ea8-5cc1-4676-ad73-4b3aae19e307" />

Adds a missing vent here

<img width="208" height="136" alt="image" src="https://github.com/user-attachments/assets/b29a5547-8ea7-4a57-87e1-8dc22fbd1a9a" />

The engineering protolathe room was missing a production R&D console, I added one.

<img width="338" height="517" alt="image" src="https://github.com/user-attachments/assets/0c7a7bd9-792d-447a-9e06-73df221dd010" />

You can't see it in game, but this spot below atmos didn't have the nearstation area set when it should have.

<img width="505" height="753" alt="image" src="https://github.com/user-attachments/assets/99fdf323-6fb2-4d1a-aa54-8945482f02ef" />

Bartenders can open this door now (I forgot to remove the req_access varedit when adding the access helper)

https://github.com/user-attachments/assets/4ec94ce2-e178-433c-a8be-f715511c377c

## Why It's Good For The Game

👍 

## Testing Photographs and Procedure

see above

## Changelog
:cl:
fix: fixed some small mistakes on MetaStation
/:cl:
