### PR TITLE
Raises distro pressure to 1000kpa

### DIFF
--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -4037,6 +4037,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
+/obj/machinery/meter,
 /turf/open/floor/iron/dark/side{
 	dir = 4
 	},
@@ -7824,6 +7825,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
 	dir = 10
 	},
+/obj/machinery/meter,
 /turf/open/floor/iron,
 /area/engine/atmos)
 "bMZ" = (
@@ -26601,7 +26603,7 @@
 /obj/machinery/atmospherics/components/binary/pump/on{
 	dir = 8;
 	name = "Air to Distro";
-	target_pressure = 500
+	target_pressure = 1000
 	},
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer2{
 	dir = 8
@@ -30849,7 +30851,8 @@
 "iNO" = (
 /obj/machinery/atmospherics/components/binary/pump/on{
 	dir = 1;
-	name = "O2 Outlet Pump"
+	name = "O2 Outlet Pump";
+	target_pressure = 4500
 	},
 /turf/open/floor/iron/dark/side,
 /area/engine/atmos)
@@ -44945,7 +44948,8 @@
 "owx" = (
 /obj/machinery/atmospherics/components/binary/pump/on{
 	dir = 1;
-	name = "N2 Outlet Pump"
+	name = "N2 Outlet Pump";
+	target_pressure = 4500
 	},
 /turf/open/floor/iron/dark/side,
 /area/engine/atmos)
@@ -46584,7 +46588,8 @@
 "pek" = (
 /obj/machinery/atmospherics/components/binary/pump/on{
 	dir = 8;
-	name = "Air to External"
+	name = "Air to External";
+	target_pressure = 200
 	},
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer4{
 	dir = 8
@@ -53444,15 +53449,11 @@
 /turf/open/floor/iron/dark,
 /area/bridge/meeting_room)
 "rIf" = (
-/obj/machinery/atmospherics/components/binary/pump/on{
-	dir = 1;
-	name = "Air Outlet Pump";
-	target_pressure = 500
-	},
 /obj/machinery/camera/directional/south,
 /obj/effect/turf_decal/tile/blue/opposingcorners{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
 /turf/open/floor/catwalk_floor/iron,
 /area/engine/atmos)
 "rIm" = (

--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -26603,7 +26603,7 @@
 /obj/machinery/atmospherics/components/binary/pump/on{
 	dir = 8;
 	name = "Air to Distro";
-	target_pressure = 1000
+	target_pressure = 200
 	},
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer2{
 	dir = 8

--- a/_maps/map_files/CardinalStation/CardinalStation.dmm
+++ b/_maps/map_files/CardinalStation/CardinalStation.dmm
@@ -32976,7 +32976,7 @@
 /obj/machinery/atmospherics/components/binary/pump/on{
 	dir = 1;
 	name = "Air to Distro";
-	target_pressure = 1000
+	target_pressure = 200
 	},
 /obj/structure/window/reinforced/spawner/directional/west,
 /obj/effect/turf_decal/tile/techfloorgrid/diagonal,

--- a/_maps/map_files/CardinalStation/CardinalStation.dmm
+++ b/_maps/map_files/CardinalStation/CardinalStation.dmm
@@ -32976,7 +32976,7 @@
 /obj/machinery/atmospherics/components/binary/pump/on{
 	dir = 1;
 	name = "Air to Distro";
-	target_pressure = 500
+	target_pressure = 1000
 	},
 /obj/structure/window/reinforced/spawner/directional/west,
 /obj/effect/turf_decal/tile/techfloorgrid/diagonal,
@@ -57689,15 +57689,13 @@
 	},
 /obj/machinery/light/cold/directional/north,
 /obj/effect/mapping_helpers/make_non_slip,
-/obj/machinery/atmospherics/components/binary/pump/on{
-	dir = 4;
-	name = "Air Outlet Pump";
-	target_pressure = 500
-	},
 /obj/machinery/atmospherics/pipe/smart/simple/yellow/visible/layer2{
 	dir = 4
 	},
 /obj/structure/platform/warning/corner{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden{
 	dir = 4
 	},
 /turf/open/floor/iron/smooth_edge{
@@ -78797,6 +78795,7 @@
 /obj/structure/platform/warning/corner{
 	dir = 1
 	},
+/obj/machinery/meter,
 /turf/open/floor/catwalk_floor/iron_smooth,
 /area/engine/atmos)
 "pYr" = (
@@ -79155,7 +79154,8 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/components/binary/pump/on{
-	name = "Nitrogen to Air mixing"
+	name = "Nitrogen to Air mixing";
+	target_pressure = 4500
 	},
 /obj/machinery/atmospherics/pipe/smart/simple/green/visible/layer1{
 	dir = 8
@@ -82047,7 +82047,8 @@
 	name = "Oxygen to Pure"
 	},
 /obj/machinery/atmospherics/components/binary/pump/on{
-	name = "Oxygen to Air mixing"
+	name = "Oxygen to Air mixing";
+	target_pressure = 4500
 	},
 /obj/machinery/atmospherics/pipe/smart/simple/green/visible{
 	dir = 4
@@ -92879,9 +92880,6 @@
 /turf/open/floor/iron/dark,
 /area/science/xenobiology)
 "sTE" = (
-/obj/machinery/atmospherics/components/unary/thermomachine/heater{
-	dir = 8
-	},
 /obj/effect/turf_decal/siding/wideplating_new/dark{
 	dir = 4
 	},
@@ -92890,6 +92888,9 @@
 	dir = 4
 	},
 /obj/effect/mapping_helpers/make_non_slip,
+/obj/machinery/atmospherics/components/unary/thermomachine/heater/on{
+	dir = 8
+	},
 /turf/open/floor/iron/ridged/steel,
 /area/engine/atmos)
 "sTG" = (

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -2285,6 +2285,16 @@
 	},
 /turf/open/floor/circuit/green,
 /area/engine/atmospherics_engine)
+"arl" = (
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/meter,
+/turf/open/floor/iron,
+/area/engine/atmos)
 "arp" = (
 /obj/structure/sign/warning/electricshock,
 /turf/closed/wall/r_wall,
@@ -33507,7 +33517,7 @@
 /obj/machinery/atmospherics/components/binary/pump/on{
 	dir = 4;
 	name = "Air to Distro";
-	target_pressure = 500
+	target_pressure = 1000
 	},
 /obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
 /turf/open/floor/iron,
@@ -42268,7 +42278,8 @@
 /obj/machinery/atmospherics/pipe/smart/simple/green/visible,
 /obj/machinery/atmospherics/components/binary/pump/on{
 	dir = 8;
-	name = "O2 to Airmix"
+	name = "O2 to Airmix";
+	target_pressure = 4500
 	},
 /obj/effect/turf_decal/tile/blue/anticorner/contrasted{
 	dir = 4
@@ -48487,6 +48498,12 @@
 	},
 /turf/open/floor/iron,
 /area/storage/primary)
+"jPk" = (
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
+/obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
+/obj/machinery/meter,
+/turf/open/floor/iron,
+/area/engine/atmos)
 "jPm" = (
 /obj/item/kirbyplants{
 	icon_state = "plant-21"
@@ -58006,7 +58023,8 @@
 /obj/machinery/atmospherics/pipe/smart/simple/green/visible,
 /obj/machinery/atmospherics/components/binary/pump/on{
 	dir = 8;
-	name = "N2 to Airmix"
+	name = "N2 to Airmix";
+	target_pressure = 4500
 	},
 /obj/effect/turf_decal/tile/red/anticorner/contrasted{
 	dir = 4
@@ -121094,7 +121112,7 @@ aRv
 cfI
 biO
 xtg
-sVr
+jPk
 kuO
 sVr
 sVr
@@ -121347,7 +121365,7 @@ tlz
 aRF
 xZR
 tCp
-aRv
+arl
 aTd
 aUW
 aWO

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -33517,7 +33517,7 @@
 /obj/machinery/atmospherics/components/binary/pump/on{
 	dir = 4;
 	name = "Air to Distro";
-	target_pressure = 1000
+	target_pressure = 200
 	},
 /obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
 /turf/open/floor/iron,

--- a/_maps/map_files/FlandStation/FlandStation.dmm
+++ b/_maps/map_files/FlandStation/FlandStation.dmm
@@ -4442,7 +4442,8 @@
 	},
 /obj/machinery/atmospherics/components/binary/pump/on{
 	dir = 1;
-	name = "O2 to Airmix"
+	name = "O2 to Airmix";
+	target_pressure = 4500
 	},
 /obj/machinery/atmospherics/pipe/smart/simple/green/visible/layer1{
 	dir = 8
@@ -26158,7 +26159,7 @@
 /obj/machinery/atmospherics/components/binary/pump/on{
 	dir = 4;
 	name = "Air to Distro";
-	target_pressure = 500
+	target_pressure = 1000
 	},
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -66969,7 +66970,8 @@
 "rjX" = (
 /obj/machinery/atmospherics/components/binary/pump/on{
 	dir = 4;
-	name = "N2 to Airmix"
+	name = "N2 to Airmix";
+	target_pressure = 4500
 	},
 /turf/open/floor/iron,
 /area/engine/atmos)

--- a/_maps/map_files/FlandStation/FlandStation.dmm
+++ b/_maps/map_files/FlandStation/FlandStation.dmm
@@ -26159,7 +26159,7 @@
 /obj/machinery/atmospherics/components/binary/pump/on{
 	dir = 4;
 	name = "Air to Distro";
-	target_pressure = 1000
+	target_pressure = 200
 	},
 /obj/structure/cable/yellow{
 	icon_state = "4-8"

--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -10755,7 +10755,8 @@
 /obj/machinery/atmospherics/pipe/smart/simple/green/visible,
 /obj/machinery/atmospherics/components/binary/pump/on{
 	dir = 4;
-	name = "O2 to Airmix"
+	name = "O2 to Airmix";
+	target_pressure = 4500
 	},
 /obj/effect/turf_decal/tile/blue/fourcorners/contrasted,
 /obj/effect/turf_decal/tile/neutral/opposingcorners,
@@ -26254,7 +26255,8 @@
 "gFB" = (
 /obj/machinery/atmospherics/components/binary/pump/on{
 	dir = 1;
-	name = "Air to Distro"
+	name = "Air to Distro";
+	target_pressure = 1000
 	},
 /obj/structure/sign/warning/fire{
 	pixel_x = 32
@@ -58772,7 +58774,8 @@
 /obj/machinery/atmospherics/pipe/smart/simple/green/visible,
 /obj/machinery/atmospherics/components/binary/pump/on{
 	dir = 4;
-	name = "Nitrogen Outlet"
+	name = "Nitrogen Outlet";
+	target_pressure = 4500
 	},
 /obj/effect/turf_decal/tile/red/fourcorners/contrasted,
 /obj/effect/turf_decal/tile/neutral/opposingcorners,

--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -26256,7 +26256,7 @@
 /obj/machinery/atmospherics/components/binary/pump/on{
 	dir = 1;
 	name = "Air to Distro";
-	target_pressure = 1000
+	target_pressure = 200
 	},
 /obj/structure/sign/warning/fire{
 	pixel_x = 32

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -4017,6 +4017,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
 	dir = 10
 	},
+/obj/machinery/meter,
 /turf/open/floor/iron,
 /area/engine/atmos)
 "aLr" = (
@@ -30415,6 +30416,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
 	dir = 10
 	},
+/obj/machinery/meter,
 /turf/open/floor/iron,
 /area/engine/atmos)
 "hjB" = (
@@ -68037,7 +68039,7 @@
 /obj/machinery/atmospherics/components/binary/pump/on{
 	dir = 8;
 	name = "Air to Distro";
-	target_pressure = 200
+	target_pressure = 1000
 	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -14520,7 +14520,8 @@
 "cui" = (
 /obj/machinery/atmospherics/components/binary/pump/on{
 	dir = 1;
-	name = "O2 to Airmix"
+	name = "O2 to Airmix";
+	target_pressure = 4500
 	},
 /turf/open/floor/iron/dark,
 /area/engine/atmos)
@@ -47658,11 +47659,6 @@
 "nbv" = (
 /turf/open/floor/plating,
 /area/maintenance/starboard/secondary)
-"nbx" = (
-/obj/effect/spawner/lootdrop/maintenance/three,
-/obj/structure/reagent_dispensers/watertank,
-/turf/open/floor/plating,
-/area/maintenance/starboard)
 "nbF" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer4{
 	dir = 1
@@ -64672,7 +64668,8 @@
 /obj/machinery/light_switch/directional/north,
 /obj/machinery/atmospherics/components/binary/pump/on{
 	dir = 8;
-	name = "Air to External Air Ports"
+	name = "Air to External Air Ports";
+	target_pressure = 200
 	},
 /turf/open/floor/iron,
 /area/engine/atmos)
@@ -68039,7 +68036,8 @@
 "tTa" = (
 /obj/machinery/atmospherics/components/binary/pump/on{
 	dir = 8;
-	name = "Air to Distro"
+	name = "Air to Distro";
+	target_pressure = 200
 	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
@@ -72674,7 +72672,8 @@
 "vvW" = (
 /obj/machinery/atmospherics/components/binary/pump/on{
 	dir = 1;
-	name = "Nitrogen Outlet"
+	name = "Nitrogen Outlet";
+	target_pressure = 4500
 	},
 /turf/open/floor/iron/dark,
 /area/engine/atmos)
@@ -79128,6 +79127,8 @@
 /obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
 	dir = 6
 	},
+/obj/structure/reagent_dispensers/watertank,
+/obj/effect/spawner/lootdrop/maintenance/three,
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "xzx" = (
@@ -120738,7 +120739,7 @@ alq
 bwi
 xGX
 odA
-cfg
+apc
 atm
 xWi
 vxJ
@@ -120995,7 +120996,7 @@ alq
 cfg
 qqZ
 apc
-nbx
+apc
 atm
 hME
 xeD

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -68039,7 +68039,7 @@
 /obj/machinery/atmospherics/components/binary/pump/on{
 	dir = 8;
 	name = "Air to Distro";
-	target_pressure = 1000
+	target_pressure = 200
 	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4

--- a/_maps/map_files/RadStation/RadStation.dmm
+++ b/_maps/map_files/RadStation/RadStation.dmm
@@ -65518,7 +65518,7 @@
 /obj/machinery/atmospherics/components/binary/pump/on{
 	dir = 4;
 	name = "Air to Distro";
-	target_pressure = 1000
+	target_pressure = 200
 	},
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/iron/tech,

--- a/_maps/map_files/RadStation/RadStation.dmm
+++ b/_maps/map_files/RadStation/RadStation.dmm
@@ -65518,7 +65518,7 @@
 /obj/machinery/atmospherics/components/binary/pump/on{
 	dir = 4;
 	name = "Air to Distro";
-	target_pressure = 500
+	target_pressure = 1000
 	},
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/iron/tech,


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Increase air > distro atmos pump to target 1000kpa

Increase tank > airmixer pumps to 4500kpa

Remove airtank > distro outlet pump because we only had that on some maps and it's better to just use the computer to do this one.

Computer will keep the outlet at 2000kpa by default. That wasn't changed.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Some of our default distro setups kept distro at atmospheric pressure, which runs out after a few breaches. This would cause the station to gradually lose pressurization as soon as distro was "saturated"

This will help fix it, or at  least delay it. If this does not work, we are going to have to add more pumps. I dislike that thought, so I will do this first, and hope it just does it well enough.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

<img width="619" height="562" alt="image" src="https://github.com/user-attachments/assets/e3ff59f8-a967-40c2-9c22-6f2f48534d77" />

<img width="400" height="291" alt="image" src="https://github.com/user-attachments/assets/3a5327fd-c53c-4474-b3c5-3ef2ac433c94" />

</details>

## Changelog
:cl:
tweak: raised default distro pressure to 1000kpa
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
