### PR TITLE
Bioscrambler anomaly tweaks

### DIFF
--- a/code/game/objects/effects/anomalies/anomaly_bioscrambler.dm
+++ b/code/game/objects/effects/anomalies/anomaly_bioscrambler.dm
@@ -35,7 +35,8 @@
 	for(var/mob/living/carbon/target in range(range, owner))
 		if(!ignore_owner && target == owner)
 			continue
-		if(target.getarmor(type = BIO) >= 100)
+		var/protection_chance = (-50) + (target.getarmor(type = BIO) * 1.7)
+		if(prob(protection_chance))
 			to_chat(target, span_notice("Your armor protects you from [owner]!"))
 			continue //We are protected
 

--- a/code/game/objects/effects/anomalies/anomaly_bioscrambler.dm
+++ b/code/game/objects/effects/anomalies/anomaly_bioscrambler.dm
@@ -17,6 +17,10 @@
 
 	var/range = 5
 
+/obj/effect/anomaly/bioscrambler/Initialize(mapload, new_lifespan, spawned_fake_harvested)
+	. = ..()
+	COOLDOWN_START(src, pulse_cooldown, pulse_interval) // give them time to react
+
 /obj/effect/anomaly/bioscrambler/anomalyEffect(delta_time)
 	. = ..()
 

--- a/code/game/objects/effects/anomalies/anomaly_bioscrambler.dm
+++ b/code/game/objects/effects/anomalies/anomaly_bioscrambler.dm
@@ -36,7 +36,7 @@
 		if(!ignore_owner && target == owner)
 			continue
 		// probability should linearly scale from no protection at 30 to guaranteed at 90 bio armor
-		var/protection_chance = (target.getarmor(type = BIO) - 30) * (1 / (90 - 30))
+		var/protection_chance = (target.getarmor(type = BIO) - 30) * (100 / (90 - 30))
 		if(prob(protection_chance))
 			to_chat(target, span_notice("Your armor protects you from [owner]!"))
 			continue //We are protected

--- a/code/game/objects/effects/anomalies/anomaly_bioscrambler.dm
+++ b/code/game/objects/effects/anomalies/anomaly_bioscrambler.dm
@@ -35,7 +35,8 @@
 	for(var/mob/living/carbon/target in range(range, owner))
 		if(!ignore_owner && target == owner)
 			continue
-		var/protection_chance = (-50) + (target.getarmor(type = BIO) * 1.7)
+		// probability should linearly scale from no protection at 30 to guaranteed at 90 bio armor
+		var/protection_chance = (target.getarmor(type = BIO) - 30) * (1 / (90 - 30))
 		if(prob(protection_chance))
 			to_chat(target, span_notice("Your armor protects you from [owner]!"))
 			continue //We are protected

--- a/code/game/objects/effects/anomalies/anomaly_bioscrambler.dm
+++ b/code/game/objects/effects/anomalies/anomaly_bioscrambler.dm
@@ -31,7 +31,8 @@
 	for(var/mob/living/carbon/target in range(range, owner))
 		if(!ignore_owner && target == owner)
 			continue
-		if(target.run_armor_check(attack_flag = BIO, absorb_text = "Your armor protects you from [owner]!") >= 100)
+		if(target.getarmor(type = BIO) >= 100)
+			to_chat(target, span_notice("Your armor protects you from [owner]!"))
 			continue //We are protected
 
 		// Add target


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

bioscrambler anomalies no longer fire right after they spawn

bio suits also now properly protect against them like the event alert suggests
run_armor_check uses the STANDARDISE_ARMOUR macro to scale armor down so a value of 100 was impossible
https://github.com/BeeStation/BeeStation-Hornet/blob/3831602c0c9de330876a04451714064bb2347ac4/code/modules/mob/living/living_defense.dm#L11-L12

## Why It's Good For The Game

The effect is unpleasant and should be more avoidable

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

https://github.com/user-attachments/assets/70563ac4-0aed-46a3-b4ab-799e8b80357e

</details>

## Changelog
:cl: lord scrubling
balance: bioscrambler anomalies no longer instantly fire after spawning
balance: the chance to have a limb replaced by a bioscrambler anomaly linearly scales from guaranteed at 30 average bio armor to full protection at 90 bio armor
fix: bio protection properly protects against bioscrambler anomalies
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
