### PR TITLE
Fixes some issues with aiming

### DIFF
--- a/code/datums/components/aiming.dm
+++ b/code/datums/components/aiming.dm
@@ -171,9 +171,11 @@ AIMING_DROP_WEAPON means they selected the "drop your weapon" command
 
 /datum/component/aiming/proc/show_ui(mob/user, mob/target, stage)
 	var/list/options = list()
-	var/list/possible_actions = list(CANCEL, SHOOT, RAISE_HANDS, POINTBLANK)
+	var/list/possible_actions = list(CANCEL, SHOOT, RAISE_HANDS)
 	if(holding_at_gunpoint)
 		possible_actions += LET_GO
+	else
+		possible_actions += POINTBLANK
 	if (auto_shoot)
 		possible_actions += DISABLE_AUTO
 	else
@@ -218,6 +220,8 @@ AIMING_DROP_WEAPON means they selected the "drop your weapon" command
 			auto_shoot = FALSE
 			user.manual_emote("hesitates, lowering their weapon")
 		if(POINTBLANK)
+			if (holding_at_gunpoint)
+				return
 			if(get_dist(target, user) > 1)
 				to_chat(user, span_warning("You need to be closer to [target] to hold [target.p_them()] at gunpoint!"))
 				return

--- a/code/datums/components/aiming.dm
+++ b/code/datums/components/aiming.dm
@@ -229,8 +229,7 @@ AIMING_DROP_WEAPON means they selected the "drop your weapon" command
 				to_chat(user, span_warning("You can't hold someone at gunpoint with an empty hand!"))
 				return
 			if(!user.pulling || user.pulling != target)
-				var/mob/living/carbon/human/H = user
-				H.CtrlClick(user)
+				target.CtrlClick(user)
 				return
 			if(user.pulling != target)
 				return

--- a/code/datums/components/aiming.dm
+++ b/code/datums/components/aiming.dm
@@ -40,7 +40,7 @@
 		return
 	if(src.target || user == target) // No double-aiming
 		return
-	if (!do_after(user, 1 SECONDS, target))
+	if (!do_after(user, 1 SECONDS, target, IGNORE_TARGET_LOC_CHANGE))
 		return
 	src.user = user
 	src.target = target
@@ -234,6 +234,8 @@ AIMING_DROP_WEAPON means they selected the "drop your weapon" command
 				return
 			if(user.pulling != target)
 				return
+			user.setGrabState(GRAB_AGGRESSIVE)
+			target.Stun(2 SECONDS)
 			user.say(pick("Freeze!", "Don't move!", "Don't twitch a muscle!", "Don't you dare move!", "Hold still!"), forced = "Weapon aiming")
 			user.visible_message(span_warning("[user] lines up \the [held] with [target]'s temple!"), \
 			span_notice("You line up \the [held] with [target]'s temple"), ignored_mobs = list(target))
@@ -285,8 +287,8 @@ AIMING_DROP_WEAPON means they selected the "drop your weapon" command
 		UnregisterSignal(target, COMSIG_MOB_DROPPED_ITEM)
 		UnregisterSignal(target, COMSIG_LIVING_STATUS_PARALYZE)
 		UnregisterSignal(target, COMSIG_MOVABLE_MOVED)
-	if(user)
 		user.manual_emote("stops aiming their weapon", "lowers their weapon, satisfied")
+	if(user)
 		UnregisterSignal(user, COMSIG_MOVABLE_MOVED)
 	// Clean up the menu if it's still open
 	QDEL_NULL(choice_menu)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

- Fixes the point blank grab mode not working if the target wasn't already grabbed.
- Fixes dropping a gun after aiming showing a 'lowers their weapon' emote for the rest of the round.
- You can now aim at a moving target, assuming you aren't moving yourself.

## Why It's Good For The Game

These fix some bugs with aiming, and allowing your target to move makes you less likely to lose a target that happens to move in maints (or sees your gun) without making it so aiming can be abused during chases.

## Testing Photographs and Procedure

<img width="339" height="414" alt="image" src="https://github.com/user-attachments/assets/1db34d5a-3c3a-4069-a374-de2484f155f8" />

<img width="298" height="272" alt="image" src="https://github.com/user-attachments/assets/3024319d-27d6-4eb8-9417-a6b5b29553d0" />

<img width="232" height="200" alt="image" src="https://github.com/user-attachments/assets/fff343d2-2adc-4f1b-8cae-7aaf3485bd8c" />

<img width="185" height="168" alt="image" src="https://github.com/user-attachments/assets/df554815-b67c-4648-8195-66daf152e776" />

No spammed emote

## Changelog
:cl:
fix: Fixes 'you lower your weapon' emote being called even after finishing aiming.
fix: Fixes the point blank hostage mode while not grabbing the target.
balance: You can now aim at moving targets as long as you yourself are standing still
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
