### PR TITLE
Rebalances and cleans up tribal claw.

### DIFF
--- a/_maps/_basemap.dm
+++ b/_maps/_basemap.dm
@@ -1,5 +1,5 @@
-// #define LOWMEMORYMODE //uncomment this to load centcom and runtime station and thats it.
-// #define QUICKSTART // uncomment this to start the round immidiately when ready and automatically spawn players with debug outfit
+#define LOWMEMORYMODE //uncomment this to load centcom and runtime station and thats it.
+#define QUICKSTART // uncomment this to start the round immidiately when ready and automatically spawn players with debug outfit
 
 // uncomment this for a map you need to use
 // #define FORCE_MAP "corgstation"

--- a/_maps/_basemap.dm
+++ b/_maps/_basemap.dm
@@ -1,5 +1,5 @@
-#define LOWMEMORYMODE //uncomment this to load centcom and runtime station and thats it.
-#define QUICKSTART // uncomment this to start the round immidiately when ready and automatically spawn players with debug outfit
+// #define LOWMEMORYMODE //uncomment this to load centcom and runtime station and thats it.
+// #define QUICKSTART // uncomment this to start the round immidiately when ready and automatically spawn players with debug outfit
 
 // uncomment this for a map you need to use
 // #define FORCE_MAP "corgstation"

--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -27,7 +27,7 @@
 #define BLEED_TINY 0.1
 #define BLEED_SCRATCH 0.8
 #define BLEED_SURFACE 1.5			// 560 > 506 blood in 75 seconds
-#define BLEED_CUT 2.3				// 560 > 442 blood ni 115 seconds
+#define BLEED_CUT 2.3				// 560 > 442 blood in 115 seconds
 #define BLEED_DEEP_WOUND 2.4		// Crit in 285 seconds, Death in 356 seconds
 #define BLEED_CRITICAL 3.6			// Crit in 190 seconds, Death in 238 seconds
 

--- a/code/datums/martial/tribal_claw.dm
+++ b/code/datums/martial/tribal_claw.dm
@@ -8,6 +8,7 @@
 	id = MARTIALART_TRIBALCLAW
 	allow_temp_override = FALSE
 	display_combos = TRUE
+	COOLDOWN_DECLARE(jugular_cut_cd)
 
 	Move1 = "Tail Sweep: Disarm Disarm Grab Harm. Requires a lizard tail. Pushes everyone around you away and knocks them down."
 	Move2 = "Face Scratch: Harm Disarm. Damages your target's head and confuses them for a short time."
@@ -63,6 +64,9 @@ Deals 15 brute to head(reduced by armor) and causes a rapid bleeding effect simi
 /datum/martial_art/tribal_claw/proc/jugularCut(mob/living/A, mob/living/D)
 	var/def_check = D.getarmor(BODY_ZONE_HEAD, MELEE)
 	if(D.body_position == LYING_DOWN || (A.pulling == D && A.grab_state >= GRAB_AGGRESSIVE) || D.confused)
+		if(!COOLDOWN_FINISHED(src, jugular_cut_cd))	// No ultra DPS with gloves of the north star
+			return
+		COOLDOWN_START(src, jugular_cut_cd, CLICK_CD_MELEE)
 		log_combat(A, D, "jugular cut (Tribal Claw)", name)
 		D.visible_message(span_warning("[A] cuts [D]'s jugular vein with their claws!"), \
 							span_userdanger("[A] cuts your jugular vein!"))

--- a/code/datums/martial/tribal_claw.dm
+++ b/code/datums/martial/tribal_claw.dm
@@ -62,7 +62,7 @@ Deals 15 brute to head(reduced by armor) and causes a rapid bleeding effect simi
 */
 /datum/martial_art/tribal_claw/proc/jugularCut(mob/living/A, mob/living/D)
 	var/def_check = D.getarmor(BODY_ZONE_HEAD, MELEE)
-	if((D.body_position == LYING_DOWN || (A.pulling == D && A.grab_state >= GRAB_AGGRESSIVE) || D.confused))
+	if(D.body_position == LYING_DOWN || (A.pulling == D && A.grab_state >= GRAB_AGGRESSIVE) || D.confused)
 		log_combat(A, D, "jugular cut (Tribal Claw)", name)
 		D.visible_message(span_warning("[A] cuts [D]'s jugular vein with their claws!"), \
 							span_userdanger("[A] cuts your jugular vein!"))

--- a/code/datums/martial/tribal_claw.dm
+++ b/code/datums/martial/tribal_claw.dm
@@ -33,7 +33,7 @@
 /datum/martial_art/tribal_claw/proc/tailSweep(mob/living/A, mob/living/D)
 	var/mob/living/carbon/L = A
 	if(!istype(L.get_organ_slot(ORGAN_SLOT_TAIL), /obj/item/organ/tail/lizard))
-		A.visible_message(span_warningbig("You lack the tail of a lizard."))
+		L.visible_message(span_warningbig("You lack the tail of a lizard."))
 		return
 	if(A == D) //Don't allow storing moves on yourself to cast on command
 		return
@@ -78,7 +78,7 @@ Deals 15 brute to head(reduced by armor) and causes a rapid bleeding effect simi
 /datum/martial_art/tribal_claw/proc/tailGrab(mob/living/A, mob/living/D)
 	var/mob/living/carbon/L = A
 	if(!istype(L.get_organ_slot(ORGAN_SLOT_TAIL), /obj/item/organ/tail/lizard))
-		A.visible_message(span_warningbig("You lack the tail of a lizard."))
+		L.visible_message(span_warningbig("You lack the tail of a lizard."))
 		return
 	if(A == D) //Don't grab yourself
 		return

--- a/code/datums/martial/tribal_claw.dm
+++ b/code/datums/martial/tribal_claw.dm
@@ -32,10 +32,11 @@
 
 //Tail Sweep, triggers an effect similar to Alien Queen's tail sweep but only affects stuff 1 tile next to you, basically 3x3.
 /datum/martial_art/tribal_claw/proc/tailSweep(mob/living/A, mob/living/D)
-	var/mob/living/carbon/L = A
-	if(!istype(L.get_organ_slot(ORGAN_SLOT_TAIL), /obj/item/organ/tail/lizard))
-		L.visible_message(span_warningbig("You lack the tail of a lizard."))
-		return
+	if(iscarbon(A))
+		var/mob/living/carbon/L = A
+		if(!istype(L.get_organ_slot(ORGAN_SLOT_TAIL), /obj/item/organ/tail/lizard))
+			L.visible_message(span_warningbig("You lack the tail of a lizard."))
+			return
 	if(A == D) //Don't allow storing moves on yourself to cast on command
 		return
 	log_combat(A, D, "tail sweeped(Tribal Claw)", name)
@@ -80,10 +81,11 @@ Deals 15 brute to head(reduced by armor) and causes a rapid bleeding effect simi
 
 //Tail Grab, instantly puts your target in a T3 grab and makes them unable to talk for a short time.
 /datum/martial_art/tribal_claw/proc/tailGrab(mob/living/A, mob/living/D)
-	var/mob/living/carbon/L = A
-	if(!istype(L.get_organ_slot(ORGAN_SLOT_TAIL), /obj/item/organ/tail/lizard))
-		L.visible_message(span_warningbig("You lack the tail of a lizard."))
-		return
+	if(iscarbon(A))
+		var/mob/living/carbon/L = A
+		if(!istype(L.get_organ_slot(ORGAN_SLOT_TAIL), /obj/item/organ/tail/lizard))
+			L.visible_message(span_warningbig("You lack the tail of a lizard."))
+			return
 	if(A == D) //Don't grab yourself
 		return
 	log_combat(A, D, "tail grabbed (Tribal Claw)", name)

--- a/code/datums/martial/tribal_claw.dm
+++ b/code/datums/martial/tribal_claw.dm
@@ -66,7 +66,7 @@ Deals 15 brute to head(reduced by armor) and causes a rapid bleeding effect simi
 	if(D.body_position == LYING_DOWN || (A.pulling == D && A.grab_state >= GRAB_AGGRESSIVE) || D.confused)
 		if(!COOLDOWN_FINISHED(src, jugular_cut_cd))	// No ultra DPS with gloves of the north star
 			return
-		COOLDOWN_START(src, jugular_cut_cd, CLICK_CD_MELEE)
+		COOLDOWN_START(src, jugular_cut_cd, CLICK_CD_MELEE * 2)
 		log_combat(A, D, "jugular cut (Tribal Claw)", name)
 		D.visible_message(span_warning("[A] cuts [D]'s jugular vein with their claws!"), \
 							span_userdanger("[A] cuts your jugular vein!"))

--- a/code/datums/martial/tribal_claw.dm
+++ b/code/datums/martial/tribal_claw.dm
@@ -54,7 +54,7 @@
 	D.confused += 8
 	D.blur_eyes(5)
 	A.do_attack_animation(D, ATTACK_EFFECT_CLAW)
-	playsound(get_turf(D), 'sound/weapons/slash.ogg', 50, 1, -1)
+	playsound(get_turf(D), 'sound/weapons/slash.ogg', 100, TRUE, -1)
 
 /*
 Jugular Cut, can only be done if the target is confused, lying down, or in aggresive grab or higher.
@@ -72,7 +72,7 @@ Deals 15 brute to head(reduced by armor) and causes a rapid bleeding effect simi
 			carbon_defender.add_bleeding(BLEED_CRITICAL)
 		D.apply_status_effect(/datum/status_effect/neck_slice)
 		A.do_attack_animation(D, ATTACK_EFFECT_CLAW)
-		playsound(get_turf(D), 'sound/weapons/slash.ogg', 50, 1, -1)
+		playsound(get_turf(D), 'sound/weapons/slash.ogg', 100, TRUE, -1)
 
 //Tail Grab, instantly puts your target in a T3 grab and makes them unable to talk for a short time.
 /datum/martial_art/tribal_claw/proc/tailGrab(mob/living/A, mob/living/D)
@@ -92,6 +92,7 @@ Deals 15 brute to head(reduced by armor) and causes a rapid bleeding effect simi
 		var/mob/living/carbon/carbon_defender = D
 		if(carbon_defender.silent <= 10)
 			carbon_defender.silent = clamp(carbon_defender.silent + 10, 0, 10)
+	playsound(get_turf(D), 'sound/effects/woodhit.ogg', 100, TRUE, -1)
 
 /datum/martial_art/tribal_claw/harm_act(mob/living/A, mob/living/D)
 	add_to_streak("H",D)

--- a/code/datums/martial/tribal_claw.dm
+++ b/code/datums/martial/tribal_claw.dm
@@ -1,7 +1,7 @@
 #define TAIL_SWEEP_COMBO "DDGH"
 #define FACE_SCRATCH_COMBO "HD"
-#define JUGULAR_CUT_COMBO "HHG"
-#define TAIL_GRAB_COMBO "DHGG"
+#define JUGULAR_CUT_COMBO "HH"
+#define TAIL_GRAB_COMBO "DHGH"
 
 /datum/martial_art/tribal_claw
 	name = "Tribal Claw"
@@ -31,12 +31,13 @@
 
 //Tail Sweep, triggers an effect similar to Alien Queen's tail sweep but only affects stuff 1 tile next to you, basically 3x3.
 /datum/martial_art/tribal_claw/proc/tailSweep(mob/living/A, mob/living/D)
-	if(A == current_target)
+	if(A == D) //Don't allow storing moves on yourself to cast on command
 		return
 	log_combat(A, D, "tail sweeped(Tribal Claw)", name)
 	D.visible_message(span_warning("[A] sweeps [D]'s legs with their tail!"), \
 					span_userdanger("[A] sweeps your legs with their tail!"))
 	var/datum/action/spell/aoe/repulse/xeno/R = new
+	R.aoe_radius = 1
 	R.on_cast(A, null)
 
 //Face Scratch, deals 10 brute to head(reduced by armor), blurs the target's vision and gives them the confused effect for a short time.
@@ -57,14 +58,14 @@ Deals 15 brute to head(reduced by armor) and causes a rapid bleeding effect simi
 */
 /datum/martial_art/tribal_claw/proc/jugularCut(mob/living/A, mob/living/D)
 	var/def_check = D.getarmor(BODY_ZONE_HEAD, MELEE)
-	if((D.health <= D.crit_threshold || (A.pulling == D && A.grab_state >= GRAB_NECK) || D.IsSleeping()))
+	if((D.health <= D.crit_threshold || (A.pulling == D && A.grab_state >= GRAB_NECK) || D.IsSleeping()))//remove this i guess
 		log_combat(A, D, "jugular cut (Tribal Claw)", name)
 		D.visible_message(span_warning("[A] cuts [D]'s jugular vein with their claws!"), \
 							span_userdanger("[A] cuts your jugular vein!"))
 		D.apply_damage(15, BRUTE, BODY_ZONE_HEAD, def_check)
 		if(iscarbon(D))
 			var/mob/living/carbon/carbon_defender = D
-			carbon_defender.add_bleeding(BLEED_SURFACE)
+			carbon_defender.add_bleeding(BLEED_CRITICAL)
 		D.apply_status_effect(/datum/status_effect/neck_slice)
 		A.do_attack_animation(D, ATTACK_EFFECT_CLAW)
 		playsound(get_turf(D), 'sound/weapons/slash.ogg', 50, 1, -1)
@@ -73,6 +74,8 @@ Deals 15 brute to head(reduced by armor) and causes a rapid bleeding effect simi
 
 //Tail Grab, instantly puts your target in a T3 grab and makes them unable to talk for a short time.
 /datum/martial_art/tribal_claw/proc/tailGrab(mob/living/A, mob/living/D)
+	if(A == D) //Don't grab yourself
+		return
 	log_combat(A, D, "tail grabbed (Tribal Claw)", name)
 	D.visible_message(span_warning("[A] grabs [D] with their tail!"), \
 						span_userdanger("[A] grabs you with their tail!"))

--- a/code/datums/martial/tribal_claw.dm
+++ b/code/datums/martial/tribal_claw.dm
@@ -9,10 +9,10 @@
 	allow_temp_override = FALSE
 	display_combos = TRUE
 
-	Move1 = "Tail Sweep: Disarm Disarm Grab Harm. Pushes everyone around you away and knocks them down."
+	Move1 = "Tail Sweep: Disarm Disarm Grab Harm. Requires a lizard tail. Pushes everyone around you away and knocks them down."
 	Move2 = "Face Scratch: Harm Disarm. Damages your target's head and confuses them for a short time."
-	Move3 = "Jugular Cut: Harm Harm Grab. Causes your target to rapidly lose blood. Works only if you grab your target by their neck, if they are sleeping, or in critical condition."
-	Move4 = "Tail Grab: Disarm Harm Grab Grab. Grabs your target by their neck and makes them unable to talk for a short time."
+	Move3 = "Jugular Cut: Harm Harm. Causes your target to rapidly lose blood. Works only if you confuse your target, if they're lying down, or if you have them in an aggresive grab or higher."
+	Move4 = "Tail Grab: Disarm Harm Grab Harm. Requires a lizard tail. Grabs your target by their neck and makes them unable to talk for a short time."
 
 /datum/martial_art/tribal_claw/proc/check_streak(mob/living/A, mob/living/D)
 	if(findtext(streak,TAIL_SWEEP_COMBO))
@@ -31,6 +31,10 @@
 
 //Tail Sweep, triggers an effect similar to Alien Queen's tail sweep but only affects stuff 1 tile next to you, basically 3x3.
 /datum/martial_art/tribal_claw/proc/tailSweep(mob/living/A, mob/living/D)
+	var/mob/living/carbon/L = A
+	if(!istype(L.get_organ_slot(ORGAN_SLOT_TAIL), /obj/item/organ/tail/lizard))
+		A.visible_message(span_warningbig("You lack the tail of a lizard."))
+		return
 	if(A == D) //Don't allow storing moves on yourself to cast on command
 		return
 	log_combat(A, D, "tail sweeped(Tribal Claw)", name)
@@ -47,18 +51,18 @@
 	D.visible_message(span_warning("[A] scratches [D]'s face with their claws!"), \
 						span_userdanger("[A] scratches your face with their claws!"))
 	D.apply_damage(10, BRUTE, BODY_ZONE_HEAD, def_check)
-	D.confused += 5
+	D.confused += 8
 	D.blur_eyes(5)
 	A.do_attack_animation(D, ATTACK_EFFECT_CLAW)
 	playsound(get_turf(D), 'sound/weapons/slash.ogg', 50, 1, -1)
 
 /*
-Jugular Cut, can only be done if the target is in crit, being held in a tier 3 grab by the user or if they are sleeping.
+Jugular Cut, can only be done if the target is confused, lying down, or in aggresive grab or higher.
 Deals 15 brute to head(reduced by armor) and causes a rapid bleeding effect similar to throat slicing someone with a sharp item.
 */
 /datum/martial_art/tribal_claw/proc/jugularCut(mob/living/A, mob/living/D)
 	var/def_check = D.getarmor(BODY_ZONE_HEAD, MELEE)
-	if((D.health <= D.crit_threshold || (A.pulling == D && A.grab_state >= GRAB_NECK) || D.IsSleeping()))//remove this i guess
+	if((D.body_position == LYING_DOWN || (A.pulling == D && A.grab_state >= GRAB_AGGRESSIVE) || D.confused))
 		log_combat(A, D, "jugular cut (Tribal Claw)", name)
 		D.visible_message(span_warning("[A] cuts [D]'s jugular vein with their claws!"), \
 							span_userdanger("[A] cuts your jugular vein!"))
@@ -69,11 +73,13 @@ Deals 15 brute to head(reduced by armor) and causes a rapid bleeding effect simi
 		D.apply_status_effect(/datum/status_effect/neck_slice)
 		A.do_attack_animation(D, ATTACK_EFFECT_CLAW)
 		playsound(get_turf(D), 'sound/weapons/slash.ogg', 50, 1, -1)
-	else
-		return FALSE
 
 //Tail Grab, instantly puts your target in a T3 grab and makes them unable to talk for a short time.
 /datum/martial_art/tribal_claw/proc/tailGrab(mob/living/A, mob/living/D)
+	var/mob/living/carbon/L = A
+	if(!istype(L.get_organ_slot(ORGAN_SLOT_TAIL), /obj/item/organ/tail/lizard))
+		A.visible_message(span_warningbig("You lack the tail of a lizard."))
+		return
 	if(A == D) //Don't grab yourself
 		return
 	log_combat(A, D, "tail grabbed (Tribal Claw)", name)

--- a/code/game/objects/items/granters/martial_arts/tribal_claw.dm
+++ b/code/game/objects/items/granters/martial_arts/tribal_claw.dm
@@ -3,14 +3,16 @@
 	name = "mysterious scroll"
 	martial_name = "tribal claw"
 	desc = "A scroll filled with strange markings. It seems to be drawings of some sort of martial art."
-	greet = "<span class='sciradio'>You have learned the ancient martial art of the Sleeping Carp! Your hand-to-hand combat has become much more effective, and you are now able to deflect any projectiles \
-		directed toward you while in Throw Mode. Your body has also hardened itself, granting extra protection against lasting wounds that would otherwise mount during extended combat. \
-		However, you are also unable to use any ranged weaponry. You can learn more about your newfound art by using the Recall Teachings verb in the Sleeping Carp tab.</span>"
+	greet = "<span class='sciradio'>You have learned the ancient martial art of the Tribal Claw! \
+		You are now able to use your tail and claws in a fight much better than before.</span>"
 	icon = 'icons/obj/wizard.dmi'
 	icon_state = "scroll2"
 	worn_icon_state = "scroll"
 	remarks = list(
-		"Something something lizard" //Pretty please helpsies with this
+		"You trace the strange markings, they twist like claw marks rather than letters...",
+		"Your tail is not for balance alone, it binds, breaks, and claims...",
+		"When the foe lunges, meet them claw to face. Blind their sight, twist their balance, leave them lost...",
+		"Only when the prey stills, gasping, bound, or broken may the river be opened. Slice cleanly..."
 	)
 
 /obj/item/book/granter/martial/tribal_claw/on_reading_finished(mob/living/carbon/user)

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -2091,11 +2091,11 @@ GLOBAL_LIST_INIT(illegal_tech_blacklist, typecacheof(list(
 
 /datum/uplink_item/race_restricted/tribal_claw
 	name = "Old Tribal Scroll"
-	desc = "We found this scroll in a abandoned lizard settlement of the Knoises clan. \
+	desc = "Our lavaland presence found this next to some collapsed tendril. \
 			It teaches you how to use your claws and tail to gain an advantage in combat, \
-			don't buy this unless you are a lizard or plan to give it to one as only they can understand the ancient draconic words."
+			don't buy this unless you are a lizard or plan to give it to one as only they can make full use of it."
 	item = /obj/item/book/granter/martial/tribal_claw
-	cost = 6
+	cost = 8
 	surplus = 0
 	restricted_species = list(SPECIES_LIZARD)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Balance:
TC cost: 6 -> 8

Jugular Cut bleed: 1.5 -> 3.6 (Accidentally(?) nerfed into uselessness at some point)
Jugular Cut requirements: Target grab level: Neck -> Aggressive, 
­                                          Allowed on confused targets, 
­                                          Allowed on sleeping and critted targets -> Allowed on all targets lying down

Jugular Cut combo: HHG -> HH

Tail Sweep: AoE radius 2 -> 1 (Accidentally buffed to 2 at some point)

Tail Grab combo: DHGG -> DHGH

Face Scratch: Confuse: 5 -> 8

Tweaks:
The hard lizard requirement that the scroll had was also accidentally removed at some point but I decided to not readd it and instead added a lizard tail requirement to Tail Sweep and Tail Grab(this is still species locked to lizard in the uplink(barring discounts)) because it's more interesting this way.

Changed a bunch of flavor text that I didn't like, along with replacing the sleeping carp placeholder text that was forgotten in there.

Fix:
Fixed the check to not cast tail sweep on yourself for ez stuns, added it to tail grab as well.

Add: 
Sound feedback to tail grab

## Why It's Good For The Game
Makes the martial art less of a pain to use.

Jugular cut has been changed because the bleed level is obviously a joke and the requirements to perform it are significantly more lax due to the fact that prior to this the target pretty much needed to be in the worst possible position for you to even perform it making this ability nothing more than RP, also synergy with face scratch is fun.

The Face Scratch confuse has been buffed since it was first added when confuse was way stronger and currently it's next to useless due to how low the rng is.

Tail sweep was never supposed to have a radius of 2 so it's back to 1.

And the Jugular Cut and Tail Grab combos have been made slightly easier because grab in combos is miserable due to CTRL being grab and character facing at the same time which makes you stop moving(Yes you can just rebind the character facing key but that has nothing to do with this PR).

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>


https://github.com/user-attachments/assets/63406ac7-3540-41ac-9430-0a10fdd9ff78


<summary>Screenshots&Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>

## Changelog
:cl:
add: Tribal Claw tail grab has better sound feedback
tweak: Tribal Claw tail related moves now actually require having a lizard tail
tweak: Tribal Claw flavor text changed
balance: Tribal Claw TC cost changed 6 -> 8
balance: Tribal Claw jugular cut bleed increased 1.5 -> 3.6/s
balance: Tribal Claw jugular cut can now be performed on all targets aggressive grabbed or higher + lying down + those confused instead of neck grabbed + sleeping + crit
balance: Tribal Claw face scratch confused increased 5 -> 8
fix: Tribal Claw tail sweep AoE radius reduced 2 -> 1
fix: Fixed being able to do tail sweep and tail grab on yourself
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
