### PR TITLE
Consume all dynamic points on midround spawn

### DIFF
--- a/code/controllers/subsystem/dynamic/dynamic.dm
+++ b/code/controllers/subsystem/dynamic/dynamic.dm
@@ -607,7 +607,7 @@ SUBSYSTEM_DEF(dynamic)
 			// If we successfully execute the midround, apply the cost and log it
 			if(result == DYNAMIC_EXECUTE_SUCCESS)
 				midround_executed_rulesets += new_midround_ruleset
-				midround_points -= new_midround_ruleset.points_cost
+				midround_points = 0
 				logged_points["logged_points"] += midround_points
 			else
 				COOLDOWN_START(src, midround_ruleset_cooldown, midround_failure_stallout)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

fixes #13494

- Dynamic sets midrounds points to 0 upon spawning a midround ruleset.

## Why It's Good For The Game

We have encountered situations where, through not spawning a midround for any reason, dynamic has saved a massive amount of points (100-150) which it then releases all at once when it becomes able to spawn midrounds that people are choosing. This releases a sudden wave of high intensity antagonists all at once.

## Testing Photographs and Procedure

<img width="685" height="269" alt="image" src="https://github.com/user-attachments/assets/f0b50918-482a-4533-80b4-af55836e2045" />

Upon spawning space pirates all 150 points were consumed, instead of just 50.

## Changelog
:cl:
tweak: Dynamic now has its midround points set to 0 when it spawns an antagonist, even if it had spare points left over.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
