### PR TITLE
fixes chaplain graverobber hat armor

### DIFF
--- a/code/game/objects/items/holy_weapons.dm
+++ b/code/game/objects/items/holy_weapons.dm
@@ -115,7 +115,7 @@
 /obj/item/storage/box/holy/graverobber/PopulateContents()
 	new /obj/item/clothing/suit/chaplainsuit/armor/templar/graverobber_coat(src)
 	new /obj/item/clothing/under/rank/civilian/graverobber_under(src)
-	new /obj/item/clothing/head/chaplain/graverobber_hat(src)
+	new /obj/item/clothing/head/helmet/chaplain/graverobber_hat(src)
 	new /obj/item/clothing/gloves/graverobber_gloves(src)
 
 /obj/item/storage/box/holy/adept

--- a/code/modules/clothing/suits/chaplainsuits.dm
+++ b/code/modules/clothing/suits/chaplainsuits.dm
@@ -324,7 +324,7 @@
 
 
 
-/obj/item/clothing/head/chaplain/graverobber_hat
+/obj/item/clothing/head/helmet/chaplain/graverobber_hat
 	name = "grave robber hat"
 	desc = "A tattered leather hat. It reeks of death."
 	icon_state = "graverobber_hat"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
repeat of #4842 but for grave robber set

## Why It's Good For The Game

no more half armored chaplain drop beacon sets, seems like an oversight from blindly copying paths

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

<img width="381" height="162" alt="image" src="https://github.com/user-attachments/assets/88e42de1-8219-4897-9278-012e9f5d57cb" />

</details>

## Changelog
:cl: lord scrubling
fix: chaplain grave robber hat now has armor
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
