### PR TITLE
Fixes job PDAs using significant amounts of power

### DIFF
--- a/code/modules/modular_computers/computers/item/computer.dm
+++ b/code/modules/modular_computers/computers/item/computer.dm
@@ -650,7 +650,7 @@ GLOBAL_LIST_EMPTY(TabletMessengers) // a list of all active messengers, similar 
   * It is separated from ui_act() to be overwritten as needed.
 */
 /obj/item/modular_computer/proc/toggle_flashlight()
-	if(!has_light && use_power(10 WATT))
+	if(!has_light || !use_power(10 WATT))
 		return FALSE
 	using_flashlight = !using_flashlight
 	set_light_on(using_flashlight)

--- a/code/modules/modular_computers/hardware/portable_disks/job_disk.dm
+++ b/code/modules/modular_computers/hardware/portable_disks/job_disk.dm
@@ -10,6 +10,7 @@
 	default_installs = FALSE
 	custom_price = 100
 	max_demand = 20
+	power_usage = 0
 	var/list/progs_to_store = list()
 	/// Job disk will ignore programs to instal if this is TRUE
 	var/dont_instal = FALSE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

In #13327 I failed to consider that job disks are subtypes of hard drives, and as such they have an insanely high power usage. Having a job disk results in your PDA running out of power in 10-15 minutes rather than 50-60 minutes.

I have set the power usage of job disks to 0, as they are just disks. All PDAs require a normal hard drive anyway to function and the job disk doesn't count as a functional drive by itself.

I also fixed a logic error that let you use the flashlight at 0% power.

## Why It's Good For The Game

Picking a job shouldn't result in your PDA running out 4x quicker.

## Testing Photographs and Procedure

https://github.com/user-attachments/assets/9fcaaa93-d04d-4830-9efd-fca089b449ac

With a 60x multiplier to power usage

## Changelog
:cl:
fix: Fixes job data disks using large amounts of PDA power.
fix: PDA flashlight no longer works at 0% power.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
