### PR TITLE
Fixes some runtimes that dionae showed me the path to

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/diona.dm
+++ b/code/modules/mob/living/carbon/human/species_types/diona.dm
@@ -218,30 +218,36 @@
 	addtimer(CALLBACK(src, PROC_REF(split), gibbed, H), 5 SECONDS, TIMER_DELETE_ME)
 
 /datum/action/diona/split/proc/split(gibbed, mob/living/carbon/human/H)
+	// Gib the corpse with nothing left of use. After all the nymphs are ALL dead.
 	if(gibbed)
-		H.gib(TRUE, TRUE, TRUE)  //Gib the corpse with nothing left of use. After all the nymphs are ALL dead.
+		H.gib(TRUE, TRUE, TRUE)
 		return
-	var/list/alive_nymphs = list()
+
+	var/list/mob/living/simple_animal/hostile/retaliate/nymph/alive_nymphs = list()
 	var/mob/living/simple_animal/hostile/retaliate/nymph/nymph = new(H.loc) //Spawn the player nymph, including this one, should be six total nymphs
-	for(var/obj/item/bodypart/BP as anything in H.bodyparts)
-		if(BP.limb_id != SPECIES_DIONA) //Robot limb? Ignore it.
-			BP.drop_limb()
+	for(var/obj/item/bodypart/limb as anything in H.bodyparts)
+		if(limb.limb_id != SPECIES_DIONA) //Robot limb? Ignore it.
+			limb.drop_limb()
 			continue
-		if(istype(BP, /obj/item/bodypart/head))
-			nymph.adjustBruteLoss(BP.brute_dam)
-			nymph.adjustFireLoss(BP.burn_dam)
+
+		// Exclude the head nymph from the alive_nymphs list, since that list is used for secondary consciousness transfer.
+		if(istype(limb, /obj/item/bodypart/head))
+			nymph.adjustBruteLoss(limb.brute_dam, updating_health = FALSE)
+			nymph.adjustFireLoss(limb.burn_dam, updating_health = FALSE)
 			nymph.updatehealth()
-			continue //Exclude the head nymph from the alive_nymphs list, since that list is used for secondary consciousness transfer.
-		var/mob/living/simple_animal/hostile/retaliate/nymph/limb_nymph = new /mob/living/simple_animal/hostile/retaliate/nymph(H.loc)
-		limb_nymph.adjustBruteLoss(BP.brute_dam)
-		limb_nymph.adjustFireLoss(BP.burn_dam)
+			continue
+
+		var/mob/living/simple_animal/hostile/retaliate/nymph/limb_nymph = new(H.loc)
+		limb_nymph.adjustBruteLoss(limb.brute_dam, updating_health = FALSE)
+		limb_nymph.adjustFireLoss(limb.burn_dam, updating_health = FALSE)
 		limb_nymph.updatehealth()
 		if(limb_nymph.stat != DEAD)
 			alive_nymphs += limb_nymph
 
-	var/mob/living/simple_animal/hostile/retaliate/nymph/gambling_nymph = alive_nymphs[rand(1, alive_nymphs)] // Let's go gambling!
-	gambling_nymph.adjustBruteLoss(50) // Aw dangit.
-	alive_nymphs -= gambling_nymph //Remove it from the alive_nymphs list.
+	if(length(alive_nymphs))
+		var/mob/living/simple_animal/hostile/retaliate/nymph/gambling_nymph = alive_nymphs[rand(1, length(alive_nymphs))] // Let's go gambling!
+		gambling_nymph.adjustBruteLoss(50) // Aw dangit.
+		alive_nymphs -= gambling_nymph //Remove it from the alive_nymphs list.
 
 	if(nymph.stat == DEAD) //If the head nymph is dead, transfer all consciousness to the next best thing - an alive limb nymph!
 		nymph = pick(alive_nymphs)

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -929,8 +929,11 @@
 	if(!has_gravity() || (movement_type & THROWN))
 		return
 	var/blood_exists = locate(/obj/effect/decal/cleanable/blood/trail_holder) in start
-	var/mob/living/carbon/human/humanoid = src
-	var/glowyblood = humanoid.dna.blood_type.glowy
+
+	var/glowyblood = FALSE
+	if(ishuman(src))
+		var/mob/living/carbon/human/humanoid = src
+		glowyblood = humanoid.dna.blood_type.glowy
 
 	if(isturf(start))
 		var/trail_type = getTrail()

--- a/code/modules/religion/sects/necro_sect.dm
+++ b/code/modules/religion/sects/necro_sect.dm
@@ -239,7 +239,7 @@
 	if(!length(movable_reltool.buckled_mobs))
 		to_chat(user, span_warning("Nothing is buckled to the altar!"))
 		return FALSE
-	for(var/creature in movable_reltool.buckled_mobs)
+	for(var/mob/living/creature in movable_reltool.buckled_mobs)
 		chosen_sacrifice = creature
 		if(chosen_sacrifice.stat == DEAD)
 			to_chat(user, span_warning("You can only sacrifice living creatures, this one is dead!"))
@@ -253,9 +253,8 @@
 			to_chat(user, span_warning("You cannot sacrifice this. It is not made of flesh!"))
 			chosen_sacrifice = null
 			return FALSE
-		var/mob/living/carbon/C = creature
-		if(!isnull(C))
-			cuff(C)
+		if(iscarbon(creature))
+			cuff(creature)
 		return ..()
 
 /datum/religion_rites/living_sacrifice/invoke_effect(mob/living/user, atom/movable/religious_tool)


### PR DESCRIPTION
## About The Pull Request

Diona are such a conceptually buggy race that they somehow always popup as a runtime during a round

Three runtimes here:

First off, when a dead non-human living mob was moved (wow that's a mouthful) it would runtime because `/mob/living/proc/makeTrail` assumed src was a human and it would then runtime when it tried to access a human variable.

SECOND. Sect code, specifically the necro sect, is stupid as balls. Whenever you perform the ritual _"Living Sacrifice"_, it will attempt to handcuff the sacrificed mob. **However**, it doesn't first check if the mob is actually a carbon, so if you ever sacrified a non-carbon (DIONA NYMPHS!!!), it would runtime.

THE THIRD AND FINAL RUNTIME: When a diona splits and does not have any limbs, its `alive_nymphs` list will be empty causing the "gambling" logic to runtime because it attempted to index a non-existent index.

## Why It's Good For The Game

you know why

 the `makeTrail()` bug was also causing a flaky test

## Testing Photographs and Procedure


https://github.com/user-attachments/assets/3401055e-3bfd-440b-902d-901ee98b053a

https://github.com/user-attachments/assets/d9c289de-0c85-4ea3-8146-3e794361c1c5

The runtime you can see in chat was because I was varediting AI controller stuff and ended up breaking something- that doesn't happen normally

https://github.com/user-attachments/assets/77645cf1-f458-4e68-8e47-1294cbcfd000

## Changelog
:cl:
fix: Fixed a runtime when buckling diona nymphs to the chaplain altar while in the necromancy sect
fix: Fixed a runtime when dragging (sufficiently damaged) dead diona nymphs
fix: Fixed dionas without limbs spawning a billion nymphs whenever they were supposed to split
/:cl:
