### PR TITLE
Near Complete Vanquishing of Botany Departments PodPeople Guides 

### DIFF
--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -32687,10 +32687,6 @@
 /obj/effect/turf_decal/tile/green/half/contrasted{
 	dir = 8
 	},
-/obj/item/book/manual/hydroponics_pod_people{
-	pixel_x = 10
-	},
-/obj/item/paper/guides/jobs/hydroponics,
 /turf/open/floor/iron,
 /area/hydroponics)
 "jyd" = (

--- a/_maps/map_files/CorgStation/CorgStation.dmm
+++ b/_maps/map_files/CorgStation/CorgStation.dmm
@@ -6745,7 +6745,6 @@
 /obj/item/clothing/suit/apron,
 /obj/item/wrench,
 /obj/item/storage/box/syringes,
-/obj/item/book/manual/hydroponics_pod_people,
 /turf/open/floor/iron,
 /area/hydroponics)
 "bRd" = (

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -10804,7 +10804,6 @@
 	dir = 4
 	},
 /obj/item/stack/package_wrap,
-/obj/item/book/manual/hydroponics_pod_people,
 /obj/item/hand_labeler,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron,

--- a/_maps/map_files/EchoStation/EchoStation.dmm
+++ b/_maps/map_files/EchoStation/EchoStation.dmm
@@ -5668,7 +5668,6 @@
 	req_access = null;
 	req_one_access_txt = "28;25;35"
 	},
-/obj/item/book/manual/hydroponics_pod_people,
 /obj/item/clothing/suit/toggle/chef,
 /obj/item/clothing/head/utility/chefhat,
 /obj/machinery/requests_console/directional/west,

--- a/_maps/map_files/FlandStation/FlandStation.dmm
+++ b/_maps/map_files/FlandStation/FlandStation.dmm
@@ -41847,7 +41847,6 @@
 /area/hallway/secondary/exit/departure_lounge)
 "kFI" = (
 /obj/item/stack/package_wrap,
-/obj/item/book/manual/hydroponics_pod_people,
 /obj/item/hand_labeler,
 /obj/effect/turf_decal/bot,
 /obj/structure/table,

--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -29065,12 +29065,7 @@
 /area/hallway/primary/central)
 "hvt" = (
 /obj/structure/table/glass,
-/obj/item/book/manual/hydroponics_pod_people{
-	pixel_y = 4
-	},
-/obj/item/paper/guides/jobs/hydroponics,
 /obj/item/reagent_containers/dropper,
-/obj/item/pen,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/camera/directional/west{
 	c_tag = "Hydroponics Pen";

--- a/_maps/map_files/RadStation/RadStation.dmm
+++ b/_maps/map_files/RadStation/RadStation.dmm
@@ -31443,7 +31443,6 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/item/paper/guides/jobs/hydroponics,
 /obj/machinery/airalarm/directional/north,
 /turf/open/floor/iron/grid/steel,
 /area/hydroponics)


### PR DESCRIPTION
There were books, and notes illustrating the use of Podpeople in revival. These methods are long since outdated and unusable, this PR removes said books and notes.

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Long since gone are the days of pod-people. Even while around their use was minimal, and yet they **PLAGUE** Botany Departments across the multitude of stations. For NO REASON these books continue to exist, these NOTES illustrating how to revive a dead body using pod-people. 

This PR Deletes Lying!! Or, atleast the false lead lead about what botany can do from all the stations still containing it
(Meta-Station remains infested but hopefully soon to be fixed by #13346)

## Why It's Good For The Game

There **should not** be guides pertaining to removed content. Its unneeded and unwanted. 

## Testing Photographs and Procedure
<sub> oh god oh please dont make me run every map for in round screenshots for the removal of one item </sub>
### Echo Station - (Book is located in Northern Locker)
<img width="305" height="407" alt="Screenshot 2025-09-23 190344" src="https://github.com/user-attachments/assets/13c7c018-02a9-4ed3-a6bc-b13b8020c7eb" />
<img width="794" height="426" alt="Screenshot 2025-09-23 190402" src="https://github.com/user-attachments/assets/8fb932fb-8463-467c-8aea-6048fe3f6f26" />

---

### Kilo Station - (Book / Note located along Eastern Wall Table outside the Pen)
<img width="659" height="744" alt="Screenshot 2025-09-23 190618" src="https://github.com/user-attachments/assets/9c475147-1d0e-4c3a-95a6-832d960d8d39" />
<img width="648" height="721" alt="Screenshot 2025-09-23 190630" src="https://github.com/user-attachments/assets/7e9f88e6-4007-441e-84a4-407d0e19bbdd" />

<sub> i deleted the pen too because it looked at me wrong </sub>

---

### Delta Station - (Book is located on table underneath botonists!)
<img width="701" height="808" alt="Screenshot 2025-09-23 190445" src="https://github.com/user-attachments/assets/685a0092-164c-46bf-a3e1-dfc2ee7105c8" />
<img width="705" height="794" alt="Screenshot 2025-09-23 190502" src="https://github.com/user-attachments/assets/48220e7e-f852-4fb5-a44a-9845e64600ae" />

---

### Fland Station - ( Book located NE of Dog Poster on Southern Wall )

<img width="760" height="700" alt="Screenshot 2025-09-23 190540" src="https://github.com/user-attachments/assets/48e8045b-33fa-4885-9dab-9c61cf2f0c5f" />

<img width="584" height="517" alt="Screenshot 2025-09-23 193707" src="https://github.com/user-attachments/assets/cb9b4bcc-2840-4019-859f-80e43438c2b9" />

---

### Box Station - (Book is located on table with Grinder in Northern Room)

<img width="556" height="330" alt="Screenshot_2025-09-23_133837" src="https://github.com/user-attachments/assets/5aded434-5bde-4845-8850-413444484bb2" />
<img width="570" height="355" alt="Screenshot 2025-09-23 194102" src="https://github.com/user-attachments/assets/9518907d-a7d7-455e-9d12-8745c69f6edf" />

---

### Corg Station - (Book located on rack under Vendor)
<img width="655" height="417" alt="Screenshot 2025-09-23 194254" src="https://github.com/user-attachments/assets/86b8d521-2bc3-4b7d-ac09-f85e4986d9d6" />
<img width="572" height="425" alt="Screenshot 2025-09-23 194357" src="https://github.com/user-attachments/assets/475f443f-45e6-447c-890f-ac4e6bc7acc3" />

---

### Radstation - (No book, but note located on desk in backroom)
<img width="284" height="225" alt="Screenshot 2025-09-23 194426" src="https://github.com/user-attachments/assets/5dbc4e7e-b8b0-4a93-bf3a-de8ab4ef8cf5" />
<img width="279" height="186" alt="Screenshot 2025-09-23 194438" src="https://github.com/user-attachments/assets/dfb3b48b-18f5-48d8-bf8e-ad6a5e78ad28" />




## Changelog
:cl:
del: Removed PodPeople books and notes from remaining stations -meta.
/:cl:
