### PR TITLE
Job group size is now based on average rather than minimum

### DIFF
--- a/code/modules/jobs/job_types/_job.dm
+++ b/code/modules/jobs/job_types/_job.dm
@@ -241,8 +241,9 @@
 			return -1
 		return max(proxy.total_positions + total_position_delta, 0)
 	// Calculate spawn group size
-	var/spawn_group_total = INFINITY
-	var/list/spawn_group_sizes = list()
+	var/spawn_group_total = 0
+	// Amount of jobs in the same job group as us
+	var/spawn_group_sizes = 0
 	for (var/datum/job/other in SSjob.occupations)
 		// Find everything in the same group, doesn't matter if its us
 		if (other.dynamic_spawn_group != proxy.dynamic_spawn_group)
@@ -252,8 +253,7 @@
 		// If the HOP adds a position to a job group, then it has to be filled before the spawn
 		// group bumps.
 		spawn_group_total += other.count_players_in_group()
-		if (other.dynamic_spawn_group)
-			spawn_group_sizes |= other.dynamic_spawn_group
+		spawn_group_sizes ++
 	// The amount of positions we have is the least filled job + our allowed variance
 	// variance is calculated per job, not based on the proxy
 	// If we are using a proxy, then the number of spawn positions is limited to the total
@@ -267,7 +267,7 @@
 	// being only limited by its spawn variance limit
 	if (proxy == src || ignore_self_limit || proxy.dynamic_spawn_group)
 		position_limit = INFINITY
-	return min(position_limit, max((spawn_group_minimum / length(spawn_group_sizes)) + proxy.dynamic_spawn_variance_limit + total_position_delta, 0))
+	return min(position_limit, max((spawn_group_total / spawn_group_sizes) + proxy.dynamic_spawn_variance_limit + total_position_delta, 0))
 
 /// Only override this proc, unless altering loadout code. Loadouts act on H but get info from M
 /// H is usually a human unless an /equip override transformed it

--- a/code/modules/jobs/job_types/_job.dm
+++ b/code/modules/jobs/job_types/_job.dm
@@ -267,7 +267,7 @@
 	// being only limited by its spawn variance limit
 	if (proxy == src || ignore_self_limit || proxy.dynamic_spawn_group)
 		position_limit = INFINITY
-	return min(position_limit, max(ceil(spawn_group_total / spawn_group_sizes) + proxy.dynamic_spawn_variance_limit + total_position_delta, 0))
+	return min(position_limit, max(ceil(spawn_group_total / min(spawn_group_sizes, 1)) + proxy.dynamic_spawn_variance_limit + total_position_delta, 0))
 
 /// Only override this proc, unless altering loadout code. Loadouts act on H but get info from M
 /// H is usually a human unless an /equip override transformed it

--- a/code/modules/jobs/job_types/_job.dm
+++ b/code/modules/jobs/job_types/_job.dm
@@ -241,7 +241,8 @@
 			return -1
 		return max(proxy.total_positions + total_position_delta, 0)
 	// Calculate spawn group size
-	var/spawn_group_minimum = INFINITY
+	var/spawn_group_total = INFINITY
+	var/list/spawn_group_sizes = list()
 	for (var/datum/job/other in SSjob.occupations)
 		// Find everything in the same group, doesn't matter if its us
 		if (other.dynamic_spawn_group != proxy.dynamic_spawn_group)
@@ -250,7 +251,9 @@
 		// If the HOP removes a position from another job, then that removed position.
 		// If the HOP adds a position to a job group, then it has to be filled before the spawn
 		// group bumps.
-		spawn_group_minimum = min(spawn_group_minimum, other.count_players_in_group())
+		spawn_group_total += other.count_players_in_group()
+		if (other.dynamic_spawn_group)
+			spawn_group_sizes |= other.dynamic_spawn_group
 	// The amount of positions we have is the least filled job + our allowed variance
 	// variance is calculated per job, not based on the proxy
 	// If we are using a proxy, then the number of spawn positions is limited to the total
