### PR TITLE
Fixes non-standard heretic races not being able to sacrifice their targets

### DIFF
--- a/code/modules/antagonists/heretic/heretic_antag.dm
+++ b/code/modules/antagonists/heretic/heretic_antag.dm
@@ -688,7 +688,7 @@
  * and returns HERETIC_HAS_LIVING_HEART if they have a living heart
  */
 /datum/antagonist/heretic/proc/has_living_heart()
-	var/obj/item/organ/our_living_heart = owner.current?.get_organ_slot(ORGAN_SLOT_HEART)
+	var/obj/item/organ/our_living_heart = owner.current?.get_organ_slot(living_heart_organ_slot)
 	if(!our_living_heart)
 		return HERETIC_NO_HEART_ORGAN
 


### PR DESCRIPTION
## About The Pull Request

See title

## Why It's Good For The Game

It's a fix

## Testing Photographs and Procedure

Originally I was gonna post a video but it had my CID all over chat and I couldn't be bothered to do the ritual of hosting a dream daemon server and connecting two different clients to it.

This was tested as a skeleton

<img width="743" height="69" alt="image" src="https://github.com/user-attachments/assets/d03bf03b-0b52-4a9a-bb78-8ecc05284297" />

## Changelog
:cl:
fix: Fixed non-standard heretic races not being able to sacrifice their targets
/:cl:
