### PR TITLE
REMOVE PACIFICATION SURGERY

### DIFF
--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -375,7 +375,6 @@
 		"surgery_muscled_veins",
 		"surgery_nerve_ground",
 		"surgery_nerve_splice",
-		"surgery_pacify",
 		"surgery_revival",
 		"surgery_vein_thread",
 	)


### PR DESCRIPTION
# About the PR
removes pacification surgery from it's tech node, nothing else.
## Why its Good For the Game
It's boring, has no real counterplay, shuts down people almost as badly as being gondolaified, and never leads to anything interesting.

<img width="286" height="129" alt="image" src="https://github.com/user-attachments/assets/8510ddbe-14dc-4701-b7f1-1b273efbfd65" />

## Changelog
:cl:
balance: Removed pacification surgery from the technodes
/:cl: