### PR TITLE
Fixes various security/medical records bugs and makes it obvious that silicons cant edit records

### DIFF
--- a/code/datums/records/record.dm
+++ b/code/datums/records/record.dm
@@ -171,7 +171,7 @@
 	return TRUE
 
 /datum/record/crew/proc/delete_medical_note(note_ref)
-	var/datum/medical_note/old_note = note_ref
+	var/datum/medical_note/old_note = locate(note_ref) in medical_notes
 	if(isnull(old_note))
 		return FALSE
 

--- a/code/game/machinery/computer/records/medical.dm
+++ b/code/game/machinery/computer/records/medical.dm
@@ -95,7 +95,7 @@
 			return TRUE
 		if ("gender")
 			return TRUE
-		if ("dna")
+		if ("dna_string")
 			return TRUE
 		if ("blood_type")
 			return TRUE

--- a/code/game/machinery/computer/records/records.dm
+++ b/code/game/machinery/computer/records/records.dm
@@ -12,8 +12,9 @@
 /obj/machinery/computer/records/ui_data(mob/user)
 	var/list/data = list()
 
-	var/has_access = (authenticated && isliving(user)) || issiliconoradminghost(user)
+	var/has_access = (authenticated && isliving(user)) || IsAdminGhost(user)
 	data["authenticated"] = has_access
+	data["is_silicon"] = issilicon(user)
 
 	return data
 
@@ -141,7 +142,7 @@
 
 /// Detects whether a user can use buttons on the machine
 /obj/machinery/computer/records/proc/has_auth(mob/user)
-	if(issiliconoradminghost(user)) // Silicons don't need to authenticate
+	if(IsAdminGhost(user)) // Admins don't need to authenticate
 		return TRUE
 
 	if(!isliving(user))
@@ -159,7 +160,7 @@
 
 /// Inserts a new record into GLOB.manifest.general. Requires a photo to be taken.
 /obj/machinery/computer/records/proc/insert_new_record(mob/user, obj/item/photo/mugshot)
-	if(!mugshot || !is_operational || !user.canUseTopic(src, be_close = !issilicon(user)))
+	if(!mugshot || !is_operational || !user.canUseTopic(src))
 		return FALSE
 
 	if(!authenticated && !has_auth(user))
@@ -174,7 +175,7 @@
 
 	var/trimmed = copytext(mugshot.name, 9, MAX_NAME_LEN) // Remove "photo - "
 	var/name = tgui_input_text(user, "Enter the name of the new record.", "New Record", trimmed, MAX_NAME_LEN)
-	if(!name || !is_operational || !user.canUseTopic(src, be_close = !issilicon(user)) || !mugshot || QDELETED(mugshot) || QDELETED(src))
+	if(!name || !is_operational || !user.canUseTopic(src) || !mugshot || QDELETED(mugshot) || QDELETED(src))
 		return FALSE
 
 	new /datum/record/crew(name = name, character_appearance = mugshot.picture.picture_image)
@@ -188,7 +189,7 @@
 
 /// Secure login
 /obj/machinery/computer/records/proc/secure_login(mob/user)
-	if(!user.canUseTopic(src, be_close = !issilicon(user)) || !is_operational)
+	if(!user.canUseTopic(src) || !is_operational)
 		return FALSE
 
 	if(!has_auth(user))

--- a/code/game/machinery/computer/records/records.dm
+++ b/code/game/machinery/computer/records/records.dm
@@ -12,7 +12,7 @@
 /obj/machinery/computer/records/ui_data(mob/user)
 	var/list/data = list()
 
-	data["authenticated"] = authenticated && isliving(user)
+	data["authenticated"] = authenticated && (isliving(user) || IsAdminGhost(user))
 	data["is_silicon"] = issilicon(user)
 
 	return data

--- a/code/game/machinery/computer/records/records.dm
+++ b/code/game/machinery/computer/records/records.dm
@@ -12,8 +12,7 @@
 /obj/machinery/computer/records/ui_data(mob/user)
 	var/list/data = list()
 
