### PR TITLE
Cardstation Medical Tint Change

### DIFF
--- a/_maps/map_files/CardinalStation/CardinalStation.dmm
+++ b/_maps/map_files/CardinalStation/CardinalStation.dmm
@@ -8815,7 +8815,6 @@
 /turf/open/floor/iron/sepia,
 /area/crew_quarters/theatre)
 "bNP" = (
-/obj/structure/window/reinforced/tinted/spawner/directional/west,
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
 	},
@@ -8825,6 +8824,7 @@
 	pixel_y = 11
 	},
 /obj/effect/loot_jobscale/medical/medkits,
+/obj/structure/window/reinforced/spawner/directional/west,
 /turf/open/floor/iron/white/smooth_large,
 /area/medical/sleeper)
 "bNW" = (
@@ -39155,7 +39155,6 @@
 /turf/open/floor/iron/dark,
 /area/engine/atmos)
 "hXe" = (
-/obj/structure/window/reinforced/tinted/spawner/directional/west,
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
 	},
@@ -39164,6 +39163,7 @@
 	dir = 8
 	},
 /obj/effect/loot_jobscale/medical/medkits,
+/obj/structure/window/reinforced/spawner/directional/west,
 /turf/open/floor/iron/white/smooth_large,
 /area/medical/sleeper)
 "hXp" = (
@@ -49725,7 +49725,7 @@
 /obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 8
 	},
-/obj/structure/window/reinforced/tinted/corner/spawner/directional/west,
+/obj/structure/window/reinforced/corner/spawner/directional/west,
 /turf/open/floor/iron/white/smooth_large,
 /area/medical/sleeper)
 "ker" = (
@@ -67457,7 +67457,6 @@
 /turf/open/floor/iron/textured_half,
 /area/quartermaster/storage)
 "nIM" = (
-/obj/structure/window/reinforced/tinted/spawner/directional/east,
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
 	},
@@ -67470,6 +67469,7 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 8
 	},
+/obj/structure/window/reinforced/spawner/directional/east,
 /turf/open/floor/iron/white/smooth_large,
 /area/medical/sleeper)
 "nIU" = (
@@ -68574,7 +68574,7 @@
 /area/engine/storage_shared)
 "nVa" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner,
-/obj/structure/window/reinforced/tinted/corner/spawner/directional/south,
+/obj/structure/window/reinforced/corner/spawner/directional/south,
 /turf/open/floor/iron/white/smooth_large,
 /area/medical/sleeper)
 "nVg" = (
@@ -101391,11 +101391,11 @@
 /turf/open/floor/carpet/black,
 /area/vacant_room/office)
 "uDL" = (
-/obj/structure/window/reinforced/tinted/spawner/directional/east,
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
 	},
 /obj/machinery/iv_drip,
+/obj/structure/window/reinforced/spawner/directional/east,
 /turf/open/floor/iron/white/smooth_large,
 /area/medical/sleeper)
 "uDS" = (


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Untints the directional windows in cardstation medical, that's it

## Why It's Good For The Game

Nobody likes these god forsaken tinted directional windows, they exist to obstruct your view in fucking horrible ways and most of the time are removed

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

Tinted

<img width="688" height="491" alt="image" src="https://github.com/user-attachments/assets/6b0b6548-b088-49c6-a728-becf78256cb2" />

<img width="519" height="417" alt="image" src="https://github.com/user-attachments/assets/459d4fd6-047e-44a8-9f1c-279f8009799d" />

<img width="482" height="400" alt="image" src="https://github.com/user-attachments/assets/b302eecd-064a-4405-92a2-ce0cae0bee5e" />

Untinted

<img width="480" height="404" alt="image" src="https://github.com/user-attachments/assets/6bfa2608-a75d-466f-9994-306346703192" />


</details>

## Changelog
:cl: Isaac

fix: Untints cardstation medical directional windows

/:cl: 

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
