### PR TITLE
Fixes magboots not updating speed until you reequip them

### DIFF
--- a/code/modules/clothing/shoes/magboots.dm
+++ b/code/modules/clothing/shoes/magboots.dm
@@ -102,7 +102,7 @@
 	stamina = 30
 	bleed = 40
 
-/obj/item/clothing/shoes/magboots/commando/attack_self(mob/user) //Code for the passive no-slip of the commando magboots to always apply, kind of a shit code solution though.
+/obj/item/clothing/shoes/magboots/commando/attack_self(mob/user)
 	. = ..()
 	clothing_flags |= NOSLIP
 

--- a/code/modules/clothing/shoes/magboots.dm
+++ b/code/modules/clothing/shoes/magboots.dm
@@ -49,6 +49,7 @@
 	icon_state = "[magboot_state][magpulse]"
 	update_gravity_trait(user)
 	user.refresh_gravity()
+	user.update_equipment_speed_mods()
 	update_action_buttons()
 
 /obj/item/clothing/shoes/magboots/examine(mob/user)
@@ -103,15 +104,7 @@
 
 /obj/item/clothing/shoes/magboots/commando/attack_self(mob/user) //Code for the passive no-slip of the commando magboots to always apply, kind of a shit code solution though.
 	. = ..()
-	if(magpulse)
-		slowdown = SHOES_SLOWDOWN
-	else
-		slowdown = slowdown_active
-	magpulse = !magpulse
-	icon_state = "[magboot_state][magpulse]"
-	to_chat(user, span_notice("You [magpulse ? "enable" : "disable"] the mag-pulse traction system."))
-	user.update_inv_shoes()
-	update_action_buttons()
+	clothing_flags |= NOSLIP
 
 /obj/item/clothing/shoes/magboots/crushing
 	desc = "Normal looking magboots that are altered to increase magnetic pull to crush anything underfoot."


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
seems like a side effect of movespeed modifiers (surely it wasn't actually like this since #9992)
also kinda refactors commando magboot code

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

https://github.com/user-attachments/assets/1a48b9c6-7b2b-4ca3-a34b-933f3e43538e

</details>

## Changelog
:cl: lord scrubling
fix: magboots not updating their slowdown when toggled
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
