### PR TITLE
Revert "Fixes Health Analyzers runtiming"

### DIFF
--- a/code/datums/diseases/advance/symptoms/heal.dm
+++ b/code/datums/diseases/advance/symptoms/heal.dm
@@ -602,7 +602,7 @@ im not even gonna bother with these for the following symptoms. typed em out, co
 	bodies = list("Blood")
 	var/bloodpoints = 0
 	var/maxbloodpoints = 50
-	var/datum/blood_type/bloodtypearchive
+	var/bloodtypearchive
 	var/bruteheal = FALSE
 	var/aggression = FALSE
 	var/vampire = FALSE
@@ -640,7 +640,7 @@ im not even gonna bother with these for the following symptoms. typed em out, co
 	if(ishuman(A.affected_mob) && A.affected_mob.get_blood_id() == /datum/reagent/blood)
 		var/mob/living/carbon/human/H = A.affected_mob
 		bloodtypearchive = H.dna.blood_type
-		H.dna.blood_type = /datum/blood_type/universal
+		H.dna.blood_type = "U"
 
 /datum/symptom/vampirism/Activate(datum/disease/advance/A)
 	if(!..())


### PR DESCRIPTION
Reverts BeeStation/BeeStation-Hornet#13499

This PR is not correct, the correct code is `blood_type = get_blood_type(/datum/blood/whatever)`