### PR TITLE
Changes high impact ruleset team size formula

### DIFF
--- a/code/controllers/subsystem/dynamic/dynamic_rulesets_roundstart.dm
+++ b/code/controllers/subsystem/dynamic/dynamic_rulesets_roundstart.dm
@@ -256,7 +256,7 @@
 	var/datum/team/clock_cult/main_cult
 
 /datum/dynamic_ruleset/roundstart/clockcult/set_drafted_players_amount()
-	drafted_players_amount = ROUND_UP(length(GLOB.player_list) / 7)
+	drafted_players_amount = max(FLOOR(length(SSdynamic.roundstart_candidates) / 7), 1)
 
 /datum/dynamic_ruleset/roundstart/clockcult/choose_candidates()
 	. = ..()
@@ -312,7 +312,7 @@
 	var/datum/team/nuclear/nuke_team
 
 /datum/dynamic_ruleset/roundstart/nuclear/set_drafted_players_amount()
-	drafted_players_amount = ROUND_UP(length(GLOB.player_list) / 7)
+	drafted_players_amount = max(FLOOR(length(SSdynamic.roundstart_candidates) / 7), 1)
 
 /datum/dynamic_ruleset/roundstart/nuclear/choose_candidates()
 	. = ..()

--- a/code/controllers/subsystem/dynamic/dynamic_rulesets_roundstart.dm
+++ b/code/controllers/subsystem/dynamic/dynamic_rulesets_roundstart.dm
@@ -209,7 +209,7 @@
 	var/datum/team/cult/team
 
 /datum/dynamic_ruleset/roundstart/bloodcult/set_drafted_players_amount()
-	drafted_players_amount = ROUND_UP(length(GLOB.player_list) / 10)
+	drafted_players_amount = max(FLOOR(length(SSdynamic.roundstart_candidates) / 9, 1), 1)
 
 /datum/dynamic_ruleset/roundstart/bloodcult/execute()
 	team = new

--- a/code/controllers/subsystem/dynamic/dynamic_rulesets_roundstart.dm
+++ b/code/controllers/subsystem/dynamic/dynamic_rulesets_roundstart.dm
@@ -256,7 +256,7 @@
 	var/datum/team/clock_cult/main_cult
 
 /datum/dynamic_ruleset/roundstart/clockcult/set_drafted_players_amount()
-	drafted_players_amount = max(FLOOR(length(SSdynamic.roundstart_candidates) / 7), 1)
+	drafted_players_amount = max(FLOOR(length(SSdynamic.roundstart_candidates) / 7, 1), 1)
 
 /datum/dynamic_ruleset/roundstart/clockcult/choose_candidates()
 	. = ..()
@@ -312,7 +312,7 @@
 	var/datum/team/nuclear/nuke_team
 
 /datum/dynamic_ruleset/roundstart/nuclear/set_drafted_players_amount()
-	drafted_players_amount = max(FLOOR(length(SSdynamic.roundstart_candidates) / 7), 1)
+	drafted_players_amount = max(FLOOR(length(SSdynamic.roundstart_candidates) / 7, 1), 1)
 
 /datum/dynamic_ruleset/roundstart/nuclear/choose_candidates()
 	. = ..()


### PR DESCRIPTION
## About The Pull Request

Changes the drafted_players_amount formula from 

`ROUND_UP(length(GLOB.player_list) / 7)`

to

`max(FLOOR(length(SSdynamic.roundstart_candidates) / 7), 1)`

## Why It's Good For The Game

This change was made sometime in the middle of dynamic being developed and it ended up being a mistake.

For example, we just had a 5 player nuke team with 21 roundstart pop (16 crew)

## Testing Photographs and Procedure

Not feasible with the tools I have

## Changelog
:cl:
config: adjusted the nuclear operative and blood cult team size formula
/:cl:
