### PR TITLE
Revert "Victims of mesmerize / feed now get warned in chat so they know what the hell is happening to them."

### DIFF
--- a/code/modules/antagonists/vampire/powers/targeted/feed.dm
+++ b/code/modules/antagonists/vampire/powers/targeted/feed.dm
@@ -124,8 +124,6 @@
 
 	// Aggressively grabbing a target will make them fall asleep and alert nearby people
 	if(owner.pulling == feed_target && owner.grab_state == GRAB_AGGRESSIVE)
-		to_chat(owner, span_cultbigbold("[owner.first_name()] takes you into a vicious embrace, sinking [owner.p_their()] fangs into your neck... [span_hypnophrase("But why does it feel so good?!")]"), type = MESSAGE_TYPE_WARNING)
-
 		feed_target.Unconscious((5 + level_current) SECONDS)
 		owner.visible_message(
 			span_warning("[owner] closes [owner.p_their()] mouth around [feed_target]'s neck!"),
@@ -133,8 +131,6 @@
 		)
 		silent_feed = FALSE
 	else
-		to_chat(owner, span_cultbigbold("[owner.first_name()] gently raises your arm to [owner.p_their()] lips, biting into your wrist... [span_hypnophrase("But why does it feel so good?!")]"), type = MESSAGE_TYPE_WARNING)
-
 		owner.visible_message(
 			span_notice("[owner] puts [feed_target]'s wrist up to [owner.p_their()] mouth."),
 			span_notice("You slip your fangs into [feed_target]'s wrist."),

--- a/code/modules/antagonists/vampire/powers/targeted/mesmerize.dm
+++ b/code/modules/antagonists/vampire/powers/targeted/mesmerize.dm
@@ -115,8 +115,6 @@
 	living_target.notransform = TRUE // <--- Fuck it. We tried using next_move, but they could STILL resist. We're just doing a hard freeze.
 	addtimer(CALLBACK(src, PROC_REF(end_mesmerize), living_target), power_time)
 
-	to_chat(living_target, span_hypnophrase("[owner.first_name()]'s eyes glitter so beautifully... You're mesmerized!"), type = MESSAGE_TYPE_WARNING)
-
 	power_activated_sucessfully() // PAY COST! BEGIN COOLDOWN!
 
 /datum/action/vampire/targeted/mesmerize/continue_active()


### PR DESCRIPTION
Reverts BeeStation/BeeStation-Hornet#13437

They wrote the code sending the message to the vampire.


🆑
del: reverted "Victims of a vampire's mesmerize / feed are now told what the hell is going on.". It did not work as intended.
/:cl: