### PR TITLE
Fixes screentip preference runtime

### DIFF
--- a/code/modules/client/preferences/entries/player/screentips.dm
+++ b/code/modules/client/preferences/entries/player/screentips.dm
@@ -8,4 +8,4 @@
 /datum/preference/toggle/screentips/apply_to_client(client/client, value)
 	client?.show_screentips = value
 	if (!value)
-		client.mob.hud_used.screentip.maptext = null
+		client.mob?.hud_used?.screentip?.maptext = null


### PR DESCRIPTION
## About The Pull Request

In all honesty, I don't know what causes this as I can't reproduce it on local, but it happens very frequently on live.

I feel like the solution here is sloppy, but I don't think there's anything more elegant. This is also what all other preferences do
```dm
client.mob?.hud_used?.update_ui_style(ui_style2icon(value))
```
From `code\modules\client\preferences\entries\player\ui_style.dm`

## Why It's Good For The Game

Fixes a runtime

## Testing Photographs and Procedure

This will work without a doubt, **but** I cannot provide testing evidence as I don't know what specific scenario must be present for this runtime to occur.

## Changelog
:cl:
fix: Fixed an infrequent runtime when the game loads your screentip preferences
/:cl: