### PR TITLE
Fixing of MOD plasma core recharging

### DIFF
--- a/code/modules/mod/mod_core.dm
+++ b/code/modules/mod/mod_core.dm
@@ -362,7 +362,11 @@
 	return NONE
 
 /obj/item/mod/core/plasma/proc/charge_plasma(obj/item/stack/plasma, mob/user)
-	var/charge_given = is_type_in_list(plasma, charger_list)
+	var/charge_given = 0
+	for(var/charger in charger_list)
+		if(istype(plasma, charger))
+			charge_given = charger_list[charger]
+			break
 	if(!charge_given)
 		return FALSE
 	var/uses_needed = min(plasma.amount, ROUND_UP((max_charge_amount() - charge_amount()) / charge_given))


### PR DESCRIPTION
## About The Pull Request

Currently, `charge_given` will always be 1 and not the energy worth of the ore/sheets specified in `charger_list` because `is_type_in_list` returns TRUE when the ore is in the list, when we actually need to get the value of it.
Because of that, the charge actually added to the MOD is only ever gonna be as much as the plasma it uses, i.e. you give it 50 ore/sheets, you get 50W of power.

## Why It's Good For The Game

Not having to insert 10000 ore/sheets of plasma to fully charge the MOD suit is good.

## Testing Photographs and Procedure
<details>
<summary>Screenshots&Videos</summary>

https://github.com/user-attachments/assets/aeab8212-4a9f-4a63-a619-7a07c5123ca5

</details>

## Changelog
:cl:
fix: Mining MOD suit gives actual meaningful power now when recharged with plasma ore/sheets
/:cl:
