### PR TITLE
Fixes alt-clicking weight machines crashing your game

### DIFF
--- a/code/game/objects/structures/gym/weight_machine.dm
+++ b/code/game/objects/structures/gym/weight_machine.dm
@@ -8,7 +8,6 @@
 	buckle_lying = 0
 	density = TRUE
 	anchored = TRUE
-	blocks_emissive = EMISSIVE_BLOCK_UNIQUE
 	var/mutable_appearance/overlay
 	var/weight_type = /obj/item/barbell/stacklifting
 


### PR DESCRIPTION
## About The Pull Request

In all honesty, I don't know what the point of setting `blocks_emissive` to `EMISSIVE_BLOCK_UNIQUE` is, but removing whatever it does is much better to having your game crash when alt-clicking it.

## Why It's Good For The Game

closes #13333

## Testing Photographs and Procedure

https://github.com/user-attachments/assets/8756497c-c74a-4e12-92d9-c71800d9ebb6

## Changelog
:cl:
fix: fixed alt-clicking weight machines crashing your game
/:cl:
