### PR TITLE
Fixed missing holodeck thunderdome eswords

### DIFF
--- a/_maps/holodeck/small/thunderdome.dmm
+++ b/_maps/holodeck/small/thunderdome.dmm
@@ -12,7 +12,7 @@
 /obj/item/clothing/head/helmet/thunderdome/holosuit,
 /obj/item/clothing/suit/armor/tdome/holosuit/green,
 /obj/item/clothing/under/color/green,
-/obj/item/holo/esword/green,
+/obj/item/melee/energy/sword/holographic/green,
 /turf/open/floor/holofloor/basalt,
 /area/template_noop)
 "m" = (
@@ -23,7 +23,7 @@
 /obj/item/clothing/head/helmet/thunderdome/holosuit,
 /obj/item/clothing/suit/armor/tdome/holosuit/red,
 /obj/item/clothing/under/color/red,
-/obj/item/holo/esword/red,
+/obj/item/melee/energy/sword/holographic/red,
 /turf/open/floor/holofloor/basalt,
 /area/template_noop)
 "x" = (

--- a/_maps/holodeck/thunderdome.dmm
+++ b/_maps/holodeck/thunderdome.dmm
@@ -12,7 +12,7 @@
 /obj/item/clothing/head/helmet/thunderdome/holosuit,
 /obj/item/clothing/suit/armor/tdome/holosuit/green,
 /obj/item/clothing/under/color/green,
-/obj/item/holo/esword/green,
+/obj/item/melee/energy/sword/holographic/green,
 /turf/open/floor/holofloor/basalt,
 /area/template_noop)
 "q" = (
@@ -20,7 +20,7 @@
 /obj/item/clothing/head/helmet/thunderdome/holosuit,
 /obj/item/clothing/suit/armor/tdome/holosuit/red,
 /obj/item/clothing/under/color/red,
-/obj/item/holo/esword/red,
+/obj/item/melee/energy/sword/holographic/red,
 /turf/open/floor/holofloor/basalt,
 /area/template_noop)
 "x" = (


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

In #11324 the typepath `/obj/item/holo/esword` was changed to `/obj/item/melee/energy/sword/holographic` but an updatepaths script was never ran.

## Why It's Good For The Game

it now works as intended

## Testing Photographs and Procedure

<img width="379" height="412" alt="image" src="https://github.com/user-attachments/assets/92fabdee-6a62-46c7-9d4c-6129a6000dcc" />

## Changelog
:cl:
fix: Fixed the holodeck thunderdome not spawning with holo energy swords
/:cl: