### PR TITLE
Clowns can now PDA everyone

### DIFF
--- a/code/modules/modular_computers/hardware/portable_disks/virus_disk.dm
+++ b/code/modules/modular_computers/hardware/portable_disks/virus_disk.dm
@@ -82,7 +82,7 @@
 	desc = "A data disk for portable microcomputers. It smells vaguely of bananas."
 	icon_state = "cart-clown"
 	virus_class = "HONK::CORE"
-	spam_delay = 2 //Every annoying role has the ability to PDA everyone. Clown should not be the exception.
+	spam_delay = 1.5 //Every annoying role has the ability to PDA everyone. Clown should not be the exception.
 
 /obj/item/computer_hardware/hard_drive/role/virus/clown/send_virus(obj/item/modular_computer/tablet/target, mob/living/user)
 	. = ..()

--- a/code/modules/modular_computers/hardware/portable_disks/virus_disk.dm
+++ b/code/modules/modular_computers/hardware/portable_disks/virus_disk.dm
@@ -82,7 +82,7 @@
 	desc = "A data disk for portable microcomputers. It smells vaguely of bananas."
 	icon_state = "cart-clown"
 	virus_class = "HONK::CORE"
-	spam_delay = 1.5 //Every annoying role has the ability to PDA everyone. Clown should not be the exception.
+	spam_delay = 3 //For my honkers, spread out your message to everyone on the station.
 
 /obj/item/computer_hardware/hard_drive/role/virus/clown/send_virus(obj/item/modular_computer/tablet/target, mob/living/user)
 	. = ..()

--- a/code/modules/modular_computers/hardware/portable_disks/virus_disk.dm
+++ b/code/modules/modular_computers/hardware/portable_disks/virus_disk.dm
@@ -82,6 +82,7 @@
 	desc = "A data disk for portable microcomputers. It smells vaguely of bananas."
 	icon_state = "cart-clown"
 	virus_class = "HONK::CORE"
+	spam_delay = 2 //Every annoying role has the ability to PDA everyone. Clown should not be the exception.
 
 /obj/item/computer_hardware/hard_drive/role/virus/clown/send_virus(obj/item/modular_computer/tablet/target, mob/living/user)
 	. = ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Every annoying pilled job (lawyer, vip) has the ability to PDA everyone. Now clowns can too. Spread misinformation, cause misschieve, share photos of your ass to the whole station.

## Why It's Good For The Game
More opportunities for funny situations

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->

<img width="439" height="161" alt="image" src="https://github.com/user-attachments/assets/2e3ef79c-7437-4875-9428-7ae0012717c6" />

## Changelog
:cl:
add: Clowns can now PDA everyone with a one and a half minute cooldown
/:cl: