### PR TITLE
Fixes wildmagic wizard apprentice getting no spells

### DIFF
--- a/code/modules/antagonists/wizard/equipment/spellbook_entries/_entry.dm
+++ b/code/modules/antagonists/wizard/equipment/spellbook_entries/_entry.dm
@@ -221,6 +221,7 @@
 	log_spellbook("[key_name(user)] cast [src] for [cost] points")
 	SSblackbox.record_feedback("tally", "wizard_spell_learned", 1, name)
 	log_purchase(user.key)
+	say_invocation(user)
 	return TRUE
 
 /datum/spellbook_entry/summon/proc/say_invocation(mob/living/carbon/human/user)

--- a/code/modules/antagonists/wizard/equipment/spellbook_entries/_entry.dm
+++ b/code/modules/antagonists/wizard/equipment/spellbook_entries/_entry.dm
@@ -32,6 +32,8 @@
 	var/requires_wizard_garb = FALSE
 	/// Used so you can't have specific spells together
 	var/list/no_coexistance_typecache
+	/// Wildmagic wizard apprentice should not get these
+	var/no_random = FALSE
 	/// Locking the purchase down for whatever reason
 	var/locked = FALSE
 /datum/spellbook_entry/New()
@@ -213,12 +215,17 @@
 	limit = 1
 	refundable = FALSE
 	buy_word = "Cast"
+	var/ritual_invocation // This does nothing. This is a flavor to ghosts observing a wizard.
 
 /datum/spellbook_entry/summon/buy_spell(mob/living/carbon/human/user, obj/item/spellbook/book)
 	log_spellbook("[key_name(user)] cast [src] for [cost] points")
 	SSblackbox.record_feedback("tally", "wizard_spell_learned", 1, name)
 	log_purchase(user.key)
 	return TRUE
+
+/datum/spellbook_entry/summon/proc/say_invocation(mob/living/carbon/human/user)
+	if(ritual_invocation)
+		user.say(ritual_invocation, forced = "spell")
 
 /// Non-purchasable flavor spells to populate the spell book with, for style.
 /datum/spellbook_entry/challenge

--- a/code/modules/antagonists/wizard/equipment/spellbook_entries/_entry.dm
+++ b/code/modules/antagonists/wizard/equipment/spellbook_entries/_entry.dm
@@ -215,7 +215,7 @@
 	limit = 1
 	refundable = FALSE
 	buy_word = "Cast"
-	var/ritual_invocation // This does nothing. This is a flavor to ghosts observing a wizard.
+	var/ritual_invocation // If set forces you to say a phrase as feedback when buying a summon spell
 
 /datum/spellbook_entry/summon/buy_spell(mob/living/carbon/human/user, obj/item/spellbook/book)
 	log_spellbook("[key_name(user)] cast [src] for [cost] points")

--- a/code/modules/antagonists/wizard/equipment/spellbook_entries/assistance.dm
+++ b/code/modules/antagonists/wizard/equipment/spellbook_entries/assistance.dm
@@ -26,6 +26,7 @@
 	spell_type = /datum/action/spell/tap
 	category = "Assistance"
 	cost = 1
+	no_random = WIZARD_NORANDOM_WILDAPPRENTICE
 
 /datum/spellbook_entry/item/staffanimation
 	name = "Staff of Animation"

--- a/code/modules/antagonists/wizard/equipment/spellbook_entries/defensive.dm
+++ b/code/modules/antagonists/wizard/equipment/spellbook_entries/defensive.dm
@@ -54,6 +54,7 @@
 		it will become easier for others to find your item of power."
 	spell_type =  /datum/action/spell/lichdom
 	category = "Defensive"
+	no_random = WIZARD_NORANDOM_WILDAPPRENTICE
 
 /datum/spellbook_entry/spacetime_dist
 	name = "Spacetime Distortion"

--- a/code/modules/antagonists/wizard/equipment/spellbook_entries/summons.dm
+++ b/code/modules/antagonists/wizard/equipment/spellbook_entries/summons.dm
@@ -15,7 +15,6 @@
 /datum/spellbook_entry/summon/guns/buy_spell(mob/living/carbon/human/user,obj/item/spellbook/book)
 	give_guns(user)
 	playsound(get_turf(user), 'sound/magic/castsummon.ogg', 50, TRUE)
-	say_invocation(user)
 	return ..()
 
 /datum/spellbook_entry/summon/magic
@@ -31,7 +30,6 @@
 /datum/spellbook_entry/summon/magic/buy_spell(mob/living/carbon/human/user,obj/item/spellbook/book)
 	give_magic(user, 10)
 	playsound(get_turf(user), 'sound/magic/castsummon.ogg', 50, TRUE)
-	say_invocation(user)
 	return ..()
 
 /datum/spellbook_entry/summon/events
@@ -50,7 +48,6 @@
 /datum/spellbook_entry/summon/events/buy_spell(mob/living/carbon/human/user, obj/item/spellbook/book)
 	summonevents(user)
 	playsound(get_turf(user), 'sound/magic/castsummon.ogg', 50, TRUE)
-	say_invocation(user)
 	return ..()
 
 /datum/spellbook_entry/summon/curse_of_madness
@@ -66,7 +63,6 @@
 		return FALSE
 	curse_of_madness(user, message)
 	playsound(user, 'sound/magic/mandswap.ogg', 50, TRUE)
-	say_invocation(user)
 	return ..()
 
 #undef MINIMUM_THREAT_FOR_RITUALS

--- a/code/modules/antagonists/wizard/equipment/spellbook_entries/summons.dm
+++ b/code/modules/antagonists/wizard/equipment/spellbook_entries/summons.dm
@@ -6,6 +6,7 @@
 	name = "Summon Guns"
 	desc = "Nothing could possibly go wrong with arming a crew of lunatics just itching for an excuse to kill you. \
 		There is a good chance that they will shoot each other first."
+	ritual_invocation = "ALADAL DESINARI ODORI'IN TUUR'IS OVOR'E POR"
 
 /datum/spellbook_entry/summon/guns/can_be_purchased()
 	// Also must be config enabled
@@ -14,12 +15,14 @@
 /datum/spellbook_entry/summon/guns/buy_spell(mob/living/carbon/human/user,obj/item/spellbook/book)
 	give_guns(user)
 	playsound(get_turf(user), 'sound/magic/castsummon.ogg', 50, TRUE)
+	say_invocation(user)
 	return ..()
 
 /datum/spellbook_entry/summon/magic
 	name = "Summon Magic"
 	desc = "Share the wonders of magic with the crew and show them \
 		why they aren't to be trusted with it at the same time."
+	ritual_invocation = "ALADAL DESINARI ODORI'IN IDO'LEX SPERMITA OVOR'E POR"
 
 /datum/spellbook_entry/summon/magic/can_be_purchased()
 	// Also must be config enabled
@@ -28,6 +31,7 @@
 /datum/spellbook_entry/summon/magic/buy_spell(mob/living/carbon/human/user,obj/item/spellbook/book)
 	give_magic(user, 10)
 	playsound(get_turf(user), 'sound/magic/castsummon.ogg', 50, TRUE)
+	say_invocation(user)
 	return ..()
 
 /datum/spellbook_entry/summon/events
@@ -37,6 +41,7 @@
 		Multiple castings increase the rate of these events."
 	cost = 2
 	limit = 5 // Each purchase can intensify it.
+	ritual_invocation = "ALADAL DESINARI ODORI'IN IDO'LEX MANAG'ROKT OVOR'E POR"
 
 /datum/spellbook_entry/summon/events/can_be_purchased()
 	// Also, must be config enabled
@@ -45,6 +50,7 @@
 /datum/spellbook_entry/summon/events/buy_spell(mob/living/carbon/human/user, obj/item/spellbook/book)
 	summonevents(user)
 	playsound(get_turf(user), 'sound/magic/castsummon.ogg', 50, TRUE)
+	say_invocation(user)
 	return ..()
 
 /datum/spellbook_entry/summon/curse_of_madness
@@ -52,6 +58,7 @@
 	desc = "Curses the station, warping the minds of everyone inside, causing lasting traumas. Warning: this spell can affect you if not cast from a safe distance."
 	cost = 4
 	locked = TRUE
+	ritual_invocation = "ALADAL DESINARI ODORI'IN PORES ENHIDO'LEN MORI MAKA TU"
 
 /datum/spellbook_entry/summon/curse_of_madness/buy_spell(mob/living/carbon/human/user, obj/item/spellbook/book)
 	var/message = tgui_input_text(user, "Whisper a secret truth to drive your victims to madness", "Whispers of Madness")
@@ -59,6 +66,7 @@
 		return FALSE
 	curse_of_madness(user, message)
 	playsound(user, 'sound/magic/mandswap.ogg', 50, TRUE)
+	say_invocation(user)
 	return ..()
 
 #undef MINIMUM_THREAT_FOR_RITUALS

--- a/code/modules/antagonists/wizard/wizard.dm
+++ b/code/modules/antagonists/wizard/wizard.dm
@@ -251,6 +251,32 @@ GLOBAL_LIST_EMPTY(wizard_spellbook_purchases_by_key)
 			to_chat(owner, ("<span class='bold'>Your service has not gone unrewarded, however. \
 				Studying under [master.current.real_name], you have learned stealthy, \
 				robeless spells. You are able to cast knock and mindswap.</span>"))
+		if(APPRENTICE_WILDMAGIC)
+			var/static/list/spell_entry
+			if(!spell_entry)
+				spell_entry = list()
+				for(var/datum/spellbook_entry/each_entry as() in subtypesof(/datum/spellbook_entry) - typesof(/datum/spellbook_entry/item) - typesof(/datum/spellbook_entry/summon))
+					spell_entry += new each_entry
+
+			var/spells_left = 2
+			while(spells_left)
+				var/failsafe = FALSE
+				var/datum/spellbook_entry/chosen_spell = pick(spell_entry)
+				if(chosen_spell.no_random)
+					continue
+				for(var/spell in owner.current.actions)
+					if(chosen_spell == spell) // You don't learn the same spell
+						failsafe = TRUE
+						break
+					if(is_type_in_typecache(spell, chosen_spell.no_coexistance_typecache)) // You don't learn a spell that isn't compatible with another
+						failsafe = TRUE
+						break
+				if(failsafe)
+					continue
+				var/new_spell = chosen_spell.spell_type
+				spells_to_grant += new_spell
+				spells_left--
+			to_chat(owner, "<b>Your service has not gone unrewarded, however. Studying under [master.current.real_name], you have learned special spells that aren't available to standard apprentices.</b>")
 
 	for(var/spell_type in spells_to_grant)
 		var/datum/action/spell/new_spell = new spell_type(owner)

--- a/code/modules/antagonists/wizard/wizard.dm
+++ b/code/modules/antagonists/wizard/wizard.dm
@@ -276,7 +276,7 @@ GLOBAL_LIST_EMPTY(wizard_spellbook_purchases_by_key)
 				var/new_spell = chosen_spell.spell_type
 				spells_to_grant += new_spell
 				spells_left--
-			to_chat(owner, "<b>Your service has not gone unrewarded, however. Studying under [master.current.real_name], you have learned special spells that aren't available to standard apprentices.</b>")
+			to_chat(owner, span_bold("Your service has not gone unrewarded, however. Studying under [master.current.real_name], you have learned special spells that aren't available to standard apprentices."))
 
 	for(var/spell_type in spells_to_grant)
 		var/datum/action/spell/new_spell = new spell_type(owner)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Restores wildmagic wizard apprentice code + the thing you say when you cast a summon spell which were erroneously removed in https://github.com/BeeStation/BeeStation-Hornet/pull/11527
There was also a spell that gave you random spells + items that got removed but we have an almost similar replacement already.
Closes https://github.com/BeeStation/BeeStation-Hornet/issues/13524

## Why It's Good For The Game
Fix

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>

Removed because it contained my CID.

<summary>Screenshots&Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>

## Changelog
:cl:
fix: Fixed wildmagic wizard apprentice getting no spells
add: Readded the invocation phrase when buying summon spells
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
