### PR TITLE
Grenades no longer delete on detonation

### DIFF
--- a/code/__DEFINES/devices.dm
+++ b/code/__DEFINES/devices.dm
@@ -90,3 +90,5 @@ GLOBAL_LIST_INIT(ntos_device_themes_emagged, list(
 #define GRENADE_WIRED 2
 /// Grenade is ready to be activated
 #define GRENADE_READY 3
+/// Grenade is detonated and useless
+#define GRENADE_DETONATED 4

--- a/code/game/objects/items/grenades/chem_grenade.dm
+++ b/code/game/objects/items/grenades/chem_grenade.dm
@@ -45,7 +45,7 @@
 				for(var/datum/reagent/R in G.reagents.reagent_list)
 					. += span_notice("[R.volume] units of [R.name] in the [G.name].")
 			for(var/datum/reagent/R in reagents.reagent_list)
-				. += span_notice("[R.volume] units of [R.name] in the [G.name].")
+				. += span_notice("[R.volume] units of [R.name] in the [name].")
 			if(beakers.len == 1)
 				. += span_notice("You detect no second beaker in the grenade.")
 		else

--- a/code/game/objects/items/grenades/chem_grenade.dm
+++ b/code/game/objects/items/grenades/chem_grenade.dm
@@ -227,7 +227,6 @@
 
 	reagents.flags |= NO_REACT
 
-	var/list/datum/reagents/reactants = list()
 	for(var/obj/item/G in beakers)
 		if (G.reagents)
 			G.reagents.trans_to(src, G.reagents.total_volume)
@@ -243,6 +242,7 @@
 
 	max_integrity = 1
 	atom_integrity = 1
+	update_icon()
 
 /obj/item/grenade/chem_grenade/ex_act(severity, target)
 	if (stage == GRENADE_DETONATED)

--- a/code/modules/reagents/chemistry/recipes/pyrotechnics.dm
+++ b/code/modules/reagents/chemistry/recipes/pyrotechnics.dm
@@ -564,7 +564,7 @@
 	hints = list(
 		REACTION_HINT_EXPLOSION_OTHER = "Reduces the temperature of the container when created",
 	)
-	reaction_tags = REACTION_TAG_OTHER
+	reaction_tags = REACTION_TAG_OTHER | REACTION_TAG_EXPLOSIVE
 
 /datum/chemical_reaction/cryostylane/on_reaction(datum/reagents/holder, created_volume)
 	holder.chem_temp = 20 // cools the fuck down
@@ -578,7 +578,7 @@
 	hints = list(
 		REACTION_HINT_EXPLOSION_OTHER = "Reduces the temperature of the container when created, according to the amount created",
 	)
-	reaction_tags = REACTION_TAG_OTHER
+	reaction_tags = REACTION_TAG_OTHER | REACTION_TAG_EXPLOSIVE
 
 /datum/chemical_reaction/cryostylane_oxygen/on_reaction(datum/reagents/holder, created_volume)
 	holder.chem_temp = max(holder.chem_temp - 10*created_volume,0)
@@ -591,7 +591,7 @@
 	hints = list(
 		REACTION_HINT_EXPLOSION_OTHER = "Increases the temperature of the container when created, according to the amount created",
 	)
-	reaction_tags = REACTION_TAG_OTHER
+	reaction_tags = REACTION_TAG_OTHER | REACTION_TAG_EXPLOSIVE
 
 /datum/chemical_reaction/pyrosium_oxygen/on_reaction(datum/reagents/holder, created_volume)
 	holder.chem_temp += 10*created_volume
@@ -603,7 +603,7 @@
 	hints = list(
 		REACTION_HINT_EXPLOSION_OTHER = "Increases the temperature of the container when created",
 	)
-	reaction_tags = REACTION_TAG_OTHER
+	reaction_tags = REACTION_TAG_OTHER | REACTION_TAG_EXPLOSIVE
 
 /datum/chemical_reaction/pyrosium/on_reaction(datum/reagents/holder, created_volume)
 	holder.chem_temp = 20 // also cools the fuck down


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

- Chemical grenades are no longer deleted upon detonation, allowing you to make advanced reactions which have a delay.

## Why It's Good For The Game

I want to be able to create more interesting grenade combinations other than just potassium + water, maybe something that sucks people in before heating up an explosive compound which then detonates.

## Testing Photographs and Procedure

Pot water grenade:

<img width="246" height="178" alt="image" src="https://github.com/user-attachments/assets/3586ce19-2bf8-4af5-8339-971a2c8440c9" />

<img width="559" height="404" alt="image" src="https://github.com/user-attachments/assets/e798fa74-d999-47e4-8a49-475d6bf97465" />

A grenade which does a reaction that requires heating using pyrosium:

<img width="241" height="250" alt="image" src="https://github.com/user-attachments/assets/839c74ad-822a-4db0-bb26-c6872245a420" />

Heat grenade:

<img width="262" height="175" alt="image" src="https://github.com/user-attachments/assets/ef1e8f13-1ce5-4204-a7a8-3dcbc860e31b" />

<img width="324" height="225" alt="image" src="https://github.com/user-attachments/assets/927bcf2b-d489-4248-bbc5-bab3064227fb" />

As a side effect, non-exploded grenades will leave behind some evidence:

<img width="797" height="70" alt="image" src="https://github.com/user-attachments/assets/5940b335-f256-447e-a3f8-90ee15927ab6" />


## Changelog
:cl:
tweak: Grenades no longer disappear when exploding, and keep their vessel so that slow reactions can take place.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
