### PR TITLE
Fixes reagent dispensers runtiming when examining them

### DIFF
--- a/code/modules/reagents/reagent_dispenser.dm
+++ b/code/modules/reagents/reagent_dispenser.dm
@@ -39,13 +39,12 @@
 	. = ..()
 	if(accepts_rig && get_dist(user, src) <= 2)
 		if(rig)
-			. += ("<span notice='warning'>There is some kind of device <b>rigged</b> to the tank!")
+			. += span_warning("There is some kind of device <b>rigged</b> to the tank!")
 		else
-			. += ("<span notice='warning'>It looks like you could <b>rig</b> a device to the tank.")
-	for(var/assembly in rig.assemblies)
-		if(istype(assembly, /obj/item/assembly/timer))
-			var/obj/item/assembly/timer/timer = assembly
-			. += span_notice("There is a timer [timer.timing ? "counting down from [timer.time]":"set for [timer.time] seconds"].")
+			. += span_notice("It looks like you could <b>rig</b> a device to the tank.")
+
+	for(var/obj/item/assembly/timer/timer in rig?.assemblies)
+		. += span_notice("There is a timer [timer.timing ? "counting down from [timer.time]" : "set for [timer.time] seconds"].")
 
 /obj/structure/reagent_dispensers/take_damage(damage_amount, damage_type = BRUTE, damage_flag = 0, sound_effect = 1, attack_dir, armour_penetration = 0)
 	. = ..()


### PR DESCRIPTION
## About The Pull Request

See title.

It never really mattered since it didn't have the closing `</span>` before, but I changed the _"It looks like you could **rig** a device to the tank."_ from a span_warning to a span_notice

## Why It's Good For The Game

Bugfix and span_notice makes more sense as you're not actually being warned about anything.

## Testing Photographs and Procedure

https://github.com/user-attachments/assets/84e3b929-4663-4d13-9862-930456d1990c

## Changelog
:cl:
fix: Fixed water and welding fuel tanks runtiming when examining them
/:cl:
