### PR TITLE
Fixes ChemMaster reagent analysis crash

### DIFF
--- a/code/modules/reagents/chemistry/machinery/chem_master.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_master.dm
@@ -489,17 +489,24 @@
 					. = TRUE
 		if("analyze")
 			var/datum/reagent/R = GLOB.name2reagent[params["id"]]
-			if(R && reagents.get_reagent_amount(R))
+			if(R)
 				var/state = "Unknown"
-				if(initial(R.reagent_state) == 1)
+				if(initial(R.reagent_state) == SOLID)
 					state = "Solid"
-				else if(initial(R.reagent_state) == 2)
+				else if(initial(R.reagent_state) == LIQUID)
 					state = "Liquid"
-				else if(initial(R.reagent_state) == 3)
+				else if(initial(R.reagent_state) == GAS)
 					state = "Gas"
-				var/const/P = 3 //The number of seconds between life ticks
-				var/T = initial(R.metabolization_rate) * (60 / P)
-				analyze_vars = list("name" = initial(R.name), "state" = state, "color" = initial(R.color), "description" = initial(R.description), "metaRate" = T, "overD" = initial(R.overdose_threshold), "addicD" = initial(R.addiction_threshold))
+
+				analyze_vars = list(
+					"name" = initial(R.name),
+					"state" = state,
+					"color" = initial(R.color),
+					"description" = initial(R.description),
+					"metaRate" = initial(R.metabolization_rate) * (60 / 3),
+					"overD" = initial(R.overdose_threshold),
+					"addicD" = initial(R.addiction_threshold)
+				)
 				screen = "analyze"
 				. = TRUE
 		if("goScreen")

--- a/tgui/packages/tgui/interfaces/ChemMaster.jsx
+++ b/tgui/packages/tgui/interfaces/ChemMaster.jsx
@@ -508,7 +508,7 @@ const PackagingControls = ({ volume, packagingName }) => {
 
 const AnalysisResults = (props) => {
   const { act, data } = useBackend();
-  const { analyzeVars } = data;
+  const { analyze_vars } = data;
   return (
     <Section
       title="Analysis Results"
@@ -525,23 +525,23 @@ const AnalysisResults = (props) => {
       }
     >
       <LabeledList>
-        <LabeledList.Item label="Name">{analyzeVars.name}</LabeledList.Item>
-        <LabeledList.Item label="State">{analyzeVars.state}</LabeledList.Item>
+        <LabeledList.Item label="Name">{analyze_vars.name}</LabeledList.Item>
+        <LabeledList.Item label="State">{analyze_vars.state}</LabeledList.Item>
         <LabeledList.Item label="Color">
-          <ColorBox color={analyzeVars.color} mr={1} />
-          {analyzeVars.color}
+          <ColorBox color={analyze_vars.color} mr={1} />
+          {analyze_vars.color}
         </LabeledList.Item>
         <LabeledList.Item label="Description">
-          {analyzeVars.description}
+          {analyze_vars.description}
         </LabeledList.Item>
         <LabeledList.Item label="Metabolization Rate">
-          {analyzeVars.metaRate} u/minute
+          {analyze_vars.metaRate} u/minute
         </LabeledList.Item>
         <LabeledList.Item label="Overdose Threshold">
-          {analyzeVars.overD}
+          {analyze_vars.overD}
         </LabeledList.Item>
         <LabeledList.Item label="Addiction Threshold">
-          {analyzeVars.addicD}
+          {analyze_vars.addicD}
         </LabeledList.Item>
       </LabeledList>
     </Section>


### PR DESCRIPTION
## About The Pull Request

Two bugs here:

**The main one:** the ChemMaster UI would crash because it was looking for `analyzeVars` when byond was sending over `analyze_vars`

**The smaller one:** the analyze function didn't work when using it on the beaker contents. This was because it checked if the reagent being analyzed was in the buffer, which was kind of a useless check so I just removed it. If you can somehow pass in a reagent id of a chemical that's not in the beaker or buffer, go ahead. I don't care.

## Why It's Good For The Game

closes #12820
closes #13205

## Testing Photographs and Procedure

https://github.com/user-attachments/assets/83f505d8-3e37-406c-874d-f5a43354aecb

## Changelog
:cl:
fix: fixed the ChemMaster reagent analysis- you can press the question mark by a chemical in the ChemMaster to see details about it.
/:cl:
