### PR TITLE
Tweaks TRAIT_DOOR_PRYER and light eaters are no longer crowbars

### DIFF
--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -202,7 +202,7 @@
 	return
 
 
-/obj/machinery/door/proc/try_to_crowbar(obj/item/acting_object, mob/user)
+/obj/machinery/door/proc/try_to_crowbar(obj/item/acting_object, mob/user, forced = FALSE)
 	return
 
 /obj/machinery/door/welder_act(mob/living/user, obj/item/tool)
@@ -210,22 +210,23 @@
 	return TOOL_ACT_TOOLTYPE_SUCCESS
 
 /obj/machinery/door/crowbar_act(mob/living/user, obj/item/tool)
-	if(user.combat_mode)
+	if(user.combat_mode || HAS_TRAIT(tool, TRAIT_DOOR_PRYER))
 		return
-
-	var/forced_open = HAS_TRAIT(tool, TRAIT_DOOR_PRYER) ? TRUE : FALSE
-	try_to_crowbar(tool, user, forced_open)
+	try_to_crowbar(tool, user)
 	return TOOL_ACT_TOOLTYPE_SUCCESS
 
-/obj/machinery/door/attackby(obj/item/I, mob/living/user, params)
-	if(!user.combat_mode && istype(I, /obj/item/fireaxe))
-		try_to_crowbar(I, user, FALSE)
+/obj/machinery/door/attackby(obj/item/attacking_item, mob/living/user, params)
+	if(!user.combat_mode && HAS_TRAIT(attacking_item, TRAIT_DOOR_PRYER))
+		try_to_crowbar(attacking_item, user, forced = TRUE)
 		return TRUE
-	else if(I.item_flags & NOBLUDGEON || user.combat_mode)
+	else if(!user.combat_mode && istype(attacking_item, /obj/item/fireaxe))
+		try_to_crowbar(attacking_item, user, forced = FALSE)
+		return TRUE
+	else if(attacking_item.item_flags & NOBLUDGEON || user.combat_mode)
 		return ..()
-	else if(!user.combat_mode && istype(I, /obj/item/stack/sheet/wood))
+	else if(!user.combat_mode && istype(attacking_item, /obj/item/stack/sheet/wood))
 		return ..() // we need this so our can_barricade element can be called using COMSIG_ATOM_ATTACKBY
-	else if(try_to_activate_door(I, user))
+	else if(try_to_activate_door(attacking_item, user))
 		return TRUE
 	return ..()
 
@@ -234,8 +235,9 @@
 	return TOOL_ACT_TOOLTYPE_SUCCESS
 
 /obj/machinery/door/crowbar_act_secondary(mob/living/user, obj/item/tool)
-	var/forced_open = HAS_TRAIT(tool, TRAIT_DOOR_PRYER) ? TRUE : FALSE
-	try_to_crowbar(tool, user, forced_open)
+	if(HAS_TRAIT(tool, TRAIT_DOOR_PRYER))
+		return
+	try_to_crowbar(tool, user)
 	return TOOL_ACT_TOOLTYPE_SUCCESS
 
 /obj/machinery/door/take_damage(damage_amount, damage_type = BRUTE, damage_flag = 0, sound_effect = 1, attack_dir, armour_penetration = 0)

--- a/code/game/machinery/doors/firedoor.dm
+++ b/code/game/machinery/doors/firedoor.dm
@@ -518,7 +518,7 @@
 		correct_state()
 
 
-/obj/machinery/door/firedoor/try_to_crowbar(obj/item/crowbar, mob/user)
+/obj/machinery/door/firedoor/try_to_crowbar(obj/item/crowbar, mob/user, forced = FALSE)
 	if(welded || operating)
 		return
 

--- a/code/game/machinery/doors/poddoor.dm
+++ b/code/game/machinery/doors/poddoor.dm
@@ -162,6 +162,6 @@
 /obj/machinery/door/poddoor/try_to_activate_door(obj/item/I, mob/user)
 	return
 
-/obj/machinery/door/poddoor/try_to_crowbar(obj/item/I, mob/user)
+/obj/machinery/door/poddoor/try_to_crowbar(obj/item/acting_object, mob/user, forced = FALSE)
 	if(machine_stat & NOPOWER)
 		open(1)

--- a/code/game/machinery/doors/windowdoor.dm
+++ b/code/game/machinery/doors/windowdoor.dm
@@ -352,18 +352,18 @@ CREATION_TEST_IGNORE_SUBTYPES(/obj/machinery/door/window)
 	if(..())
 		autoclose = FALSE
 
-/obj/machinery/door/window/try_to_crowbar(obj/item/crowbar, mob/user)
+/obj/machinery/door/window/try_to_crowbar(obj/item/acting_object, mob/user, forced = FALSE)
 	if(density)
-		if(!HAS_TRAIT(crowbar, TRAIT_DOOR_PRYER) && hasPower())
+		if(!HAS_TRAIT(acting_object, TRAIT_DOOR_PRYER) && hasPower())
 			to_chat(user, span_warning("The windoor's motors resist your efforts to force it!"))
 			return
 		else if(!hasPower())
 			to_chat(user, span_warning("You begin forcing open \the [src], the motors don't resist..."))
-			if(!crowbar.use_tool(src, user, 1 SECONDS))
+			if(!acting_object.use_tool(src, user, 1 SECONDS))
 				return
 		else
 			to_chat(user, span_warning("You begin forcing open \the [src]..."))
-			if(!crowbar.use_tool(src, user, 5 SECONDS))
+			if(!acting_object.use_tool(src, user, 5 SECONDS))
 				return
 		open(2)
 	else

--- a/code/modules/mob/living/carbon/human/species_types/shadowpeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/shadowpeople.dm
@@ -260,8 +260,6 @@
 	w_class = WEIGHT_CLASS_HUGE
 	sharpness = SHARP_DISMEMBER_EASY
 	bleed_force = BLEED_DEEP_WOUND
-	//Fuck you, *crowbars your evil thing
-	tool_behaviour = TOOL_CROWBAR
 
 /obj/item/light_eater/Initialize(mapload)
 	. = ..()


### PR DESCRIPTION
## About The Pull Request

Previously an item must have had the crowbar tool behavior for `TRAIT_DOOR_PRYER` to be checked, I went ahead and adjusted the code that any item can have the trait applied to it and still pry open a door.

I removed the crowbar tool behavior from the lighteater

## Why It's Good For The Game

closes #13427

I removed the crowbar tool behavior from the lighteater for 2 reasons:
- It doesn't really make sense. Yes, it is an incredibly sharp and robust... thing, but it's not a crowbar.
- aaand secondly, the real reason: It's super annoying when playing as a nightmare. While everything is working correctly, I still expect to attack a borg when hitting them with my lighteater while not on combat mode, I promise that I have never actually intended to expose a borg's battery when clicking on them while it shoots me. Not to mention the spam clicking during combat and accidentally pulling up all of the tiles.

## Testing Photographs and Procedure

https://github.com/user-attachments/assets/73042d6f-af2a-4d1d-9015-441284015ae6

https://github.com/user-attachments/assets/77c8f32c-5223-4f03-9f9c-3d003009fa62

## Changelog
:cl:
tweak: Nightmare light eaters no longer act as crowbars (they can still pry open doors)
fix: Fixed changeling arm blades not being able to pry open doors
/:cl:
