### PR TITLE
Splits the clown car into two vehicles, one from uplink and one from mechfab. 

### DIFF
--- a/code/__DEFINES/machines.dm
+++ b/code/__DEFINES/machines.dm
@@ -43,7 +43,7 @@
 #define PROTOLATHE		(1<<1)	//New stuff. Uses glass/iron/chemicals
 #define AUTOLATHE		(1<<2)	//Uses glass/iron only.
 #define CRAFTLATHE		(1<<3)	//Uses fuck if I know. For use eventually.
-#define MECHFAB			(1<<4) 	//Remember, objects utilising this flag should have construction_time and construction_cost vars.
+#define MECHFAB			(1<<4) 	//Remember, objects utilising this flag should have construction_time var.
 #define BIOGENERATOR	(1<<5) 	//Uses biomass
 #define LIMBGROWER		(1<<6) 	//Uses synthetic flesh
 #define SMELTER			(1<<7) 	//uses various minerals

--- a/code/modules/research/designs/mechfabricator_designs.dm
+++ b/code/modules/research/designs/mechfabricator_designs.dm
@@ -1441,3 +1441,13 @@
 	materials = list(/datum/material/iron = 2000, /datum/material/diamond = 500)
 	construction_time = 40
 	category = list("Cyborg Upgrade Modules")
+
+/datum/design/clown_car
+	name = "Clown Car"
+	desc = "A small car that the clown can use to take people around the station in style!"
+	id = "clown_car"
+	build_type = MECHFAB
+	build_path = /obj/vehicle/sealed/car/clowncar
+	materials = list(/datum/material/iron = 10000, /datum/material/bananium = 5000, /datum/material/plastic = 2000)
+	construction_time = 100
+	category = list("Misc")

--- a/code/modules/research/designs/misc_designs.dm
+++ b/code/modules/research/designs/misc_designs.dm
@@ -97,6 +97,16 @@
 	category = list("Equipment")
 	departmental_flags = DEPARTMENTAL_FLAG_ALL			//HONK!
 
+/datum/design/clown_car
+	name = "Clown Car"
+	desc = "A small car that the clown can use to take people around the station in style!"
+	id = "clown_car"
+	build_type = PROTOLATHE
+	materials = list(/datum/material/iron = 10000, /datum/material/bananium = 5000, /datum/material/plastic = 2000)
+	build_path = /obj/vehicle/sealed/car/clowncar
+	category = list("Equipment")
+	departmental_flags = DEPARTMENTAL_FLAG_SERVICE
+
 /datum/design/mesons
 	name = "Optical Meson Scanners"
 	desc = "Used by engineering and mining staff to see basic structural and terrain layouts through walls, regardless of lighting condition."

--- a/code/modules/research/designs/misc_designs.dm
+++ b/code/modules/research/designs/misc_designs.dm
@@ -97,16 +97,6 @@
 	category = list("Equipment")
 	departmental_flags = DEPARTMENTAL_FLAG_ALL			//HONK!
 
-/datum/design/clown_car
-	name = "Clown Car"
-	desc = "A small car that the clown can use to take people around the station in style!"
-	id = "clown_car"
-	build_type = PROTOLATHE
-	materials = list(/datum/material/iron = 10000, /datum/material/bananium = 5000, /datum/material/plastic = 2000)
-	build_path = /obj/vehicle/sealed/car/clowncar
-	category = list("Equipment")
-	departmental_flags = DEPARTMENTAL_FLAG_SERVICE
-
 /datum/design/mesons
 	name = "Optical Meson Scanners"
 	desc = "Used by engineering and mining staff to see basic structural and terrain layouts through walls, regardless of lighting condition."

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -1099,6 +1099,7 @@
 	description = "Honk?!"
 	prereq_ids = list("base")
 	design_ids = list(
+		"clown_car",
 		"air_horn",
 		"borg_transform_clown",
 		"clown_mine",

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -2223,9 +2223,8 @@ GLOBAL_LIST_INIT(illegal_tech_blacklist, typecacheof(list(
 			Simply insert your bikehorn and get in, and get ready to have the funniest ride of your life! \
 			You can ram any spacemen you come across and stuff them into your car, kidnapping them and locking them inside until \
 			someone saves them or they manage to crawl out. Be sure not to ram into any walls or vending machines, as the springloaded seats \
-			are very sensitive. Now with our included lube defense mechanism which will protect you against any angry shitcurity! \
-			Premium features can be unlocked with a cryptographic sequencer!"
-	item = /obj/vehicle/sealed/car/clowncar
+			are very sensitive. Now with our included lube defense mechanism which will protect you against any angry shitcurity!"
+	item = /obj/vehicle/sealed/car/clowncar/syndicate
 	cost = 20
 	restricted_roles = list(JOB_NAME_CLOWN)
 

--- a/code/modules/vehicles/cars/clowncar.dm
+++ b/code/modules/vehicles/cars/clowncar.dm
@@ -1,4 +1,4 @@
-/obj/vehicle/sealed/car/clowncar
+/obj/vehicle/sealed/car/clowncar/
 	name = "clown car"
 	desc = "How someone could even fit in there is beyond me."
 	icon_state = "clowncar"
@@ -16,7 +16,6 @@
 	var/cannonmode = FALSE
 	var/cannonbusy = FALSE
 
-
 /datum/armor/car_clowncar
 	melee = 70
 	bullet = 40
@@ -30,11 +29,16 @@
 	initialize_controller_action_type(/datum/action/vehicle/sealed/horn/clowncar, VEHICLE_CONTROL_DRIVE)
 	initialize_controller_action_type(/datum/action/vehicle/sealed/Thank, VEHICLE_CONTROL_KIDNAPPED)
 
-/obj/vehicle/sealed/car/clowncar/relaymove(mob/living/user, direction)
+/obj/vehicle/sealed/car/clowncar/syndicate/generate_actions()
+	. = ..()
+	initialize_controller_action_type(/datum/action/vehicle/sealed/RollTheDice, VEHICLE_CONTROL_DRIVE)
+	initialize_controller_action_type(/datum/action/vehicle/sealed/Cannon, VEHICLE_CONTROL_DRIVE)
+
+/obj/vehicle/sealed/car/clowncar/syndicate/relaymove(mob/living/user, direction)
 	if(!ishuman(user))
 		return FALSE
 	var/mob/living/carbon/human/rider = user
-	if(rider.mind?.assigned_role != JOB_NAME_CLOWN) //Only clowns can drive the car.
+	if(rider.mind?.assigned_role != JOB_NAME_CLOWN) //Only clowns can drive the syndicate version of the clown car.
 		return FALSE
 	return ..()
 
@@ -126,10 +130,9 @@
 
 /obj/vehicle/sealed/car/clowncar/on_emag(mob/user)
 	..()
-	to_chat(user, span_danger("You scramble the clowncar child safety lock and a panel with 6 colorful buttons appears!"))
-	initialize_controller_action_type(/datum/action/vehicle/sealed/RollTheDice, VEHICLE_CONTROL_DRIVE)
-	initialize_controller_action_type(/datum/action/vehicle/sealed/Cannon, VEHICLE_CONTROL_DRIVE)
+	to_chat(user, span_danger("You scramble the clowncar safety lock and enable high-octane waddling!"))
 	AddComponent(/datum/component/waddling)
+	movedelay = 0.5
 
 /obj/vehicle/sealed/car/clowncar/Destroy()
 	playsound(src, 'sound/vehicles/clowncar_fart.ogg', 100)

--- a/code/modules/vehicles/cars/clowncar.dm
+++ b/code/modules/vehicles/cars/clowncar.dm
@@ -1,4 +1,4 @@
-/obj/vehicle/sealed/car/clowncar/
+/obj/vehicle/sealed/car/clowncar
 	name = "clown car"
 	desc = "How someone could even fit in there is beyond me."
 	icon_state = "clowncar"

--- a/code/modules/vehicles/cars/clowncar.dm
+++ b/code/modules/vehicles/cars/clowncar.dm
@@ -112,6 +112,8 @@
 	try_pickup_target(H)
 
 /obj/vehicle/sealed/car/clowncar/proc/try_pickup_target(mob/living/L)
+	if(!isliving(L))
+		return
 	var/picking_up = (!L.combat_mode || upgraded) //Upgraded can always pick up, normal needs target to be outside of combat mode
 
 	if(picking_up)

--- a/code/modules/vehicles/cars/clowncar.dm
+++ b/code/modules/vehicles/cars/clowncar.dm
@@ -15,6 +15,10 @@
 	var/thankscount
 	var/cannonmode = FALSE
 	var/cannonbusy = FALSE
+	var/upgraded = FALSE
+
+/obj/vehicle/sealed/car/clowncar/syndicate
+	upgraded = TRUE
 
 /datum/armor/car_clowncar
 	melee = 70
@@ -34,12 +38,13 @@
 	initialize_controller_action_type(/datum/action/vehicle/sealed/RollTheDice, VEHICLE_CONTROL_DRIVE)
 	initialize_controller_action_type(/datum/action/vehicle/sealed/Cannon, VEHICLE_CONTROL_DRIVE)
 
-/obj/vehicle/sealed/car/clowncar/syndicate/relaymove(mob/living/user, direction)
-	if(!ishuman(user))
-		return FALSE
-	var/mob/living/carbon/human/rider = user
-	if(rider.mind?.assigned_role != JOB_NAME_CLOWN) //Only clowns can drive the syndicate version of the clown car.
-		return FALSE
+/obj/vehicle/sealed/car/clowncar/relaymove(mob/living/user, direction)
+	if(upgraded)
+		if(!ishuman(user))
+			return FALSE
+		var/mob/living/carbon/human/rider = user
+		if(rider.mind?.assigned_role != JOB_NAME_CLOWN) //Only clowns can drive the syndicate version of the clown car.
+			return FALSE
 	return ..()
 
 /obj/vehicle/sealed/car/clowncar/auto_assign_occupant_flags(mob/M)
@@ -95,14 +100,8 @@
 	if(isliving(M))
 		if(ismegafauna(M))
 			return
-		var/mob/living/L = M
-		if(iscarbon(L))
-			var/mob/living/carbon/C = L
-			C.Paralyze(40) //I play to make sprites go horizontal
-			restraintarget(C)
-		L.visible_message(span_warning("[src] rams into [L] and sucks him up!")) //fuck off shezza this isn't ERP.
-		mob_forced_enter(L)
-		playsound(src, pick('sound/vehicles/clowncar_ram1.ogg', 'sound/vehicles/clowncar_ram2.ogg', 'sound/vehicles/clowncar_ram3.ogg'), 75)
+		try_pickup_target(M)
+
 	else if(istype(M, /turf/closed))
 		visible_message(span_warning("[src] rams into [M] and crashes!"))
 		playsound(src, pick('sound/vehicles/clowncar_crash1.ogg', 'sound/vehicles/clowncar_crash2.ogg'), 75)
@@ -110,11 +109,26 @@
 		DumpMobs(TRUE)
 
 /obj/vehicle/sealed/car/clowncar/RunOver(mob/living/carbon/human/H)
-	mob_forced_enter(H)
-	H.visible_message(span_warning("[src] drives over [H] and sucks him up!"))
-	restraintarget(H)
+	try_pickup_target(H)
 
-/obj/vehicle/sealed/car/clowncar/proc/restraintarget(mob/living/carbon/C)
+/obj/vehicle/sealed/car/clowncar/proc/try_pickup_target(mob/living/L)
+	var/picking_up = (!L.combat_mode || upgraded) //Upgraded can always pick up, normal needs target to be outside of combat mode
+
+	if(picking_up)
+		playsound(src, pick('sound/vehicles/clowncar_ram1.ogg', 'sound/vehicles/clowncar_ram2.ogg', 'sound/vehicles/clowncar_ram3.ogg'), 75)
+		restraintarget(L)
+		L.visible_message(span_warning("[L] is stuffed into [src]!"))
+		mob_forced_enter(L)
+
+	else if(!L.IsKnockdown())
+		L.visible_message(span_warning("[src] rams into [L] and runs them over!"))
+		L.Knockdown(3 SECONDS)
+		playsound(src, pick('sound/vehicles/clowncar_crash1.ogg', 'sound/vehicles/clowncar_crash2.ogg'), 75)
+
+/obj/vehicle/sealed/car/clowncar/proc/restraintarget(mob/living/L)
+	if(!iscarbon(L))
+		return //can't restrain what doesn't have hands
+	var/mob/living/carbon/C = L
 	if(istype(C))
 		// Dont try and apply more handcuffs if already handcuffed, obviously
 		if(C.handcuffed)
@@ -132,7 +146,7 @@
 	..()
 	to_chat(user, span_danger("You scramble the clowncar safety lock and enable high-octane waddling!"))
 	AddComponent(/datum/component/waddling)
-	movedelay = 0.5
+	upgraded = TRUE
 
 /obj/vehicle/sealed/car/clowncar/Destroy()
 	playsound(src, 'sound/vehicles/clowncar_fart.ogg', 100)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This PR capitalizes on an idea I had when I was fixing clown cars recently. What if there was a non-antagonist variant of the clown car which preserved this bug as a feature. Clown can still get up to hijinks and try kidnapping people with a clown car, but any unwilling passengers can easily crash the car if they wish. 

Specifically this PR:
* Adds a syndicate version of the clown car. This is the one available in uplinks.
* Adds clown car to the clown research node. The clown car takes Bananium, Iron and Plastic to produce at a mechfab
* Moves the fix from #13361 to the syndicate version of the clown car, meaning anyone inside can control the non-syndicate version and crash it easily if they don't wish to ride along with the clown. 
* Emagging either car adds waddling (this already happened, but highlighting it)
* Emagging the printed car disables the ability for non-clowns to control it, effectively making it a lighter version of the syndicate car that requires both research and rare resources to obtain.
* The extra abilities that used to be unlocked by emagging are now innately available on the syndicate clown car. Considering the car costs 20 TC I don't think this is cause for concern. There is no way to get these abilities on the printable clown car.
* Being in combat mode will prevent you from being picked up by the printed clown car, unless it has been emagged. 

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

While the bug allowing everyone to control clown cars was present I was able to freely spawn clown cars for clowns knowing they couldn't do any *real* harm with them and could just have fun with everyone. I'd like to preserve this and give additional purpose to bananium. 

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->

<img width="474" height="300" alt="image" src="https://github.com/user-attachments/assets/c25f5fa8-045d-4bef-a7c6-e868de7a6265" />

![dreamseeker_6Xeg6NdZPz](https://github.com/user-attachments/assets/f2dd92a8-e1a7-4c07-ae37-f2ca40cea48f)

Emagging the car in the middle. 
![dreamseeker_lUcALAQTgV](https://github.com/user-attachments/assets/b3423722-0c51-4fd3-84d8-9732d722080e)


## Changelog
:cl:
tweak: You can now print clown cars at a mechfab as part of the clown technology research node. They take bananium, plastic and iron. This version of the clown car can be controlled by anyone inside making it pretty difficult to actually go anywhere with an unwilling passenger. 
add: Added a new subtype of the clown car which is now purchasable from uplinks instead of the base version. The uplink version is only controllable by clowns and also innately comes with the the toys that used to require emagging a clown car to unlock. 
tweak: Emagging either clown car enables waddling motion with the car, and if it was a printed clown car emagging will also lock the controls so that only the clown can steer. 
tweak: Being in combat mode will prevent the printable clown car from kidnapping you unless it has been emagged. 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
