### PR TITLE
Fixes holy books not using preference name

### DIFF
--- a/code/modules/jobs/job_types/chaplain.dm
+++ b/code/modules/jobs/job_types/chaplain.dm
@@ -102,7 +102,7 @@
 		if("weeaboo","kawaii")
 			B.name = pick("Fanfiction Compendium","Japanese for Dummies","The Manganomicon","Establishing Your O.T.P")
 		else
-			B.name = "The Holy Book of [new_religion]"
+			B.name = preference_source?.prefs?.read_character_preference(/datum/preference/name/bible) || "The Holy Book of [new_religion]"
 
 	GLOB.religion = new_religion
 	GLOB.bible_name = B.name


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
previously useless
<img width="474" height="352" alt="image" src="https://github.com/user-attachments/assets/f5f99016-ba92-4ecb-a18a-1b79e581bccc" />

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

the preference didn't do anything before

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

https://github.com/user-attachments/assets/f1979d3e-694e-4f85-b44f-7bad01c83c36

</details>

## Changelog
:cl:
fix: holy books properly use your preferred bible name, unless your religion name matches a preset
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
