### PR TITLE
Antag info can be used while unconscious or dead.

### DIFF
--- a/code/modules/antagonists/_common/antag_datum.dm
+++ b/code/modules/antagonists/_common/antag_datum.dm
@@ -253,8 +253,6 @@ GLOBAL_LIST(admin_antag_list)
 	return ..()
 
 /datum/antagonist/ui_state(mob/user)
-	if(owner?.current)
-		return GLOB.self_state
 	return GLOB.always_state
 
 ///generic helper to send objectives as data through tgui.


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

The antag help page can be used while unconscious or dead.

## Why It's Good For The Game

This is particularly important for vampires, who have a 60 second period of sleeping which they can use to read up on their powers.

## Testing Photographs and Procedure

<img width="1084" height="894" alt="image" src="https://github.com/user-attachments/assets/3566cfb3-1035-4ffe-b94a-37c57381dccc" />


## Changelog
:cl:
tweak: You can now read your antag information while sleeping, unconscious, or dead.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
