### PR TITLE
Don't start if there is nobody on the server

### DIFF
--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -164,8 +164,6 @@ SUBSYSTEM_DEF(ticker)
 /datum/controller/subsystem/ticker/fire()
 	switch(current_state)
 		if(GAME_STATE_STARTUP)
-			if(Master.initializations_finished_with_no_players_logged_in)
-				start_at = world.time + (CONFIG_GET(number/lobby_countdown) * 10)
 			for(var/client/C in GLOB.clients_unsafe)
 				window_flash(C, ignorepref = TRUE) //let them know lobby has opened up.
 			to_chat(world, span_boldnotice("Welcome to [station_name()]!"))
@@ -188,6 +186,11 @@ SUBSYSTEM_DEF(ticker)
 				++totalPlayers
 				if(player.ready == PLAYER_READY_TO_PLAY)
 					++totalPlayersReady
+
+			// If there are no players, stay in the lobby until someone joins
+			// and give enough time for them to do the storyteller vote
+			if ((totalPlayers - totalPlayersPreAuth) == 0)
+				timeleft = min(timeleft, 120 SECONDS)
 
 			if(start_immediately)
 				timeLeft = 0

--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -190,7 +190,7 @@ SUBSYSTEM_DEF(ticker)
 			// If there are no players, stay in the lobby until someone joins
 			// and give enough time for them to do the storyteller vote
 			if ((totalPlayers - totalPlayersPreAuth) == 0)
-				timeleft = min(timeleft, 120 SECONDS)
+				timeLeft = min(timeLeft, 120 SECONDS)
 
 			if(start_immediately)
 				timeLeft = 0


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Prevent the round-start timer from going below 2 minutes until someone is connected, regardless of whether or not they ready up.

## Why It's Good For The Game

We don't want lowpop rounds to constantly be cycling with nobody on, if someone wants to play when there was nobody on then they would probably rather have a round-start where station hasn't lost all power. It also looks bad in OOC.

This will need testing as to whether or not this is the prefered option for lowpop, I know lowpop players don't want short rounds but rounds cycle when there are 0 people online and so by starting when there is nobody online we are more likely to have scenarios where players join only to be greeted with the round already ending.

## Testing Photographs and Procedure

<img width="426" height="167" alt="image" src="https://github.com/user-attachments/assets/8adcf04f-7910-4428-8318-63e7c93687a8" />

<img width="304" height="56" alt="image" src="https://github.com/user-attachments/assets/641546e9-63db-4fc8-8b7c-85e9a2704bb0" />

Once someone leaves and joins again, the timer just waits. This is because the RESUME_AFTER_INITIALIZATIONS is unset on local, if it is not set then the timer will remain at 120 seconds indefinitely.

## Changelog
:cl:
tweak: Rounds will now only start when at least one person has connected, regardless of whether they are playing or not.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
