### PR TITLE
Fixed loading foam guns

### DIFF
--- a/code/modules/projectiles/boxes_magazines/external/toy.dm
+++ b/code/modules/projectiles/boxes_magazines/external/toy.dm
@@ -1,7 +1,7 @@
 /obj/item/ammo_box/magazine/toy
 	name = "foam force META magazine"
 	ammo_type = /obj/item/ammo_casing/caseless/foam_dart
-	caliber = list("foam_force")
+	caliber = list("foam_dart")
 
 /obj/item/ammo_box/magazine/toy/smg
 	name = "foam force SMG magazine"

--- a/code/modules/projectiles/boxes_magazines/internal/toy.dm
+++ b/code/modules/projectiles/boxes_magazines/internal/toy.dm
@@ -1,6 +1,6 @@
 /obj/item/ammo_box/magazine/internal/shot/toy
 	ammo_type = /obj/item/ammo_casing/caseless/foam_dart
-	caliber = list("foam_force")
+	caliber = list("foam_dart")
 	max_ammo = 4
 
 /obj/item/ammo_box/magazine/internal/shot/toy/crossbow


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Title.
Foam darts were changed to have the caliber foam_dart instead of foam_force but magazines still expected foam_force.

Fixes https://github.com/BeeStation/BeeStation-Hornet/issues/13344

## Why It's Good For The Game
fix

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>


https://github.com/user-attachments/assets/248416e7-d8b1-4243-8376-d26596e1d423


Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>

## Changelog
:cl:
fix: Fixed being unable to load foam force guns
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
