### PR TITLE
Fixes metabolite reagents runtiming on their final tick

### DIFF
--- a/code/modules/reagents/chemistry/reagents.dm
+++ b/code/modules/reagents/chemistry/reagents.dm
@@ -119,9 +119,9 @@ GLOBAL_LIST_INIT(name2reagent, build_name2reagent())
 	current_cycle++
 
 	if(!QDELETED(holder))
-		holder.remove_reagent(type, metabolization_rate * affected_mob.metabolism_efficiency * delta_time) //By default it slowly disappears.
 		if(metabolite)
 			holder.add_reagent(metabolite, metabolization_rate * affected_mob.metabolism_efficiency * METABOLITE_RATE * delta_time)
+		holder.remove_reagent(type, metabolization_rate * affected_mob.metabolism_efficiency * delta_time) //By default it slowly disappears.
 
 ///Called after a reagent is transfered
 /datum/reagent/proc/on_transfer(atom/A, method = TOUCH, trans_volume)


### PR DESCRIPTION
## About The Pull Request

When `remove_reagent()` is called and the remainder of the reagent is removed, `holder` is set to null, causing the runtime on the line below. The simple solution is to add the metabolite beforehand.

This PR doesn't ~~fix~~ change it, but a similar runtime occurs if you do `holder.something` after `. = ..()` in any `on_mob_life()`.

I didn't do it here because of codesmell and I would honestly rather just do `affected_mob.reagents` than deal with the burden of the solution. If you're curious, the "fix" is:

```dm
/datum/reagent/medicine/pen_acid/on_mob_life(mob/living/carbon/affected_mob, delta_time, times_fired)
	// Removal of . = ..()
	for(var/datum/reagent/reagent in holder.reagent_list) // holder instead of affected_mob.reagents
		if(reagent == src)
			continue
		holder.remove_reagent(reagent.type, 2 * REM * delta_time) // holder instead of affected_mob.reagents

	affected_mob.radiation -= (max(affected_mob.radiation - RAD_MOB_SAFE, 0) / 50) * REM * delta_time
	affected_mob.adjustToxLoss(-2 * REM * delta_time, updating_health = FALSE)
	..() // Call our parent
	return UPDATE_MOB_HEALTH
```

## Why It's Good For The Game

Bug fix

## Testing Photographs and Procedure

https://github.com/user-attachments/assets/1c4d4e82-62d1-4a4d-9ba6-f835d9b21479

## Changelog
:cl:
fix: Fixed metabolite reagents runtiming on their final tick
/:cl:
