### PR TITLE
Rapid cable layer tweaks

### DIFF
--- a/code/game/objects/items/RCL.dm
+++ b/code/game/objects/items/RCL.dm
@@ -327,7 +327,6 @@
 			showWiringGui(user)
 
 /obj/item/rcl/ghetto
-	actions_types = list()
 	max_amount = 30
 	name = "makeshift rapid cable layer"
 	ghetto = TRUE

--- a/code/modules/research/designs/tool_designs.dm
+++ b/code/modules/research/designs/tool_designs.dm
@@ -310,3 +310,13 @@
 	build_path = /obj/item/wirebrush/advanced
 	category = list("Equipment")
 	departmental_flags = DEPARTMENTAL_FLAG_SERVICE
+
+/datum/design/rcl
+	name = "Rapid Cable Layer"
+	desc = "A device that can lay down cables quickly, as well as recolor them. Still requires insulation."
+	id = "rcl"
+	build_path = /obj/item/rcl
+	build_type = PROTOLATHE
+	materials = list(/datum/material/iron = 30000, /datum/material/glass = 4000)
+	category = list("Tool Designs")
+	departmental_flags = DEPARTMENTAL_FLAG_ENGINEERING

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -478,6 +478,7 @@
 		"magboots",
 		"ranged_analyzer",
 		"rcd_loaded",
+		"rcl",
 		"rpd_loaded",
 		"weldingmask",
 		"sheetifier"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

makes rcls printable and the gives the makeshift variant the same basic functions
the makeshift version still has its problems like having a chance to stop laying cable or a chance to fall apart when trying to remove cables from it when screwing
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

they should be more accessible than just being in specific spots on some maps

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

<img width="649" height="774" alt="image" src="https://github.com/user-attachments/assets/c918e90d-980c-41dd-8657-aeaeaa51b32b" />

<img width="425" height="172" alt="image" src="https://github.com/user-attachments/assets/2bfbbe47-9730-4d05-a76a-2fa97588e5bd" />

</details>

## Changelog
:cl: lord scrubling
add: Rapid cable layers have a protolathe design under the advanced engineering technode
balance: Makeshift rcls have the same basic functions as the normal version
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
