### PR TITLE
Fixes Ventrue Favorite Vassal Leveling

### DIFF
--- a/code/modules/antagonists/vampire/clans/brujah.dm
+++ b/code/modules/antagonists/vampire/clans/brujah.dm
@@ -84,7 +84,8 @@
 		if(!is_valid_target(possible_target))
 			target_options.Remove(possible_target)
 
-	target = pick(target_options)
+	if(length(target_options))
+		target = pick(target_options)
 	update_explanation_text()
 
 #undef BRUJAH_FAVORITE_VASSAL_ATTACK_BONUS

--- a/code/modules/antagonists/vampire/clans/ventrue.dm
+++ b/code/modules/antagonists/vampire/clans/ventrue.dm
@@ -109,7 +109,7 @@
 	if(vampiredatum.vampire_level_unspent > 0)
 		spend_rank(carbon_vassal)
 
-/datum/vampire_clan/ventrue/interact_with_vassal(datum/antagonist/vampire/source, datum/antagonist/vassal/favorite/vassaldatum)
+/datum/vampire_clan/ventrue/interact_with_vassal(datum/antagonist/vassal/favorite/vassaldatum)
 	. = ..()
 	if(.)
 		return TRUE
@@ -121,7 +121,7 @@
 		spend_rank(vassaldatum.owner.current)
 		return TRUE
 
-	to_chat(vampiredatum.owner.current, span_danger("You don't have any levels or enough to rank [vassaldatum.owner.current] up with."))
+	to_chat(vampiredatum.owner.current, span_danger("You don't have any levels to rank [vassaldatum.owner.current] up with."))
 	return TRUE
 
 /datum/vampire_clan/ventrue/on_favorite_vassal(datum/antagonist/vassal/favorite/favorite_vassal)


### PR DESCRIPTION
## About The Pull Request

In #13189 while I was removing all of the signal logic from vampire clans, I forgot to remove the `source` argument from one of the procs.

I also fixed a very rare brujah runtime when trying to select a discordant vassal target.

## Why It's Good For The Game

this sort of nullifies the entire clan's gimmick. oops

## Testing Photographs and Procedure

https://github.com/user-attachments/assets/c2dcdba3-5ae3-4cbc-b312-3cca11f79f62

## Changelog
:cl:
fix: Fixed Ventrue vampires not being able to level up their favorite vassal
/:cl:
