### PR TITLE
Fixes deathsquads not getting mindshield implants

### DIFF
--- a/code/modules/clothing/outfits/ert.dm
+++ b/code/modules/clothing/outfits/ert.dm
@@ -483,6 +483,7 @@
 	l_hand = /obj/item/gun/energy/pulse/loyalpin
 
 /datum/outfit/centcom/death_commando/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
+	. = ..()
 	if(visualsOnly)
 		return
 


### PR DESCRIPTION
## About The Pull Request

see title

## Why It's Good For The Game

closes #12863

## Testing Photographs and Procedure

https://github.com/user-attachments/assets/67b8f5a0-4bc8-4864-be9e-efb7114383d0

## Changelog
:cl:
fix: Fixed deathsquads not spawning in with mindshield implants
/:cl:
