### PR TITLE
Better PDA power consumpion

### DIFF
--- a/code/modules/modular_computers/computers/item/computer.dm
+++ b/code/modules/modular_computers/computers/item/computer.dm
@@ -32,6 +32,8 @@ GLOBAL_LIST_EMPTY(TabletMessengers) // a list of all active messengers, similar 
 	var/ignore_theme_pref = FALSE
 	/// List of themes for this device to allow.
 	var/list/allowed_themes
+	/// Are we using the flashlight
+	var/using_flashlight = FALSE
 	/// Color used for the Thinktronic Classic theme.
 	var/classic_color = COLOR_OLIVE
 	var/datum/computer_file/program/active_program = null	// A currently active program running on the computer.
@@ -40,8 +42,10 @@ GLOBAL_LIST_EMPTY(TabletMessengers) // a list of all active messengers, similar 
 	var/last_world_time = "00:00"
 	var/list/last_header_icons
 
-	var/base_active_power_usage = 10 WATT	// Aurs per second, Power usage when the computer is on. Remember hardware can use power too.
-	var/base_idle_power_usage = 5 WATT	// Aurs per second, Power usage when the computer is turned off
+	// Power consumption of the modular computer per second when the device is on
+	// but the computer is not using any power.
+	var/base_power_usage = 0 WATT
+	var/flashlight_power_usage = 30 WATT
 
 	// Modular computers can run on various devices. Each DEVICE (Laptop, Console, Tablet,..)
 	// must have it's own DMI file. Icon states must be called exactly the same in all files, but may look differently
@@ -98,6 +102,8 @@ GLOBAL_LIST_EMPTY(TabletMessengers) // a list of all active messengers, similar 
 	var/can_store_pai = FALSE
 	/// Level of Virus Defense to be added on initialize to the pre instaled hard drive this happens in tablet/PDA, Normal detomatix halves at 2, fails at 3
 	var/default_virus_defense = ANTIVIRUS_NONE
+	/// Multiplier for power usage
+	var/power_usage_multiplier = 1
 
 /datum/armor/item_modular_computer
 	bullet = 20
@@ -422,6 +428,8 @@ GLOBAL_LIST_EMPTY(TabletMessengers) // a list of all active messengers, similar 
 		else
 			idle_threads.Remove(P)
 
+	handle_flashlight()
+
 	handle_power(delta_time) // Handles all computer power interaction
 	//check_update_ui_need()
 
@@ -642,9 +650,10 @@ GLOBAL_LIST_EMPTY(TabletMessengers) // a list of all active messengers, similar 
   * It is separated from ui_act() to be overwritten as needed.
 */
 /obj/item/modular_computer/proc/toggle_flashlight()
-	if(!has_light)
+	if(!has_light && use_power(10 WATT))
 		return FALSE
-	set_light_on(!light_on)
+	using_flashlight = !using_flashlight
+	set_light_on(using_flashlight)
 	update_appearance()
 	// Show the light_on overlay on top of the action button icon
 	update_action_buttons(force = TRUE) //force it because we added an overlay, not changed its icon
@@ -664,6 +673,19 @@ GLOBAL_LIST_EMPTY(TabletMessengers) // a list of all active messengers, similar 
 	comp_light_color = color
 	set_light_color(color)
 	return TRUE
+
+/obj/item/modular_computer/proc/handle_flashlight(delta_time)
+	if (!using_flashlight)
+		return
+	var/power_ratio = 1 - CLAMP01(get_power() / 10 KILOWATT)
+	if (DT_PROB(power_ratio * 10, delta_time))
+		do_flicker()
+
+/obj/item/modular_computer/proc/do_flicker(amounts = 5)
+	if (!using_flashlight || amounts <= 0)
+		return
+	set_light_on(!light_on)
+	addtimer(CALLBACK(src, PROC_REF(handle_flashlight), amounts - 1), rand(0.1 SECONDS, 0.3 SECONDS))
 
 /obj/item/modular_computer/screwdriver_act(mob/user, obj/item/tool)
 	if(!deconstructable)

--- a/code/modules/modular_computers/computers/item/computer.dm
+++ b/code/modules/modular_computers/computers/item/computer.dm
@@ -428,7 +428,7 @@ GLOBAL_LIST_EMPTY(TabletMessengers) // a list of all active messengers, similar 
 		else
 			idle_threads.Remove(P)
 
-	handle_flashlight()
+	handle_flashlight(delta_time)
 
 	handle_power(delta_time) // Handles all computer power interaction
 	//check_update_ui_need()
@@ -677,15 +677,18 @@ GLOBAL_LIST_EMPTY(TabletMessengers) // a list of all active messengers, similar 
 /obj/item/modular_computer/proc/handle_flashlight(delta_time)
 	if (!using_flashlight)
 		return
-	var/power_ratio = 1 - CLAMP01(get_power() / 10 KILOWATT)
-	if (DT_PROB(power_ratio * 10, delta_time))
+	var/power_ratio = 1 - CLAMP01(get_power() / (10 KILOWATT))
+	if (DT_PROB(power_ratio * 20, delta_time))
 		do_flicker()
 
 /obj/item/modular_computer/proc/do_flicker(amounts = 5)
-	if (!using_flashlight || amounts <= 0)
+	if (!using_flashlight)
+		return
+	if (amounts <= 0)
+		set_light_on(TRUE)
 		return
 	set_light_on(!light_on)
-	addtimer(CALLBACK(src, PROC_REF(handle_flashlight), amounts - 1), rand(0.1 SECONDS, 0.3 SECONDS))
+	addtimer(CALLBACK(src, PROC_REF(do_flicker), amounts - 1), rand(0.1 SECONDS, 0.3 SECONDS))
 
 /obj/item/modular_computer/screwdriver_act(mob/user, obj/item/tool)
 	if(!deconstructable)

--- a/code/modules/modular_computers/computers/item/processor.dm
+++ b/code/modules/modular_computers/computers/item/processor.dm
@@ -35,8 +35,7 @@ CREATION_TEST_IGNORE_SUBTYPES(/obj/item/modular_computer/processor)
 	update_integrity(machinery_computer.get_integrity())
 	max_integrity = machinery_computer.max_integrity
 	integrity_failure = machinery_computer.integrity_failure
-	base_active_power_usage = machinery_computer.base_active_power_usage
-	base_idle_power_usage = machinery_computer.base_idle_power_usage
+	base_power_usage = machinery_computer.base_power_usage
 
 /obj/item/modular_computer/processor/relay_qdel()
 	qdel(machinery_computer)

--- a/code/modules/modular_computers/computers/machinery/modular_computer.dm
+++ b/code/modules/modular_computers/computers/machinery/modular_computer.dm
@@ -19,8 +19,7 @@
 	var/max_hardware_size = 0							// Maximal hardware size. Currently, tablets have 1, laptops 2 and consoles 3. Limits what hardware types can be installed.
 	var/steel_sheet_cost = 10							// Amount of steel sheets refunded when disassembling an empty frame of this computer.
 	var/light_strength = 0								// Light luminosity when turned on
-	var/base_active_power_usage = 100					// Power usage when the computer is open (screen is active) and can be interacted with. Remember hardware can use power too.
-	var/base_idle_power_usage = 10						// Power usage when the computer is idle and screen is off (currently only applies to laptops)
+	var/base_power_usage = 100							// Power usage when the computer is open (screen is active) and can be interacted with. Remember hardware can use power too.
 
 	var/obj/item/modular_computer/processor/cpu = null				// CPU that handles most logic while this type only handles power and other specific things.
 

--- a/code/modules/modular_computers/computers/machinery/modular_console.dm
+++ b/code/modules/modular_computers/computers/machinery/modular_console.dm
@@ -10,8 +10,7 @@
 	canSmoothWith = list(SMOOTH_GROUP_COMPUTERS)
 	screen_icon_state_menu = "menu"
 	density = TRUE
-	base_idle_power_usage = 100
-	base_active_power_usage = 500
+	base_power_usage = 500
 	max_hardware_size = 4
 	steel_sheet_cost = 10
 	light_strength = 2

--- a/code/modules/modular_computers/file_system/program.dm
+++ b/code/modules/modular_computers/file_system/program.dm
@@ -40,6 +40,8 @@
 	var/sound_channel
 	/// Hardware required to run this program
 	var/hardware_requirement
+	/// Power consumption of this program, per second
+	var/power_consumption
 
 /datum/computer_file/program/New(obj/item/modular_computer/comp = null)
 	..()

--- a/code/modules/modular_computers/file_system/programs/airestorer.dm
+++ b/code/modules/modular_computers/file_system/programs/airestorer.dm
@@ -9,6 +9,7 @@
 	tgui_id = "NtosAiRestorer"
 	program_icon = "laptop-code"
 	hardware_requirement = MC_AI
+	power_consumption = 100 WATT
 	/// Variable dictating if we are in the process of restoring the AI in the inserted intellicard
 	var/restoring = FALSE
 

--- a/code/modules/modular_computers/file_system/programs/alarm.dm
+++ b/code/modules/modular_computers/file_system/programs/alarm.dm
@@ -10,6 +10,7 @@
 	size = 4
 	tgui_id = "NtosStationAlertConsole"
 	program_icon = "bell"
+	power_consumption = 50 WATT
 	/// If there is any station alert
 	var/has_alert = FALSE
 	/// Station alert datum for showing alerts UI

--- a/code/modules/modular_computers/file_system/programs/antagonist/contract_uplink.dm
+++ b/code/modules/modular_computers/file_system/programs/antagonist/contract_uplink.dm
@@ -11,6 +11,7 @@
 	undeletable = TRUE // Antag datum is baked directly into the SSD that spawns with the Contractor Tablet. Changing this will cause runtimes whenever the program is transfered into another drive.
 	tgui_id = "SyndContractor"
 	program_icon = "tasks"
+	power_consumption = 0
 	var/error = ""
 	var/info_screen = TRUE
 	var/assigned = FALSE

--- a/code/modules/modular_computers/file_system/programs/antagonist/disk_viruses.dm
+++ b/code/modules/modular_computers/file_system/programs/antagonist/disk_viruses.dm
@@ -7,6 +7,7 @@
 	available_on_ntnet = FALSE
 	tgui_id = "antivirus_readme"
 	program_icon = "file-lines"
+	power_consumption = 80 WATT
 
 /datum/computer_file/program/readme/coil_readme
 	filename = "Coilvrs-README.txt"

--- a/code/modules/modular_computers/file_system/programs/antagonist/dos.dm
+++ b/code/modules/modular_computers/file_system/programs/antagonist/dos.dm
@@ -10,6 +10,7 @@
 	available_on_syndinet = TRUE
 	tgui_id = "NtosNetDos"
 	program_icon = "satellite-dish"
+	power_consumption = 300 WATT
 
 
 

--- a/code/modules/modular_computers/file_system/programs/antagonist/emag.dm
+++ b/code/modules/modular_computers/file_system/programs/antagonist/emag.dm
@@ -7,6 +7,7 @@
 	size = 0
 	available_on_ntnet = FALSE
 	tgui_id = "NtosEmagConsole"
+	power_consumption = 300 WATT
 
 /datum/computer_file/program/emag_console/ui_act(action,params,datum/tgui/ui)
 	if(!ui || ui.status != UI_INTERACTIVE)

--- a/code/modules/modular_computers/file_system/programs/arcade.dm
+++ b/code/modules/modular_computers/file_system/programs/arcade.dm
@@ -9,6 +9,7 @@
 	size = 6
 	tgui_id = "NtosArcade"
 	program_icon = "gamepad"
+	power_consumption = 80 WATT
 
 
 

--- a/code/modules/modular_computers/file_system/programs/atmosscan.dm
+++ b/code/modules/modular_computers/file_system/programs/atmosscan.dm
@@ -14,6 +14,7 @@
 	tgui_id = "NtosGasAnalyzer"
 	program_icon = "thermometer-half"
 	hardware_requirement = MC_SENSORS
+	power_consumption = 50 WATT
 
 /// Whether we scan the current turf automatically (env) or scan tapped objects manually (click).
 	var/atmozphere_mode = ATMOZPHERE_SCAN_ENV

--- a/code/modules/modular_computers/file_system/programs/borg_monitor.dm
+++ b/code/modules/modular_computers/file_system/programs/borg_monitor.dm
@@ -11,6 +11,7 @@
 	size = 6
 	tgui_id = "NtosCyborgRemoteMonitor"
 	program_icon = "project-diagram"
+	power_consumption = 100 WATT
 	var/emagged = FALSE
 
 /datum/computer_file/program/borg_monitor/run_emag()
@@ -111,6 +112,7 @@
 	available_on_syndinet = TRUE
 	transfer_access = null
 	tgui_id = "NtosCyborgRemoteMonitorSyndicate"
+	power_consumption = 10 WATT
 
 /datum/computer_file/program/borg_monitor/syndicate/run_emag()
 	return FALSE

--- a/code/modules/modular_computers/file_system/programs/borg_self_monitor.dm
+++ b/code/modules/modular_computers/file_system/programs/borg_self_monitor.dm
@@ -10,6 +10,7 @@
 	undeletable = TRUE
 	size = 5
 	tgui_id = "NtosCyborgSelfMonitor"
+	power_consumption = 0
 	///A typed reference to the computer, specifying the borg tablet type
 	var/obj/item/modular_computer/tablet/integrated/tablet
 

--- a/code/modules/modular_computers/file_system/programs/budgetordering.dm
+++ b/code/modules/modular_computers/file_system/programs/budgetordering.dm
@@ -8,6 +8,7 @@
 	size = 10
 	tgui_id = "NtosCargo"
 	program_icon = "credit-card"
+	power_consumption = 40 WATT
 	//Are you actually placing orders with it?
 	var/requestonly = TRUE
 	//Can the tablet see or buy illegal stuff?

--- a/code/modules/modular_computers/file_system/programs/card.dm
+++ b/code/modules/modular_computers/file_system/programs/card.dm
@@ -17,6 +17,7 @@
 	tgui_id = "NtosCard"
 	program_icon = "id-card"
 	hardware_requirement = MC_CARD2
+	power_consumption = 80 WATT
 
 
 

--- a/code/modules/modular_computers/file_system/programs/cargobounty.dm
+++ b/code/modules/modular_computers/file_system/programs/cargobounty.dm
@@ -13,6 +13,7 @@
 	tgui_id = "NtosBountyConsole"
 	program_icon = "tags"
 	hardware_requirement = MC_PRINT
+	power_consumption = 60 WATT
 
 	/// Cooldown var for printing paper sheets.
 	COOLDOWN_DECLARE(printer_ready)

--- a/code/modules/modular_computers/file_system/programs/configurator.dm
+++ b/code/modules/modular_computers/file_system/programs/configurator.dm
@@ -12,6 +12,7 @@
 	available_on_ntnet = TRUE
 	tgui_id = "NtosConfiguration"
 	program_icon = "cog"
+	power_consumption = 40 WATT
 
 /datum/computer_file/program/computerconfig/ui_static_data(mob/user)
 	var/list/data = ..()

--- a/code/modules/modular_computers/file_system/programs/crewmanifest.dm
+++ b/code/modules/modular_computers/file_system/programs/crewmanifest.dm
@@ -7,6 +7,7 @@
 	size = 4
 	tgui_id = "NtosCrewManifest"
 	program_icon = "clipboard-list"
+	power_consumption = 20 WATT
 
 /datum/computer_file/program/crew_manifest/ui_static_data(mob/user)
 	var/list/data = list()

--- a/code/modules/modular_computers/file_system/programs/file_browser.dm
+++ b/code/modules/modular_computers/file_system/programs/file_browser.dm
@@ -9,6 +9,7 @@
 	undeletable = TRUE
 	tgui_id = "NtosFileManager"
 	program_icon = "folder"
+	power_consumption = 20 WATT
 
 	var/open_file
 	var/error

--- a/code/modules/modular_computers/file_system/programs/gasrig_monitor.dm
+++ b/code/modules/modular_computers/file_system/programs/gasrig_monitor.dm
@@ -8,6 +8,7 @@
 	tgui_id = "NtosAtmosGasRig"
 	program_icon = "clipboard-list"
 	requires_ntnet = TRUE
+	power_consumption = 60 WATT
 	var/obj/machinery/atmospherics/gasrig/core/gasrig
 
 

--- a/code/modules/modular_computers/file_system/programs/jobmanagement.dm
+++ b/code/modules/modular_computers/file_system/programs/jobmanagement.dm
@@ -8,6 +8,7 @@
 	size = 4
 	tgui_id = "NtosJobManager"
 	program_icon = "address-book"
+	power_consumption = 80 WATT
 
 	var/change_position_cooldown = 30
 

--- a/code/modules/modular_computers/file_system/programs/log_viewer.dm
+++ b/code/modules/modular_computers/file_system/programs/log_viewer.dm
@@ -7,6 +7,7 @@
 	size = 4
 	tgui_id = "NtosLogViewer"
 	program_icon = "database"
+	power_consumption = 20 WATT
 
 /datum/computer_file/program/log_viewer/ui_act(action, list/params, datum/tgui/ui)
 	. = ..()

--- a/code/modules/modular_computers/file_system/programs/newscaster.dm
+++ b/code/modules/modular_computers/file_system/programs/newscaster.dm
@@ -9,6 +9,7 @@
 	available_on_ntnet = TRUE
 	tgui_id = "NtosNewscaster"
 	program_icon = "newspaper"
+	power_consumption = 60 WATT
 	///The UI we use for the newscaster
 	var/obj/machinery/newscaster/newscaster_ui
 

--- a/code/modules/modular_computers/file_system/programs/notepad.dm
+++ b/code/modules/modular_computers/file_system/programs/notepad.dm
@@ -9,6 +9,7 @@
 	size = 2
 	tgui_id = "NtosNotepad"
 	program_icon = "book"
+	power_consumption = 20 WATT
 	/// Cooldown var for printing paper sheets.
 	COOLDOWN_DECLARE(printer_ready)
 

--- a/code/modules/modular_computers/file_system/programs/ntdownloader.dm
+++ b/code/modules/modular_computers/file_system/programs/ntdownloader.dm
@@ -11,6 +11,7 @@
 	ui_header = "downloader_finished.gif"
 	tgui_id = "NtosNetDownloader"
 	program_icon = "download"
+	power_consumption = 80 WATT
 
 
 
@@ -199,6 +200,7 @@
 	ui_header = "downloader_finished.gif"
 	tgui_id = "NtosNetDownloader"
 	emagged = TRUE
+	power_consumption = 10 WATT
 
 /datum/computer_file/program/ntnetdownload/syndicate/on_start()
 	. = ..()

--- a/code/modules/modular_computers/file_system/programs/ntmessenger.dm
+++ b/code/modules/modular_computers/file_system/programs/ntmessenger.dm
@@ -12,6 +12,7 @@
 	tgui_id = "NtosMessenger"
 	program_icon = "comment-alt"
 	alert_able = TRUE
+	power_consumption = 20 WATT
 
 	/// The current ringtone (displayed in the chat when a message is received).
 	var/ringtone = "beep"

