### PR TITLE
Reduces the price of the Syndicate Lawnmower to 15 TC 

### DIFF
--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -2607,3 +2607,11 @@ GLOBAL_LIST_INIT(illegal_tech_blacklist, typecacheof(list(
 	cost = 3
 	surplus = 0
 	disabled = TRUE	// #11346 Currently in a broken state, lasso'd mobs will never unregister a target once they have locked onto one, making them unusable.
+
+/datum/uplink_item/support/nukielawnmower
+	name = "Syndicate Organism Shredder"
+	desc = "An armoured and modified lawn mower that can mow down any organic in its path. It is a fast and armoured to melee and ranged weaponry, but it's extremely vunerable to: bombs, fire, and form of acid"
+	item = /obj/vehicle/ridden/lawnmower/nukie
+	cost = 15
+	surplus = 0
+	purchasable_from = UPLINK_NUKE_OPS

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -2607,11 +2607,3 @@ GLOBAL_LIST_INIT(illegal_tech_blacklist, typecacheof(list(
 	cost = 3
 	surplus = 0
 	disabled = TRUE	// #11346 Currently in a broken state, lasso'd mobs will never unregister a target once they have locked onto one, making them unusable.
-
-/datum/uplink_item/support/nukielawnmower
-	name = "Syndicate Organism Shredder"
-	desc = "An armoured and modified lawn mower that can mow down any organic in its path. It is a fast and armoured to melee and ranged weaponry, but it's extremely vunerable to: bombs, fire, and form of acid"
-	item = /obj/vehicle/ridden/lawnmower/nukie
-	cost = 30
-	surplus = 0
-	purchasable_from = UPLINK_NUKE_OPS


### PR DESCRIPTION
## About The Pull Request
The lawnmower has been removed from the nukie uplink

## Why It's Good For The Game
After the nerf It is now a 30 TC moving people around machine, it does not enough damage to warrant 30 TC and is so slow is basically useless, you can just laugh at whoever is using it because you can just circle them around and demount them . We just had a nukie round where we spent 60 TC in 2 machines that did nothing but push people around a little and did not crit a single person. 

<img width="531" height="118" alt="image" src="https://github.com/user-attachments/assets/c764aa59-d088-47c9-b356-2f7eb8bc50bd" />

In order for this to work, it has to be more balanced, and right now as it is, it's a very 'Oooh buy me' uplink item that is basically useless and will cause you to go in and die

## Testing Photographs and Procedure
I'm gonna reuse the evidence from https://github.com/BeeStation/BeeStation-Hornet/pull/13250 You can go at 00:59 if you want to see the lawnmower being useless in effect.

(https://www.youtube.com/watch?v=badkuBeFrgw)

Changelog
🆑
tweak: Changed the Syndicate Lawnmower price to 15 TC
/:cl:
