### PR TITLE
Nice Shop - Mapping QOL for Commisaries

### DIFF
--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -41412,7 +41412,7 @@
 "mVs" = (
 /obj/machinery/button/door/directional/east{
 	id = "commissarydoor";
-	name = doorlock
+	name = "Door Bolts"
 	},
 /obj/effect/turf_decal/siding/wood{
 	dir = 4

--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -4356,7 +4356,14 @@
 /turf/open/floor/iron/freezer,
 /area/crew_quarters/toilet/locker)
 "aYi" = (
-/turf/open/floor/plating,
+/obj/effect/turf_decal/siding/wood{
+	dir = 9
+	},
+/obj/structure/table/wood,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/wood,
 /area/vacant_room/commissary)
 "aYl" = (
 /obj/effect/turf_decal/tile/dark_blue/half/contrasted,
@@ -4612,10 +4619,6 @@
 "baU" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table/reinforced,
-/obj/machinery/door/poddoor/shutters{
-	id = "commissaryshutter";
-	name = "Vacant Commissary Shutter"
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
@@ -4626,16 +4629,24 @@
 	dir = 10
 	},
 /obj/machinery/door/firedoor,
+/obj/item/paper_bin{
+	pixel_x = -2;
+	pixel_y = 4
+	},
+/obj/item/pen,
+/obj/machinery/door/poddoor/shutters{
+	id = "commissaryshutter";
+	name = "Vacant Commissary Shutter"
+	},
 /turf/open/floor/iron,
 /area/vacant_room/commissary)
 "baX" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/holopad,
 /obj/effect/turf_decal/bot,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/turf/open/floor/wood,
 /area/vacant_room/commissary)
 "bbb" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer2{
@@ -7290,6 +7301,18 @@
 "bHE" = (
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"bHO" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/obj/structure/chair/fancy/comfy{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/vacant_room/commissary)
 "bHP" = (
 /obj/effect/turf_decal/tile/yellow,
 /turf/open/floor/iron,
@@ -14408,9 +14431,11 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/machinery/door/airlock/personal,
-/turf/open/floor/plating,
-/area/maintenance/port)
+/obj/machinery/door/airlock/personal{
+	id_tag = "commissarydoor"
+	},
+/turf/open/floor/iron,
+/area/vacant_room/commissary)
 "cGd" = (
 /obj/structure/closet/crate/bin,
 /obj/effect/turf_decal/stripes/line{
@@ -17842,11 +17867,13 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
-/obj/effect/turf_decal/tile/neutral/opposingcorners,
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/turf/open/floor/wood,
 /area/vacant_room/commissary)
 "dPv" = (
 /obj/structure/table/wood,
@@ -18316,13 +18343,9 @@
 /turf/open/floor/prison,
 /area/security/prison)
 "dYh" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/brown/opposingcorners{
-	dir = 1
-	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/siding/wood,
+/obj/structure/table/wood/poker,
+/turf/open/floor/wood,
 /area/vacant_room/commissary)
 "dYi" = (
 /obj/effect/turf_decal/siding/white/corner{
@@ -27803,14 +27826,13 @@
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "hIK" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 1
-	},
 /obj/item/storage/secure/safe{
 	pixel_x = 6;
 	pixel_y = -30
 	},
-/turf/open/floor/plating,
+/obj/effect/turf_decal/siding/wood,
+/obj/structure/closet/crate/wooden,
+/turf/open/floor/wood,
 /area/vacant_room/commissary)
 "hJe" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/high_volume/siphon/monitored/air_output{
@@ -29934,6 +29956,9 @@
 /obj/item/kirbyplants/random,
 /turf/open/floor/iron/tech,
 /area/quartermaster/office)
+"irH" = (
+/turf/open/floor/wood,
+/area/vacant_room/commissary)
 "irK" = (
 /obj/machinery/door/airlock/external,
 /obj/structure/cable/yellow{
@@ -30821,21 +30846,9 @@
 /turf/open/floor/iron,
 /area/science/robotics/mechbay)
 "iKG" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/brown/opposingcorners{
-	dir = 1
-	},
-/obj/machinery/button/door{
-	id = "commissarydoor";
-	name = "Commissary Door Lock";
-	normaldoorcontrol = 1;
-	pixel_y = -28;
-	specialfunctions = 4
-	},
-/obj/item/kirbyplants/random,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/siding/wood,
+/obj/machinery/modular_fabricator/autolathe,
+/turf/open/floor/wood,
 /area/vacant_room/commissary)
 "iKJ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer4{
@@ -32502,8 +32515,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer2{
 	dir = 9
 	},
-/obj/effect/turf_decal/tile/neutral/opposingcorners,
-/turf/open/floor/iron,
+/turf/open/floor/wood,
 /area/vacant_room/commissary)
 "jvd" = (
 /obj/structure/disposalpipe/segment,
@@ -32912,8 +32924,11 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/tile/neutral/opposingcorners,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/obj/item/kirbyplants/random,
+/turf/open/floor/wood,
 /area/vacant_room/commissary)
 "jAL" = (
 /obj/structure/cable/yellow{
@@ -33508,18 +33523,13 @@
 /turf/open/floor/iron/dark,
 /area/bridge)
 "jMQ" = (
-/obj/structure/table,
 /obj/machinery/firealarm{
 	pixel_y = 26
 	},
-/obj/item/stack/sheet/iron/five,
-/obj/item/circuitboard/machine/paystand,
-/obj/item/stack/cable_coil/random/five,
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
 	},
-/obj/effect/turf_decal/tile/neutral/opposingcorners,
-/turf/open/floor/iron,
+/turf/open/floor/wood,
 /area/vacant_room/commissary)
 "jMY" = (
 /obj/structure/table,
@@ -35746,11 +35756,10 @@
 /turf/open/floor/iron/dark,
 /area/security/warden)
 "kDq" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer4{
-	dir = 10
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 8
 	},
-/obj/effect/turf_decal/tile/neutral/opposingcorners,
-/turf/open/floor/iron,
+/turf/open/floor/wood,
 /area/vacant_room/commissary)
 "kDt" = (
 /obj/effect/turf_decal/stripes/line{
@@ -36541,6 +36550,14 @@
 "kSk" = (
 /turf/open/floor/iron,
 /area/crew_quarters/fitness)
+"kSs" = (
+/obj/item/radio/intercom/directional/north,
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wood/corner,
+/turf/open/floor/wood,
+/area/vacant_room/commissary)
 "kSu" = (
 /obj/structure/table/wood,
 /obj/item/storage/crayons,
@@ -37782,15 +37799,11 @@
 /obj/machinery/airalarm/directional/north{
 	pixel_y = 28
 	},
-/obj/structure/closet/secure_closet/personal,
-/obj/item/storage/secure/briefcase,
-/obj/effect/turf_decal/tile/brown/opposingcorners{
+/obj/effect/turf_decal/siding/wood{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/turf/open/floor/iron,
+/obj/structure/table/wood,
+/turf/open/floor/wood,
 /area/vacant_room/commissary)
 "lqv" = (
 /obj/structure/filingcabinet,
@@ -41397,12 +41410,16 @@
 /turf/open/floor/engine,
 /area/maintenance/disposal/incinerator)
 "mVs" = (
-/obj/item/radio/intercom{
-	pixel_x = 28;
-	pixel_y = 5
+/obj/machinery/button/door/directional/east{
+	id = "commissarydoor";
+	name = doorlock
 	},
-/obj/effect/turf_decal/tile/neutral/opposingcorners,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/obj/structure/table/wood,
+/obj/machinery/cell_charger,
+/turf/open/floor/wood,
 /area/vacant_room/commissary)
 "mVI" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer4{
@@ -41488,15 +41505,10 @@
 /turf/open/floor/plating,
 /area/security/brig)
 "mXU" = (
-/obj/structure/rack,
-/obj/item/wrench,
-/obj/item/screwdriver,
-/obj/machinery/camera/directional/east,
-/obj/effect/turf_decal/tile/brown/opposingcorners{
-	dir = 1
+/obj/effect/turf_decal/siding/wood/end{
+	dir = 4
 	},
-/obj/effect/turf_decal/tile/neutral,
-/turf/open/floor/iron,
+/turf/open/floor/wood,
 /area/vacant_room/commissary)
 "mXW" = (
 /obj/effect/turf_decal/tile/red/opposingcorners,
@@ -42011,8 +42023,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/neutral/opposingcorners,
-/turf/open/floor/iron,
+/turf/open/floor/wood,
 /area/vacant_room/commissary)
 "niE" = (
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
@@ -42247,13 +42258,14 @@
 	pixel_x = 26;
 	pixel_y = 6
 	},
-/obj/structure/table,
-/obj/item/stack/package_wrap,
-/obj/item/hand_labeler,
-/obj/effect/turf_decal/tile/brown/opposingcorners{
-	dir = 1
+/obj/effect/turf_decal/siding/wood{
+	dir = 6
 	},
-/turf/open/floor/iron,
+/obj/structure/table/wood/poker,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/wood,
 /area/vacant_room/commissary)
 "noK" = (
 /obj/structure/girder,
@@ -44123,10 +44135,6 @@
 "nXi" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table/reinforced,
-/obj/machinery/door/poddoor/shutters{
-	id = "commissaryshutter";
-	name = "Vacant Commissary Shutter"
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
@@ -44135,6 +44143,10 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment,
+/obj/machinery/door/poddoor/shutters{
+	id = "commissaryshutter";
+	name = "Vacant Commissary Shutter"
+	},
 /turf/open/floor/iron,
 /area/vacant_room/commissary)
 "nXm" = (
@@ -45542,8 +45554,10 @@
 /obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
-/obj/effect/turf_decal/tile/neutral/opposingcorners,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/turf/open/floor/wood,
 /area/vacant_room/commissary)
 "oER" = (
 /obj/structure/chair/office/light,
@@ -46377,8 +46391,10 @@
 	},
 /area/science/research)
 "oVC" = (
-/obj/effect/turf_decal/tile/neutral/opposingcorners,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/turf/open/floor/wood,
 /area/vacant_room/commissary)
 "oVM" = (
 /obj/machinery/camera/directional/north{
@@ -47072,15 +47088,14 @@
 /turf/open/floor/grass/no_border,
 /area/medical/genetics)
 "pjG" = (
-/obj/effect/turf_decal/tile/neutral/opposingcorners,
-/obj/effect/turf_decal/tile/brown/opposingcorners{
-	dir = 1
-	},
-/obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
 	dir = 1
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/siding/wood{
+	dir = 10
+	},
+/obj/machinery/disposal/bin,
+/turf/open/floor/wood,
 /area/vacant_room/commissary)
 "pjI" = (
 /obj/structure/table,
@@ -49808,8 +49823,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
-/obj/effect/turf_decal/tile/neutral/opposingcorners,
-/turf/open/floor/iron,
+/turf/open/floor/wood,
 /area/vacant_room/commissary)
 "qoi" = (
 /obj/structure/grille,
@@ -65409,6 +65423,12 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/genetics/cloning)
+"weL" = (
+/obj/machinery/door/airlock/personal{
+	id_tag = "commissarydoor"
+	},
+/turf/open/floor/iron,
+/area/vacant_room/commissary)
 "weV" = (
 /obj/structure/table/reinforced,
 /obj/item/pen,
@@ -65444,17 +65464,7 @@
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "wfq" = (
-/obj/structure/sign/warning/electricshock{
-	pixel_y = 32
-	},
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tile/neutral/half/contrasted{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/dark_blue/filled/line{
-	dir = 5
-	},
-/turf/open/floor/iron/dark,
+/turf/open/space/basic,
 /area/hallway/primary/central)
 "wfv" = (
 /obj/effect/turf_decal/stripes/line{
@@ -69462,22 +69472,20 @@
 /turf/open/floor/prison,
 /area/security/prison)
 "xIQ" = (
-/obj/structure/table,
 /obj/machinery/newscaster{
 	pixel_y = 32
 	},
-/obj/item/paper_bin{
-	pixel_x = -2;
-	pixel_y = 4
-	},
-/obj/item/pen,
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
+/obj/effect/turf_decal/siding/wood{
 	dir = 1
 	},
-/turf/open/floor/iron,
+/obj/machinery/camera/directional/north,
+/obj/item/storage/backpack/duffelbag,
+/obj/item/stack/sheet/wood/twenty,
+/obj/item/stack/sheet/iron/twenty,
+/obj/structure/closet/secure_closet/personal/empty,
+/obj/item/stack/sheet/glass/five,
+/obj/item/stack/package_wrap,
+/turf/open/floor/wood,
 /area/vacant_room/commissary)
 "xJf" = (
 /turf/closed/wall,
@@ -93723,7 +93731,7 @@ enr
 aVa
 tav
 lqq
-oVC
+irH
 qnW
 juV
 iKG
@@ -93980,7 +93988,7 @@ rdI
 aWF
 tav
 xIQ
-oVC
+irH
 baX
 kDq
 hIK
@@ -94237,9 +94245,9 @@ hbA
 aUw
 tav
 jMQ
-oVC
+irH
 nie
-oVC
+irH
 dYh
 tav
 vRK
@@ -94493,9 +94501,9 @@ aSa
 vKD
 xnB
 tav
-oVC
+kSs
 mVs
-nie
+bHO
 oVC
 nox
 tav
@@ -95007,7 +95015,7 @@ aSs
 aSs
 aSs
 tav
-tav
+weL
 tav
 qyN
 nrB

--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -65464,7 +65464,14 @@
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "wfq" = (
-/turf/open/space/basic,
+/obj/effect/turf_decal/tile/neutral/half/contrasted{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/dark_blue/filled/line{
+	dir = 5
+	},
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron/dark,
 /area/hallway/primary/central)
 "wfv" = (
 /obj/effect/turf_decal/stripes/line{

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -20009,19 +20009,14 @@
 	},
 /area/chapel/main)
 "cCN" = (
-/obj/structure/table,
 /obj/item/radio/intercom{
 	pixel_y = 26
 	},
-/obj/item/stack/sheet/iron/five,
-/obj/item/circuitboard/machine/paystand,
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
+/obj/effect/turf_decal/siding/wood{
 	dir = 1
 	},
-/turf/open/floor/iron,
+/obj/structure/table/wood,
+/turf/open/floor/wood,
 /area/vacant_room/commissary)
 "cCP" = (
 /turf/closed/wall,
@@ -20274,13 +20269,13 @@
 /turf/open/floor/iron/dark,
 /area/library)
 "cEz" = (
-/obj/structure/chair/stool,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/tile/brown{
+/obj/effect/turf_decal/siding/wood{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/neutral,
-/turf/open/floor/iron,
+/obj/structure/chair/fancy/comfy{
+	dir = 4
+	},
+/turf/open/floor/wood,
 /area/vacant_room/commissary)
 "cEC" = (
 /obj/effect/turf_decal/stripes/line{
@@ -20710,10 +20705,10 @@
 /obj/structure/table/wood,
 /obj/item/taperecorder,
 /obj/item/camera,
+/obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
 /obj/structure/sign/painting/library_private{
 	pixel_y = -32
 	},
-/obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
 /turf/open/floor/iron/dark,
 /area/library)
 "cGd" = (
@@ -25145,17 +25140,14 @@
 /obj/machinery/power/apc/auto_name/directional/west{
 	pixel_x = -24
 	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer2{
 	dir = 5
 	},
 /obj/structure/cable/yellow,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/turf/open/floor/wood,
 /area/vacant_room/commissary)
 "dmD" = (
 /obj/effect/turf_decal/tile/red/half/contrasted{
@@ -37694,11 +37686,10 @@
 /turf/open/floor/iron,
 /area/security/courtroom)
 "giU" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/turf/open/floor/wood,
 /area/vacant_room/commissary)
 "gjg" = (
 /obj/structure/disposalpipe/segment,
@@ -42978,12 +42969,6 @@
 /turf/open/floor/carpet/grimy,
 /area/chapel/main)
 "hOf" = (
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
@@ -42993,7 +42978,10 @@
 /obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/turf/open/floor/wood,
 /area/vacant_room/commissary)
 "hOh" = (
 /obj/structure/cable/yellow{
@@ -47123,7 +47111,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/turf/open/floor/wood,
 /area/vacant_room/commissary)
 "jgF" = (
 /obj/machinery/telecomms/processor/preset_two,
@@ -51497,12 +51485,6 @@
 /turf/open/floor/iron/white,
 /area/medical/surgery)
 "kDT" = (
-/obj/structure/table,
-/obj/item/storage/secure/safe{
-	pixel_y = 32
-	},
-/obj/item/paper_bin,
-/obj/item/pen,
 /obj/machinery/button/door{
 	id = "commissaryshutters";
 	name = "Commissary Shutters Control";
@@ -51510,11 +51492,14 @@
 	pixel_y = -5;
 	req_access_txt = null
 	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
+/obj/effect/turf_decal/siding/wood{
+	dir = 5
 	},
-/obj/effect/turf_decal/tile/neutral/opposingcorners,
-/turf/open/floor/iron,
+/obj/structure/table/wood,
+/obj/item/storage/secure/safe{
+	pixel_y = 32
+	},
+/turf/open/floor/wood,
 /area/vacant_room/commissary)
 "kDX" = (
 /obj/effect/turf_decal/delivery,
@@ -53735,15 +53720,14 @@
 /obj/machinery/airalarm/directional/south{
 	pixel_y = -22
 	},
-/obj/structure/closet/secure_closet/personal,
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -26
 	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
+/obj/effect/turf_decal/siding/wood{
+	dir = 10
 	},
-/obj/effect/turf_decal/tile/neutral/opposingcorners,
-/turf/open/floor/iron,
+/obj/machinery/modular_fabricator/autolathe,
+/turf/open/floor/wood,
 /area/vacant_room/commissary)
 "ltT" = (
 /obj/structure/cable/yellow{
@@ -53948,11 +53932,10 @@
 	},
 /area/engine/atmos)
 "lwG" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/turf/open/floor/wood,
 /area/vacant_room/commissary)
 "lwK" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -60233,11 +60216,10 @@
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "nsH" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer2{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/turf/open/floor/wood,
 /area/vacant_room/commissary)
 "nsJ" = (
 /obj/structure/cable/yellow{
@@ -66909,20 +66891,17 @@
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
 "pAL" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/structure/sign/poster/random{
 	pixel_y = 32
 	},
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
+/obj/effect/turf_decal/siding/wood{
 	dir = 1
 	},
-/turf/open/floor/iron,
+/obj/structure/table/wood,
+/turf/open/floor/wood,
 /area/vacant_room/commissary)
 "pAS" = (
 /obj/structure/table/wood,
@@ -67375,15 +67354,11 @@
 	pixel_x = 7;
 	pixel_y = -26
 	},
-/obj/effect/turf_decal/tile/brown/opposingcorners{
-	dir = 1
+/obj/effect/turf_decal/siding/wood{
+	dir = 6
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/structure/rack,
-/obj/item/wrench,
-/obj/item/screwdriver,
-/obj/item/stack/cable_coil/random/five,
-/turf/open/floor/iron,
+/obj/structure/closet/crate/wooden,
+/turf/open/floor/wood,
 /area/vacant_room/commissary)
 "pJg" = (
 /obj/machinery/button/door{
@@ -70039,15 +70014,20 @@
 /turf/open/floor/iron,
 /area/security/checkpoint/customs)
 "qzX" = (
-/obj/structure/table,
-/obj/item/stack/package_wrap,
-/obj/item/hand_labeler,
 /obj/machinery/firealarm{
 	dir = 4;
 	pixel_x = -24
 	},
-/obj/effect/turf_decal/tile/brown,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/siding/wood{
+	dir = 9
+	},
+/obj/structure/closet/secure_closet/personal/empty,
+/obj/item/storage/backpack/duffelbag,
+/obj/item/stack/sheet/wood/twenty,
+/obj/item/stack/sheet/iron/twenty,
+/obj/item/stack/sheet/glass/five,
+/obj/item/stack/package_wrap,
+/turf/open/floor/wood,
 /area/vacant_room/commissary)
 "qAc" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
@@ -71476,6 +71456,21 @@
 	},
 /turf/open/floor/wood,
 /area/quartermaster/exploration_prep)
+"qXw" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/structure/table/reinforced,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/poddoor/shutters{
+	id = "commissaryshutters";
+	name = "Vacant Commissary Shutters"
+	},
+/turf/open/floor/iron,
+/area/vacant_room/commissary)
 "qXy" = (
 /obj/effect/turf_decal/tile/red/half/contrasted{
 	dir = 8
@@ -75177,12 +75172,11 @@
 /turf/open/floor/iron/dark,
 /area/engine/gravity_generator)
 "saU" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
+/obj/effect/turf_decal/siding/wood,
+/obj/machinery/camera/directional/south{
+	c_tag = "Vacant Commissary"
 	},
-/obj/effect/turf_decal/tile/neutral,
-/turf/open/floor/iron,
+/turf/open/floor/wood,
 /area/vacant_room/commissary)
 "saY" = (
 /obj/effect/turf_decal/delivery,
@@ -79566,12 +79560,10 @@
 /turf/open/floor/iron,
 /area/hydroponics)
 "tub" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/tile/brown{
+/obj/effect/turf_decal/siding/wood{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/neutral,
-/turf/open/floor/iron,
+/turf/open/floor/wood,
 /area/vacant_room/commissary)
 "tuv" = (
 /obj/machinery/door/airlock/hatch{
@@ -79803,11 +79795,13 @@
 	dir = 8
 	},
 /obj/structure/table/reinforced,
+/obj/machinery/door/firedoor,
+/obj/item/paper_bin,
+/obj/item/pen,
 /obj/machinery/door/poddoor/shutters{
 	id = "commissaryshutters";
 	name = "Vacant Commissary Shutters"
 	},
-/obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/vacant_room/commissary)
 "txE" = (
@@ -86774,17 +86768,10 @@
 /turf/open/floor/iron/dark,
 /area/chapel/office)
 "vNK" = (
-/obj/machinery/camera/directional/south{
-	c_tag = "Vacant Commissary"
-	},
 /obj/machinery/firealarm/directional/south,
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/structure/table,
-/obj/item/storage/secure/briefcase,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/siding/wood,
+/obj/structure/table/wood,
+/turf/open/floor/wood,
 /area/vacant_room/commissary)
 "vNN" = (
 /obj/structure/closet/secure_closet/security,
@@ -128612,7 +128599,7 @@ czO
 caG
 cCP
 txy
-txy
+qXw
 cCP
 cCP
 tBD

--- a/_maps/map_files/FlandStation/FlandStation.dmm
+++ b/_maps/map_files/FlandStation/FlandStation.dmm
@@ -7958,8 +7958,13 @@
 /turf/open/floor/iron/techmaint,
 /area/science/shuttle)
 "cah" = (
-/obj/structure/closet/secure_closet/personal,
 /obj/effect/turf_decal/bot,
+/obj/structure/closet/secure_closet/personal/empty,
+/obj/item/storage/backpack/duffelbag,
+/obj/item/stack/sheet/wood/twenty,
+/obj/item/stack/sheet/iron/twenty,
+/obj/item/stack/sheet/glass/five,
+/obj/item/stack/package_wrap,
 /turf/open/floor/iron/dark,
 /area/vacant_room/commissary/commissary2)
 "cai" = (
@@ -14944,6 +14949,12 @@
 	},
 /turf/open/floor/iron/dark,
 /area/hallway/secondary/exit/departure_lounge)
+"dUs" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/turf/open/floor/wood,
+/area/vacant_room/commissary/commissary1)
 "dUG" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -15084,6 +15095,13 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/port)
+"dWp" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/structure/table/wood,
+/turf/open/floor/wood,
+/area/vacant_room/commissary/commissary1)
 "dWt" = (
 /obj/effect/turf_decal/trimline/red/filled/corner{
 	dir = 8
@@ -16882,9 +16900,6 @@
 /turf/open/space/basic,
 /area/space)
 "exI" = (
-/obj/structure/table,
-/obj/item/circuitboard/machine/paystand,
-/obj/item/stack/sheet/iron/five,
 /obj/machinery/button/door{
 	id = "commissaryshutters1";
 	name = "Commissary Shutters Control #1";
@@ -16894,7 +16909,11 @@
 /obj/item/radio/intercom{
 	pixel_y = -28
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/siding/wood{
+	dir = 10
+	},
+/obj/structure/table/wood/poker,
+/turf/open/floor/wood,
 /area/vacant_room/commissary/commissary1)
 "exP" = (
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -17925,7 +17944,10 @@
 /obj/machinery/airalarm/directional/east{
 	pixel_x = 22
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/turf/open/floor/wood,
 /area/vacant_room/commissary/commissary1)
 "eJY" = (
 /obj/machinery/door/firedoor,
@@ -19182,8 +19204,13 @@
 /turf/open/floor/iron,
 /area/maintenance/port)
 "eXR" = (
-/obj/structure/closet/secure_closet/personal,
 /obj/effect/turf_decal/bot,
+/obj/structure/closet/secure_closet/personal/empty,
+/obj/item/storage/backpack/duffelbag,
+/obj/item/stack/sheet/wood/twenty,
+/obj/item/stack/sheet/iron/twenty,
+/obj/item/stack/sheet/glass/five,
+/obj/item/stack/package_wrap,
 /turf/open/floor/iron/dark,
 /area/vacant_room/commissary/commissary1)
 "eXS" = (
@@ -22500,6 +22527,9 @@
 /obj/effect/spawner/lootdrop/trap/reusable,
 /turf/open/floor/iron,
 /area/maintenance/port/central)
+"fMf" = (
+/turf/open/floor/wood,
+/area/vacant_room/commissary/commissary1)
 "fMh" = (
 /obj/item/storage/secure/safe{
 	pixel_x = 34
@@ -23404,14 +23434,11 @@
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/ai_upload_foyer)
 "fYt" = (
-/obj/structure/rack,
-/obj/item/wrench,
-/obj/item/screwdriver,
-/obj/item/stack/cable_coil/random/five,
 /obj/machinery/light_switch{
 	pixel_x = 24
 	},
-/turf/open/floor/iron,
+/obj/machinery/smartfridge/organ,
+/turf/open/floor/iron/white,
 /area/vacant_room/commissary/commissary2)
 "fYw" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer2,
@@ -23740,7 +23767,6 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
 /area/vacant_room/commissary/commissary1)
 "gcg" = (
@@ -28013,7 +28039,9 @@
 /obj/machinery/newscaster{
 	pixel_y = -28
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/siding/wood,
+/obj/machinery/modular_fabricator/autolathe,
+/turf/open/floor/wood,
 /area/vacant_room/commissary/commissary1)
 "hgc" = (
 /obj/effect/decal/cleanable/dirt,
@@ -32607,9 +32635,7 @@
 /obj/machinery/door/window{
 	dir = 8
 	},
-/turf/open/floor/iron/dark/side{
-	dir = 4
-	},
+/turf/open/floor/iron/dark,
 /area/vacant_room/commissary/commissary1)
 "iqy" = (
 /turf/open/floor/engine/co2/light,
@@ -34390,8 +34416,17 @@
 /turf/open/floor/iron/cafeteria,
 /area/crew_quarters/kitchen)
 "iLj" = (
+/obj/machinery/newscaster{
+	pixel_y = 31
+	},
 /obj/structure/table,
-/turf/open/floor/iron,
+/obj/item/storage/backpack/duffelbag/med/surgery{
+	pixel_y = 8
+	},
+/obj/effect/turf_decal/tile/blue/half{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
 /area/vacant_room/commissary/commissary2)
 "iLD" = (
 /turf/closed/wall,
@@ -36630,6 +36665,12 @@
 /obj/effect/turf_decal/tile/purple/fourcorners/contrasted,
 /turf/open/floor/iron/techmaint,
 /area/science/lab)
+"jqI" = (
+/obj/effect/turf_decal/tile/blue/half{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/vacant_room/commissary/commissary2)
 "jrk" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer4,
 /obj/effect/landmark/navigate_destination,
@@ -38989,8 +39030,10 @@
 /turf/closed/wall,
 /area/security/execution/transfer)
 "jWI" = (
-/obj/structure/chair/stool/directional/west,
-/turf/open/floor/iron,
+/obj/structure/chair/office/light{
+	dir = 8
+	},
+/turf/open/floor/iron/cafeteria,
 /area/vacant_room/commissary/commissary2)
 "jWM" = (
 /obj/effect/turf_decal/stripes/closeup{
@@ -40838,6 +40881,12 @@
 	},
 /turf/open/floor/iron,
 /area/engine/atmos)
+"ktW" = (
+/obj/effect/turf_decal/tile/blue/anticorner/contrasted{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/vacant_room/commissary/commissary2)
 "ktY" = (
 /obj/effect/turf_decal/trimline/red/line{
 	dir = 8
@@ -46001,8 +46050,9 @@
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "lDG" = (
-/obj/structure/table,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/siding/wood,
+/obj/structure/table/wood/poker,
+/turf/open/floor/wood,
 /area/vacant_room/commissary/commissary1)
 "lDL" = (
 /obj/effect/turf_decal/tile/yellow{
@@ -51183,7 +51233,8 @@
 /obj/machinery/airalarm/directional/east{
 	pixel_x = 22
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/blue/anticorner/contrasted,
+/turf/open/floor/iron/white,
 /area/vacant_room/commissary/commissary2)
 "nak" = (
 /turf/open/floor/iron/dark,
@@ -54577,6 +54628,10 @@
 	},
 /turf/open/floor/iron/techmaint,
 /area/quartermaster/office)
+"nVN" = (
+/obj/machinery/iv_drip,
+/turf/open/floor/iron/cafeteria,
+/area/vacant_room/commissary/commissary2)
 "nVO" = (
 /obj/structure/table/reinforced,
 /obj/effect/turf_decal/bot,
@@ -59467,7 +59522,10 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/turf/open/floor/wood,
 /area/vacant_room/commissary/commissary1)
 "pla" = (
 /obj/machinery/camera/directional/west{
@@ -65458,7 +65516,6 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
 /area/vacant_room/commissary/commissary2)
 "qNl" = (
@@ -67325,7 +67382,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
-/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
 /area/vacant_room/commissary/commissary2)
 "rnb" = (
@@ -67401,10 +67457,6 @@
 	dir = 8
 	},
 /area/hallway/primary/port)
-"roh" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
-/area/vacant_room/commissary/commissary1)
 "rol" = (
 /obj/effect/turf_decal/tile/purple/opposingcorners,
 /obj/effect/turf_decal/tile/green/opposingcorners{
@@ -71589,7 +71641,7 @@
 "spb" = (
 /obj/machinery/holopad,
 /obj/effect/turf_decal/box,
-/turf/open/floor/iron/dark,
+/turf/open/floor/wood,
 /area/vacant_room/commissary/commissary1)
 "sph" = (
 /obj/effect/turf_decal/tile/dark_blue/fourcorners/contrasted,
@@ -72297,7 +72349,10 @@
 /turf/open/floor/iron/dark,
 /area/bridge)
 "szp" = (
-/turf/open/floor/iron,
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/turf/open/floor/wood,
 /area/vacant_room/commissary/commissary1)
 "szs" = (
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
@@ -73582,14 +73637,14 @@
 /turf/open/floor/iron/dark,
 /area/engine/storage_shared)
 "sQo" = (
-/obj/structure/rack,
-/obj/item/wrench,
-/obj/item/screwdriver,
-/obj/item/stack/cable_coil/random/five,
 /obj/machinery/light_switch{
 	pixel_x = 24
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/siding/wood{
+	dir = 6
+	},
+/obj/structure/closet/crate/wooden,
+/turf/open/floor/wood,
 /area/vacant_room/commissary/commissary1)
 "sQs" = (
 /obj/structure/cable/yellow{
@@ -73626,7 +73681,6 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 1
 	},
-/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
 /area/vacant_room/commissary/commissary1)
 "sQK" = (
@@ -73665,11 +73719,10 @@
 /turf/open/floor/iron/white,
 /area/science/explab)
 "sQT" = (
-/obj/machinery/newscaster{
-	pixel_y = 31
+/obj/structure/table/optable{
+	name = "Robotics Operating Table"
 	},
-/obj/machinery/camera/directional/north,
-/turf/open/floor/iron,
+/turf/open/floor/iron/white/textured_large,
 /area/vacant_room/commissary/commissary2)
 "sRl" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer2{
@@ -75682,9 +75735,7 @@
 /obj/effect/turf_decal/siding/wideplating/dark{
 	dir = 8
 	},
-/turf/open/floor/iron/dark/side{
-	dir = 4
-	},
+/turf/open/floor/iron/dark,
 /area/vacant_room/commissary/commissary2)
 "tsq" = (
 /obj/machinery/status_display/evac{
@@ -76127,7 +76178,9 @@
 /area/science/shuttle)
 "tyW" = (
 /obj/machinery/firealarm/directional/south,
-/turf/open/floor/iron,
+/obj/item/glove_box,
+/obj/structure/table,
+/turf/open/floor/iron/cafeteria,
 /area/vacant_room/commissary/commissary2)
 "tyX" = (
 /obj/machinery/atmospherics/pipe/smart/simple/pink/visible,
@@ -77304,9 +77357,9 @@
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "tOd" = (
-/obj/machinery/holopad,
 /obj/effect/turf_decal/box,
-/turf/open/floor/iron/dark,
+/obj/machinery/holopad,
+/turf/open/floor/iron/cafeteria,
 /area/vacant_room/commissary/commissary2)
 "tOs" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer2,
@@ -77543,7 +77596,7 @@
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "tQT" = (
-/turf/open/floor/iron,
+/turf/open/floor/iron/cafeteria,
 /area/vacant_room/commissary/commissary2)
 "tQX" = (
 /obj/structure/cable/yellow{
@@ -78029,7 +78082,6 @@
 	dir = 8;
 	pixel_x = -12
 	},
-/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
 /area/vacant_room/commissary/commissary2)
 "tXb" = (
@@ -82154,7 +82206,7 @@
 	pixel_y = -30
 	},
 /obj/item/kirbyplants/random,
-/turf/open/floor/iron,
+/turf/open/floor/iron/cafeteria,
 /area/vacant_room/commissary/commissary2)
 "uZl" = (
 /obj/structure/rack,
@@ -84826,8 +84878,13 @@
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
 "vyZ" = (
-/obj/structure/chair/stool/directional/west,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/obj/structure/chair/fancy/comfy{
+	dir = 8
+	},
+/turf/open/floor/wood,
 /area/vacant_room/commissary/commissary1)
 "vzm" = (
 /obj/machinery/disposal/bin,
@@ -86723,13 +86780,12 @@
 	pixel_x = -24;
 	pixel_y = -4
 	},
-/obj/structure/table,
-/obj/item/circuitboard/machine/paystand,
-/obj/item/stack/sheet/iron/five,
 /obj/item/radio/intercom{
 	pixel_y = 24
 	},
-/turf/open/floor/iron,
+/obj/machinery/camera/directional/north,
+/obj/machinery/chem_master,
+/turf/open/floor/iron/cafeteria,
 /area/vacant_room/commissary/commissary2)
 "vUZ" = (
 /obj/structure/bookcase/random/religion,
@@ -87487,7 +87543,12 @@
 /area/medical/virology)
 "wgl" = (
 /obj/machinery/light,
-/turf/open/floor/iron,
+/obj/item/reagent_containers/blood,
+/obj/item/reagent_containers/blood,
+/obj/item/reagent_containers/blood,
+/obj/item/reagent_containers/blood,
+/obj/structure/closet/crate/medical,
+/turf/open/floor/iron/cafeteria,
 /area/vacant_room/commissary/commissary2)
 "wgo" = (
 /obj/effect/decal/cleanable/dirt,
@@ -92208,8 +92269,11 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_y = 30
 	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 5
+	},
 /obj/item/kirbyplants/random,
-/turf/open/floor/iron,
+/turf/open/floor/wood,
 /area/vacant_room/commissary/commissary1)
 "xjV" = (
 /obj/machinery/light,
@@ -94302,7 +94366,11 @@
 /area/hallway/secondary/entry)
 "xFv" = (
 /obj/machinery/firealarm/directional/north,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/siding/wood{
+	dir = 9
+	},
+/obj/structure/table/wood,
+/turf/open/floor/wood,
 /area/vacant_room/commissary/commissary1)
 "xFI" = (
 /obj/structure/sign/directions/medical{
@@ -124119,7 +124187,7 @@ tyW
 viG
 xFv
 vyZ
-szp
+dUs
 exI
 viG
 mKU
@@ -124370,13 +124438,13 @@ wyg
 wyg
 xKl
 iLj
+ktW
 tQT
-tQT
-tQT
+nVN
 viG
-szp
-szp
-szp
+dWp
+fMf
+fMf
 lDG
 viG
 xUL
@@ -124627,13 +124695,13 @@ kha
 qnZ
 xKl
 sQT
-tQT
+jqI
 tOd
 wgl
 viG
 pkV
 spb
-szp
+fMf
 hfY
 viG
 hBa
@@ -124889,7 +124957,7 @@ tQT
 uZj
 viG
 xjP
-roh
+szp
 eJT
 sQo
 viG

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -7567,10 +7567,6 @@
 "bfj" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table/reinforced,
-/obj/machinery/door/poddoor/shutters{
-	id = "commissaryshutter";
-	name = "Vacant Commissary Shutter"
-	},
 /obj/structure/noticeboard{
 	pixel_y = 31
 	},
@@ -7581,16 +7577,25 @@
 	dir = 4
 	},
 /obj/machinery/door/firedoor,
+/obj/item/paper_bin{
+	pixel_x = -2;
+	pixel_y = 4
+	},
+/obj/item/pen,
+/obj/machinery/door/poddoor/shutters{
+	id = "commissaryshutter";
+	name = "Vacant Commissary Shutter"
+	},
 /turf/open/floor/iron,
 /area/vacant_room/commissary)
 "bfk" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 4
 	},
-/turf/open/floor/plating,
+/obj/effect/turf_decal/tile/neutral/opposingcorners,
+/turf/open/floor/iron,
 /area/vacant_room/commissary)
 "bfl" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/holopad,
 /obj/effect/turf_decal/bot,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer4{
@@ -7602,12 +7607,8 @@
 /turf/open/floor/iron,
 /area/vacant_room/commissary)
 "bfm" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/yellow{
 	icon_state = "2-4"
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
 	},
 /obj/effect/turf_decal/tile/neutral,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer4{
@@ -7616,6 +7617,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer2{
 	dir = 4
 	},
+/obj/effect/turf_decal/tile/neutral/opposingcorners,
 /turf/open/floor/iron,
 /area/vacant_room/commissary)
 "bfo" = (
@@ -7949,7 +7951,6 @@
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "bhd" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
@@ -7964,10 +7965,8 @@
 /obj/machinery/light/small{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral/opposingcorners,
 /turf/open/floor/iron,
 /area/vacant_room/commissary)
 "bhg" = (
@@ -8282,8 +8281,9 @@
 	pixel_x = 6;
 	pixel_y = -30
 	},
-/obj/item/kirbyplants/random,
-/turf/open/floor/plating,
+/obj/machinery/modular_fabricator/autolathe,
+/obj/effect/turf_decal/tile/neutral/opposingcorners,
+/turf/open/floor/iron,
 /area/vacant_room/commissary)
 "biX" = (
 /obj/item/clothing/mask/gas,
@@ -22890,14 +22890,13 @@
 /obj/machinery/airalarm/directional/north{
 	pixel_y = 28
 	},
-/obj/structure/closet/secure_closet/personal,
-/obj/item/storage/secure/briefcase,
-/obj/effect/turf_decal/tile/brown/opposingcorners{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
+/obj/structure/closet/secure_closet/personal/empty,
+/obj/item/storage/backpack/duffelbag,
+/obj/item/stack/sheet/iron/twenty,
+/obj/item/stack/sheet/wood/twenty,
+/obj/effect/turf_decal/tile/neutral/opposingcorners,
+/obj/item/stack/package_wrap,
+/obj/item/stack/sheet/glass/five,
 /turf/open/floor/iron,
 /area/vacant_room/commissary)
 "exX" = (
@@ -23428,17 +23427,7 @@
 /obj/machinery/newscaster{
 	pixel_y = 32
 	},
-/obj/item/paper_bin{
-	pixel_x = -2;
-	pixel_y = 4
-	},
-/obj/item/pen,
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
+/obj/effect/turf_decal/tile/neutral/opposingcorners,
 /turf/open/floor/iron,
 /area/vacant_room/commissary)
 "eIG" = (
@@ -27173,15 +27162,9 @@
 /obj/machinery/firealarm{
 	pixel_y = 26
 	},
-/obj/item/stack/sheet/iron/five,
 /obj/item/radio/intercom{
 	pixel_x = 28;
 	pixel_y = 5
-	},
-/obj/item/circuitboard/machine/paystand,
-/obj/item/stack/cable_coil/random/five,
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
 	},
 /obj/effect/turf_decal/tile/neutral/opposingcorners,
 /turf/open/floor/iron,
@@ -30452,16 +30435,12 @@
 	pixel_x = 24
 	},
 /obj/structure/cable/yellow,
-/obj/structure/rack,
-/obj/item/wrench,
-/obj/item/screwdriver,
 /obj/machinery/camera/directional/east{
 	c_tag = "Vacant Commissary"
 	},
-/obj/effect/turf_decal/tile/brown/opposingcorners{
-	dir = 1
-	},
 /obj/effect/turf_decal/tile/neutral,
+/obj/structure/rack,
+/obj/effect/turf_decal/tile/neutral/opposingcorners,
 /turf/open/floor/iron,
 /area/vacant_room/commissary)
 "hii" = (
@@ -40193,7 +40172,8 @@
 /obj/machinery/door/airlock/personal{
 	id_tag = "commissarydoor"
 	},
-/turf/open/floor/plating,
+/obj/effect/turf_decal/tile/neutral/opposingcorners,
+/turf/open/floor/iron,
 /area/vacant_room/commissary)
 "kvS" = (
 /obj/effect/turf_decal/tile/bar/opposingcorners,
@@ -46744,14 +46724,8 @@
 /turf/open/floor/carpet/blue,
 /area/crew_quarters/heads/cmo)
 "mLh" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/chair/stool,
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
+/obj/effect/turf_decal/tile/neutral/opposingcorners,
+/obj/structure/chair/stool/directional/west,
 /turf/open/floor/iron,
 /area/vacant_room/commissary)
 "mLq" = (
@@ -47818,7 +47792,6 @@
 /turf/open/space,
 /area/space/nearstation)
 "ndG" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/button/door{
 	id = "commissaryshutter";
 	name = "Commissary Shutter Control";
@@ -47826,11 +47799,6 @@
 	pixel_y = 6
 	},
 /obj/structure/table,
-/obj/item/stack/package_wrap,
-/obj/item/hand_labeler,
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
-	},
 /obj/effect/turf_decal/tile/neutral/opposingcorners,
 /turf/open/floor/iron,
 /area/vacant_room/commissary)
@@ -65581,7 +65549,6 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "thO" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 1
 	},
@@ -78867,7 +78834,6 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
-/obj/structure/rack,
 /obj/item/storage/box,
 /obj/item/storage/box,
 /obj/item/storage/box,

--- a/_maps/map_files/RadStation/RadStation.dmm
+++ b/_maps/map_files/RadStation/RadStation.dmm
@@ -10174,7 +10174,6 @@
 /area/hallway/secondary/exit/departure_lounge)
 "dlY" = (
 /obj/structure/table,
-/obj/machinery/camera/directional/north,
 /turf/open/floor/iron/dark,
 /area/vacant_room/commissary/commissary1)
 "dmd" = (
@@ -42848,6 +42847,7 @@
 /obj/item/stack/sheet/iron/twenty,
 /obj/item/stack/sheet/glass/five,
 /obj/item/stack/package_wrap,
+/obj/machinery/camera/directional/north,
 /turf/open/floor/iron/dark,
 /area/vacant_room/commissary/commissary1)
 "ohp" = (

--- a/_maps/map_files/RadStation/RadStation.dmm
+++ b/_maps/map_files/RadStation/RadStation.dmm
@@ -2065,9 +2065,11 @@
 /turf/open/floor/iron/white,
 /area/medical/apothecary)
 "aGA" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/blood/splatter,
-/turf/open/floor/plating,
+/obj/effect/turf_decal/tile/brown/half/contrasted{
+	dir = 1
+	},
+/obj/machinery/modular_fabricator/autolathe,
+/turf/open/floor/iron,
 /area/vacant_room/commissary/commissary1)
 "aGC" = (
 /obj/structure/cable/yellow{
@@ -10171,10 +10173,8 @@
 	},
 /area/hallway/secondary/exit/departure_lounge)
 "dlY" = (
-/obj/effect/decal/cleanable/cobweb,
 /obj/structure/table,
-/obj/item/soap,
-/obj/item/stack/sheet/wood/ten,
+/obj/machinery/camera/directional/north,
 /turf/open/floor/iron/dark,
 /area/vacant_room/commissary/commissary1)
 "dmd" = (
@@ -13825,10 +13825,10 @@
 /turf/open/floor/iron/dark,
 /area/maintenance/department/bridge)
 "esW" = (
-/obj/effect/decal/cleanable/crayon,
 /obj/machinery/light/small{
 	dir = 4
 	},
+/obj/effect/turf_decal/tile/brown/half/contrasted,
 /turf/open/floor/iron,
 /area/vacant_room/commissary/commissary1)
 "ete" = (
@@ -15625,7 +15625,7 @@
 /obj/machinery/door/airlock/personal{
 	id_tag = "commissarydoor1"
 	},
-/obj/effect/mapping_helpers/airlock/abandoned,
+/obj/structure/barricade/wooden/crude,
 /turf/open/floor/iron,
 /area/vacant_room/commissary/commissary1)
 "fah" = (
@@ -16674,7 +16674,9 @@
 /turf/open/floor/iron/tech,
 /area/engine/engine_room)
 "fpn" = (
-/obj/effect/decal/cleanable/oil,
+/obj/effect/turf_decal/tile/brown/half/contrasted{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/vacant_room/commissary/commissary1)
 "fpA" = (
@@ -23401,7 +23403,8 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/turf/open/floor/plating,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron,
 /area/vacant_room/commissary/commissary2)
 "hBZ" = (
 /obj/structure/disposalpipe/segment{
@@ -30228,7 +30231,6 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 4
 	},
-/obj/effect/decal/cleanable/shreds,
 /turf/open/floor/iron/dark,
 /area/vacant_room/commissary/commissary1)
 "jPm" = (
@@ -31232,7 +31234,11 @@
 /turf/open/floor/iron,
 /area/maintenance/port/aft)
 "kii" = (
-/turf/open/floor/plating,
+/obj/structure/table,
+/obj/effect/turf_decal/tile/brown/anticorner/contrasted{
+	dir = 4
+	},
+/turf/open/floor/iron,
 /area/vacant_room/commissary/commissary1)
 "kiy" = (
 /turf/open/floor/carpet/red,
@@ -33865,10 +33871,10 @@
 /area/chapel/main)
 "lhn" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/landmark/xeno_spawn,
 /obj/machinery/light/small{
 	dir = 8
 	},
+/obj/effect/landmark/xeno_spawn,
 /turf/open/floor/iron/dark,
 /area/vacant_room/commissary/commissary1)
 "lhu" = (
@@ -35911,7 +35917,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
-/obj/effect/decal/cleanable/blood/old,
+/obj/effect/turf_decal/tile/brown/anticorner/contrasted,
 /turf/open/floor/iron,
 /area/vacant_room/commissary/commissary1)
 "lUg" = (
@@ -40474,7 +40480,6 @@
 /turf/open/floor/iron,
 /area/security/brig)
 "nrZ" = (
-/obj/effect/decal/cleanable/oil,
 /turf/open/floor/iron/dark,
 /area/vacant_room/commissary/commissary1)
 "nsg" = (
@@ -42218,8 +42223,11 @@
 /turf/open/floor/carpet/purple,
 /area/chapel/main)
 "nWv" = (
-/obj/structure/closet/secure_closet/personal,
-/turf/open/floor/plating,
+/obj/structure/closet/crate/wooden,
+/obj/effect/turf_decal/tile/brown/anticorner/contrasted{
+	dir = 1
+	},
+/turf/open/floor/iron,
 /area/vacant_room/commissary/commissary1)
 "nWx" = (
 /obj/machinery/newscaster/directional/east,
@@ -42834,6 +42842,12 @@
 	pixel_x = 28;
 	pixel_y = -5
 	},
+/obj/structure/closet/secure_closet/personal/empty,
+/obj/item/storage/backpack/duffelbag,
+/obj/item/stack/sheet/wood/twenty,
+/obj/item/stack/sheet/iron/twenty,
+/obj/item/stack/sheet/glass/five,
+/obj/item/stack/package_wrap,
 /turf/open/floor/iron/dark,
 /area/vacant_room/commissary/commissary1)
 "ohp" = (
@@ -46421,7 +46435,10 @@
 	pixel_y = -31;
 	specialfunctions = 4
 	},
-/turf/open/floor/plating,
+/obj/effect/turf_decal/tile/brown/half/contrasted{
+	dir = 8
+	},
+/turf/open/floor/iron,
 /area/vacant_room/commissary/commissary1)
 "pmB" = (
 /obj/structure/cable/yellow{
@@ -46808,10 +46825,12 @@
 /turf/open/floor/iron/dark,
 /area/security/brig/dock)
 "puS" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/lootdrop/grille_or_trash,
 /obj/machinery/airalarm/directional/north,
-/turf/open/floor/plating,
+/obj/structure/table,
+/obj/effect/turf_decal/tile/brown/half/contrasted{
+	dir = 4
+	},
+/turf/open/floor/iron,
 /area/vacant_room/commissary/commissary1)
 "puT" = (
 /obj/structure/window/reinforced{
@@ -54120,8 +54139,14 @@
 /turf/open/floor/catwalk_floor,
 /area/engine/atmos)
 "rTU" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/obj/structure/closet/crate/large,
+/obj/effect/turf_decal/tile/brown/anticorner/contrasted{
+	dir = 8
+	},
+/obj/item/circuitboard/machine/chem_dispenser,
+/obj/item/reagent_containers/cup/beaker/large,
+/obj/item/reagent_containers/cup/beaker,
+/turf/open/floor/iron,
 /area/vacant_room/commissary/commissary1)
 "rUg" = (
 /turf/open/floor/iron/dark/side{
@@ -62817,7 +62842,6 @@
 /obj/machinery/door/window{
 	dir = 8
 	},
-/obj/effect/decal/cleanable/ash/large,
 /turf/open/floor/iron/dark,
 /area/vacant_room/commissary/commissary1)
 "uEN" = (
@@ -63762,11 +63786,11 @@
 /turf/closed/wall/r_wall,
 /area/science/explab)
 "uUI" = (
-/obj/effect/decal/cleanable/dirt/dust,
 /obj/item/storage/secure/safe{
 	pixel_x = 37;
 	pixel_y = 1
 	},
+/obj/effect/turf_decal/tile/brown/half/contrasted,
 /turf/open/floor/iron,
 /area/vacant_room/commissary/commissary1)
 "uUZ" = (
@@ -72781,10 +72805,6 @@
 	},
 /obj/structure/table,
 /obj/machinery/power/apc/auto_name/directional/north,
-/obj/item/stack/cable_coil/random/five,
-/obj/item/screwdriver,
-/obj/item/wrench,
-/obj/item/circuitboard/machine/paystand,
 /turf/open/floor/iron/dark,
 /area/vacant_room/commissary/commissary1)
 "xUR" = (
@@ -101624,8 +101644,8 @@ xWC
 voS
 nWv
 fpn
-kii
-goV
+aGA
+rTU
 eRb
 oSG
 ojG
@@ -101880,8 +101900,8 @@ jnw
 pkz
 voS
 puS
-rTU
-aGA
+goV
+goV
 pmu
 gQP
 lKq


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Given our rounds are shorter than what they were a year ago the many obstacles a player faces when trying to do something creative become extremely costly.

Setting up a shop is, in my opinion one of the best RP things ever.
A shop is something that draws in players, gets them talking to one another, gets raided by security, its awesome all around!

However, if you want your shop to look good you must not only scavenge for the resources to do it but you also need to waste time constructing. Then you still need to procure something to sell. This can take upwards of 30 minutes if someone is giga locked in and speedrunning as I used to do.

My solution?
Make the shop areas fit to be used from the get-go.
Mostly getting rid of debris, uncovered floor tiles and adding a couple things to spice it up.

My approach was to keep every shop mechanically the same, same resources, same machinery, but change the looks here and there of some of them and adding an extra bonus to specific shops:

In meta we can see nothing much has changed.
The shop still has its metical colours, but now it includes something you'll see in every shop:
A private locker with a duffel bag, wood, iron, glass and wrapping paper.

<img width="204" height="185" alt="image" src="https://github.com/user-attachments/assets/4ca5cf59-f8b8-4398-904e-f15bbe035248" />

And an autolathe.
One thing we will see is either racks or boxes for storing items. A rack in the case of meta.

<img width="697" height="580" alt="image" src="https://github.com/user-attachments/assets/ada12c5d-ae0b-45e4-9be3-4cfc4696ab5d" />

For Delta we can see that it has the wooden look. Specially because of its proximity to the library.
I went with this look on many of the shops because its not only more time consuming to make in game but also to give them a distinct look. It can be disassembled easily, should the player choose.
Instead of a rack we can see a wooden box.

<img width="774" height="657" alt="image" src="https://github.com/user-attachments/assets/973dd26f-01ca-4888-afcb-6eb20f30f6c1" />

Radstation follows what we have seen until now with a small twist.
A large box containing some beakers and a chem dispenser circuit board.
Players will only need to procure the parts (with the help of their lathe) to start selling some drugs.

<img width="669" height="389" alt="image" src="https://github.com/user-attachments/assets/e63a26a5-360a-4ee7-99ae-877f8364973f" />
<img width="334" height="350" alt="image" src="https://github.com/user-attachments/assets/c2559f63-4384-4fd0-aa6e-67876b0f409e" />
<img width="179" height="166" alt="image" src="https://github.com/user-attachments/assets/b219517d-7c1b-44d3-a9bd-f19cd2aa422e" />

I kept the cook shop as it is because some players told me they do enjoy cleaning the mess.
I have only made it a fraction of a second easier by placing the missing floortile.
<img width="372" height="451" alt="image" src="https://github.com/user-attachments/assets/d2dfb436-a385-4b42-9cda-cdae97498627" />

Box gets the most out of this PR because it now has an extra door, and you no longer need to loop trough maintenance just to get inside the shop.
A charger was added for PC shop type gimmicks, or just to chill there for a long time.
This shop is ideal for you to set up a bed and live here with your betrothed. No ERP tho. (unless? 😳 )

<img width="594" height="512" alt="image" src="https://github.com/user-attachments/assets/267dfdc9-65f7-40b4-bc22-05c01b0e062d" />

Fland is the winner because it has two shops, so I elected to do something a little different.
Since I have seen many times players do a medical shop I decided to set one up for them.
This includes a chemmaster (no dispenser don't be greedy!) surgery tools, empty IV bags, whatever you might need!

<img width="665" height="804" alt="image" src="https://github.com/user-attachments/assets/155e06af-0036-4cca-88ac-6094dc73e9b0" />
<img width="636" height="687" alt="image" src="https://github.com/user-attachments/assets/ab426bbd-1027-4ae2-bccc-ffef69894894" />

I think it looks pretty and hope it helps players in their RP!

## I did not touch Echo, Kilo or Card!

Card needs to have a COMPLETE change if its shops are to work.
Cards shops are in the least populated area of the station. They should be in the middle, where the action is! But I cant be bothered will all that for now!


## Why It's Good For The Game

As I've explained the shorter round style leads players to cut corners.
This PR is here to help players not have to cut corners when it amounts to good RP scenarios.

Should these shops be used for crime then that is also a good thing because it may help antagonists act sooner.

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

Upthere

</details>

## Changelog
:cl: PinkSuzuki
tweak: Reworked empty shops to make them more prepared for business (or crime)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