@@ -264,7 +267,7 @@
 	// being only limited by its spawn variance limit
 	if (proxy == src || ignore_self_limit || proxy.dynamic_spawn_group)
 		position_limit = INFINITY
-	return min(position_limit, max(spawn_group_minimum + proxy.dynamic_spawn_variance_limit + total_position_delta, 0))
+	return min(position_limit, max((spawn_group_minimum / length(spawn_group_sizes)) + proxy.dynamic_spawn_variance_limit + total_position_delta, 0))
 
 /// Only override this proc, unless altering loadout code. Loadouts act on H but get info from M
 /// H is usually a human unless an /equip override transformed it

--- a/code/modules/jobs/job_types/_job.dm
+++ b/code/modules/jobs/job_types/_job.dm
@@ -135,7 +135,7 @@
 	var/dynamic_spawn_group = null
 	/// The maximum allowed variance to other job roles in this group.
 	/// Should be the same as everything else in the dynamic spawn group
-	var/dynamic_spawn_variance_limit = 3
+	var/dynamic_spawn_variance_limit = 2
 	/// How many times should this role count towards the spawn group size?
 	var/dynamic_spawn_group_multiplier = 1
 

--- a/code/modules/jobs/job_types/_job.dm
+++ b/code/modules/jobs/job_types/_job.dm
@@ -267,7 +267,7 @@
 	// being only limited by its spawn variance limit
 	if (proxy == src || ignore_self_limit || proxy.dynamic_spawn_group)
 		position_limit = INFINITY
-	return min(position_limit, max(ceil(spawn_group_total / min(spawn_group_sizes, 1)) + proxy.dynamic_spawn_variance_limit + total_position_delta, 0))
+	return min(position_limit, max(ceil(spawn_group_total / max(spawn_group_sizes, 1)) + proxy.dynamic_spawn_variance_limit + total_position_delta, 0))
 
 /// Only override this proc, unless altering loadout code. Loadouts act on H but get info from M
 /// H is usually a human unless an /equip override transformed it

--- a/code/modules/jobs/job_types/_job.dm
+++ b/code/modules/jobs/job_types/_job.dm
@@ -267,7 +267,7 @@
 	// being only limited by its spawn variance limit
 	if (proxy == src || ignore_self_limit || proxy.dynamic_spawn_group)
 		position_limit = INFINITY
-	return min(position_limit, max((spawn_group_total / spawn_group_sizes) + proxy.dynamic_spawn_variance_limit + total_position_delta, 0))
+	return min(position_limit, max(ceil(spawn_group_total / spawn_group_sizes) + proxy.dynamic_spawn_variance_limit + total_position_delta, 0))
 
 /// Only override this proc, unless altering loadout code. Loadouts act on H but get info from M
 /// H is usually a human unless an /equip override transformed it


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

- Job group size is no longer based off of the average of all departments populations, rather than minimum.
- This means if all jobs have 3 people, but cargo has 0, then the average will be (3 * 4 + 0) / 5, instead of using the minimum value of 0

## Why It's Good For The Game

Allow people to play the roles they want at higher pops, even if a department is lacking one specific person.

## Testing Photographs and Procedure

<img width="248" height="50" alt="image" src="https://github.com/user-attachments/assets/2d1641ad-2219-4cac-8cc0-ff1b8c5423cc" />

<img width="1135" height="75" alt="image" src="https://github.com/user-attachments/assets/1eed27b4-4921-49ba-90ff-f42b55207610" />

<img width="206" height="209" alt="image" src="https://github.com/user-attachments/assets/2b302c6e-e10f-47c6-9b71-4db5cb343916" />

I could take that role, but adding all new roles in engineering, it unlocks again:

<img width="234" height="240" alt="image" src="https://github.com/user-attachments/assets/cf999bf9-b2c1-4300-bdd9-717cff10910c" />

## Changelog
:cl:
tweak: Job group size is now based off of average job fill numbers, rather than the least populated department.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
