### PR TITLE
Alt clicking on shuttle map clears target and thrust

### DIFF
--- a/code/modules/shuttle/super_cruise/shuttle_components/shuttle_console.dm
+++ b/code/modules/shuttle/super_cruise/shuttle_components/shuttle_console.dm
@@ -305,6 +305,11 @@ CREATION_TEST_IGNORE_SUBTYPES(/obj/machinery/computer/shuttle_flight)
 				return
 			var/x = text2num(params["x"])
 			var/y = text2num(params["y"])
+			var/altKey = params["altKey"]
+			if (altKey == 1)	// If the user alt+clicked, clear their target position and thrust
+				shuttleObject.thrust = 0
+				shuttleObject.shuttleTargetPos = null
+				return
 			if(!shuttleObject.shuttleTargetPos)
 				shuttleObject.shuttleTargetPos = new(x, y)
 			else

--- a/tgui/packages/tgui/interfaces/OrbitalMap.jsx
+++ b/tgui/packages/tgui/interfaces/OrbitalMap.jsx
@@ -482,6 +482,7 @@ export const OrbitalMapDisplay = (props) => {
           let proportionalY =
             ((e.clientY - rect.top) / radar.offsetHeight) * 500;
           act('setTargetCoords', {
+            altKey: e.altKey,
             x:
               (proportionalX - 250) / zoomScale +
               (isTracking ? dynamicXOffset : xOffset),


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This pull request adds the ability for a shuttle pilot to clear their target position and thrust by alt+clicking on the primary display in the shuttle console.

## Why It's Good For The Game

Without the ability to cut thrust to 0, a shuttle pilot is likely to burn fuel at a much faster pace than desired. This matters a lot for the exploration shuttle which is often on long trips without easy access to more fuel.

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
### To test:
1. Get in a shuttle and launch.
2. Click on the map to set a target waypoint
3. Note that Shuttle Thrust is set to 100 (screenshot below)
4. Alt click anywhere on the map
5. Note that Shuttle Thrust drops to 0 and the waypoint goes away (screenshot below)
<details>
<summary>Screenshots&Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

## Waypoint and thrust after step 3
<img width="1123" height="769" alt="ShuttleWithWaypoint" src="https://github.com/user-attachments/assets/9888a735-2616-48a1-9689-4103d925af92" />

## No waypoint or thrust after step 5
<img width="1124" height="769" alt="ShuttleWithWaypointCleared" src="https://github.com/user-attachments/assets/e7e2f7b0-b545-4627-83b3-aba8b64c2c90" />
</details>

## Changelog
:cl:
add: Alt+clicking on the map in a shuttle clears target and thrust
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
