### PR TITLE
Fixes Sleeping Carp instant aggressive grab

### DIFF
--- a/code/datums/martial/sleeping_carp.dm
+++ b/code/datums/martial/sleeping_carp.dm
@@ -135,6 +135,7 @@
 		D.visible_message("<span class='warning'>[A] violently grabs [D]!</span>", \
 						"<span class='userdanger'>You're violently grabbed by [A]!</span>", "<span class='hear'>You hear aggressive shuffling!</span>", null, A)
 		to_chat(A, "<span class='danger'>You violently grab [D]!</span>")
+		return TRUE
 	return FALSE
 
 /datum/martial_art/the_sleeping_carp/harm_act(mob/living/A, mob/living/D)

--- a/code/datums/martial/sleeping_carp.dm
+++ b/code/datums/martial/sleeping_carp.dm
@@ -119,24 +119,22 @@
 		return 1
 	return FALSE
 
-/datum/martial_art/the_sleeping_carp/grab_act(mob/living/A, mob/living/D, params)
+/datum/martial_art/the_sleeping_carp/grab_act(mob/living/A, mob/living/D)
 	if(A==D)
 		return 0 //prevents grabbing yourself
-	var/list/modifiers = params2list(params)
-	if(LAZYACCESS(modifiers, RIGHT_CLICK))
-		add_to_streak("G",D)
-		if(check_streak(A,D)) //if a combo is made no grab upgrade is done
-			return TRUE
-		old_grab_state = A.grab_state
-		D.grabbedby(A, 1)
-		if(old_grab_state == GRAB_PASSIVE)
-			D.drop_all_held_items()
-			A.setGrabState(GRAB_AGGRESSIVE) //Instant aggressive grab if on grab intent
-			log_combat(A, D, "grabbed", name, addition="aggressively")
-			D.visible_message("<span class='warning'>[A] violently grabs [D]!</span>", \
-							"<span class='userdanger'>You're violently grabbed by [A]!</span>", "<span class='hear'>You hear aggressive shuffling!</span>", null, A)
-			to_chat(A, "<span class='danger'>You violently grab [D]!</span>")
+
+	add_to_streak("G",D)
+	if(check_streak(A,D)) //if a combo is made no grab upgrade is done
 		return TRUE
+	old_grab_state = A.grab_state
+	D.grabbedby(A, 1)
+	if(old_grab_state == GRAB_PASSIVE)
+		D.drop_all_held_items()
+		A.setGrabState(GRAB_AGGRESSIVE) //Instant aggressive grab if on grab intent
+		log_combat(A, D, "grabbed", name, addition="aggressively")
+		D.visible_message("<span class='warning'>[A] violently grabs [D]!</span>", \
+						"<span class='userdanger'>You're violently grabbed by [A]!</span>", "<span class='hear'>You hear aggressive shuffling!</span>", null, A)
+		to_chat(A, "<span class='danger'>You violently grab [D]!</span>")
 	return FALSE
 
 /datum/martial_art/the_sleeping_carp/harm_act(mob/living/A, mob/living/D)


### PR DESCRIPTION
## About The Pull Request

It was broken because it checked the argument `params` when it was removed during combat mode

## Why It's Good For The Game

closes #13219

## Testing Photographs and Procedure

https://github.com/user-attachments/assets/fc793258-5a2a-44cd-84bb-567f33bba669

## Changelog
:cl:
fix: Fixed Sleeping Carp users not being able to do instant aggressive grabs- it is a good traitor item once more
/:cl: