### PR TITLE
Fixes mail not delivering to antagonists

### DIFF
--- a/code/game/objects/items/mail.dm
+++ b/code/game/objects/items/mail.dm
@@ -246,7 +246,8 @@
 	var/list/mail_recipients = list()
 
 	for(var/mob/living/carbon/human/human in GLOB.player_list)
-		// Skip wizards, nuke ops, cyborgs and dead people; Centcom does not send them mail
+		// Mail is not routed to anyone who isn't present on the manifest, since how would we know
+		// to send their mail here?
 		if(!human.mind || !find_record(human.mind.name, GLOB.manifest.general))
 			continue
 

--- a/code/game/objects/items/mail.dm
+++ b/code/game/objects/items/mail.dm
@@ -247,7 +247,7 @@
 
 	for(var/mob/living/carbon/human/human in GLOB.player_list)
 		// Skip wizards, nuke ops, cyborgs and dead people; Centcom does not send them mail
-		if(!human.mind || !find_record(human.mind.name))
+		if(!human.mind || !find_record(human.mind.name, GLOB.manifest.general))
 			continue
 
 		mail_recipients += human.mind

--- a/code/game/objects/items/mail.dm
+++ b/code/game/objects/items/mail.dm
@@ -247,7 +247,7 @@
 
 	for(var/mob/living/carbon/human/human in GLOB.player_list)
 		// Skip wizards, nuke ops, cyborgs and dead people; Centcom does not send them mail
-		if(human.stat == DEAD || !human.mind || !SSjob.GetJob(human.mind.assigned_role) || human.mind.special_role)
+		if(!human.mind || !find_record(human.mind.name))
 			continue
 
 		mail_recipients += human.mind


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Mail will now deliver to dead people and antagonists, anyone who is present on the crew manifest. It doesn't make sense that mail stops being delivered to someone when they are dead, and the mail system could be exploited to hard-clear someone or recognize that they are alive.

## Why It's Good For The Game

Self-explanatory, we do not want mail to be a hard-clear that someone is not an antagonist.

## Testing Photographs and Procedure

Set loads of mail waiting:

<img width="481" height="339" alt="image" src="https://github.com/user-attachments/assets/20e132ce-8bf1-4f40-99b0-ec427635983e" />

Spawn a mail crate:

<img width="412" height="44" alt="image" src="https://github.com/user-attachments/assets/0abc2eda-cfeb-4fb7-9cf4-5dff8d2c4fd0" />

<img width="135" height="92" alt="image" src="https://github.com/user-attachments/assets/87c6a65c-9829-4feb-8f5d-8115a4876e52" />

Remove ourselves from the manifest:

<img width="242" height="52" alt="image" src="https://github.com/user-attachments/assets/d8d45cf4-4d52-432d-a41f-c0d78e74ae6c" />

No more mail:

<img width="157" height="110" alt="image" src="https://github.com/user-attachments/assets/7e9db938-ece8-403b-838b-22eeb130ba75" />

## Changelog
:cl:
fix: Mail can now be delivered to antagonists and dead people, provided they are present on the station's manifest.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
