### PR TITLE
generalizes protective headwear for bibles

### DIFF
--- a/code/game/objects/items/storage/book.dm
+++ b/code/game/objects/items/storage/book.dm
@@ -185,7 +185,7 @@
 			smack = 0
 		else if(iscarbon(M))
 			var/mob/living/carbon/C = M
-			if(!istype(C.head, /obj/item/clothing/head/helmet))
+			if(isnull(C.head) || istype(C.head.get_armor(), /datum/armor/none))
 				C.adjustOrganLoss(ORGAN_SLOT_BRAIN, 5, 60)
 				to_chat(C, span_danger("You feel dumber."))
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

brain damage from bibles is now prevented by any hat with armor

## Why It's Good For The Game

brain damage from bibles was only prevented by helmets which brought weird cases such as hard hats and modsuit helmets not protecting against it

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

no armor
<img width="531" height="121" alt="image" src="https://github.com/user-attachments/assets/a905180e-be30-400c-94e7-97c0e3f5b94c" />
<img width="192" height="214" alt="image" src="https://github.com/user-attachments/assets/9dc114de-ab58-4cde-8803-0842f06fb4c8" />
armor
<img width="519" height="180" alt="image" src="https://github.com/user-attachments/assets/05cdf4c3-cb8c-4962-9f54-9f6b9c856180" />
<img width="482" height="112" alt="image" src="https://github.com/user-attachments/assets/a8245985-e2fd-4135-8383-2d7f6d0a42fa" />
<img width="184" height="211" alt="image" src="https://github.com/user-attachments/assets/5fe9de66-74f1-4ec3-9495-5a84efe21c92" />
no hat
<img width="518" height="112" alt="image" src="https://github.com/user-attachments/assets/842885a0-4689-47be-8a0e-8cf114972b4e" />
<img width="185" height="204" alt="image" src="https://github.com/user-attachments/assets/55fbf9ef-2488-497e-bfb1-82c2ed4b1914" />

</details>

## Changelog
:cl:
balance: any hat with armor prevents bible brain damage
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
