### PR TITLE
Dynamic storyteller versions (Storyteller Testmerge Support)

### DIFF
--- a/code/__DEFINES/dynamic.dm
+++ b/code/__DEFINES/dynamic.dm
@@ -32,3 +32,7 @@
 #define DYNAMIC_EXECUTE_FAILURE 0
 #define DYNAMIC_EXECUTE_SUCCESS 1
 #define RULESET_STOP_PROCESSING 1
+
+// If this is defined, then any storyteller configs which do not have
+// a 'Version' tag that match this value will not be loaded.
+//#define STORYTELLER_VERSION "GamemodeAntagonists"

--- a/code/controllers/subsystem/dynamic/dynamic.dm
+++ b/code/controllers/subsystem/dynamic/dynamic.dm
@@ -1,3 +1,5 @@
+#define STORYTELLER_VERSION "GamemodeAntagonists"
+
 SUBSYSTEM_DEF(dynamic)
 	name = "Dynamic"
 	runlevels = RUNLEVEL_GAME
@@ -246,6 +248,15 @@ SUBSYSTEM_DEF(dynamic)
 		if (!loaded_json["Description"])
 			stack_trace("Dynamic config: \"[file_path]\" could not be loaded because it did not have a description.")
 			continue
+
+#ifdef STORYTELLER_VERSION
+		if (!loaded_json["Version"])
+			log_dynamic("Skipped loading storyteller [json_name], it did not provide a storyteller version but one was required.")
+			continue
+		if (loaded_json["Version"] != STORYTELLER_VERSION)
+			log_dynamic("Skipped loading storyteller [json_name], it did not have the required storyteller version.")
+			continue
+#endif
 
 		dynamic_storyteller_jsons[json_name] = loaded_json
 
@@ -897,3 +908,5 @@ SUBSYSTEM_DEF(dynamic)
 	if (flag & DYNAMIC_MIDROUND_HEAVY)
 		texts += "HEAVY"
 	return jointext(texts, " | ")
+
+#undef STORYTELLER_VERSION

--- a/code/controllers/subsystem/dynamic/dynamic.dm
+++ b/code/controllers/subsystem/dynamic/dynamic.dm
@@ -915,4 +915,6 @@ SUBSYSTEM_DEF(dynamic)
 		texts += "HEAVY"
 	return jointext(texts, " | ")
 
+#ifdef STORYTELLER_VERSION
 #undef STORYTELLER_VERSION
+#endif

--- a/code/controllers/subsystem/dynamic/dynamic.dm
+++ b/code/controllers/subsystem/dynamic/dynamic.dm
@@ -1,4 +1,6 @@
-#define STORYTELLER_VERSION "GamemodeAntagonists"
+// If this is defined, then any storyteller configs which do not have
+// a 'Version' tag that match this value will not be loaded.
+//#define STORYTELLER_VERSION "GamemodeAntagonists"
 
 SUBSYSTEM_DEF(dynamic)
 	name = "Dynamic"
@@ -251,10 +253,14 @@ SUBSYSTEM_DEF(dynamic)
 
 #ifdef STORYTELLER_VERSION
 		if (!loaded_json["Version"])
-			log_dynamic("Skipped loading storyteller [json_name], it did not provide a storyteller version but one was required.")
+			log_dynamic("Skipped loading storyteller [json_name], it did not provide a storyteller version but one was required. (Required '[STORYTELLER_VERSION]')")
 			continue
 		if (loaded_json["Version"] != STORYTELLER_VERSION)
-			log_dynamic("Skipped loading storyteller [json_name], it did not have the required storyteller version.")
+			log_dynamic("Skipped loading storyteller [json_name], it did not have the required storyteller version (Required '[STORYTELLER_VERSION]', got '[loaded_json["Version"]]').")
+			continue
+#else
+		if (loaded_json["Version"])
+			log_dynamic("Skipped loading storyteller [json_name] as it has a version of '[loaded_json["Version"]]', but we expected none.")
 			continue
 #endif
 

--- a/code/controllers/subsystem/dynamic/dynamic.dm
+++ b/code/controllers/subsystem/dynamic/dynamic.dm
@@ -1,7 +1,3 @@
-// If this is defined, then any storyteller configs which do not have
-// a 'Version' tag that match this value will not be loaded.
-//#define STORYTELLER_VERSION "GamemodeAntagonists"
-
 SUBSYSTEM_DEF(dynamic)
 	name = "Dynamic"
 	runlevels = RUNLEVEL_GAME
@@ -914,7 +910,3 @@ SUBSYSTEM_DEF(dynamic)
 	if (flag & DYNAMIC_MIDROUND_HEAVY)
 		texts += "HEAVY"
 	return jointext(texts, " | ")
-
-#ifdef STORYTELLER_VERSION
-#undef STORYTELLER_VERSION
-#endif


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Managing testmerges that modify dynamic storytellers is difficult because config changes are not included as part of testmerges. To manage this, I have added a version flag which must match with the version set in the config.

This means that we can have per-TM configs defined on the repo and can remove/add TMs without worrying about conflicting config changes.

## Why It's Good For The Game

See above.

## Testing Photographs and Procedure

<img width="695" height="159" alt="image" src="https://github.com/user-attachments/assets/a8c60d45-cfa1-4f37-851f-718d132331bf" />

<img width="167" height="81" alt="image" src="https://github.com/user-attachments/assets/6167d6f5-0873-4478-be88-c66bdf32bd89" />

<img width="1406" height="64" alt="image" src="https://github.com/user-attachments/assets/36c152c2-2909-4465-b855-43b5c9a20bf2" />

3 disabled configs

<img width="286" height="111" alt="image" src="https://github.com/user-attachments/assets/30ecfb35-e597-4fb2-aaaa-79bb158cdb9c" />

<img width="1340" height="94" alt="image" src="https://github.com/user-attachments/assets/cba1bb61-bd62-4a9d-9726-71f235d46796" />


## Changelog
:cl:
tweak: Adds server-side support for versioning storytellers.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
