### PR TITLE
Fixes inconsistent cybernetic stomach naming

### DIFF
--- a/code/modules/surgery/organs/stomach.dm
+++ b/code/modules/surgery/organs/stomach.dm
@@ -200,7 +200,7 @@
 	maxHealth = STANDARD_ORGAN_THRESHOLD * 0.5
 
 /obj/item/organ/stomach/cybernetic/upgraded
-	name = "advanced cybernetic stomach"
+	name = "upgraded cybernetic stomach"
 	icon_state = "stomach-c-u"
 	desc = "An electronic device designed to mimic the functions of a human stomach. Handles disgusting food a bit better."
 	maxHealth = 1.5 * STANDARD_ORGAN_THRESHOLD


### PR DESCRIPTION
## About The Pull Request

Renames the "advanced cybernetic stomach" to "upgraded cybernetic stomach".

## Why It's Good For The Game

#13316  didn't account for the fact that other cybernetic organ upgrades (liver, heart, lungs) use "upgraded" instead of "advanced" in the name. This changes the stomach to be more consistent with the naming convention.

<img width="1129" height="134" alt="image" src="https://github.com/user-attachments/assets/2b19250c-c09d-49c2-92a3-e77096980966" />


## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

<img width="781" height="82" alt="oldcyberneticstomach" src="https://github.com/user-attachments/assets/3333c6ae-56db-4082-b7b5-c3ee0f9545a8" />

Old naming

<img width="743" height="99" alt="image" src="https://github.com/user-attachments/assets/981ba9f0-65f7-463a-b557-1947a96e464d" />

New naming

</details>

## Changelog
:cl:
tweak: Renamed the "advanced cybernetic stomach" to "upgraded cybernetic stomach" to be more consistent with other cybernetic organs.
/:cl:
