### PR TITLE
Fix AI being round removed when shell falls into chasm

### DIFF
--- a/code/datums/components/chasm.dm
+++ b/code/datums/components/chasm.dm
@@ -139,7 +139,10 @@
 
 		if(iscyborg(AM))
 			var/mob/living/silicon/robot/S = AM
-			qdel(S.mmi)
+			if(S.shell && S.deployed && S.mainframe)
+				S.undeploy()
+			else
+				qdel(S.mmi)
 
 		falling_atoms -= falling_ref
 		qdel(AM)


### PR DESCRIPTION
## About The Pull Request

fixes #13503 

When a cyborg fell inside of a Chasm the game just deleted the MMI and then the Cyborg, now it checks if it's a shell and undeploys the AI first

(This is my first PR in a while, I did test it and all that but just letting you all know:)!)

## Why It's Good For The Game

Being round removed when your shell dies isn't fun!!!

## Testing Photographs and Procedure

<details>
<summary>Screenshots&Videos</summary>

https://github.com/user-attachments/assets/9577bd46-d41a-4cb9-9ef2-903ba80df6fe



</details>

## Changelog
:cl:
fix: AI no longer gets round removed when shell falls into a chasm
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
