### PR TITLE
Fix engineering borgs being pulled by the supermatter

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -318,6 +318,7 @@
 		/obj/item/stack/sheet/brass/cyborg)
 	cyborg_base_icon = "engineer"
 	model_select_icon = "engineer"
+	module_traits = list(TRAIT_NEGATES_GRAVITY)
 	hat_offset = -4
 
 // --------------------- Janitor


### PR DESCRIPTION
## About The Pull Request

Engineering cyborgs now can't be moved/pulled by the supermatter or pressure differences again.
This behaviour was removed in #11340 when the `magpulsing` var was removed in favor of having such things added as traits per model. (Syndicate saboteurs did get the new behaviour there but normal engineering borgs didn't)

## Why It's Good For The Game

Fixes an intended feature.

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

Mobs, in this case humans without magboots, get pulled towards the supermatter, meanwhile the engineering borg doesn't.

https://github.com/user-attachments/assets/2050b4e6-6d7d-4f97-8e94-f1484945f303

</details>

## Changelog
:cl:
fix: Engineering borgs can once again not be pulled/moved by the supermatter/pressure differences
/:cl: