### PR TITLE
Clowncars can only be moved by clowns again. 

### DIFF
--- a/code/modules/vehicles/cars/clowncar.dm
+++ b/code/modules/vehicles/cars/clowncar.dm
@@ -30,6 +30,14 @@
 	initialize_controller_action_type(/datum/action/vehicle/sealed/horn/clowncar, VEHICLE_CONTROL_DRIVE)
 	initialize_controller_action_type(/datum/action/vehicle/sealed/Thank, VEHICLE_CONTROL_KIDNAPPED)
 
+/obj/vehicle/sealed/car/clowncar/relaymove(mob/living/user, direction)
+	if(!ishuman(user))
+		return FALSE
+	var/mob/living/carbon/human/rider = user
+	if(rider.mind?.assigned_role != JOB_NAME_CLOWN) //Only clowns can drive the car.
+		return FALSE
+	return ..()
+
 /obj/vehicle/sealed/car/clowncar/auto_assign_occupant_flags(mob/M)
 	if(ishuman(M))
 		var/mob/living/carbon/human/H = M


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Closes #12881 

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

This is a very expensive and exclusive uplink item. It's somewhat invalidated when the abducted players can control the car, though I won't deny that it's also pretty funny and chaotic. 

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

![dreamseeker_2QNhMVygaf](https://github.com/user-attachments/assets/b55ae3ed-1c1a-4f6f-be93-128456341ade)

![dreamseeker_eGLFcL6XZX](https://github.com/user-attachments/assets/b5db0018-1c5b-404e-b176-29162bbd4aa1)

</details>

## Changelog
:cl:
fix: Clown cars may now only be controlled by clowns
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