--- a/code/modules/modular_computers/file_system/programs/ntmonitor.dm
+++ b/code/modules/modular_computers/file_system/programs/ntmonitor.dm
@@ -10,6 +10,7 @@
 	tgui_id = "NtosNetMonitor"
 	program_icon = "network-wired"
 	hardware_requirement = MC_NET	// It doesn't require a network connection directly but it does require a network card
+	power_consumption = 80 WATT
 
 /datum/computer_file/program/ntnetmonitor/ui_act(action, params)
 	if(..())

--- a/code/modules/modular_computers/file_system/programs/ntnrc_client.dm
+++ b/code/modules/modular_computers/file_system/programs/ntnrc_client.dm
@@ -14,6 +14,7 @@
 	tgui_id = "NtosNetChat"
 	program_icon = "comment-alt"
 	alert_able = TRUE
+	power_consumption = 60 WATT
 	/// Used to generate the toolbar icon
 	var/last_message
 	var/username

--- a/code/modules/modular_computers/file_system/programs/phys_scanner.dm
+++ b/code/modules/modular_computers/file_system/programs/phys_scanner.dm
@@ -9,6 +9,7 @@
 	tgui_id = "NtosPhysScanner"
 	program_icon = "barcode"
 	hardware_requirement = MC_SENSORS
+	power_consumption = 100 WATT
 	/// Information from the last scanned person, to display on the app.
 	var/last_record = ""
 

--- a/code/modules/modular_computers/file_system/programs/portrait_printer.dm
+++ b/code/modules/modular_computers/file_system/programs/portrait_printer.dm
@@ -20,6 +20,7 @@
 	tgui_id = "NtosPortraitPrinter"
 	program_icon = "print"
 	hardware_requirement = MC_PRINT
+	power_consumption = 100 WATT
 	/**
 	* The last input in the search tab, stored here and reused in the UI to show successive users if
 	* the current list of paintings is limited to the results of a search or not.

--- a/code/modules/modular_computers/file_system/programs/powermonitor.dm
+++ b/code/modules/modular_computers/file_system/programs/powermonitor.dm
@@ -13,6 +13,7 @@
 	tgui_id = "NtosPowerMonitor"
 	program_icon = "plug"
 	hardware_requirement = MC_CHARGER
+	power_consumption = 80 WATT
 
 	var/has_alert = 0
 	var/obj/structure/cable/attached_wire

--- a/code/modules/modular_computers/file_system/programs/radar.dm
+++ b/code/modules/modular_computers/file_system/programs/radar.dm
@@ -251,6 +251,7 @@
 	transfer_access = list(ACCESS_MEDICAL)
 	available_on_ntnet = TRUE
 	program_icon = "heartbeat"
+	power_consumption = 200 WATT
 
 /datum/computer_file/program/radar/lifeline/find_atom()
 	return locate(selected) in GLOB.suit_sensors_list
@@ -292,6 +293,7 @@
 	available_on_ntnet = TRUE
 	program_icon = "broom"
 	size = 2
+	power_consumption = 140 WATT
 
 /datum/computer_file/program/radar/custodial_locator/find_atom()
 	return locate(selected) in GLOB.janitor_devices
@@ -344,6 +346,7 @@
 	arrowstyle = "ntosradarpointerS.png"
 	pointercolor = "red"
 	tracks_grand_z = TRUE
+	power_consumption = 0 WATT
 
 /datum/computer_file/program/radar/fission360/find_atom()
 	return locate(selected) in GLOB.poi_list

--- a/code/modules/modular_computers/file_system/programs/records.dm
+++ b/code/modules/modular_computers/file_system/programs/records.dm
@@ -8,6 +8,7 @@
 	tgui_id = "NtosRecords"
 	size = 4
 	available_on_ntnet = FALSE
+	power_consumption = 60 WATT
 
 	var/mode
 
@@ -20,6 +21,7 @@
 	transfer_access = list(ACCESS_MEDICAL, ACCESS_HEADS)
 	available_on_ntnet = TRUE
 	mode = "medical"
+	power_consumption = 60 WATT
 
 /datum/computer_file/program/records/security
 	filedesc = "Security Records"
@@ -29,6 +31,7 @@
 	transfer_access = list(ACCESS_SECURITY, ACCESS_HEADS)
 	available_on_ntnet = TRUE
 	mode = "security"
+	power_consumption = 60 WATT
 
 /datum/computer_file/program/records/proc/GetRecordsReadable()
 	var/list/all_records = list()

--- a/code/modules/modular_computers/file_system/programs/remote_airlock.dm
+++ b/code/modules/modular_computers/file_system/programs/remote_airlock.dm
@@ -8,6 +8,7 @@
 	size = 1
 	available_on_ntnet = FALSE
 	undeletable = TRUE
+	power_consumption = 10 WATT
 
 /datum/computer_file/program/remote_airlock/ui_data(mob/user)
 	var/list/data = list()

--- a/code/modules/modular_computers/file_system/programs/robocontrol.dm
+++ b/code/modules/modular_computers/file_system/programs/robocontrol.dm
@@ -10,6 +10,7 @@
 	size = 10
 	tgui_id = "NtosRoboControl"
 	program_icon = "robot"
+	power_consumption = 80 WATT
 	///Number of simple robots on-station.
 	var/botcount = 0
 	///Used to find the location of the user for the purposes of summoning robots.

--- a/code/modules/modular_computers/file_system/programs/secureye.dm
+++ b/code/modules/modular_computers/file_system/programs/secureye.dm
@@ -12,6 +12,7 @@
 	tgui_id = "NtosSecurEye"
 	program_icon = "eye"
 	hardware_requirement = MC_CAMERA // Doesn't make sense to use a camera a lot, but this will get security off their ass
+	power_consumption = 200 WATT
 
 	var/list/network = list(CAMERA_NETWORK_STATION)
 	/// Weakref to the active camera

--- a/code/modules/modular_computers/file_system/programs/signaller.dm
+++ b/code/modules/modular_computers/file_system/programs/signaller.dm
@@ -8,6 +8,7 @@
 	tgui_id = "NtosSignaller"
 	program_icon = "satellite-dish"
 	hardware_requirement = MC_SIGNALLER
+	power_consumption = 60 WATT
 	///What is the saved signal frequency?
 	var/signal_frequency = FREQ_SIGNALER
 	/// What is the saved signal code?

--- a/code/modules/modular_computers/file_system/programs/sm_monitor.dm
+++ b/code/modules/modular_computers/file_system/programs/sm_monitor.dm
@@ -12,6 +12,7 @@
 	tgui_id = "NtosSupermatterMonitor"
 	program_icon = "radiation"
 	alert_able = TRUE
+	power_consumption = 60 WATT
 	var/last_status = SUPERMATTER_INACTIVE
 	var/list/supermatters
 	var/obj/machinery/power/supermatter_crystal/active		// Currently selected supermatter crystal.

--- a/code/modules/modular_computers/file_system/programs/statusdisplay.dm
+++ b/code/modules/modular_computers/file_system/programs/statusdisplay.dm
@@ -8,6 +8,7 @@
 	extended_desc = "An app used to change the message on the station status displays."
 	tgui_id = "NtosStatus"
 	transfer_access = list(ACCESS_HEADS)
+	power_consumption = 60 WATT
 	var/upper_text = ""
 	var/lower_text = ""
 

--- a/code/modules/modular_computers/file_system/programs/wiki_uplink.dm
+++ b/code/modules/modular_computers/file_system/programs/wiki_uplink.dm
@@ -7,6 +7,7 @@
 	tgui_id = "NtosDatabank"
 	program_icon = "book"
 	size = 2
+	power_consumption = 10 WATT
 
 /datum/computer_file/program/databank_uplink/ui_data(mob/user)
 	var/list/data = list()

--- a/code/modules/modular_computers/hardware/CPU.dm
+++ b/code/modules/modular_computers/hardware/CPU.dm
@@ -29,7 +29,7 @@
 	desc = "A miniaturised CPU used in portable devices. It can run up to two programs simultaneously."
 	icon_state = "cpu"
 	w_class = WEIGHT_CLASS_TINY
-	power_usage = 2.5 // Watts per second
+	power_usage = 3 // Watts per second
 	max_idle_programs = 1
 	custom_price = PAYCHECK_EASY * 2
 

--- a/code/modules/modular_computers/hardware/battery_module.dm
+++ b/code/modules/modular_computers/hardware/battery_module.dm
@@ -40,6 +40,10 @@ CREATION_TEST_IGNORE_SUBTYPES(/obj/item/computer_hardware/battery)
 		balloon_alert(user, "<font color='#e06eb1'>Update:</font> // Battery Integrity Sensor // <font color='#17c011'>Engaged</font>")
 		to_chat(user, "<span class='cfc_magenta'>Update:</span> // Battery Integrity Sensor // <span class='cfc_green'>Engaged</span>")
 
+// =================================
+// Battery Hardware
+// =================================
+
 /obj/item/computer_hardware/battery/tiny	//I just wanted to create a subtype to facilitate coding since seeing battery alone isn't very helpful at a glance
 	name = "tiny battery"
 	desc = "The smallest battery available. Commonly seen in low-end portable microcomputers"
@@ -83,36 +87,19 @@ CREATION_TEST_IGNORE_SUBTYPES(/obj/item/computer_hardware/battery)
 	rating = PART_TIER_5
 	custom_price = PAYCHECK_MEDIUM * 3
 
-/obj/item/stock_parts/cell/computer
-	name = "standard battery"
-	desc = "A standard power cell, commonly seen in high-end portable microcomputers or low-end laptops."
-	icon = 'icons/obj/module.dmi'
-	icon_state = "cell_mini"
-	w_class = WEIGHT_CLASS_SMALL
-	maxcharge = 80 KILOWATT
-	chargerate_divide = 8
-	/// rating affects the size of the explosion created by the detonation of the battery (trough Power Cell Controler hacking)
-	rating = PART_TIER_3
-	custom_price = PAYCHECK_MEDIUM
+// =================================
+// Battery Cells: Each tier increases by 50%
+// =================================
 
-/obj/item/stock_parts/cell/computer/advanced
-	name = "advanced battery"
-	desc = "An advanced power cell, often used in most laptops, or high-end Tablets."
-	icon_state = "cell"
-	w_class = WEIGHT_CLASS_SMALL
-	maxcharge = 120 KILOWATT
-	custom_price = PAYCHECK_MEDIUM * 2
-	rating = PART_TIER_4
-
-/obj/item/stock_parts/cell/computer/super
-	name = "super battery"
-	desc = "An advanced power cell, often used in high-end laptops."
-	icon_state = "cell"
-	w_class = WEIGHT_CLASS_NORMAL	// Fits only laptops
-	maxcharge = 200 KILOWATT
-	chargerate_divide = 10
-	custom_price = PAYCHECK_MEDIUM * 3
-	rating = PART_TIER_5
+/obj/item/stock_parts/cell/computer/nano
+	name = "nano battery"
+	desc = "A tiny power cell, commonly seen in low-end portable microcomputers."
+	icon_state = "cell_micro"
+	w_class = WEIGHT_CLASS_TINY
+	maxcharge = 40 KILOWATT
+	chargerate_divide = 4
+	custom_price = PAYCHECK_EASY
+	rating = PART_TIER_1
 
 /obj/item/stock_parts/cell/computer/micro
 	name = "micro battery"
@@ -122,13 +109,34 @@ CREATION_TEST_IGNORE_SUBTYPES(/obj/item/computer_hardware/battery)
 	w_class = WEIGHT_CLASS_TINY
 	custom_price = PAYCHECK_EASY * 2
 	rating = PART_TIER_2
+	chargerate_divide = 2
 
-/obj/item/stock_parts/cell/computer/nano
-	name = "nano battery"
-	desc = "A tiny power cell, commonly seen in low-end portable microcomputers."
-	icon_state = "cell_micro"
-	w_class = WEIGHT_CLASS_TINY
-	maxcharge = 40 KILOWATT
+/obj/item/stock_parts/cell/computer
+	name = "standard battery"
+	desc = "A standard power cell, commonly seen in high-end portable microcomputers or low-end laptops."
+	icon = 'icons/obj/module.dmi'
+	icon_state = "cell_mini"
+	w_class = WEIGHT_CLASS_SMALL
+	maxcharge = 100 KILOWATT
+	/// rating affects the size of the explosion created by the detonation of the battery (trough Power Cell Controler hacking)
+	rating = PART_TIER_3
+	custom_price = PAYCHECK_MEDIUM
+
+/obj/item/stock_parts/cell/computer/advanced
+	name = "advanced battery"
+	desc = "An advanced power cell, often used in most laptops, or high-end Tablets."
+	icon_state = "cell"
+	w_class = WEIGHT_CLASS_SMALL
+	maxcharge = 140 KILOWATT
+	custom_price = PAYCHECK_MEDIUM * 2
+	rating = PART_TIER_4
+
+/obj/item/stock_parts/cell/computer/super
+	name = "super battery"
+	desc = "An advanced power cell, often used in high-end laptops."
+	icon_state = "cell"
+	w_class = WEIGHT_CLASS_NORMAL	// Fits only laptops
+	maxcharge = 220 KILOWATT
 	chargerate_divide = 10
-	custom_price = PAYCHECK_EASY
-	rating = PART_TIER_1
+	custom_price = PAYCHECK_MEDIUM * 3
+	rating = PART_TIER_5

--- a/code/modules/modular_computers/hardware/card_slot.dm
+++ b/code/modules/modular_computers/hardware/card_slot.dm
@@ -1,7 +1,7 @@
 /obj/item/computer_hardware/card_slot
 	name = "primary RFID card module"	// \improper breaks the find_hardware_by_name proc
 	desc = "A module allowing this computer to read or write data on ID cards. Necessary for some programs to run properly."
-	power_usage = 10 // Watts per second
+	power_usage = 0 // Watts per second
 	icon_state = "card_mini"
 	w_class = WEIGHT_CLASS_TINY
 	device_type = MC_CARD

--- a/code/modules/modular_computers/hardware/hard_drive.dm
+++ b/code/modules/modular_computers/hardware/hard_drive.dm
@@ -261,7 +261,7 @@
 /obj/item/computer_hardware/hard_drive/micro
 	name = "micro solid state drive"
 	desc = "A highly efficient SSD chip for portable devices. It comes pre-installed with all default programs common in PDAs."
-	power_usage = 5  // Watts per second
+	power_usage = 4  // Watts per second
 	max_capacity = 32
 	icon_state = "ssd_micro"
 	w_class = WEIGHT_CLASS_TINY

--- a/code/modules/modular_computers/hardware/modules.dm
+++ b/code/modules/modular_computers/hardware/modules.dm
@@ -6,7 +6,7 @@
 	w_class = WEIGHT_CLASS_TINY
 	device_type = MC_SENSORS
 	expansion_hw = TRUE
-	power_usage = 10 // Watts per second
+	power_usage = 2 // Watts per second
 	custom_price = PAYCHECK_MEDIUM
 	can_hack = FALSE
 
@@ -17,7 +17,7 @@
 	w_class = WEIGHT_CLASS_TINY
 	device_type = MC_SIGNALLER
 	expansion_hw = TRUE
-	power_usage = 10 // Watts per second
+	power_usage = 2 // Watts per second
 	custom_price = PAYCHECK_MEDIUM
 	can_hack = FALSE
 
@@ -28,6 +28,6 @@
 	w_class = WEIGHT_CLASS_TINY
 	device_type = MC_CAMERA
 	expansion_hw = TRUE
-	power_usage = 20 // Watts per second
+	power_usage = 10 // Watts per second
 	custom_price = 30
 	can_hack = FALSE

--- a/code/modules/modular_computers/hardware/network_card.dm
+++ b/code/modules/modular_computers/hardware/network_card.dm
@@ -1,7 +1,7 @@
 /obj/item/computer_hardware/network_card
 	name = "network card"
 	desc = "A basic wireless network card for usage with standard NTNet frequencies."
-	power_usage = 5  // Watts per second
+	power_usage = 1  // Watts per second
 	icon_state = "radio_mini"
 	network_id = NETWORK_CARDS	// Network we are on
 	var/hardware_id = null	// Identification ID. Technically MAC address of this device. Can't be changed by user.
@@ -83,7 +83,7 @@
 	name = "advanced network card"
 	desc = "An advanced network card for usage with standard NTNet frequencies. Its transmitter is strong enough to connect even off-station."
 	signal_level = SIGNAL_HIGH
-	power_usage = 10 // Watts per second
+	power_usage = 5 // Watts per second
 	icon_state = "radio"
 	lefthand_file = 'icons/mob/inhands/misc/devices_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/misc/devices_righthand.dmi'

--- a/code/modules/power/rbmk/rbmk_monitoring.dm
+++ b/code/modules/power/rbmk/rbmk_monitoring.dm
@@ -15,6 +15,7 @@
 	tgui_id = "NtosRbmkStats"
 	program_icon = "radiation"
 	alert_able = TRUE
+	power_consumption = 80 WATT
 	var/active = TRUE //Easy process throttle
 	var/last_status
 	COOLDOWN_DECLARE(next_stat_interval)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

fixes #13321

- PDAs no longer use power while turned off.
- Flashlights on PDAs now consume and require power to use. They will flicker when the power is low.
- Reduces the power consumption for PDA base parts. The rate is now such that it will take 66 minutes of being enabled to discharge without any programs open.
- Adds power consumption to programs, most programs will discharge the base battery in ~10 minutes, but some more intensive programs will drain it incredibly fast and require a bigger battery to use (such as lifeline and the security camera program)

## Why It's Good For The Game

PDA power consumption was previously too high and was simply frustrating. Players were not encouraged to upgrade since they were being punished for a system that they generally weren't interacting with. If the user is to be encouraged to seek upgrades, then they need to feel like they were responsible for the device losing power, and so now programs are the primary cause of power consumption. This means that the user is always the one responsible for them losing power, and there are more effects from it such as the flashlight flickering and going dark.

The PDA is a necessary tool for station life, so it discharging in about 10 minutes even when sitting in the pocket is not appropriate and just makes the gameplay frustrating. It also makes it impossible to add more dependency on PDA programs and modular computers. Players completely disengaging with the PDA and giving up on using it represents a failure of the system and that changes are necessary and required, these I think are the changes that are necessary and required while still maintaining some worth in investing in upgrades for your PDA.

## Testing Photographs and Procedure

Test base rate on 60x speed:

https://github.com/user-attachments/assets/9e68bc61-1d3f-4c45-9e94-3a8c64e6fd96

1x speed using expensive programs such as lifeline:

https://github.com/user-attachments/assets/66db9417-c15b-4bc1-9fb2-51d431109e82


https://github.com/user-attachments/assets/02b2c61e-99ae-491f-b560-65898f3690d4

## Changelog
:cl:
balance: Reduces the PDA's inactive power consumption, power consumption is now higher when you have programs open. PDAs never use power while turned off.
balance: Flashlight PDA now consumes and requires power, flickering when low on power.
balance: PDA batteries charge slightly faster.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