-	var/has_access = (authenticated && isliving(user)) || IsAdminGhost(user)
-	data["authenticated"] = has_access
+	data["authenticated"] = authenticated && isliving(user)
 	data["is_silicon"] = issilicon(user)
 
 	return data

--- a/tgui/packages/tgui/interfaces/MedicalRecords/NoteKeeper.tsx
+++ b/tgui/packages/tgui/interfaces/MedicalRecords/NoteKeeper.tsx
@@ -86,6 +86,9 @@ const NoteTabs = (props) => {
   if (!foundRecord) return <> </>;
   const { medical_notes } = foundRecord;
 
+  const { data } = useBackend<MedicalRecordData>();
+  const { is_silicon } = data;
+
   const [selectedNote, setSelectedNote] = useLocalState<
     MedicalNote | undefined
   >('selectedNote', undefined);
@@ -120,14 +123,16 @@ const NoteTabs = (props) => {
             </Tabs.Tab>
           ))
         : null}
-      <Tooltip
-        content={multiline`Add a new note. Press enter or escape to exit view.`}
-        position="bottom"
-      >
-        <Tabs.Tab onClick={composeNew} selected={writing}>
-          <Icon name="plus" /> New
-        </Tabs.Tab>
-      </Tooltip>
+      {!is_silicon && (
+        <Tooltip
+          content={multiline`Add a new note. Press enter or escape to exit view.`}
+          position="bottom"
+        >
+          <Tabs.Tab onClick={composeNew} selected={writing}>
+            <Icon name="plus" /> New
+          </Tabs.Tab>
+        </Tooltip>
+      )}
     </Tabs>
   );
 };

--- a/tgui/packages/tgui/interfaces/MedicalRecords/NoteKeeper.tsx
+++ b/tgui/packages/tgui/interfaces/MedicalRecords/NoteKeeper.tsx
@@ -20,7 +20,8 @@ export const NoteKeeper = (props) => {
   const foundRecord = getMedicalRecord();
   if (!foundRecord) return <> </>;
 
-  const { act } = useBackend<MedicalRecordData>();
+  const { data, act } = useBackend<MedicalRecordData>();
+  const { is_silicon } = data;
   const { record_ref } = foundRecord;
 
   const [selectedNote, setSelectedNote] = useLocalState<
@@ -62,7 +63,11 @@ export const NoteKeeper = (props) => {
           <LabeledList>
             <LabeledList.Item
               label="Author"
-              buttons={<Button color="bad" icon="trash" onClick={deleteNote} />}
+              buttons={
+                !is_silicon && (
+                  <Button color="bad" icon="trash" onClick={deleteNote} />
+                )
+              }
             >
               {selectedNote.author}
             </LabeledList.Item>
@@ -119,7 +124,7 @@ const NoteTabs = (props) => {
               onClick={() => setNote(note)}
               selected={selectedNote?.note_ref === note.note_ref}
             >
-              {index + 1}
+              {`Note ${index + 1}`}
             </Tabs.Tab>
           ))
         : null}

--- a/tgui/packages/tgui/interfaces/MedicalRecords/RecordView.tsx
+++ b/tgui/packages/tgui/interfaces/MedicalRecords/RecordView.tsx
@@ -29,7 +29,12 @@ export const MedicalRecordView = (props) => {
   if (!foundRecord) return <NoticeBox>No record selected.</NoticeBox>;
 
   const { act, data } = useBackend<MedicalRecordData>();
-  const { character_preview_view, physical_statuses, mental_statuses } = data;
+  const {
+    character_preview_view,
+    physical_statuses,
+    mental_statuses,
+    is_silicon,
+  } = data;
 
   const { min_age, max_age } = data;
 
@@ -69,6 +74,7 @@ export const MedicalRecordView = (props) => {
         <Section
           buttons={
             <Button.Confirm
+              disabled={is_silicon}
               content="Anonymize"
               icon="mask"
               onClick={() =>
@@ -83,60 +89,77 @@ export const MedicalRecordView = (props) => {
           wrap
         >
           <LabeledList>
-            <LabeledList.Item label="Name">
-              <Box>{name}</Box>
-            </LabeledList.Item>
-            <LabeledList.Item label="Job">
-              <Box>{rank}</Box>
-            </LabeledList.Item>
+            <LabeledList.Item label="Name">{name}</LabeledList.Item>
+            <LabeledList.Item label="Job">{rank}</LabeledList.Item>
             <LabeledList.Item label="Age">
-              <RestrictedInput
-                minValue={min_age}
-                maxValue={max_age}
-                onEnter={(event, value) =>
-                  act('edit_field', {
-                    field: 'age',
-                    ref: record_ref,
-                    value: value,
-                  })
-                }
-                value={age}
-              />
+              {is_silicon ? (
+                age
+              ) : (
+                <RestrictedInput
+                  minValue={min_age}
+                  maxValue={max_age}
+                  onEnter={(event, value) =>
+                    act('edit_field', {
+                      field: 'age',
+                      ref: record_ref,
+                      value: value,
+                    })
+                  }
+                  value={age}
+                />
+              )}
             </LabeledList.Item>
             <LabeledList.Item label="Species">
-              <EditableText
-                field="species"
-                target_ref={record_ref}
-                text={species}
-              />
+              {is_silicon ? (
+                species
+              ) : (
+                <EditableText
+                  field="species"
+                  target_ref={record_ref}
+                  text={species}
+                />
+              )}
             </LabeledList.Item>
             <LabeledList.Item label="Gender">
-              <EditableText
-                field="gender"
-                target_ref={record_ref}
-                text={gender}
-              />
+              {is_silicon ? (
+                gender
+              ) : (
+                <EditableText
+                  field="gender"
+                  target_ref={record_ref}
+                  text={gender}
+                />
+              )}
             </LabeledList.Item>
-            <LabeledList.Item label="DNA">
-              <EditableText
-                color="good"
-                field="dna"
-                target_ref={record_ref}
-                text={dna}
-              />
+            <LabeledList.Item color="good" label="DNA">
+              {is_silicon ? (
+                dna
+              ) : (
+                <EditableText
+                  color="good"
+                  field="dna"
+                  target_ref={record_ref}
+                  text={dna}
+                />
+              )}
             </LabeledList.Item>
             <LabeledList.Item color="bad" label="Blood Type">
-              <EditableText
-                field="blood_type"
-                target_ref={record_ref}
-                text={blood_type}
-              />
+              {is_silicon ? (
+                blood_type
+              ) : (
+                <EditableText
+                  field="blood_type"
+                  target_ref={record_ref}
+                  text={blood_type}
+                />
+              )}
             </LabeledList.Item>
             <LabeledList.Item
               buttons={physical_statuses.map((button, index) => {
                 const isSelected = button === physical_status;
                 return (
                   <Button
+                    disabled={is_silicon}
                     color={isSelected ? PHYSICALSTATUS2COLOR[button] : 'grey'}
                     height={'1.75rem'}
                     icon={PHYSICALSTATUS2ICON[button]}
@@ -167,6 +190,7 @@ export const MedicalRecordView = (props) => {
                 const isSelected = button === mental_status;
                 return (
                   <Button
+                    disabled={is_silicon}
                     color={isSelected ? MENTALSTATUS2COLOR[button] : 'grey'}
                     height={'1.75rem'}
                     icon={MENTALSTATUS2ICON[button]}

--- a/tgui/packages/tgui/interfaces/MedicalRecords/RecordView.tsx
+++ b/tgui/packages/tgui/interfaces/MedicalRecords/RecordView.tsx
@@ -98,7 +98,7 @@ export const MedicalRecordView = (props) => {
                 <RestrictedInput
                   minValue={min_age}
                   maxValue={max_age}
-                  onEnter={(event, value) =>
+                  onChange={(_, value) =>
                     act('edit_field', {
                       field: 'age',
                       ref: record_ref,

--- a/tgui/packages/tgui/interfaces/MedicalRecords/RecordView.tsx
+++ b/tgui/packages/tgui/interfaces/MedicalRecords/RecordView.tsx
@@ -137,7 +137,7 @@ export const MedicalRecordView = (props) => {
               ) : (
                 <EditableText
                   color="good"
-                  field="dna"
+                  field="dna_string"
                   target_ref={record_ref}
                   text={dna}
                 />

--- a/tgui/packages/tgui/interfaces/MedicalRecords/index.tsx
+++ b/tgui/packages/tgui/interfaces/MedicalRecords/index.tsx
@@ -50,7 +50,7 @@ const UnauthorizedView = (props) => {
 };
 
 const AuthView = (props) => {
-  const { act } = useBackend<MedicalRecordData>();
+  const { data, act } = useBackend<MedicalRecordData>();
 
   return (
     <>
@@ -62,20 +62,29 @@ const AuthView = (props) => {
           <Stack.Item grow>
             <MedicalRecordView />
           </Stack.Item>
-          <Stack.Item>
-            <NoticeBox align="right" info>
-              Secure Your Workspace.
-              <Button
-                align="right"
-                icon="lock"
-                color="good"
-                ml={2}
-                onClick={() => act('logout')}
-              >
-                Log Out
-              </Button>
-            </NoticeBox>
-          </Stack.Item>
+          {data.is_silicon ? (
+            <Stack.Item>
+              <NoticeBox danger>
+                For security reasons, silicons are not permitted to change
+                record data.
+              </NoticeBox>
+            </Stack.Item>
+          ) : (
+            <Stack.Item>
+              <NoticeBox align="right" info>
+                Secure Your Workspace.
+                <Button
+                  align="right"
+                  icon="lock"
+                  color="good"
+                  ml={2}
+                  onClick={() => act('logout')}
+                >
+                  Log Out
+                </Button>
+              </NoticeBox>
+            </Stack.Item>
+          )}
         </Stack>
       </Stack.Item>
     </>

--- a/tgui/packages/tgui/interfaces/MedicalRecords/types.ts
+++ b/tgui/packages/tgui/interfaces/MedicalRecords/types.ts
@@ -3,6 +3,7 @@ import { BooleanLike } from 'common/react';
 export type MedicalRecordData = {
   character_preview_view: string;
   authenticated: BooleanLike;
+  is_silicon: BooleanLike;
   physical_statuses: string[];
   mental_statuses: string[];
   records: MedicalRecord[];

--- a/tgui/packages/tgui/interfaces/SecurityRecords/CrimeWatcher.tsx
+++ b/tgui/packages/tgui/interfaces/SecurityRecords/CrimeWatcher.tsx
@@ -300,6 +300,7 @@ const CrimeAuthor = (props) => {
       <Stack.Item color="label">
         Fine (leave blank to arrest)
         <RestrictedInput
+          value={crimeFine}
           onChange={(_, value) => setCrimeFine(value)}
           fluid
           maxValue={1000}

--- a/tgui/packages/tgui/interfaces/SecurityRecords/CrimeWatcher.tsx
+++ b/tgui/packages/tgui/interfaces/SecurityRecords/CrimeWatcher.tsx
@@ -24,6 +24,9 @@ export const CrimeWatcher = (props) => {
   const foundRecord = getSecurityRecord();
   if (!foundRecord) return <> </>;
 
+  const { data } = useBackend<SecurityRecordsData>();
+  const { is_silicon } = data;
+
   const { crimes, citations } = foundRecord;
   const [selectedTab, setSelectedTab] = useLocalState<SECURETAB>(
     'selectedTab',
@@ -47,12 +50,14 @@ export const CrimeWatcher = (props) => {
             Citations: {citations.length}
           </Tabs.Tab>
           <Tooltip content="Add a new crime or citation" position="bottom">
-            <Tabs.Tab
-              onClick={() => setSelectedTab(SECURETAB.Add)}
-              selected={selectedTab === SECURETAB.Add}
-            >
-              <Icon name="plus" />
-            </Tabs.Tab>
+            {!is_silicon && (
+              <Tabs.Tab
+                onClick={() => setSelectedTab(SECURETAB.Add)}
+                selected={selectedTab === SECURETAB.Add}
+              >
+                <Icon name="plus" />
+              </Tabs.Tab>
+            )}
           </Tooltip>
         </Tabs>
       </Stack.Item>
@@ -100,7 +105,7 @@ const CrimeDisplay = ({ item }: { item: Crime }) => {
 
   const { record_ref } = foundRecord;
   const { act, data } = useBackend<SecurityRecordsData>();
-  const { current_user, higher_access } = data;
+  const { current_user, higher_access, is_silicon } = data;
   const { author, crime_ref, details, fine, name, paid, time, valid, voider } =
     item;
   const showFine = !!fine && fine > 0 ? `: ${fine} cr` : ': PAID OFF';
@@ -155,7 +160,11 @@ const CrimeDisplay = ({ item }: { item: Crime }) => {
         {!editing ? (
           <Box mt={2}>
             <Button
-              disabled={!valid || (!higher_access && author !== current_user)}
+              disabled={
+                !valid ||
+                (!higher_access && author !== current_user) ||
+                is_silicon
+              }
               icon="pen"
               onClick={() => setEditing(true)}
             >
@@ -163,7 +172,11 @@ const CrimeDisplay = ({ item }: { item: Crime }) => {
             </Button>
             <Button.Confirm
               content="Invalidate"
-              disabled={!valid || (!higher_access && author !== current_user)}
+              disabled={
+                !valid ||
+                (!higher_access && author !== current_user) ||
+                is_silicon
+              }
               icon="ban"
               onClick={() =>
                 act('invalidate_crime', {
@@ -174,7 +187,9 @@ const CrimeDisplay = ({ item }: { item: Crime }) => {
             />
             <Button.Confirm
               content="Delete"
-              disabled={!higher_access && author !== current_user}
+              disabled={
+                (!higher_access && author !== current_user) || is_silicon
+              }
               icon="trash"
               onClick={() =>
                 act('delete_crime', {

--- a/tgui/packages/tgui/interfaces/SecurityRecords/RecordTabs.tsx
+++ b/tgui/packages/tgui/interfaces/SecurityRecords/RecordTabs.tsx
@@ -19,7 +19,7 @@ import { SecurityRecord, SecurityRecordsData } from './types';
 /** Tabs on left, with search bar */
 export const SecurityRecordTabs = (props) => {
   const { act, data } = useBackend<SecurityRecordsData>();
-  const { higher_access, records = [] } = data;
+  const { is_silicon, higher_access, records = [] } = data;
 
   const errorMessage = !records.length
     ? 'No records found.'
@@ -68,7 +68,7 @@ export const SecurityRecordTabs = (props) => {
           <Stack.Item>
             <Button.Confirm
               content="Purge"
-              disabled={!higher_access}
+              disabled={!higher_access || is_silicon}
               icon="trash"
               onClick={() => act('purge_records')}
               tooltip="Wipe criminal record data."

--- a/tgui/packages/tgui/interfaces/SecurityRecords/RecordView.tsx
+++ b/tgui/packages/tgui/interfaces/SecurityRecords/RecordView.tsx
@@ -48,7 +48,7 @@ const RecordInfo = (props) => {
   if (!foundRecord) return <NoticeBox>Nothing selected.</NoticeBox>;
 
   const { act, data } = useBackend<SecurityRecordsData>();
-  const { available_statuses } = data;
+  const { available_statuses, is_silicon } = data;
   const [open, setOpen] = useLocalState<boolean>('printOpen', false);
 
   const {
@@ -76,6 +76,7 @@ const RecordInfo = (props) => {
             <Stack>
               <Stack.Item>
                 <Button
+                  disabled={is_silicon}
                   height="1.7rem"
                   icon="print"
                   onClick={() => setOpen(true)}
@@ -86,6 +87,7 @@ const RecordInfo = (props) => {
               </Stack.Item>
               <Stack.Item>
                 <Button.Confirm
+                  disabled={is_silicon}
                   content="Delete"
                   icon="trash"
                   onClick={() =>
@@ -111,7 +113,9 @@ const RecordInfo = (props) => {
                 return (
                   <Button
                     color={isSelected ? CRIMESTATUS2COLOR[button] : 'grey'}
-                    disabled={button === 'Arrest' && !hasValidCrimes}
+                    disabled={
+                      (button === 'Arrest' && !hasValidCrimes) || is_silicon
+                    }
                     icon={isSelected ? 'check' : ''}
                     key={index}
                     onClick={() =>
@@ -141,53 +145,89 @@ const RecordInfo = (props) => {
         <Section fill scrollable>
           <LabeledList>
             <LabeledList.Item label="Name">
-              <EditableText field="name" target_ref={record_ref} text={name} />
+              {is_silicon ? (
+                name
+              ) : (
+                <EditableText
+                  field="name"
+                  target_ref={record_ref}
+                  text={name}
+                />
+              )}
             </LabeledList.Item>
             <LabeledList.Item label="Job">
-              <EditableText field="rank" target_ref={record_ref} text={rank} />
+              {is_silicon ? (
+                rank
+              ) : (
+                <EditableText
+                  field="rank"
+                  target_ref={record_ref}
+                  text={rank}
+                />
+              )}
             </LabeledList.Item>
             <LabeledList.Item label="Age">
-              <RestrictedInput
-                minValue={min_age}
-                maxValue={max_age}
-                onEnter={(event, value) =>
-                  act('edit_field', {
-                    record_ref: record_ref,
-                    field: 'age',
-                    value: value,
-                  })
-                }
-                value={age}
-              />
+              {is_silicon ? (
+                age
+              ) : (
+                <RestrictedInput
+                  minValue={min_age}
+                  maxValue={max_age}
+                  onEnter={(event, value) =>
+                    act('edit_field', {
+                      record_ref: record_ref,
+                      field: 'age',
+                      value: value,
+                    })
+                  }
+                  value={age}
+                />
+              )}
             </LabeledList.Item>
             <LabeledList.Item label="Species">
-              <EditableText
-                field="species"
-                target_ref={record_ref}
-                text={species}
-              />
+              {is_silicon ? (
+                species
+              ) : (
+                <EditableText
+                  field="species"
+                  target_ref={record_ref}
+                  text={species}
+                />
+              )}
             </LabeledList.Item>
             <LabeledList.Item label="Gender">
-              <EditableText
-                field="gender"
-                target_ref={record_ref}
-                text={gender}
-              />
+              {is_silicon ? (
+                gender
+              ) : (
+                <EditableText
+                  field="gender"
+                  target_ref={record_ref}
+                  text={gender}
+                />
+              )}
             </LabeledList.Item>
             <LabeledList.Item color="good" label="Fingerprint">
-              <EditableText
-                color="good"
-                field="fingerprint"
-                target_ref={record_ref}
-                text={fingerprint}
-              />
+              {is_silicon ? (
+                fingerprint
+              ) : (
+                <EditableText
+                  color="good"
+                  field="fingerprint"
+                  target_ref={record_ref}
+                  text={fingerprint}
+                />
+              )}
             </LabeledList.Item>
             <LabeledList.Item label="Note">
-              <EditableText
-                field="security_note"
-                target_ref={record_ref}
-                text={security_note}
-              />
+              {is_silicon ? (
+                security_note
+              ) : (
+                <EditableText
+                  field="security_note"
+                  target_ref={record_ref}
+                  text={security_note}
+                />
+              )}
             </LabeledList.Item>
           </LabeledList>
         </Section>

--- a/tgui/packages/tgui/interfaces/SecurityRecords/RecordView.tsx
+++ b/tgui/packages/tgui/interfaces/SecurityRecords/RecordView.tsx
@@ -173,7 +173,7 @@ const RecordInfo = (props) => {
                 <RestrictedInput
                   minValue={min_age}
                   maxValue={max_age}
-                  onEnter={(event, value) =>
+                  onChange={(_, value) =>
                     act('edit_field', {
                       record_ref: record_ref,
                       field: 'age',

--- a/tgui/packages/tgui/interfaces/SecurityRecords/index.tsx
+++ b/tgui/packages/tgui/interfaces/SecurityRecords/index.tsx
@@ -8,12 +8,14 @@ import { SecurityRecordsData } from './types';
 
 export const SecurityRecords = (props) => {
   const { data } = useBackend<SecurityRecordsData>();
-  const { authenticated } = data;
+  const { authenticated, is_silicon } = data;
 
   return (
     <Window title="Security Records" width={750} height={550}>
       <Window.Content>
-        <Stack fill>{!authenticated ? <RestrictedView /> : <AuthView />}</Stack>
+        <Stack fill>
+          {authenticated || is_silicon ? <AuthView /> : <RestrictedView />}
+        </Stack>
       </Window.Content>
     </Window>
   );
@@ -50,7 +52,8 @@ const RestrictedView = (props) => {
 
 /** Logged in view */
 const AuthView = (props) => {
-  const { act } = useBackend<SecurityRecordsData>();
+  const { data, act } = useBackend<SecurityRecordsData>();
+  const { is_silicon } = data;
 
   return (
     <>
@@ -62,20 +65,29 @@ const AuthView = (props) => {
           <Stack.Item grow>
             <SecurityRecordView />
           </Stack.Item>
-          <Stack.Item>
-            <NoticeBox align="right" info>
-              Secure Your Workspace.
-              <Button
-                align="right"
-                icon="lock"
-                color="good"
-                ml={2}
-                onClick={() => act('logout')}
-              >
-                Log Out
-              </Button>
-            </NoticeBox>
-          </Stack.Item>
+          {is_silicon ? (
+            <Stack.Item>
+              <NoticeBox danger>
+                For security reasons, silicons are not permitted to change
+                record data.
+              </NoticeBox>
+            </Stack.Item>
+          ) : (
+            <Stack.Item>
+              <NoticeBox align="right" info>
+                Secure Your Workspace.
+                <Button
+                  align="right"
+                  icon="lock"
+                  color="good"
+                  ml={2}
+                  onClick={() => act('logout')}
+                >
+                  Log Out
+                </Button>
+              </NoticeBox>
+            </Stack.Item>
+          )}
         </Stack>
       </Stack.Item>
     </>

--- a/tgui/packages/tgui/interfaces/SecurityRecords/types.ts
+++ b/tgui/packages/tgui/interfaces/SecurityRecords/types.ts
@@ -3,6 +3,7 @@ import { BooleanLike } from 'common/react';
 export type SecurityRecordsData = {
   character_preview_view: string;
   authenticated: BooleanLike;
+  is_silicon: BooleanLike;
   amount: number;
   available_statuses: string[];
   current_user: string;


### PR DESCRIPTION
## About The Pull Request

This PR adds a label to the security and medical console tguis telling silicons they cannot edit records and disables the buttons so it looks more "complete"

Additionally, the fine amount input was bugged and would always display as 0. This happened because the value wasn't actually set for the input component.

Third and final bug: changing a person's age was, for lack of a better word, **weird**. This was because it was listening for _onEnter_ instead of _onChange_

And also, silicons not being able to edit access before was a bug but maints are just rolling with it now. The bug happened because silicons were always said to be authenticated on the tgui ui_data, but they didn't actually authenticate the console and thus could not make any edits to values.

## Why It's Good For The Game

closes #13269

## Testing Photographs and Procedure

https://github.com/user-attachments/assets/ad4110f6-ba16-438d-a5cb-ca62325c83ac

https://github.com/user-attachments/assets/322d824e-5f62-4140-a48b-07a6743ea760

^ the dna editing bug was fixed, I'm just too lazy to re-record testing evidence.

https://github.com/user-attachments/assets/d7454d82-6922-4727-892a-c573646a4aad

^ the two bugs in this video were fixed, I'm just too lazy to re-record testing evidence.

## Changelog
:cl:
fix: Fixed various security/medical records bugs
add: Made it more obvious that silicons aren't intended to be able to edit security/medical records
/:cl:
