### PR TITLE
Prevents observers from using the workshop console

### DIFF
--- a/code/modules/holodeck/computer.dm
+++ b/code/modules/holodeck/computer.dm
@@ -157,7 +157,7 @@ GLOBAL_LIST_INIT(typecache_holodeck_linked_floorcheck_ok, typecacheof(list(/turf
 
 /obj/machinery/computer/holodeck/ui_act(action, params)
 	if(..())
-		return
+		return TRUE
 	switch(action)
 		if("load_program")
 			var/program_to_load = params["id"]

--- a/code/modules/security/workshop.dm
+++ b/code/modules/security/workshop.dm
@@ -46,8 +46,6 @@
 	if(!allowed(usr))
 		to_chat(usr, span_warning("Access denied."))
 		return
-	if(isobserver(usr))
-		return
 	if(..())
 		return
 	switch(action)

--- a/code/modules/security/workshop.dm
+++ b/code/modules/security/workshop.dm
@@ -46,6 +46,8 @@
 	if(!allowed(usr))
 		to_chat(usr, span_warning("Access denied."))
 		return
+	if(isobserver(usr))
+		return
 	if(..())
 		return
 	switch(action)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Observers were unintentionally able to use the security workshop. This change prevents them from accessing it.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Ghosts should not be able to do this.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

I swear i am clicking here
<img width="491" height="285" alt="image" src="https://github.com/user-attachments/assets/56c3b136-76d4-4da6-8f8b-ecc0f1ee95dd" />

</details>

## Changelog
:cl:
fix: Observers were unintentionally able to use the security workshop.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
