### PR TITLE
Dynamic elasticity

### DIFF
--- a/code/controllers/subsystem/dynamic/dynamic.dm
+++ b/code/controllers/subsystem/dynamic/dynamic.dm
@@ -483,8 +483,7 @@ SUBSYSTEM_DEF(dynamic)
 				break
 		while (prob(ruleset.elasticity))
 
-		if(CHECK_BITFIELD(ruleset.flags, NO_OTHER_RULESETS))
-			no_other_rulesets = TRUE
+		if(no_other_rulesets)
 			break
 
 	// Deal with the NO_OTHER_RULESETS flag

--- a/code/controllers/subsystem/dynamic/dynamic.dm
+++ b/code/controllers/subsystem/dynamic/dynamic.dm
@@ -452,30 +452,36 @@ SUBSYSTEM_DEF(dynamic)
 			log_dynamic("ROUNDSTART: No more rulesets can be applied, stopping with [roundstart_points_left] points left.")
 			break
 
-		// Something changed and this ruleset is no longer allowed
-		// Most common occurance is all previous candidates were assigned an antag position
-		ruleset.trim_candidates()
-		if(!ruleset.allowed())
-			possible_rulesets -= ruleset
-			continue
+		do
+			// Something changed and this ruleset is no longer allowed
+			// Most common occurance is all previous candidates were assigned an antag position
+			ruleset.trim_candidates()
+			if(!ruleset.allowed())
+				possible_rulesets -= ruleset
+				continue
 
-		// Not enough points left
-		if(ruleset.points_cost > roundstart_points_left)
-			possible_rulesets -= ruleset
-			continue
+			// Not enough points left
+			if(ruleset.points_cost > roundstart_points_left)
+				possible_rulesets -= ruleset
+				continue
 
-		// check_is_ruleset_blocked()
-		if(check_is_ruleset_blocked(ruleset, roundstart_executed_rulesets))
-			possible_rulesets -= ruleset
-			continue
+			// check_is_ruleset_blocked()
+			if(check_is_ruleset_blocked(ruleset, roundstart_executed_rulesets))
+				possible_rulesets -= ruleset
+				continue
 
-		// Apply cost and add ruleset to 'roundstart_executed_rulesets'
-		roundstart_points_left -= ruleset.points_cost
+			// Apply cost and add ruleset to 'roundstart_executed_rulesets'
+			roundstart_points_left -= ruleset.points_cost
 
-		roundstart_executed_rulesets += ruleset
-		ruleset.choose_candidates()
+			roundstart_executed_rulesets += ruleset
+			ruleset.choose_candidates()
 
-		log_dynamic("ROUNDSTART: Chose [ruleset] with [roundstart_points_left] points left")
+			log_dynamic("ROUNDSTART: Chose [ruleset] with [roundstart_points_left] points left")
+
+			if(CHECK_BITFIELD(ruleset.flags, NO_OTHER_RULESETS))
+				no_other_rulesets = TRUE
+				break
+		while (prob(ruleset.elasticity))
 
 		if(CHECK_BITFIELD(ruleset.flags, NO_OTHER_RULESETS))
 			no_other_rulesets = TRUE

--- a/code/controllers/subsystem/dynamic/dynamic_rulesets_roundstart.dm
+++ b/code/controllers/subsystem/dynamic/dynamic_rulesets_roundstart.dm
@@ -2,6 +2,9 @@
 	rule_category = DYNAMIC_CATEGORY_ROUNDSTART
 	flags = SHOULD_USE_ANTAG_REP
 	abstract_type = /datum/dynamic_ruleset/roundstart
+	/// The percentage (0 to 100) chance that this ruleset will be repicked
+	/// when selected, assuming there are cost points available.
+	var/elasticity = 0
 
 /datum/dynamic_ruleset/roundstart/get_candidates()
 	candidates = SSdynamic.roundstart_candidates.Copy()

--- a/config/dynamic/rising_tension.json
+++ b/config/dynamic/rising_tension.json
@@ -50,8 +50,7 @@
 			"restricted_roles": [
 				"Cyborg",
 				"AI"
-			],
-			"elasticity": 100
+			]
 		},
 		"Revolution": {
 			"points_cost": 100

--- a/config/dynamic/rising_tension.json
+++ b/config/dynamic/rising_tension.json
@@ -50,7 +50,8 @@
 			"restricted_roles": [
 				"Cyborg",
 				"AI"
-			]
+			],
+			"elasticity": 100
 		},
 		"Revolution": {
 			"points_cost": 100


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

- Roundstart rulesets now have an elasticity value.
- The elasticity is a value between 0 and 100.
- Every time a roundstart ruleset is selected, then if the probability of this value is met, the ruleset will be selected again until it fails.

## Why It's Good For The Game

This means we can make it so that certain antags prefer to stick together with their own types, but still allowing other antagonists to be selected. This can be configured on a per-storyteller basis.

## Testing Photographs and Procedure

Due to the removal of dynamic simulations, testing is rather difficult. I am currently checking how I could do this.

This has been testmerged on live and has been running with a new storyteller, however due to lower populations its hard to see the effects.

## Changelog
:cl:
add: Adds the ability to set the elasticity of rulesets, which will cause the same ruleset to be re-picked with the probability provided in the elasticity variable.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
