### PR TITLE
Fixes augury runtime

### DIFF
--- a/code/controllers/subsystem/augury.dm
+++ b/code/controllers/subsystem/augury.dm
@@ -31,17 +31,15 @@ SUBSYSTEM_DEF(augury)
 			biggest_threat = threat
 
 	if(length(doombringers))
-		for(var/mob/dead/observer/O in GLOB.player_list)
-			if(!(O in observers_given_action))
-				var/datum/action/augury/A = new
-				A.Grant(O)
-				observers_given_action += O
+		for(var/mob/dead/observer/observer in GLOB.player_list - observers_given_action)
+			var/datum/action/augury/action = new()
+			action.Grant(observer)
+			observers_given_action += observer
 	else
-		for(var/mob/dead/observer/O as() in observers_given_action)
-			for(var/datum/action/augury/A in O.actions)
-				qdel(A)
-				O.actions -= A
-			observers_given_action -= O
+		for(var/mob/dead/observer/observer in observers_given_action)
+			for(var/datum/action/augury/action in observer.actions)
+				qdel(action)
+			observers_given_action -= observer
 
 	for(var/mob/dead/observer/W as() in watchers)
 		if(QDELETED(W))


### PR DESCRIPTION
## About The Pull Request

Observers can disappear at practically any moment. They can disconnect, be revived, or gain a new body. So the `as()` in the code below was including null observers.

```dm
for(var/mob/dead/observer/O as() in observers_given_action)
```

I also replaced this code:

```dm
for(var/mob/dead/observer/O in GLOB.player_list)
	if(!(O in observers_given_action))
```

with:

```dm
for(var/mob/dead/observer/observer in GLOB.player_list - observers_given_action)
```

It's functionally the same and a bit neater in my opinion.

Aaaand one last thing... This tiny code block here wasn't properly converted in the proc holders removal. When an action is destroyed it is removed from its mob's actions. The simple solution was to remove the `O.actions -= A`

```dm
for(var/datum/action/augury/A in O.actions)
	qdel(A)
	O.actions -= A
```

This PR doesn't fix the stupidity of the system because I honestly couldn't be bothered. Ghosts being deleted will still hard del.

## Why It's Good For The Game

I want to be able to have the auto runtime breakpoints on without it pausing on something that isn't my fault

## Testing Photographs and Procedure

<img width="590" height="423" alt="image" src="https://github.com/user-attachments/assets/dd112d92-386b-4957-afde-bd5ef356d67e" />

## Changelog

no user facing changes