### PR TITLE
Fixes TTV suicide bombing

### DIFF
--- a/code/game/objects/items/devices/transfer_valve.dm
+++ b/code/game/objects/items/devices/transfer_valve.dm
@@ -248,7 +248,7 @@
 				tank_two = null
 				. = TRUE
 		if("toggle")
-			toggle_valve(TRUE)
+			toggle_valve()
 			. = TRUE
 		if("device")
 			if(attached_device)


### PR DESCRIPTION
## About The Pull Request

Linda broke this by passing in TRUE into the target tank argument for `/obj/item/transfer_valve/proc/toggle_valve()`

## Why It's Good For The Game

works as intended

## Testing Photographs and Procedure

https://github.com/user-attachments/assets/41fc128b-ff0a-4319-9f32-22f37427d011

## Changelog
:cl:
fix: Fixed not being able to manually open a TTV valve
/:cl:
