### PR TITLE
Makes cargo crates easier to open

### DIFF
--- a/code/game/objects/structures/crates_lockers/crates/secure.dm
+++ b/code/game/objects/structures/crates_lockers/crates/secure.dm
@@ -8,8 +8,7 @@
 	armor_type = /datum/armor/crate_secure
 	var/tamperproof = 0
 	icon_door = "crate"
-	damage_deflection = 25
-
+	damage_deflection = 20
 
 /datum/armor/crate_secure
 	melee = 30

--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -6,9 +6,8 @@
 	var/current_supply
 	var/max_supply = 5
 	var/cost = 400 // Minimum cost, or infinite points are possible. I've already had to fix it once because someone didn't listen. Don't be THAT person.
-	var/access = FALSE
+	var/access = null
 	var/access_budget = FALSE //prevents people from requesting stupid stuff with their department's budget via app
-	var/access_any = FALSE
 	var/list/contains = null
 	var/crate_name = "crate"
 	var/desc = ""//no desc by default
@@ -34,10 +33,12 @@
 	else
 		C = new crate_type(A)
 		C.name = crate_name
-	if(access)
-		C.req_access = list(access)
-	if(access_any)
-		C.req_one_access = access_any
+	if(access && !paying_account)
+		// Assign access
+		if (islist(access))
+			C.req_one_access = access
+		else
+			C.req_one_access = list(access)
 
 	fill(C)
 	return C
@@ -455,9 +456,8 @@
 	desc = "Contains one speedloader of .38 DumDum ammunition, good for embedding in soft targets. Requires Security or Forensics access to open."
 	cost = 1200
 	max_supply = 4
-	access = FALSE
 	small_item = TRUE
-	access_any = list(ACCESS_SECURITY, ACCESS_FORENSICS_LOCKERS)
+	access = list(ACCESS_SECURITY, ACCESS_FORENSICS_LOCKERS)
 	contains = list(/obj/item/ammo_box/c38/dumdum)
 	crate_name = ".38 match crate"
 
@@ -466,9 +466,8 @@
 	desc = "Contains one speedloader of match grade .38 ammunition, perfect for showing off trickshots. Requires Security or Forensics access to open."
 	cost = 1200
 	max_supply = 3
-	access = FALSE
 	small_item = TRUE
-	access_any = list(ACCESS_SECURITY, ACCESS_FORENSICS_LOCKERS)
+	access = list(ACCESS_SECURITY, ACCESS_FORENSICS_LOCKERS)
 	contains = list(/obj/item/ammo_box/c38/match)
 	crate_name = ".38 match crate"
 

--- a/code/modules/shuttle/supply.dm
+++ b/code/modules/shuttle/supply.dm
@@ -146,8 +146,6 @@ GLOBAL_LIST_INIT(whitelisted_cargo_types, typecacheof(list(
 					misc_contents[D.account_holder] += item
 				misc_costs[D.account_holder] += SO.pack.cost
 				misc_order_num[D.account_holder] = "[misc_order_num[D.account_holder]]#[SO.id]  "
-				if(SO.pack.access)
-					miscboxes[D.account_holder].req_access |= SO.pack.access
 			else //No private payment, so we just stuff it all into a generic crate
 				if(!miscboxes.len || !miscboxes["Cargo"])
 					miscboxes["Cargo"] = new /obj/structure/closet/crate/secure(pick_n_take(empty_turfs))

--- a/code/modules/xenoarchaeology/tools/console/xenoarchaeology_seller.dm
+++ b/code/modules/xenoarchaeology/tools/console/xenoarchaeology_seller.dm
@@ -117,7 +117,6 @@
 	hidden = TRUE
 	crate_name = "research material container"
 	crate_type = /obj/structure/closet/crate/science
-	access_any = TRUE
 	max_supply = 1
 	current_supply = 1
 	cost = 0


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

- Privately purchased crates no longer require access to open.
- Spears can now break open crates

## Why It's Good For The Game

Its fun to be able to privately purchase things from cargo for your evil deeds. In an emergency you can pay a premium to get crates that you can open.

## Testing Photographs and Procedure

<img width="215" height="214" alt="image" src="https://github.com/user-attachments/assets/55ccded3-0d1a-4f87-9aa8-4436e7ce1dae" />

## Changelog
:cl:
balance: Privately purchased crates can be opened without access requirements.
balance: Spears can break open locked crates.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
