### PR TITLE
Gives personal crafting menu category/material list a scroll bar

### DIFF
--- a/tgui/packages/tgui/interfaces/PersonalCrafting.tsx
+++ b/tgui/packages/tgui/interfaces/PersonalCrafting.tsx
@@ -335,7 +335,8 @@ export const PersonalCrafting = (props) => {
                             <Tabs.Tab
                               key={foodtype}
                               selected={
-                                activeType === foodtype && searchText.length === 0
+                                activeType === foodtype &&
+                                searchText.length === 0
                               }
                               onClick={(e) => {
                                 setFoodType(foodtype);
@@ -351,7 +352,9 @@ export const PersonalCrafting = (props) => {
                               <FoodtypeContent
                                 type={foodtype}
                                 diet={diet}
-                                craftableCount={Object.keys(craftability).length}
+                                craftableCount={
+                                  Object.keys(craftability).length
+                                }
                               />
                             </Tabs.Tab>
                           ))}
@@ -413,7 +416,9 @@ export const PersonalCrafting = (props) => {
                                 <Stack.Item
                                   grow
                                   color={
-                                    category === 'Blood Cult' ? 'red' : 'default'
+                                    category === 'Blood Cult'
+                                      ? 'red'
+                                      : 'default'
                                   }
                                 >
                                   {category}

--- a/tgui/packages/tgui/interfaces/PersonalCrafting.tsx
+++ b/tgui/packages/tgui/interfaces/PersonalCrafting.tsx
@@ -325,114 +325,107 @@ export const PersonalCrafting = (props) => {
                     </Tabs.Tab>
                   </Tabs>
                 </Stack.Item>
-                <Stack.Item grow m={-1}>
-                  <Box height={'100%'} p={1} style={{ overflowY: 'auto' }}>
-                    <Section fill scrollable>
-                      <Tabs vertical>
-                        {tabMode === TABS.foodtype &&
-                          mode === MODE.cooking &&
-                          foodtypes.map((foodtype) => (
-                            <Tabs.Tab
-                              key={foodtype}
-                              selected={
-                                activeType === foodtype &&
-                                searchText.length === 0
+                <Stack.Item grow m={-1} style={{ overflowY: 'auto' }}>
+                  <Box height={'100%'} p={1}>
+                    <Tabs vertical>
+                      {tabMode === TABS.foodtype &&
+                        mode === MODE.cooking &&
+                        foodtypes.map((foodtype) => (
+                          <Tabs.Tab
+                            key={foodtype}
+                            selected={
+                              activeType === foodtype && searchText.length === 0
+                            }
+                            onClick={(e) => {
+                              setFoodType(foodtype);
+                              setPages(1);
+                              if (content) {
+                                content.scrollTop = 0;
                               }
-                              onClick={(e) => {
-                                setFoodType(foodtype);
-                                setPages(1);
-                                if (content) {
-                                  content.scrollTop = 0;
-                                }
-                                if (searchText.length > 0) {
-                                  setSearchText('');
-                                }
-                              }}
-                            >
-                              <FoodtypeContent
-                                type={foodtype}
-                                diet={diet}
-                                craftableCount={
-                                  Object.keys(craftability).length
-                                }
-                              />
-                            </Tabs.Tab>
-                          ))}
-                        {tabMode === TABS.material &&
-                          material_occurences.map((material) => (
-                            <Tabs.Tab
-                              key={material.atom_id}
-                              selected={
-                                activeMaterial === material.atom_id &&
-                                searchText.length === 0
+                              if (searchText.length > 0) {
+                                setSearchText('');
                               }
-                              onClick={(e) => {
-                                setMaterial(material.atom_id);
-                                setPages(1);
-                                if (content) {
-                                  content.scrollTop = 0;
-                                }
-                                if (searchText.length > 0) {
-                                  setSearchText('');
-                                }
-                              }}
-                            >
-                              <MaterialContent
-                                atom_id={material.atom_id}
-                                occurences={material.occurences}
-                              />
-                            </Tabs.Tab>
-                          ))}
-                        {tabMode === TABS.category &&
-                          categories.map((category) => (
-                            <Tabs.Tab
-                              key={category}
-                              selected={
-                                activeCategory === category &&
-                                searchText.length === 0
+                            }}
+                          >
+                            <FoodtypeContent
+                              type={foodtype}
+                              diet={diet}
+                              craftableCount={Object.keys(craftability).length}
+                            />
+                          </Tabs.Tab>
+                        ))}
+                      {tabMode === TABS.material &&
+                        material_occurences.map((material) => (
+                          <Tabs.Tab
+                            key={material.atom_id}
+                            selected={
+                              activeMaterial === material.atom_id &&
+                              searchText.length === 0
+                            }
+                            onClick={(e) => {
+                              setMaterial(material.atom_id);
+                              setPages(1);
+                              if (content) {
+                                content.scrollTop = 0;
                               }
-                              onClick={(e) => {
-                                setCategory(category);
-                                setPages(1);
-                                if (content) {
-                                  content.scrollTop = 0;
-                                }
-                                if (searchText.length > 0) {
-                                  setSearchText('');
-                                }
-                              }}
-                            >
-                              <Stack>
-                                <Stack.Item width="14px" textAlign="center">
-                                  <Icon
-                                    color={
-                                      category === 'Blood Cult'
-                                        ? 'red'
-                                        : 'default'
-                                    }
-                                    name={CATEGORY_ICONS[category] || 'circle'}
-                                  />
-                                </Stack.Item>
-                                <Stack.Item
-                                  grow
+                              if (searchText.length > 0) {
+                                setSearchText('');
+                              }
+                            }}
+                          >
+                            <MaterialContent
+                              atom_id={material.atom_id}
+                              occurences={material.occurences}
+                            />
+                          </Tabs.Tab>
+                        ))}
+                      {tabMode === TABS.category &&
+                        categories.map((category) => (
+                          <Tabs.Tab
+                            key={category}
+                            selected={
+                              activeCategory === category &&
+                              searchText.length === 0
+                            }
+                            onClick={(e) => {
+                              setCategory(category);
+                              setPages(1);
+                              if (content) {
+                                content.scrollTop = 0;
+                              }
+                              if (searchText.length > 0) {
+                                setSearchText('');
+                              }
+                            }}
+                          >
+                            <Stack>
+                              <Stack.Item width="14px" textAlign="center">
+                                <Icon
                                   color={
                                     category === 'Blood Cult'
                                       ? 'red'
                                       : 'default'
                                   }
-                                >
-                                  {category}
+                                  name={CATEGORY_ICONS[category] || 'circle'}
+                                />
+                              </Stack.Item>
+                              <Stack.Item
+                                grow
+                                color={
+                                  category === 'Blood Cult' ? 'red' : 'default'
+                                }
+                              >
+                                {category}
+                              </Stack.Item>
+                              {category === 'Can Make' && (
+                                <Stack.Item>
+                                  {Object.keys(craftability).length}
                                 </Stack.Item>
-                                {category === 'Can Make' && (
-                                  <Stack.Item>
-                                    {Object.keys(craftability).length}
-                                  </Stack.Item>
-                                )}
-                              </Stack>
-                            </Tabs.Tab>
-                          ))}
-                      </Tabs>
-                    </Section>
+                              )}
+                            </Stack>
+                          </Tabs.Tab>
+                        ))}
+                    </Tabs>
                   </Box>
                 </Stack.Item>
                 <Stack.Item>
@@ -584,6 +577,7 @@ const MaterialContent = (props) => {
       <Stack.Item
         height="32px"
         lineHeight="32px"
+        width="0px"
         grow
         style={{
           textTransform: 'capitalize',

--- a/tgui/packages/tgui/interfaces/PersonalCrafting.tsx
+++ b/tgui/packages/tgui/interfaces/PersonalCrafting.tsx
@@ -327,105 +327,107 @@ export const PersonalCrafting = (props) => {
                 </Stack.Item>
                 <Stack.Item grow m={-1}>
                   <Box height={'100%'} p={1} style={{ overflowY: 'auto' }}>
-                    <Tabs vertical>
-                      {tabMode === TABS.foodtype &&
-                        mode === MODE.cooking &&
-                        foodtypes.map((foodtype) => (
-                          <Tabs.Tab
-                            key={foodtype}
-                            selected={
-                              activeType === foodtype && searchText.length === 0
-                            }
-                            onClick={(e) => {
-                              setFoodType(foodtype);
-                              setPages(1);
-                              if (content) {
-                                content.scrollTop = 0;
+                    <Section fill scrollable>
+                      <Tabs vertical>
+                        {tabMode === TABS.foodtype &&
+                          mode === MODE.cooking &&
+                          foodtypes.map((foodtype) => (
+                            <Tabs.Tab
+                              key={foodtype}
+                              selected={
+                                activeType === foodtype && searchText.length === 0
                               }
-                              if (searchText.length > 0) {
-                                setSearchText('');
-                              }
-                            }}
-                          >
-                            <FoodtypeContent
-                              type={foodtype}
-                              diet={diet}
-                              craftableCount={Object.keys(craftability).length}
-                            />
-                          </Tabs.Tab>
-                        ))}
-                      {tabMode === TABS.material &&
-                        material_occurences.map((material) => (
-                          <Tabs.Tab
-                            key={material.atom_id}
-                            selected={
-                              activeMaterial === material.atom_id &&
-                              searchText.length === 0
-                            }
-                            onClick={(e) => {
-                              setMaterial(material.atom_id);
-                              setPages(1);
-                              if (content) {
-                                content.scrollTop = 0;
-                              }
-                              if (searchText.length > 0) {
-                                setSearchText('');
-                              }
-                            }}
-                          >
-                            <MaterialContent
-                              atom_id={material.atom_id}
-                              occurences={material.occurences}
-                            />
-                          </Tabs.Tab>
-                        ))}
-                      {tabMode === TABS.category &&
-                        categories.map((category) => (
-                          <Tabs.Tab
-                            key={category}
-                            selected={
-                              activeCategory === category &&
-                              searchText.length === 0
-                            }
-                            onClick={(e) => {
-                              setCategory(category);
-                              setPages(1);
-                              if (content) {
-                                content.scrollTop = 0;
-                              }
-                              if (searchText.length > 0) {
-                                setSearchText('');
-                              }
-                            }}
-                          >
-                            <Stack>
-                              <Stack.Item width="14px" textAlign="center">
-                                <Icon
-                                  color={
-                                    category === 'Blood Cult'
-                                      ? 'red'
-                                      : 'default'
-                                  }
-                                  name={CATEGORY_ICONS[category] || 'circle'}
-                                />
-                              </Stack.Item>
-                              <Stack.Item
-                                grow
-                                color={
-                                  category === 'Blood Cult' ? 'red' : 'default'
+                              onClick={(e) => {
+                                setFoodType(foodtype);
+                                setPages(1);
+                                if (content) {
+                                  content.scrollTop = 0;
                                 }
-                              >
-                                {category}
-                              </Stack.Item>
-                              {category === 'Can Make' && (
-                                <Stack.Item>
-                                  {Object.keys(craftability).length}
+                                if (searchText.length > 0) {
+                                  setSearchText('');
+                                }
+                              }}
+                            >
+                              <FoodtypeContent
+                                type={foodtype}
+                                diet={diet}
+                                craftableCount={Object.keys(craftability).length}
+                              />
+                            </Tabs.Tab>
+                          ))}
+                        {tabMode === TABS.material &&
+                          material_occurences.map((material) => (
+                            <Tabs.Tab
+                              key={material.atom_id}
+                              selected={
+                                activeMaterial === material.atom_id &&
+                                searchText.length === 0
+                              }
+                              onClick={(e) => {
+                                setMaterial(material.atom_id);
+                                setPages(1);
+                                if (content) {
+                                  content.scrollTop = 0;
+                                }
+                                if (searchText.length > 0) {
+                                  setSearchText('');
+                                }
+                              }}
+                            >
+                              <MaterialContent
+                                atom_id={material.atom_id}
+                                occurences={material.occurences}
+                              />
+                            </Tabs.Tab>
+                          ))}
+                        {tabMode === TABS.category &&
+                          categories.map((category) => (
+                            <Tabs.Tab
+                              key={category}
+                              selected={
+                                activeCategory === category &&
+                                searchText.length === 0
+                              }
+                              onClick={(e) => {
+                                setCategory(category);
+                                setPages(1);
+                                if (content) {
+                                  content.scrollTop = 0;
+                                }
+                                if (searchText.length > 0) {
+                                  setSearchText('');
+                                }
+                              }}
+                            >
+                              <Stack>
+                                <Stack.Item width="14px" textAlign="center">
+                                  <Icon
+                                    color={
+                                      category === 'Blood Cult'
+                                        ? 'red'
+                                        : 'default'
+                                    }
+                                    name={CATEGORY_ICONS[category] || 'circle'}
+                                  />
                                 </Stack.Item>
-                              )}
-                            </Stack>
-                          </Tabs.Tab>
-                        ))}
-                    </Tabs>
+                                <Stack.Item
+                                  grow
+                                  color={
+                                    category === 'Blood Cult' ? 'red' : 'default'
+                                  }
+                                >
+                                  {category}
+                                </Stack.Item>
+                                {category === 'Can Make' && (
+                                  <Stack.Item>
+                                    {Object.keys(craftability).length}
+                                  </Stack.Item>
+                                )}
+                              </Stack>
+                            </Tabs.Tab>
+                          ))}
+                      </Tabs>
+                    </Section>
                   </Box>
                 </Stack.Item>
                 <Stack.Item>


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
fixes #13473
## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

<img width="700" height="720" alt="image" src="https://github.com/user-attachments/assets/eaafda2c-4818-4681-b370-6b58e213057a" />

</details>

## Changelog
:cl: lord scrubling
fix: materials list in crafting can be scrolled
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
