### PR TITLE
Fix storage implants putting contents into people

### DIFF
--- a/code/game/objects/items/implants/implant_storage.dm
+++ b/code/game/objects/items/implants/implant_storage.dm
@@ -19,7 +19,7 @@
 
 		for (var/obj/item/I in resolve_parent.contents)
 			I.add_mob_blood(implantee)
-		atom_storage.remove_all(implantee)
+		atom_storage.remove_all()
 		implantee.visible_message(span_warning("A bluespace pocket opens around [src] as it exits [implantee], spewing out its contents and rupturing the surrounding tissue!"))
 		implantee.apply_damage(20, BRUTE, BODY_ZONE_CHEST)
 		qdel(atom_storage)


### PR DESCRIPTION
## About The Pull Request

Changes where the contents of the storage implant are put into, so we drop them on the floor and not into people.
Fixes #13495 

## Why It's Good For The Game

Fixes a bug.

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

https://github.com/user-attachments/assets/f3aa3dac-1258-4f0b-ae2e-9531e45ea87e

</details>

## Changelog
:cl:
fix: Storage implants drop their contents on the floor again when they are removed
/:cl: