### PR TITLE
Hovering over clickable UI elements (and some objects) will display the finger cursor thing

### DIFF
--- a/code/__DEFINES/colors.dm
+++ b/code/__DEFINES/colors.dm
@@ -52,6 +52,7 @@
 
 #define COLOR_YELLOW "#FFFF00"
 #define COLOR_VIVID_YELLOW "#FBFF23"
+#define COLOR_GOLD "#FFD700"
 
 #define COLOR_OLIVE            "#808000"
 #define COLOR_VIBRANT_LIME     "#00FF00"

--- a/code/_onclick/hud/action_button.dm
+++ b/code/_onclick/hud/action_button.dm
@@ -4,6 +4,7 @@
 	var/datum/hud/our_hud
 	var/actiontooltipstyle = ""
 	screen_loc = null
+	mouse_over_pointer = MOUSE_HAND_POINTER
 
 	var/button_icon_state
 	var/appearance_cache
@@ -202,6 +203,7 @@
 	icon = 'icons/hud/64x16_actions.dmi'
 	icon_state = "screen_gen_palette"
 	screen_loc = ui_action_palette
+	mouse_over_pointer = MOUSE_HAND_POINTER
 	var/datum/hud/our_hud
 	var/expanded = FALSE
 	/// Id of any currently running timers that set our color matrix
@@ -326,6 +328,7 @@ GLOBAL_LIST_INIT(palette_removed_matrix, list(1.4,0,0,0, 0.7,0.4,0,0, 0.4,0,0.6,
 /atom/movable/screen/palette_scroll
 	icon = 'icons/hud/screen_gen.dmi'
 	screen_loc = ui_palette_scroll
+	mouse_over_pointer = MOUSE_HAND_POINTER
 	/// How should we move the palette's actions?
 	/// Positive scrolls down the list, negative scrolls back
 	var/scroll_direction = 0

--- a/code/_onclick/hud/ai.dm
+++ b/code/_onclick/hud/ai.dm
@@ -1,5 +1,6 @@
 /atom/movable/screen/ai
 	icon = 'icons/hud/screen_ai.dmi'
+	mouse_over_pointer = MOUSE_HAND_POINTER
 
 /atom/movable/screen/ai/Click()
 	if(isobserver(usr) || usr.incapacitated())

--- a/code/_onclick/hud/alert.dm
+++ b/code/_onclick/hud/alert.dm
@@ -113,6 +113,7 @@
 	. = ..()
 	if(clickable_glow)
 		add_filter("clickglow", 2, outline_filter(color = COLOR_GOLD, size = 1))
+		mouse_over_pointer = MOUSE_HAND_POINTER
 
 /atom/movable/screen/alert/MouseEntered(location,control,params)
 	..()

--- a/code/_onclick/hud/alert.dm
+++ b/code/_onclick/hud/alert.dm
@@ -99,6 +99,8 @@
 	name = "Alert"
 	desc = "Something seems to have gone wrong with this alert, so report this bug please"
 	mouse_opacity = MOUSE_OPACITY_ICON
+	/// Do we glow to represent we do stuff when clicked
+	var/clickable_glow = FALSE
 	var/timeout = 0 //If set to a number, this alert will clear itself after that many deciseconds
 	var/severity = 0
 	var/alerttooltipstyle = ""
@@ -106,6 +108,11 @@
 	var/mob/owner //Alert owner
 	/// The thing that this alert is showing
 	var/obj/master
+
+/atom/movable/screen/alert/Initialize(mapload, datum/hud/hud_owner)
+	. = ..()
+	if(clickable_glow)
+		add_filter("clickglow", 2, outline_filter(color = COLOR_GOLD, size = 1))
 
 /atom/movable/screen/alert/MouseEntered(location,control,params)
 	..()
@@ -231,13 +238,14 @@ or something covering your eyes."
 	name = "Mind Control"
 	desc = "Your mind has been hijacked! Click to view the mind control command."
 	icon_state = "mind_control"
+	clickable_glow = TRUE
 	var/command
 
 /atom/movable/screen/alert/mind_control/Click()
 	var/mob/living/L = usr
 	if(L != owner)
 		return
-	to_chat(L, "[span_mindcontrol("[command]")]")
+	to_chat(L, span_mindcontrol("[command]"))
 
 /atom/movable/screen/alert/drunk
 	name = "Drunk"
@@ -247,8 +255,9 @@ or something covering your eyes."
 /atom/movable/screen/alert/embeddedobject
 	name = "Embedded Object"
 	desc = "Something got lodged into your flesh and is causing major bleeding. It might fall out with time, but surgery is the safest way. \
-If you're feeling frisky, examine yourself and click the underlined item to pull the object out."
+		If you're feeling frisky, examine yourself and click the underlined item to pull the object out."
 	icon_state = "embeddedobject"
+	clickable_glow = TRUE
 
 /atom/movable/screen/alert/embeddedobject/Click()
 	if(isliving(usr) && usr == owner)
@@ -282,6 +291,7 @@ or shoot a gun to move around via Newton's 3rd Law of Motion."
 	name = "On Fire"
 	desc = "You're on fire. Stop, drop and roll to put the fire out or move to a vacuum area."
 	icon_state = "fire"
+	clickable_glow = TRUE
 
 /atom/movable/screen/alert/fire/Click()
 	var/mob/living/L = usr
@@ -294,6 +304,7 @@ or shoot a gun to move around via Newton's 3rd Law of Motion."
 
 /atom/movable/screen/alert/give // information set when the give alert is made
 	icon_state = "default"
+	clickable_glow = TRUE
 	var/mob/living/carbon/offerer
 	var/obj/item/receiving
 
@@ -337,6 +348,7 @@ or shoot a gun to move around via Newton's 3rd Law of Motion."
 	name = "Succumb"
 	desc = "Shuffle off this mortal coil."
 	icon_state = "succumb"
+	clickable_glow = TRUE
 
 /atom/movable/screen/alert/succumb/Click()
 	if (isobserver(usr))
@@ -598,18 +610,18 @@ Recharging stations are available in robotics, the dormitory bathrooms, and the 
 		complete, you will have exclusive control of it, and you will gain \
 		additional processing time to unlock more malfunction abilities."
 	icon_state = "hackingapc"
-	timeout = 600
+	timeout = 60 SECONDS
+	clickable_glow = TRUE
 	var/atom/target = null
 
 /atom/movable/screen/alert/hackingapc/Click()
 	if(!usr || !usr.client || usr != owner)
 		return
-	if(!target)
-		return
-	var/mob/living/silicon/ai/AI = usr
-	var/turf/T = get_turf(target)
-	if(T)
-		AI.eyeobj.setLoc(T)
+
+	var/mob/living/silicon/ai/ai_owner = owner
+	var/turf/target_turf = get_turf(target)
+	if(target_turf)
+		ai_owner.eyeobj.setLoc(target_turf)
 
 //MECHS
 
@@ -625,7 +637,8 @@ Recharging stations are available in robotics, the dormitory bathrooms, and the 
 	name = "Revival"
 	desc = "Someone is trying to revive you. Re-enter your corpse if you want to be revived!"
 	icon_state = "template"
-	timeout = 300
+	timeout = 30 SECONDS
+	clickable_glow = TRUE
 
 /atom/movable/screen/alert/notify_cloning/Click()
 	if(!usr || !usr.client || usr != owner)
@@ -637,7 +650,8 @@ Recharging stations are available in robotics, the dormitory bathrooms, and the 
 	name = "Body created"
 	desc = "A body was created. You can enter it."
 	icon_state = "template"
-	timeout = 300
+	timeout = 30 SECONDS
+	clickable_glow = TRUE
 	var/atom/target = null
 	var/action = NOTIFY_JUMP
 
@@ -809,14 +823,19 @@ Recharging stations are available in robotics, the dormitory bathrooms, and the 
 	name = "Buckled"
 	desc = "You've been buckled to something. Click the alert to unbuckle unless you're handcuffed."
 	icon_state = "buckled"
+	clickable_glow = TRUE
 
 /atom/movable/screen/alert/restrained/handcuffed
 	name = "Handcuffed"
-	desc = "You're handcuffed and can't act. If anyone drags you, you won't be able to move. Left-click the alert to free yourself over time. Right-click the alert if you're willing to severely injure yourself to break out immediately."
+	desc = "You're handcuffed and can't act. If anyone drags you, you won't be able to move. \
+		Left-click the alert to free yourself over time. \
+		Right-click the alert if you're willing to severely injure yourself to break out immediately."
+	clickable_glow = TRUE
 
 /atom/movable/screen/alert/restrained/legcuffed
 	name = "Legcuffed"
 	desc = "You're legcuffed, which slows you down considerably. Click the alert to free yourself."
+	clickable_glow = TRUE
 
 /atom/movable/screen/alert/restrained/Click(location, control, params)
 	var/mob/living/living_mob = usr

--- a/code/_onclick/hud/blob_overmind.dm
+++ b/code/_onclick/hud/blob_overmind.dm
@@ -1,6 +1,7 @@
 
 /atom/movable/screen/blob
 	icon = 'icons/hud/actions/actions_blob.dmi'
+	mouse_over_pointer = MOUSE_HAND_POINTER
 
 /atom/movable/screen/blob/MouseEntered(location,control,params)
 	..()

--- a/code/_onclick/hud/ghost.dm
+++ b/code/_onclick/hud/ghost.dm
@@ -1,5 +1,6 @@
 /atom/movable/screen/ghost
 	icon = 'icons/hud/screen_ghost.dmi'
+	mouse_over_pointer = MOUSE_HAND_POINTER
 
 /atom/movable/screen/ghost/MouseEntered()
 	..()

--- a/code/_onclick/hud/holoparasite.dm
+++ b/code/_onclick/hud/holoparasite.dm
@@ -106,6 +106,7 @@
 
 /atom/movable/screen/holoparasite
 	icon = 'icons/mob/holoparasite.dmi'
+	mouse_over_pointer = MOUSE_HAND_POINTER
 	var/mob/living/simple_animal/hostile/holoparasite/owner
 	var/can_toggle = FALSE
 	var/last_params

--- a/code/_onclick/hud/human.dm
+++ b/code/_onclick/hud/human.dm
@@ -4,6 +4,7 @@
 /atom/movable/screen/human/toggle
 	name = "toggle"
 	icon_state = "toggle"
+	mouse_over_pointer = MOUSE_HAND_POINTER
 
 /atom/movable/screen/human/toggle/Click()
 
@@ -26,6 +27,7 @@
 /atom/movable/screen/human/equip
 	name = "equip"
 	icon_state = "act_equip"
+	mouse_over_pointer = MOUSE_HAND_POINTER
 
 /atom/movable/screen/human/equip/Click()
 	var/mob/living/carbon/human/H = usr
@@ -37,6 +39,7 @@
 /atom/movable/screen/ling/sting
 	name = "current sting"
 	screen_loc = ui_lingstingdisplay
+	mouse_over_pointer = MOUSE_HAND_POINTER
 
 /atom/movable/screen/ling/sting/Click()
 	if(isobserver(usr))

--- a/code/_onclick/hud/pai.dm
+++ b/code/_onclick/hud/pai.dm
@@ -2,6 +2,7 @@
 
 /atom/movable/screen/pai
 	icon = 'icons/hud/screen_pai.dmi'
+	mouse_over_pointer = MOUSE_HAND_POINTER
 	var/required_software
 
 /atom/movable/screen/pai/Click()

--- a/code/_onclick/hud/robot.dm
+++ b/code/_onclick/hud/robot.dm
@@ -1,5 +1,6 @@
 /atom/movable/screen/robot
 	icon = 'icons/hud/screen_cyborg.dmi'
+	mouse_over_pointer = MOUSE_HAND_POINTER
 
 /atom/movable/screen/robot/module
 	name = "cyborg module"

--- a/code/_onclick/hud/screen_objects.dm
+++ b/code/_onclick/hud/screen_objects.dm
@@ -54,6 +54,7 @@
 /atom/movable/screen/swap_hand
 	plane = HUD_PLANE
 	name = "swap hand"
+	mouse_over_pointer = MOUSE_HAND_POINTER
 
 /atom/movable/screen/swap_hand/Click()
 	// At this point in client Click() code we have passed the 1/10 sec check and little else
@@ -74,6 +75,7 @@
 	icon = 'icons/hud/style/screen_midnight.dmi'
 	icon_state = "navigate"
 	screen_loc = ui_navigate_menu
+	mouse_over_pointer = MOUSE_HAND_POINTER
 
 /atom/movable/screen/navigate/Click()
 	if(!isliving(usr))
@@ -86,12 +88,14 @@
 	icon = 'icons/hud/style/screen_midnight.dmi'
 	icon_state = "craft"
 	screen_loc = ui_crafting
+	mouse_over_pointer = MOUSE_HAND_POINTER
 
 /atom/movable/screen/area_creator
 	name = "create new area"
 	icon = 'icons/hud/style/screen_midnight.dmi'
 	icon_state = "area_edit"
 	screen_loc = ui_building
+	mouse_over_pointer = MOUSE_HAND_POINTER
 
 /atom/movable/screen/area_creator/Click()
 	if(usr.incapacitated() || (isobserver(usr) && !IsAdminGhost(usr)))
@@ -107,6 +111,7 @@
 	icon = 'icons/hud/style/screen_midnight.dmi'
 	icon_state = "talk_wheel"
 	screen_loc = ui_language_menu
+	mouse_over_pointer = MOUSE_HAND_POINTER
 
 /atom/movable/screen/language_menu/Click()
 	usr.get_language_holder().open_language_menu(usr)
@@ -241,9 +246,9 @@
 
 /atom/movable/screen/close
 	name = "close"
-
 	plane = ABOVE_HUD_PLANE
 	icon_state = "backpack_close"
+	mouse_over_pointer = MOUSE_HAND_POINTER
 
 	/// A reference to the object in the slot. Grabs or items, generally.
 	var/datum/component/master = null
@@ -266,6 +271,7 @@ CREATION_TEST_IGNORE_SUBTYPES(/atom/movable/screen/close)
 	icon = 'icons/hud/style/screen_midnight.dmi'
 	icon_state = "act_drop"
 	plane = HUD_PLANE
+	mouse_over_pointer = MOUSE_HAND_POINTER
 
 /atom/movable/screen/drop/Click()
 	if(usr.stat == CONSCIOUS)
@@ -281,6 +287,7 @@ CREATION_TEST_IGNORE_SUBTYPES(/atom/movable/screen/close)
 	icon = 'icons/hud/style/screen_midnight.dmi'
 	icon_state = "combat_off"
 	screen_loc = ui_combat_toggle
+	mouse_over_pointer = MOUSE_HAND_POINTER
 
 /atom/movable/screen/combattoggle/New(loc, ...)
 	. = ..()
@@ -331,6 +338,7 @@ CREATION_TEST_IGNORE_SUBTYPES(/atom/movable/screen/close)
 	name = "run/walk toggle"
 	icon = 'icons/hud/style/screen_midnight.dmi'
 	icon_state = "running"
+	mouse_over_pointer = MOUSE_HAND_POINTER
 
 /atom/movable/screen/mov_intent/Click()
 	toggle(usr)
@@ -352,6 +360,7 @@ CREATION_TEST_IGNORE_SUBTYPES(/atom/movable/screen/close)
 	name = "stop pulling"
 	icon = 'icons/hud/style/screen_midnight.dmi'
 	icon_state = "pull"
+	mouse_over_pointer = MOUSE_HAND_POINTER
 
 /atom/movable/screen/pull/Click()
 	if(isobserver(usr))
@@ -370,6 +379,7 @@ CREATION_TEST_IGNORE_SUBTYPES(/atom/movable/screen/close)
 	icon = 'icons/hud/style/screen_midnight.dmi'
 	icon_state = "act_resist"
 	plane = HUD_PLANE
+	mouse_over_pointer = MOUSE_HAND_POINTER
 
 /atom/movable/screen/resist/Click()
 	if(isliving(usr))
@@ -381,6 +391,7 @@ CREATION_TEST_IGNORE_SUBTYPES(/atom/movable/screen/close)
 	icon = 'icons/hud/style/screen_midnight.dmi'
 	icon_state = "act_rest"
 	plane = HUD_PLANE
+	mouse_over_pointer = MOUSE_HAND_POINTER
 
 /atom/movable/screen/rest/Click()
 	if(isliving(usr))
@@ -429,6 +440,7 @@ CREATION_TEST_IGNORE_SUBTYPES(/atom/movable/screen/storage)
 	name = "throw/catch"
 	icon = 'icons/hud/style/screen_midnight.dmi'
 	icon_state = "act_throw_off"
+	mouse_over_pointer = MOUSE_HAND_POINTER
 
 /atom/movable/screen/throw_catch/Click()
 	if(iscarbon(usr))
@@ -439,6 +451,7 @@ CREATION_TEST_IGNORE_SUBTYPES(/atom/movable/screen/storage)
 	name = "damage zone"
 	icon_state = "zone_sel"
 	screen_loc = ui_zonesel
+	mouse_over_pointer = MOUSE_HAND_POINTER
 	var/selecting = BODY_ZONE_CHEST
 	var/static/list/hover_overlays_cache = list()
 	var/hovering
@@ -636,6 +649,7 @@ CREATION_TEST_IGNORE_SUBTYPES(/atom/movable/screen/storage)
 /atom/movable/screen/healthdoll
 	name = "health doll"
 	screen_loc = ui_healthdoll
+	mouse_over_pointer = MOUSE_HAND_POINTER
 
 /atom/movable/screen/healthdoll/Click()
 	if (iscarbon(usr))
@@ -651,6 +665,7 @@ CREATION_TEST_IGNORE_SUBTYPES(/atom/movable/screen/storage)
 	name = "mood"
 	icon_state = "mood5"
 	screen_loc = ui_mood
+	mouse_over_pointer = MOUSE_HAND_POINTER
 
 /atom/movable/screen/sanity
 	name = "sanity"
@@ -707,6 +722,7 @@ CREATION_TEST_IGNORE_SUBTYPES(/atom/movable/screen/splash)
 
 
 /atom/movable/screen/component_button
+	mouse_over_pointer = MOUSE_HAND_POINTER
 	var/atom/movable/screen/parent
 
 CREATION_TEST_IGNORE_SUBTYPES(/atom/movable/screen/component_button)

--- a/code/datums/status_effects/debuffs/debuffs.dm
+++ b/code/datums/status_effects/debuffs/debuffs.dm
@@ -235,6 +235,7 @@
 	desc = "A magical strand of Durathread is wrapped around your neck, preventing you from breathing! Click this icon to remove the strand."
 	icon_state = "his_grace"
 	alerttooltipstyle = "hisgrace"
+	clickable_glow = TRUE
 
 /atom/movable/screen/alert/status_effect/strandling/Click(location, control, params)
 	. = ..()
@@ -1188,7 +1189,7 @@
 /datum/status_effect/ants/on_creation(mob/living/new_owner, amount_left)
 	if(isnum(amount_left) && new_owner.stat < HARD_CRIT)
 		if(new_owner.stat < UNCONSCIOUS) // Unconcious people won't get messages
-			to_chat(new_owner, "<span class='userdanger'>You're covered in ants!</span>")
+			to_chat(new_owner, span_userdanger("You're covered in ants!"))
 		ants_remaining += amount_left
 		RegisterSignal(new_owner, COMSIG_COMPONENT_CLEAN_ACT, PROC_REF(ants_washed))
 	. = ..()
@@ -1198,7 +1199,7 @@
 	if(isnum(amount_left) && ants_remaining >= 1 && victim.stat < HARD_CRIT)
 		if(victim.stat < UNCONSCIOUS) // Unconcious people won't get messages
 			if(!prob(1)) // 99%
-				to_chat(victim, "<span class='userdanger'>You're covered in MORE ants!</span>")
+				to_chat(victim, span_userdanger("You're covered in MORE ants!"))
 			else // 1%
 				victim.say("AAHH! THIS SITUATION HAS ONLY BEEN MADE WORSE WITH THE ADDITION OF YET MORE ANTS!!", forced = /datum/status_effect/ants)
 		ants_remaining += amount_left
@@ -1206,7 +1207,7 @@
 
 /datum/status_effect/ants/on_remove()
 	ants_remaining = 0
-	to_chat(owner, "<span class='notice'>All of the ants are off of your body!</span>")
+	to_chat(owner, span_notice("All of the ants are off of your body!"))
 	UnregisterSignal(owner, COMSIG_COMPONENT_CLEAN_ACT, PROC_REF(ants_washed))
 	. = ..()
 
@@ -1232,18 +1233,18 @@
 			switch(rand(1,50))
 				if (1 to 8) //16% Chance
 					var/obj/item/bodypart/head/hed = victim.get_bodypart(BODY_ZONE_HEAD)
-					to_chat(victim, "<span class='danger'>You scratch at the ants on your scalp!.</span>")
+					to_chat(victim, span_danger("You scratch at the ants on your scalp!"))
 					hed.receive_damage(1,0)
 				if (9 to 29) //40% chance
 					var/obj/item/bodypart/arm = victim.get_bodypart(pick(BODY_ZONE_L_ARM,BODY_ZONE_R_ARM))
-					to_chat(victim, "<span class='danger'>You scratch at the ants on your arms!</span>")
+					to_chat(victim, span_danger("You scratch at the ants on your arms!"))
 					arm.receive_damage(3,0)
 				if (30 to 49) //38% chance
 					var/obj/item/bodypart/leg = victim.get_bodypart(pick(BODY_ZONE_L_LEG,BODY_ZONE_R_LEG))
-					to_chat(victim, "<span class='danger'>You scratch at the ants on your leg!</span>")
+					to_chat(victim, span_danger("You scratch at the ants on your leg!"))
 					leg.receive_damage(3,0)
 				if(50) // 2% chance
-					to_chat(victim, "<span class='danger'>You rub some ants away from your eyes!</span>")
+					to_chat(victim, span_danger("You rub some ants away from your eyes!"))
 					victim.blur_eyes(3)
 					ants_remaining -= 5 // To balance out the blindness, it'll be a little shorter.
 	ants_remaining--
@@ -1252,18 +1253,19 @@
 
 /atom/movable/screen/alert/status_effect/ants
 	name = "Ants!"
-	desc = "<span class='warning'>JESUS FUCKING CHRIST! CLICK TO GET THOSE THINGS OFF!</span>"
+	desc = span_warning("JESUS FUCKING CHRIST! CLICK TO GET THOSE THINGS OFF!")
 	icon_state = "antalert"
+	clickable_glow = TRUE
 
 /atom/movable/screen/alert/status_effect/ants/Click()
 	var/mob/living/living = owner
 	if(!istype(living) || !living.can_resist() || living != owner)
 		return
-	to_chat(living, "<span class='notice'>You start to shake the ants off!</span>")
+	to_chat(living, span_notice("You start to shake the ants off!"))
 	if(!do_after(living, 2 SECONDS, target = living))
 		return
 	for (var/datum/status_effect/ants/ant_covered in living.status_effects)
-		to_chat(living, "<span class='notice'>You manage to get some of the ants off!</span>")
+		to_chat(living, span_notice("You manage to get some of the ants off!"))
 		ant_covered.ants_remaining -= 10 // 5 Times more ants removed per second than just waiting in place
 
 /datum/status_effect/smoke

--- a/code/datums/status_effects/gas.dm
+++ b/code/datums/status_effects/gas.dm
@@ -31,6 +31,7 @@
 	name = "Frozen Solid"
 	desc = "You're frozen inside an ice cube, and cannot move! You can still do stuff, like shooting. Resist out of the cube!"
 	icon_state = "frozen"
+	clickable_glow = TRUE
 
 /atom/movable/screen/alert/status_effect/freon/Click(location, control, params)
 	. = ..()

--- a/code/datums/status_effects/neutral.dm
+++ b/code/datums/status_effects/neutral.dm
@@ -253,6 +253,7 @@
 	name = "Leaning"
 	desc = "You're leaning on something!"
 	icon_state = "buckled"
+	clickable_glow = TRUE
 
 /atom/movable/screen/alert/status_effect/leaning/Click()
 	var/mob/living/L = usr

--- a/code/game/machinery/buttons.dm
+++ b/code/game/machinery/buttons.dm
@@ -3,18 +3,19 @@
 	desc = "A remote control switch."
 	icon = 'icons/obj/stationobjs.dmi'
 	icon_state = "doorctrl"
-	var/skin = "doorctrl"
+	base_icon_state = "doorctrl"
 	layer = ABOVE_WINDOW_LAYER
-	var/obj/item/assembly/device
-	var/obj/item/electronics/airlock/board
-	var/device_type = null
-	var/id = null
-	var/initialized_button = 0
 	armor_type = /datum/armor/machinery_button
 	use_power = IDLE_POWER_USE
 	idle_power_usage = 2
 	resistance_flags = LAVA_PROOF | FIRE_PROOF
+	mouse_over_pointer = MOUSE_HAND_POINTER
 
+	var/obj/item/assembly/device
+	var/obj/item/electronics/airlock/board
+	var/device_type = null
+	var/id = null
+	var/initialized_button = FALSE
 
 /datum/armor/machinery_button
 	melee = 50
@@ -58,9 +59,9 @@ CREATION_TEST_IGNORE_SUBTYPES(/obj/machinery/button)
 		icon_state = "button-open"
 		return ..()
 	if(machine_stat & (NOPOWER|BROKEN))
-		icon_state = "[skin]-p"
+		icon_state = "[base_icon_state]-p"
 		return ..()
-	icon_state = skin
+	icon_state = base_icon_state
 	return ..()
 
 /obj/machinery/button/update_overlays()
@@ -75,11 +76,11 @@ CREATION_TEST_IGNORE_SUBTYPES(/obj/machinery/button)
 /obj/machinery/button/attackby(obj/item/W, mob/living/user, params)
 	if(W.tool_behaviour == TOOL_SCREWDRIVER)
 		if(panel_open || allowed(user))
-			default_deconstruction_screwdriver(user, "button-open", "[skin]",W)
+			default_deconstruction_screwdriver(user, "button-open", "[base_icon_state]",W)
 			update_appearance()
 		else
 			to_chat(user, span_danger("Maintenance Access Denied."))
-			flick("[skin]-denied", src)
+			flick("[base_icon_state]-denied", src)
 		return
 
 	if(panel_open)
@@ -138,7 +139,7 @@ CREATION_TEST_IGNORE_SUBTYPES(/obj/machinery/button)
 	if(id && istype(device, /obj/item/assembly/control))
 		var/obj/item/assembly/control/A = device
 		A.id = id
-	initialized_button = 1
+	initialized_button = TRUE
 
 /obj/machinery/button/attack_hand(mob/user, list/modifiers)
 	. = ..()
@@ -162,10 +163,10 @@ CREATION_TEST_IGNORE_SUBTYPES(/obj/machinery/button)
 			to_chat(user, span_notice("You remove electronics from the button frame."))
 
 		else
-			if(skin == "doorctrl")
-				skin = "launcher"
+			if(base_icon_state == "doorctrl")
+				base_icon_state = "launcher"
 			else
-				skin = "doorctrl"
+				base_icon_state = "doorctrl"
 			to_chat(user, span_notice("You change the button frame's front panel."))
 		return
 
@@ -177,11 +178,11 @@ CREATION_TEST_IGNORE_SUBTYPES(/obj/machinery/button)
 
 	if(!allowed(user) && !istype(user, /mob/living/simple_animal/eminence))
 		to_chat(user, span_danger("Access Denied."))
-		flick("[skin]-denied", src)
+		flick("[base_icon_state]-denied", src)
 		return
 
 	use_power(5)
-	icon_state = "[skin]1"
+	icon_state = "[base_icon_state]1"
 
 	if(device)
 		device.pulsed(user)
@@ -242,7 +243,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/button/door, 24)
 	name = "mass driver button"
 	desc = "A remote control switch for a mass driver."
 	icon_state = "launcher"
-	skin = "launcher"
+	base_icon_state = "launcher"
 	device_type = /obj/item/assembly/control/massdriver
 
 /obj/machinery/button/massdriver/indestructible
@@ -252,7 +253,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/button/door, 24)
 	name = "ignition switch"
 	desc = "A remote control switch for a mounted igniter."
 	icon_state = "launcher"
-	skin = "launcher"
+	base_icon_state = "launcher"
 	device_type = /obj/item/assembly/control/igniter
 
 /obj/machinery/button/ignition/indestructible
@@ -275,7 +276,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/button/door, 24)
 	name = "flasher button"
 	desc = "A remote control switch for a mounted flasher."
 	icon_state = "launcher"
-	skin = "launcher"
+	base_icon_state = "launcher"
 	device_type = /obj/item/assembly/control/flasher
 
 /obj/machinery/button/flasher/indestructible
@@ -285,7 +286,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/button/door, 24)
 	name = "crematorium igniter"
 	desc = "Burn baby burn!"
 	icon_state = "launcher"
-	skin = "launcher"
+	base_icon_state = "launcher"
 	device_type = /obj/item/assembly/control/crematorium
 	id = 1
 
@@ -306,7 +307,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/button/shieldwallgen, 24)
 	name = "holofield switch"
 	desc = "A remote switch for a holofield generator"
 	icon_state = "launcher"
-	skin = "launcher"
+	base_icon_state = "launcher"
 	device_type = /obj/item/assembly/control/shieldwallgen
 	req_access = list()
 	id = 1

--- a/code/game/machinery/embedded_controller/access_controller.dm
+++ b/code/game/machinery/embedded_controller/access_controller.dm
@@ -1,15 +1,10 @@
-#define CLOSING			1
-#define OPENING			2
-#define CYCLE			3
-#define CYCLE_EXTERIOR	4
-#define CYCLE_INTERIOR	5
-
 /obj/machinery/doorButtons
 	power_channel = AREA_USAGE_ENVIRON
 	use_power = IDLE_POWER_USE
 	idle_power_usage = 2
 	active_power_usage = 4
 	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | UNACIDABLE | ACID_PROOF
+	mouse_over_pointer = MOUSE_HAND_POINTER
 	var/idSelf
 
 /obj/machinery/doorButtons/attackby(obj/O, mob/user)
@@ -143,13 +138,13 @@
 
 /obj/machinery/doorButtons/airlock_controller/proc/onlyOpen(obj/machinery/door/airlock/A)
 	if(A)
-		busy = CLOSING
+		busy = TRUE
 		update_icon()
 		openDoor(A)
 
 /obj/machinery/doorButtons/airlock_controller/proc/onlyClose(obj/machinery/door/airlock/A)
 	if(A)
-		busy = CLOSING
+		busy = TRUE
 		closeDoor(A)
 
 /obj/machinery/doorButtons/airlock_controller/proc/closeDoor(obj/machinery/door/airlock/A)
@@ -174,14 +169,14 @@
 		return
 	if(exteriorAirlock.density == interiorAirlock.density || !A.density)
 		return
-	busy = CYCLE
+	busy = TRUE
 	update_icon()
 	if(A == interiorAirlock)
 		if(closeDoor(exteriorAirlock))
-			busy = CYCLE_INTERIOR
+			busy = TRUE
 	else
 		if(closeDoor(interiorAirlock))
-			busy = CYCLE_EXTERIOR
+			busy = TRUE
 
 /obj/machinery/doorButtons/airlock_controller/proc/cycleOpen(obj/machinery/door/airlock/A)
 	if(!A)
@@ -194,8 +189,8 @@
 		if(exteriorAirlock)
 			if(!exteriorAirlock.density || !exteriorAirlock.locked)
 				return
-	if(busy != OPENING)
-		busy = OPENING
+	if(busy != TRUE)
+		busy = TRUE
 		openDoor(A)
 
 /obj/machinery/doorButtons/airlock_controller/proc/openDoor(obj/machinery/door/airlock/A)
@@ -219,9 +214,9 @@
 /obj/machinery/doorButtons/airlock_controller/process()
 	if(machine_stat & NOPOWER)
 		return
-	if(busy == CYCLE_EXTERIOR)
+	if(busy == TRUE)
 		cycleOpen(exteriorAirlock)
-	else if(busy == CYCLE_INTERIOR)
+	else if(busy == TRUE)
 		cycleOpen(interiorAirlock)
 
 /obj/machinery/doorButtons/airlock_controller/power_change()
@@ -296,9 +291,3 @@
 		output += "<B>Interior Door: </B> [interiorAirlock.density ? "closed" : "open"]<BR>"
 
 	return output
-
-#undef CLOSING
-#undef OPENING
-#undef CYCLE
-#undef CYCLE_EXTERIOR
-#undef CYCLE_INTERIOR

--- a/code/game/machinery/firealarm.dm
+++ b/code/game/machinery/firealarm.dm
@@ -19,6 +19,7 @@
 	max_integrity = 250
 	integrity_failure = 0.4
 	armor_type = /datum/armor/machinery_firealarm
+	mouse_over_pointer = MOUSE_HAND_POINTER
 	use_power = IDLE_POWER_USE
 	idle_power_usage = 2
 	active_power_usage = 6

--- a/code/game/machinery/lightswitch.dm
+++ b/code/game/machinery/lightswitch.dm
@@ -6,6 +6,7 @@
 	desc = "Make dark."
 	power_channel = AREA_USAGE_LIGHT
 	layer = ABOVE_WINDOW_LAYER
+	mouse_over_pointer = MOUSE_HAND_POINTER
 	/// Set this to a string, path, or area instance to control that area
 	/// instead of the switch's location.
 	var/area/area = null

--- a/code/modules/buildmode/buttons.dm
+++ b/code/modules/buildmode/buttons.dm
@@ -1,5 +1,6 @@
 /atom/movable/screen/buildmode
 	icon = 'icons/misc/buildmode.dmi'
+	mouse_over_pointer = MOUSE_HAND_POINTER
 	var/datum/buildmode/bd
 
 /atom/movable/screen/buildmode/New(bld)

--- a/code/modules/mob/living/blood.dm
+++ b/code/modules/mob/living/blood.dm
@@ -122,6 +122,7 @@ bleedsuppress has been replaced for is_bandaged(). Note that is_bleeding() retur
 	name = "Bleeding"
 	desc = "You are bleeding, find something to bandage the wound or you will die."
 	icon_state = "bleed"
+	clickable_glow = TRUE
 
 /atom/movable/screen/alert/status_effect/bleeding/Click(location, control, params)
 	var/mob/living/carbon/human/human = usr

--- a/code/modules/projectiles/projectile/energy/stun.dm
+++ b/code/modules/projectiles/projectile/energy/stun.dm
@@ -500,6 +500,7 @@
 	name = "Tased!"
 	desc = "You're being tased! You can click this or resist to attempt to stop it, assuming you've not already collapsed."
 	icon_state = "stun"
+	clickable_glow = TRUE
 
 /atom/movable/screen/alert/tazed/Click(location, control, params)
 	. = ..()

--- a/code/modules/spells/spell_types/shapeshift/_shape_status.dm
+++ b/code/modules/spells/spell_types/shapeshift/_shape_status.dm
@@ -237,6 +237,7 @@
 	desc = "Your form is not your own... you're shapeshifted into another creature! \
 		A wizard could turn you back - or maybe you're stuck like this for good?"
 	icon_state = "shapeshifted"
+	clickable_glow = TRUE
 
 /atom/movable/screen/alert/status_effect/shapeshifted/Click(location, control, params)
 	. = ..()


### PR DESCRIPTION
## About The Pull Request

See title- also adds a glow around clickable alerts. This was a dependency for the main port

Attributions:

- https://github.com/tgstation/tgstation/pull/87902
- https://github.com/tgstation/tgstation/pull/88470

## Why It's Good For The Game

qol

## Testing Photographs and Procedure

https://github.com/user-attachments/assets/6c21816f-e47f-4498-951f-54e7f9abcd18

## Changelog
:cl: mrmanlikesbt, mc-oofert, MrMelbert
add: Clickable screen alerts now have a golden border
add: Clickable UI elements and some real world objects will change your cursor to make it obvious they can be clicked.
/:cl:
