### PR TITLE
Fixes firelocks runtiming when broken

### DIFF
--- a/code/game/machinery/doors/firedoor.dm
+++ b/code/game/machinery/doors/firedoor.dm
@@ -104,6 +104,9 @@
 
 /obj/machinery/door/firedoor/take_damage(damage_amount, damage_type, damage_flag, sound_effect, attack_dir, armour_penetration)
 	. = ..()
+	if (QDELETED(src))
+		return
+
 	damage_until_open -= damage_amount
 	if (damage_until_open <= 0)
 		playsound(src, 'sound/machines/terminal_error.ogg', 50, 1)


### PR DESCRIPTION
## About The Pull Request

Bacon failed to account for the fact that `..()` in `take_damage()` could delete the firelock and therefore null the soundloop causing the runtime in `crack_open()`

## Why It's Good For The Game

Fixes a runtime

## Testing Photographs and Procedure

https://github.com/user-attachments/assets/eedb6a22-d88d-4f81-8277-ff59e2ab3411

## Changelog
:cl:
fix: Fixed firelocks runtiming when destroyed
/:cl:
