### PR TITLE
Fixes platforms created via build-mode

### DIFF
--- a/code/game/objects/structures/platforms.dm
+++ b/code/game/objects/structures/platforms.dm
@@ -121,6 +121,7 @@
 
 /obj/structure/platform/update_icon_state()
 	. = ..()
+	layer = initial(layer)
 	if(!climbable) //janky way of distinguishing corners from everything else
 		if(dir == WEST || dir == SOUTH)
 			layer = ABOVE_MOB_LAYER

--- a/code/game/objects/structures/platforms.dm
+++ b/code/game/objects/structures/platforms.dm
@@ -103,11 +103,6 @@
 
 /obj/structure/platform/Initialize(mapload)
 	. = ..()
-	if(!blocking_dir)
-		if(reverse)
-			blocking_dir = (NORTH | SOUTH | EAST | WEST) - REVERSE_DIR(dir)
-		else
-			blocking_dir = dir
 	if(climbable)
 		AddElement(/datum/element/climbable)
 
@@ -116,33 +111,42 @@
 			COMSIG_ATOM_EXIT = PROC_REF(on_exit),
 		)
 		AddElement(/datum/element/connect_loc, loc_connections)
-
-	if(!climbable) //janky way of distinguishing corners from everything else
-		if(dir == WEST || dir == SOUTH)
-			layer = ABOVE_MOB_LAYER
-	else
-		var/mutable_appearance/overlay = mutable_appearance(initial(icon), icon_state, ABOVE_MOB_LAYER)
-		switch(blocking_dir) //depending on the direction, either sets the layer of the whole object to above the mob or adds a partial overlay so some parts may still be blow the mob
-			if(SOUTH)
-				layer = ABOVE_MOB_LAYER
-			if(EAST,NORTHEAST)
-				overlay.filters += filter(type="alpha",icon=icon(icon, "platform_gray", dir = EAST))
-			if(WEST,NORTHWEST)
-				overlay.filters += filter(type="alpha",icon=icon(icon, "platform_gray", dir = WEST))
-			if(SOUTHEAST, NORTH|SOUTH|EAST)
-				overlay.filters += filter(type="alpha",icon=icon(icon, "platform_gray", dir = SOUTHEAST))
-			if(SOUTHWEST, NORTH|SOUTH|WEST)
-				overlay.filters += filter(type="alpha",icon=icon(icon, "platform_gray", dir = SOUTHWEST))
-			if(SOUTH|WEST|EAST, NORTH|WEST|EAST)
-				overlay.filters += filter(type="alpha",icon=icon(icon, "platform_gray_end", dir = SOUTH))
-		if(overlay.filters.len)
-			add_overlay(overlay)
+	compute_blocking_directions()
 
 /obj/structure/platform/CanPass(atom/movable/mover, border_dir)
 	. = ..()
 	if(border_dir & blocking_dir)
 		return . || mover.throwing || mover.movement_type & MOVETYPES_NOT_TOUCHING_GROUND
 	return TRUE
+
+/obj/structure/platform/update_icon_state()
+	. = ..()
+	if(!climbable) //janky way of distinguishing corners from everything else
+		if(dir == WEST || dir == SOUTH)
+			layer = ABOVE_MOB_LAYER
+	else
+		switch(blocking_dir) //depending on the direction, either sets the layer of the whole object to above the mob or adds a partial overlay so some parts may still be blow the mob
+			if(SOUTH)
+				layer = ABOVE_MOB_LAYER
+
+/obj/structure/platform/update_overlays()
+	. = ..()
+	if (!climbable)
+		return
+	var/mutable_appearance/overlay = mutable_appearance(initial(icon), icon_state, ABOVE_MOB_LAYER)
+	switch(blocking_dir) //depending on the direction, either sets the layer of the whole object to above the mob or adds a partial overlay so some parts may still be blow the mob
+		if(EAST,NORTHEAST)
+			overlay.filters += filter(type="alpha",icon=icon(icon, "platform_gray", dir = EAST))
+		if(WEST,NORTHWEST)
+			overlay.filters += filter(type="alpha",icon=icon(icon, "platform_gray", dir = WEST))
+		if(SOUTHEAST, NORTH|SOUTH|EAST)
+			overlay.filters += filter(type="alpha",icon=icon(icon, "platform_gray", dir = SOUTHEAST))
+		if(SOUTHWEST, NORTH|SOUTH|WEST)
+			overlay.filters += filter(type="alpha",icon=icon(icon, "platform_gray", dir = SOUTHWEST))
+		if(SOUTH|WEST|EAST, NORTH|WEST|EAST)
+			overlay.filters += filter(type="alpha",icon=icon(icon, "platform_gray_end", dir = SOUTH))
+	if(overlay.filters.len)
+		. += overlay
 
 /obj/structure/platform/proc/on_exit(datum/source, atom/movable/leaving, direction)
 	SIGNAL_HANDLER
@@ -167,3 +171,15 @@
 
 	leaving.Bump(src)
 	return COMPONENT_ATOM_BLOCK_EXIT
+
+/obj/structure/platform/proc/compute_blocking_directions()
+	if(reverse)
+		blocking_dir = (NORTH | SOUTH | EAST | WEST) - REVERSE_DIR(dir)
+	else
+		blocking_dir = dir
+
+	update_appearance(UPDATE_ICON)
+
+/obj/structure/platform/setDir(ndir)
+	. = ..()
+	compute_blocking_directions()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes platforms having an incorrect blocking direction when their direction is changed post initialization, such as when created via build mode.

## Why It's Good For The Game

I know platforms aren't craftable yet, but they could be and this issue is annoying when you want to create custom maps.

Closes #13483 (Testing evidence provided, cannot be reproduced)

## Testing Photographs and Procedure

https://github.com/user-attachments/assets/32bdde55-ec33-4ebb-be3c-2af9c3ad09ff

https://github.com/user-attachments/assets/0c1c9808-34e8-4eb8-9e99-8267f8001673


## Changelog
:cl:
fix: Platforms will now correctly update their blocking directions when they change their facing direction.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
