### PR TITLE
Always attack borgs with your held item while on combat mode

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -284,12 +284,15 @@
 	togglelock(user)
 
 /mob/living/silicon/robot/attackby(obj/item/attacking_item, mob/living/user, params)
+	if (user.combat_mode)
+		return ..()
+
 	if(length(user.progressbars))
 		if(attacking_item.tool_behaviour == TOOL_WELDER || istype(attacking_item, /obj/item/stack/cable_coil))
 			user.changeNext_move(CLICK_CD_MELEE)
 			to_chat(user, span_notice("You are already busy!"))
 			return
-	if(attacking_item.tool_behaviour == TOOL_WELDER && (!user.combat_mode))
+	if(attacking_item.tool_behaviour == TOOL_WELDER)
 		user.changeNext_move(CLICK_CD_MELEE)
 		if(user == src)
 			to_chat(user, span_warning("You are unable to maneuver [attacking_item] properly to repair yourself, seek assistance!"))


### PR DESCRIPTION
## About The Pull Request

see title

## Why It's Good For The Game

closes #12518

## Testing Photographs and Procedure

https://github.com/user-attachments/assets/51424e50-ecbb-40fd-b91a-447dca8d40ef

## Changelog
:cl:
fix: You will always attack borgs with your held item while in combat mode instead of attempting whatever relevant item interaction (fixes nightmares not being able to attack borgs)
/:cl:
