### PR TITLE
Fixes runtime when deleting xenoartifacts with labels on them

### DIFF
--- a/code/modules/xenoarchaeology/tools/xenoarchaeology_labeler.dm
+++ b/code/modules/xenoarchaeology/tools/xenoarchaeology_labeler.dm
@@ -218,6 +218,10 @@
 	sticker_icon_state = "[icon_state]_small"
 	return ..()
 
+/obj/item/sticker/xenoartifact_label/Destroy()
+	UnregisterSignal(loc, COMSIG_ATOM_EXAMINE)
+	return ..()
+
 /obj/item/sticker/xenoartifact_label/examine(mob/user)
 	. = ..()
 	. += examine_override
@@ -248,6 +252,9 @@
 	RegisterSignal(target, COMSIG_ATOM_EXAMINE, PROC_REF(parent_examine))
 
 /obj/item/sticker/xenoartifact_label/unstick(atom/override)
+	if(QDELETED(src))
+		return
+
 	if(sticker_state == STICKER_STATE_STUCK)
 		UnregisterSignal(loc, COMSIG_ATOM_EXAMINE)
 	//Set custom price back


### PR DESCRIPTION
## About The Pull Request

See title.

The runtime was caused because when an object has `Destroy()` called it's moved to nullspace and both of these logic blocks were checking `loc`

## Why It's Good For The Game

I'm trying to fix runtimes that I see on the server

## Testing Photographs and Procedure

https://github.com/user-attachments/assets/68c1cd4f-bb67-4a78-96f3-59e0d33f3475

## Changelog

no user facing changes