### PR TITLE
Moves clientside storage to an iframe instead of byond storage

### DIFF
--- a/.github/workflows/generate_client_storage.yml
+++ b/.github/workflows/generate_client_storage.yml
@@ -1,0 +1,33 @@
+name: "Generate Client Storage"
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - tgui/public/*
+
+jobs:
+  dispatch_repo:
+    if: ( !contains(github.event.head_commit.message, '[ci skip]') )
+    name: Repository Dispatch
+    runs-on: ubuntu-latest
+    steps:
+      - name: Generate App Token
+        id: app-token-generation
+        uses: actions/create-github-app-token@v2
+        if: env.APP_PRIVATE_KEY != '' && env.APP_ID != ''
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          owner: tgstation
+        env:
+          APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}
+          APP_ID: ${{ secrets.APP_ID }}
+
+      - name: Send Repository Dispatch
+        if: success()
+        uses: peter-evans/repository-dispatch@v4
+        with:
+          token: ${{ steps.app-token-generation.outputs.token }}
+          repository: tgstation/byond-client-storage
+          event-type: on_master_push

--- a/code/controllers/configuration/entries/resources.dm
+++ b/code/controllers/configuration/entries/resources.dm
@@ -32,3 +32,7 @@
 /datum/config_entry/flag/cache_assets
 
 /datum/config_entry/flag/smart_cache_assets
+
+/datum/config_entry/string/storage_cdn_iframe
+	protection = CONFIG_ENTRY_LOCKED
+	config_entry_value = "https://tgstation.github.io/byond-client-storage/iframe.html"

--- a/code/controllers/subsystem/tgui.dm
+++ b/code/controllers/subsystem/tgui.dm
@@ -31,6 +31,25 @@ SUBSYSTEM_DEF(tgui)
 	basehtml = replacetextEx(basehtml, "<!-- tgui:inline-polyfill -->", polyfill)
 	basehtml = replacetextEx(basehtml, "<!-- tgui:nt-copyright -->", "Nanotrasen (c) 2525-[GLOB.year_integer+YEAR_OFFSET]")
 
+/datum/controller/subsystem/tgui/OnConfigLoad()
+	var/storage_iframe = CONFIG_GET(string/storage_cdn_iframe)
+
+	if(storage_iframe && storage_iframe != /datum/config_entry/string/storage_cdn_iframe::default)
+		basehtml = replacetext(basehtml, "\[tgui:storagecdn\]", storage_iframe)
+		return
+
+	if(CONFIG_GET(string/asset_transport) == "webroot")
+		var/datum/asset_transport/webroot/webroot = SSassets.transport
+
+		var/datum/asset_cache_item/item = webroot.register_asset("iframe.html", file("tgui/public/iframe.html"))
+		basehtml = replacetext(basehtml, "\[tgui:storagecdn\]", webroot.get_asset_url("iframe.html", item))
+		return
+
+	if(!storage_iframe)
+		return
+
+	basehtml = replacetext(basehtml, "\[tgui:storagecdn\]", storage_iframe)
+
 /datum/controller/subsystem/tgui/Shutdown()
 	close_all_uis()
 

--- a/code/modules/client/login/client_login.dm
+++ b/code/modules/client/login/client_login.dm
@@ -118,8 +118,8 @@
 	if(authenticated)
 		GLOB.clients += src
 
-	if(first_run && byond_version >= 516)
-		winset(src, null, list("browser-options" = "find,refresh,byondstorage"))
+	if(first_run)
+		winset(src, null, list("browser-options" = "find,refresh"))
 
 	// Instantiate tgui panel
 	if(first_run)

--- a/config/resources.txt
+++ b/config/resources.txt
@@ -52,3 +52,12 @@ CACHE_ASSETS
 ## This cache is only cleared by the game or manually, but it shouldn't affect the results.
 ## This setting is independent of `CACHE_ASSETS`, they do not affect each other whatsoever.
 SMART_CACHE_ASSETS
+
+# If configured, this allows server operators to define the persistent origin used for clientside
+# storage. This must host the same file as available in tgui/public/iframe.html. This is also hosted
+# on the GitHub Pages site for the /tg/station repository, so does not need to be configured.
+# If multiple servers use the same domain name, clientside features such as message saving
+# and chat tabs will be persistent across both.
+# If this setting is not configured, but the webroot CDN is, that will be used instead of GitHub Pages.
+# If this setting is mpty, and the webroot CDN is disabled, byondstorage will be used.
+# STORAGE_CDN_IFRAME https://tgstation.github.io/byond-client-storage/iframe.html

--- a/tgui/global.d.ts
+++ b/tgui/global.d.ts
@@ -72,6 +72,11 @@ type ByondType = {
   strictMode: boolean;
 
   /**
+   * The external URL for the IndexedDB IFrame to use as the origin
+   */
+  storageCdn: string;
+
+  /**
    * Makes a BYOND call.
    *
    * If path is empty, this will trigger a Topic call.

--- a/tgui/packages/common/storage.ts
+++ b/tgui/packages/common/storage.ts
@@ -9,11 +9,13 @@
 export const IMPL_MEMORY = 0;
 export const IMPL_HUB_STORAGE = 1;
 export const IMPL_INDEXED_DB = 2;
+export const IMPL_IFRAME_INDEXED_DB = 3;
 
 type StorageImplementation =
   | typeof IMPL_MEMORY
   | typeof IMPL_HUB_STORAGE
-  | typeof IMPL_INDEXED_DB;
+  | typeof IMPL_INDEXED_DB
+  | typeof IMPL_IFRAME_INDEXED_DB;
 
 const INDEXED_DB_VERSION = 1;
 const INDEXED_DB_NAME = 'tgui';
@@ -103,6 +105,80 @@ class HubStorageBackend implements StorageBackend {
   }
 }
 
+class IFrameIndexedDbBackend implements StorageBackend {
+  public impl: StorageImplementation;
+
+  private documentElement: HTMLIFrameElement;
+  private iframeWindow: Window;
+
+  constructor() {
+    this.impl = IMPL_IFRAME_INDEXED_DB;
+  }
+
+  async ready(): Promise<boolean | null> {
+    const iframe = document.createElement('iframe');
+    iframe.style.display = 'none';
+    iframe.src = Byond.storageCdn;
+
+    const completePromise: Promise<boolean> = new Promise((resolve) => {
+      iframe.onload = () => resolve(true);
+    });
+
+    this.documentElement = document.body.appendChild(iframe);
+    if (!this.documentElement.contentWindow) {
+      return new Promise((res) => res(false));
+    }
+
+    this.iframeWindow = this.documentElement.contentWindow;
+
+    return completePromise;
+  }
+
+  async get(key: string): Promise<any> {
+    const promise = new Promise((resolve) => {
+      window.addEventListener('message', (message) => {
+        if (message.data.key && message.data.key === key) {
+          resolve(message.data.value);
+        }
+      });
+    });
+
+    this.iframeWindow.postMessage({ type: 'get', key: key }, '*');
+    return promise;
+  }
+
+  async set(key: string, value: any): Promise<void> {
+    this.iframeWindow.postMessage({ type: 'set', key: key, value: value }, '*');
+  }
+
+  async remove(key: string): Promise<void> {
+    this.iframeWindow.postMessage({ type: 'remove', key: key }, '*');
+  }
+
+  async clear(): Promise<void> {
+    this.iframeWindow.postMessage({ type: 'clear' }, '*');
+  }
+
+  async ping(): Promise<boolean> {
+    const promise: Promise<boolean> = new Promise((resolve) => {
+      window.addEventListener('message', (message) => {
+        if (message.data === true) {
+          resolve(true);
+        }
+      });
+
+      setTimeout(() => resolve(false), 100);
+    });
+
+    this.iframeWindow.postMessage({ type: 'ping' }, '*');
+    return promise;
+  }
+
+  async destroy(): Promise<void> {
+    document.body.removeChild(this.documentElement);
+  }
+}
+
 class IndexedDbBackend implements StorageBackend {
   public impl: StorageImplementation;
   public dbPromise: Promise<IDBDatabase>;
@@ -176,7 +252,55 @@ class StorageProxy implements StorageBackend {
 
   constructor() {
     this.backendPromise = (async () => {
-      if (!Byond.TRIDENT && testHubStorage()) {
+      if (!Byond.TRIDENT && Byond.storageCdn && !window.hubStorage) {
+        const iframe = new IFrameIndexedDbBackend();
+        await iframe.ready();
+
+        if ((await iframe.ping()) === true) {
+          if (await iframe.get('byondstorage-migrated')) return iframe;
+
+          Byond.winset(null, 'browser-options', '+byondstorage');
+
+          await new Promise<void>((resolve) => {
+            document.addEventListener('byondstorageupdated', async () => {
+              setTimeout(() => {
+                const hub = new HubStorageBackend();
+
+                for (const setting of [
+                  'panel-settings',
+                  'chat-state',
+                  'chat-messages',
+                ]) {
+                  hub
+                    .get(setting)
+                    .then((settings) => iframe.set(setting, settings));
+                }
+
+                iframe.set('byondstorage-migrated', true);
+                Byond.winset(null, 'browser-options', '-byondstorage');
+
+                resolve();
+              }, 1);
+            });
+          });
+
+          return iframe;
+        }
+
+        iframe.destroy();
+
+        if (!testHubStorage()) {
+          Byond.winset(null, 'browser-options', '+byondstorage');
+
+          return new Promise((resolve) => {
+            const listener = () => {
+              document.removeEventListener('byondstorageupdated', listener);
+              resolve(new HubStorageBackend());
+            };
+
+            document.addEventListener('byondstorageupdated', listener);
+          });
+        }
         return new HubStorageBackend();
       }
       // TODO: Remove with 516

--- a/tgui/public/iframe.html
+++ b/tgui/public/iframe.html
@@ -1,0 +1,98 @@
+<!doctype html>
+<html>
+  <head>
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta charset="utf-8" />
+
+    <script type="text/javascript">
+      const INDEXED_DB_VERSION = 1;
+      const INDEXED_DB_NAME = 'tgui';
+      const INDEXED_DB_STORE_NAME = 'storage';
+
+      const READ_ONLY = 'readonly';
+      const READ_WRITE = 'readwrite';
+
+      const MAX_MESSAGES = 1000;
+
+      const dbPromise = new Promise((resolve, reject) => {
+        const indexedDB = window.indexedDB;
+        const req = indexedDB.open(INDEXED_DB_NAME, INDEXED_DB_VERSION);
+        req.onupgradeneeded = (event) => {
+          try {
+            if (event.oldVersion < 1) {
+              req.result.createObjectStore(INDEXED_DB_STORE_NAME);
+            }
+          } catch (err) {
+            reject(new Error('Failed to upgrade IDB: ' + req.error));
+          }
+        };
+
+        req.onsuccess = () => resolve(req.result);
+
+        req.onerror = () => {
+          reject(new Error('Failed to open IDB: ' + req.error));
+        };
+      });
+
+      window.addEventListener('message', (messageEvent) => {
+        switch (messageEvent.data.type) {
+          case 'ping':
+            messageEvent.source.postMessage(true, '*');
+            break;
+          case 'get':
+            get(messageEvent.data.key).then((value) => {
+              messageEvent.source.postMessage(
+                { key: messageEvent.data.key, value: value },
+                '*',
+              );
+            });
+            break;
+          case 'set':
+            set(messageEvent.data.key, messageEvent.data.value);
+            break;
+          case 'remove':
+            remove(messageEvent.data.key);
+            break;
+          case 'clear':
+            clear();
+            break;
+
+          default:
+            break;
+        }
+      });
+
+      const getStore = async (mode) => {
+        return dbPromise.then((db) =>
+          db
+            .transaction(INDEXED_DB_STORE_NAME, mode)
+            .objectStore(INDEXED_DB_STORE_NAME),
+        );
+      };
+
+      const get = async (key) => {
+        const store = await getStore(READ_ONLY);
+        return new Promise((resolve, reject) => {
+          const req = store.get(key);
+          req.onsuccess = () => resolve(req.result);
+          req.onerror = () => reject(req.error);
+        });
+      };
+
+      const set = async (key, value) => {
+        const store = await getStore(READ_WRITE);
+        store.put(value, key);
+      };
+
+      const remove = async (key) => {
+        const store = await getStore(READ_WRITE);
+        store.delete(key);
+      };
+
+      const clear = async () => {
+        const store = await getStore(READ_WRITE);
+        store.clear();
+      };
+    </script>
+  </head>
+</html>

--- a/tgui/public/tgui.html
+++ b/tgui/public/tgui.html
@@ -7,6 +7,7 @@
 <!-- Inlined metadata -->
 <meta id="tgui:windowId" content="[tgui:windowId]">
 <meta id="tgui:strictMode" content="[tgui:strictMode]">
+<meta id="tgui:storagecdn" content="[tgui:storagecdn]" />
 <meta id="tgui:byondMajor" content="[tgui:byondMajor]">
 <meta id="tgui:byondMinor" content="[tgui:byondMinor]">
 
@@ -41,6 +42,7 @@
 
   // Expose inlined metadata
   Byond.windowId = parseMetaTag('tgui:windowId');
+  Byond.storageCdn = parseMetaTag('tgui:storagecdn');
   Byond.BYOND_MAJOR = parseMetaTag('tgui:byondMajor');
   Byond.BYOND_MINOR = parseMetaTag('tgui:byondMinor');
 


### PR DESCRIPTION
## About The Pull Request

Ports https://github.com/tgstation/tgstation/pull/93044
I'm not nearly as knowledgeable about this as the original author is, so I'll just copy and paste his words.

>this converts the dependency on byondstorage, which is laggy (due to being a large json file written to disk every 10 seconds), to using indexeddb, like we did prior to 516. this is achieved by using an iframe to give us a persistent origin, as the web is evil and has invented same-origin policy https://developer.mozilla.org/en-US/docs/Web/Security/Same-origin_policy.

>this also hosts the iframe page on the github pages site for a secondary repository (see tgstation/byond-client-storage) so it works OOTB without requiring server operators to setup the webroot cdn (which i don't believe is configured on the tg servers at the moment)

>however, if a server is using the webroot cdn, it will use that instead of github pages

>you could also host the iframe.html page on a separate host from your cdn or github pages if you wanted to

>if we can't access the configured cdn at all, it failovers to use byondstorage anyway, if the internet stops working and you still want your chat history to save, i guess

## Why It's Good For The Game

Right now my `Exadv1.spacestation13.json` file is sitting at 387 KB. Saving this massive file causes considerable lag and every time it saves on live I get a lagspike.

## Testing Photographs and Procedure

https://github.com/user-attachments/assets/f099c1c3-1ba0-48c4-85f3-d828191ddf9b

## Changelog
:cl: hry-gh
fix: you should experience less stutters every 10 seconds
server: server operators can now configure an alternative storage domain for clientside data storage, read the example configuration for more
/:cl:
