### PR TITLE
Nerfs the possessed chainsword's damage

### DIFF
--- a/code/game/objects/items/holy_weapons.dm
+++ b/code/game/objects/items/holy_weapons.dm
@@ -571,7 +571,6 @@
 	item_state = "chainswordon"
 	worn_icon_state = "chainswordon"
 	chaplain_spawnable = FALSE
-	force = 30
 	slot_flags = ITEM_SLOT_BELT
 	attack_verb_continuous = list("saws", "tears", "lacerates", "cuts", "chops", "dices")
 	attack_verb_simple = list("saw", "tear", "lacerate", "cut", "chop", "dice")


### PR DESCRIPTION
## About The Pull Request

Reduces the damage of the possessed chainsword from 30 to 18. 

Fixes #12749.

Ports:
- https://github.com/tgstation/tgstation/pull/38765

## Why It's Good For The Game

The possessed chainsword does significantly higher damage than other nullrod options, to the point that it is clearly unintentional. Reducing the damage to 18 should bring it in line with other holy weapons.


## Testing Photographs and Procedure

<details>
<summary>Screenshots&Videos</summary>


https://github.com/user-attachments/assets/e26418d5-6e55-4d16-acce-356603c0ac20

Old possessed chainsword damage (30)


https://github.com/user-attachments/assets/2b159da0-b6ea-460c-9ebb-22be8571f03e

New possessed chainsword damage (18)

</details>

## Changelog
:cl: ACanOpener, Anonmare
balance: Reduced damage of the possessed chainsword to 18, down from 30.
/:cl: