### PR TITLE
Moves the map vote to the shuttle undocking

### DIFF
--- a/code/__HELPERS/roundend.dm
+++ b/code/__HELPERS/roundend.dm
@@ -303,7 +303,7 @@ GLOBAL_VAR(survivor_report) //! Contains shared survivor report for roundend rep
 	//stop collecting feedback during grifftime
 	SSblackbox.Seal()
 
-	if(GLOB.station_was_nuked && CONFIG_GET(flag/automapvote))
+	if(CONFIG_GET(flag/automapvote))
 		INVOKE_ASYNC(SSvote, TYPE_PROC_REF(/datum/controller/subsystem/vote, initiate_vote), /datum/vote/map_vote, "Map Rotation", null, TRUE)
 
 	sleep(50)

--- a/code/__HELPERS/roundend.dm
+++ b/code/__HELPERS/roundend.dm
@@ -303,7 +303,7 @@ GLOBAL_VAR(survivor_report) //! Contains shared survivor report for roundend rep
 	//stop collecting feedback during grifftime
 	SSblackbox.Seal()
 
-	if(CONFIG_GET(flag/automapvote))
+	if(GLOB.station_was_nuked && CONFIG_GET(flag/automapvote))
 		INVOKE_ASYNC(SSvote, TYPE_PROC_REF(/datum/controller/subsystem/vote, initiate_vote), /datum/vote/map_vote, "Map Rotation", null, TRUE)
 
 	sleep(50)

--- a/code/modules/shuttle/emergency.dm
+++ b/code/modules/shuttle/emergency.dm
@@ -520,6 +520,9 @@
 					color_override = "orange",
 				)
 
+				if(CONFIG_GET(flag/automapvote))
+					INVOKE_ASYNC(SSvote, TYPE_PROC_REF(/datum/controller/subsystem/vote, initiate_vote), /datum/vote/map_vote, "Map Rotation", null, TRUE)
+
 		if(SHUTTLE_STRANDED)
 			SSshuttle.checkHostileEnvironment()
 


### PR DESCRIPTION
## About The Pull Request

See title.

I (sort of) left the previous logic in on roundend so that the map vote is still called when the station is nuked

## Why It's Good For The Game

People don't really engage with the map vote now that it doesn't automatically popup- I still don't think it should since it's really disruptive to players and I hate having UIs opened when I don't click anything

## Testing Photographs and Procedure

https://github.com/user-attachments/assets/060a4135-5473-4752-9c87-409bbae95cc0

## Changelog
:cl:
tweak: The map vote is now sent during the shuttle ride to centcom
/:cl:
