### PR TITLE
Replaces the clown title music with title0

### DIFF
--- a/strings/round_start_sounds.txt
+++ b/strings/round_start_sounds.txt
@@ -1,4 +1,4 @@
+sound/ambience/title0.ogg
 sound/ambience/title1.ogg
 sound/ambience/title2.ogg
 sound/ambience/title3.ogg
-sound/ambience/clown.ogg


### PR DESCRIPTION
## About The Pull Request

See title.

I would've linked something where you could listen to the entirety of title0, but I couldn't find anything. It's directory is `sound/ambience/title0.ogg` if you want to listen to it.

## Why It's Good For The Game

I honestly find the clown theme incredibly obnoxious and is why I have title music disabled, I'm sure others agree.

I'm readding title0 because I like it and if the clown theme is removed with no replacement the others are gonna run a bunch more and become stale

## Testing Photographs and Procedure

https://github.com/user-attachments/assets/024935aa-ce44-4e0b-b10f-315c5bd009fa

## Changelog
:cl:
soundadd: Added title0 to the title music pool
sounddel: Removed the clown theme from the title music pool
/:cl:
