### PR TITLE
Food Renaming

### DIFF
--- a/code/game/objects/items/food/_food.dm
+++ b/code/game/objects/items/food/_food.dm
@@ -124,10 +124,9 @@
 	if(istype(attacking_item, /obj/item/pen))
 		var/target_name = tgui_input_text(user, "What would you like to name your masterpiece?", "Name:", name || "Food", MAX_MESSAGE_LEN)
 		if(!target_name || !length(target_name))
-			to_chat(usr, span_warning("You need to enter something!"))
 			return
 		if(CHAT_FILTER_CHECK(target_name))
-			to_chat(usr, span_warning("The given name contains prohibited word(s)."))
+			to_chat(user, span_warning("The given name contains prohibited word(s)."))
 			return
 		to_chat(user, span_notice("You rename the '<span class='cfc_bluesky'>[name]</span>' to '<span class='cfc_orange'>[target_name]</span>'."))
 		name = target_name

--- a/code/game/objects/items/food/_food.dm
+++ b/code/game/objects/items/food/_food.dm
@@ -118,3 +118,11 @@
 		if(resistance_flags & ON_FIRE)
 			SSfire_burning.processing -= src
 		qdel(src)
+
+/obj/item/food/attackby(obj/item/attacking_item, mob/living/user)
+	. = ..()
+	if(istype(attacking_item, /obj/item/pen))
+		var/target_name = tgui_input_text(user, "What would you like to name your masterpiece?", "Name:", name || "Food", MAX_MESSAGE_LEN)
+		to_chat(user, span_notice("You rename the '<span class='cfc_bluesky'>[name]</span>' to '<span class='cfc_orange'>[target_name]</span>'."))
+		name = target_name || name  // in case they hit cancel
+		update_appearance()

--- a/code/game/objects/items/food/_food.dm
+++ b/code/game/objects/items/food/_food.dm
@@ -123,6 +123,12 @@
 	. = ..()
 	if(istype(attacking_item, /obj/item/pen))
 		var/target_name = tgui_input_text(user, "What would you like to name your masterpiece?", "Name:", name || "Food", MAX_MESSAGE_LEN)
+		if(!target_name || !length(target_name))
+			to_chat(usr, span_warning("You need to enter something!"))
+			return
+		if(CHAT_FILTER_CHECK(target_name))
+			to_chat(usr, span_warning("The given name contains prohibited word(s)."))
+			return
 		to_chat(user, span_notice("You rename the '<span class='cfc_bluesky'>[name]</span>' to '<span class='cfc_orange'>[target_name]</span>'."))
-		name = target_name || name  // in case they hit cancel
+		name = target_name
 		update_appearance()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Food Renaming was removed with newfoods (I think).

While playing a player was very sad they couldn't do their custom restaurant gimmick.

Well now they can again.

<img width="788" height="206" alt="image" src="https://github.com/user-attachments/assets/c7aa2f62-5241-439f-987c-b6378dd0d367" />

Fairly simple PR.

## Why It's Good For The Game

Its something we could do before and now we can't.

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>

## Changelog
:cl:
tweak: You can now rename foods with pens again.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
