### PR TITLE
Boxstation Garden/Club Zoning Fix

### DIFF
--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -49725,7 +49725,6 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "qap" = (
-/obj/machinery/power/apc/auto_name/directional/north,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/siding/purple{
 	dir = 4

--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -114,7 +114,7 @@
 	},
 /obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
 /turf/open/floor/plating,
-/area/maintenance/port/fore)
+/area/hydroponics/garden)
 "abx" = (
 /obj/machinery/door/airlock{
 	name = "Kitchen";
@@ -580,7 +580,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/hydroponics/garden)
+/area/maintenance/port/fore)
 "agL" = (
 /obj/effect/spawner/room/fivexthree,
 /turf/open/floor/plating,
@@ -1896,7 +1896,7 @@
 	},
 /obj/effect/turf_decal/siding/wideplating_new,
 /turf/open/floor/concrete/tile,
-/area/maintenance/club)
+/area/hallway/primary/port)
 "azr" = (
 /obj/structure/grille/broken,
 /turf/open/floor/plating,
@@ -3060,7 +3060,7 @@
 	dir = 6
 	},
 /turf/open/floor/wood,
-/area/maintenance/club)
+/area/hydroponics/garden)
 "aQi" = (
 /obj/structure/chair{
 	dir = 8
@@ -4113,7 +4113,7 @@
 "bdl" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/open/floor/grass,
-/area/maintenance/club)
+/area/hydroponics/garden)
 "bds" = (
 /obj/structure/cable/yellow{
 	icon_state = "2-4"
@@ -5639,7 +5639,7 @@
 	dir = 8
 	},
 /turf/open/floor/concrete/tile,
-/area/maintenance/club)
+/area/hydroponics/garden)
 "bvu" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
@@ -7624,7 +7624,7 @@
 	pixel_x = -5
 	},
 /turf/open/floor/iron/dark/smooth_large,
-/area/hydroponics/garden)
+/area/maintenance/port/fore)
 "bRn" = (
 /obj/machinery/modular_computer/console/preset/command,
 /obj/effect/turf_decal/tile/blue/anticorner/contrasted{
@@ -7638,7 +7638,7 @@
 	dir = 10
 	},
 /turf/open/floor/carpet/purple,
-/area/hydroponics/garden)
+/area/maintenance/port/fore)
 "bRs" = (
 /obj/structure/chair{
 	dir = 8
@@ -11766,7 +11766,7 @@
 	dir = 8
 	},
 /turf/open/floor/concrete/tile,
-/area/maintenance/club)
+/area/hydroponics/garden)
 "cvc" = (
 /turf/closed/wall/r_wall,
 /area/ai_monitored/turret_protected/aisat/service)
@@ -11879,7 +11879,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/dark/smooth_large,
-/area/hydroponics/garden)
+/area/maintenance/port/fore)
 "cwV" = (
 /obj/docking_port/stationary/random{
 	dir = 8;
@@ -14306,7 +14306,7 @@
 /obj/item/clothing/suit/apron/overalls,
 /obj/item/clothing/gloves/botanic_leather,
 /turf/open/floor/wood,
-/area/maintenance/club)
+/area/hydroponics/garden)
 "cVy" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer2{
 	dir = 4
@@ -15536,7 +15536,7 @@
 /obj/structure/flora/ausbushes/lavendergrass,
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/open/floor/grass,
-/area/maintenance/club)
+/area/hydroponics/garden)
 "drG" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/crate,
@@ -15682,7 +15682,7 @@
 	dir = 5
 	},
 /turf/open/floor/plating,
-/area/hydroponics/garden)
+/area/maintenance/port/fore)
 "duz" = (
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "MiniSat Maintenance";
@@ -17075,7 +17075,7 @@
 "dVT" = (
 /obj/effect/turf_decal/siding/wood,
 /turf/open/floor/wood,
-/area/maintenance/club)
+/area/hydroponics/garden)
 "dVW" = (
 /obj/effect/turf_decal/tile/red,
 /turf/open/floor/iron/dark,
@@ -17152,7 +17152,7 @@
 	pixel_y = 32
 	},
 /turf/open/floor/carpet/purple,
-/area/hydroponics/garden)
+/area/maintenance/port/fore)
 "dWz" = (
 /obj/structure/table,
 /obj/item/gps/mining/exploration,
@@ -17232,7 +17232,7 @@
 	pixel_y = 3
 	},
 /turf/open/floor/plating,
-/area/hydroponics/garden)
+/area/maintenance/port/fore)
 "dWV" = (
 /obj/effect/turf_decal/tile/yellow/half/contrasted{
 	dir = 1
@@ -17320,7 +17320,7 @@
 /obj/structure/flora/ausbushes/brflowers,
 /obj/structure/beebox,
 /turf/open/floor/grass,
-/area/maintenance/club)
+/area/hydroponics/garden)
 "dYk" = (
 /obj/structure/closet/wardrobe/white,
 /obj/machinery/light/directional/north,
@@ -18413,7 +18413,7 @@
 /obj/structure/flora/ausbushes/ywflowers,
 /obj/structure/flora/ausbushes/ppflowers,
 /turf/open/floor/grass,
-/area/maintenance/club)
+/area/hydroponics/garden)
 "euG" = (
 /obj/machinery/atmospherics/pipe/smart/simple,
 /turf/open/floor/plating,
@@ -18664,7 +18664,7 @@
 	id = "casinoshutter"
 	},
 /turf/open/floor/iron,
-/area/hydroponics/garden)
+/area/hallway/primary/port)
 "eyD" = (
 /obj/machinery/light/small/directional/west,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
@@ -18854,7 +18854,7 @@
 	icon_state = "1-4"
 	},
 /turf/open/floor/concrete/tile,
-/area/maintenance/club)
+/area/hydroponics/garden)
 "eBH" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer4,
@@ -19816,7 +19816,7 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/concrete/tile,
-/area/maintenance/club)
+/area/hydroponics/garden)
 "eTa" = (
 /obj/structure/grille,
 /obj/structure/disposalpipe/segment,
@@ -20918,7 +20918,7 @@
 /obj/effect/spawner/structure/window,
 /obj/structure/barricade/wooden,
 /turf/open/floor/plating,
-/area/hydroponics/garden)
+/area/hallway/primary/port)
 "fne" = (
 /obj/effect/turf_decal/tile/dark/half,
 /obj/effect/turf_decal/tile/dark_red/half{
@@ -22200,7 +22200,7 @@
 	dir = 4
 	},
 /turf/open/floor/wood,
-/area/maintenance/club)
+/area/hydroponics/garden)
 "fMn" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 4
@@ -22434,7 +22434,7 @@
 	pixel_y = 2
 	},
 /turf/open/floor/grass,
-/area/maintenance/club)
+/area/hydroponics/garden)
 "fQq" = (
 /obj/machinery/ai_slipper{
 	uses = 10
@@ -22896,7 +22896,7 @@
 	},
 /obj/effect/turf_decal/siding/dirt,
 /turf/open/floor/plating/asteroid,
-/area/maintenance/club)
+/area/hydroponics/garden)
 "fYS" = (
 /turf/open/floor/iron/dark/side{
 	dir = 4
@@ -23653,9 +23653,6 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
 /obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
@@ -23982,9 +23979,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer4{
 	dir = 8
 	},
-/obj/structure/cable/yellow{
-	icon_state = "2-4"
-	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "gum" = (
@@ -24217,7 +24211,7 @@
 	dir = 8
 	},
 /turf/open/floor/plating,
-/area/hydroponics/garden)
+/area/maintenance/port/fore)
 "gyW" = (
 /obj/effect/turf_decal/tile/blue,
 /turf/open/floor/iron/white,
@@ -24528,7 +24522,7 @@
 	dir = 8
 	},
 /turf/open/floor/wood,
-/area/maintenance/club)
+/area/hydroponics/garden)
 "gEn" = (
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron,
@@ -24677,7 +24671,7 @@
 "gFW" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/carpet/purple,
-/area/hydroponics/garden)
+/area/maintenance/port/fore)
 "gGK" = (
 /obj/machinery/atmospherics/pipe/layer_manifold/scrubbers/hidden,
 /turf/closed/wall,
@@ -24944,7 +24938,7 @@
 /obj/item/food/grown/wheat,
 /obj/item/food/grown/chili,
 /turf/open/floor/grass,
-/area/maintenance/club)
+/area/hydroponics/garden)
 "gKG" = (
 /obj/structure/reagent_dispensers/fueltank,
 /obj/structure/railing{
@@ -25113,7 +25107,7 @@
 	dir = 8
 	},
 /turf/open/floor/plating,
-/area/hydroponics/garden)
+/area/maintenance/port/fore)
 "gOB" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-4"
@@ -25679,7 +25673,7 @@
 	dir = 1
 	},
 /turf/open/floor/plating/asteroid,
-/area/maintenance/club)
+/area/hydroponics/garden)
 "hcn" = (
 /obj/structure/table/glass,
 /obj/item/reagent_containers/cup/bottle/spaceacillin{
@@ -25772,7 +25766,7 @@
 	dir = 8
 	},
 /turf/open/floor/carpet/purple,
-/area/hydroponics/garden)
+/area/maintenance/port/fore)
 "hem" = (
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
@@ -26968,7 +26962,7 @@
 	},
 /obj/machinery/power/apc/auto_name/directional/north,
 /turf/open/floor/plating/asteroid,
-/area/maintenance/club)
+/area/hydroponics/garden)
 "hAI" = (
 /obj/structure/cable/yellow{
 	icon_state = "2-4"
@@ -29024,7 +29018,7 @@
 /turf/open/floor/iron/dark/smooth_half{
 	dir = 1
 	},
-/area/hydroponics/garden)
+/area/maintenance/port/fore)
 "ijk" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer4,
 /obj/effect/turf_decal/siding/white{
@@ -30036,7 +30030,7 @@
 	pixel_y = 5
 	},
 /turf/open/floor/plating/dirt/planetary,
-/area/maintenance/club)
+/area/hydroponics/garden)
 "iDo" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -30262,7 +30256,7 @@
 	pixel_y = 13
 	},
 /turf/open/floor/plating/asteroid,
-/area/maintenance/club)
+/area/hydroponics/garden)
 "iIx" = (
 /obj/effect/turf_decal/tile/yellow/fourcorners/contrasted,
 /obj/structure/closet/toolcloset,
@@ -30559,7 +30553,7 @@
 	dir = 1
 	},
 /turf/open/floor/concrete/tile,
-/area/maintenance/club)
+/area/hydroponics/garden)
 "iOe" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
 /turf/open/floor/iron,
@@ -30925,7 +30919,7 @@
 /obj/structure/flora/ausbushes/leafybush,
 /obj/structure/flora/ausbushes/sunnybush,
 /turf/open/floor/grass,
-/area/maintenance/club)
+/area/hydroponics/garden)
 "iVu" = (
 /obj/effect/turf_decal/siding/wood/corner{
 	dir = 1
@@ -31014,7 +31008,7 @@
 	pixel_x = -8
 	},
 /turf/open/floor/carpet/purple,
-/area/hydroponics/garden)
+/area/maintenance/port/fore)
 "iXb" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/cable/yellow{
@@ -31069,9 +31063,6 @@
 	},
 /turf/open/floor/iron,
 /area/engine/engineering)
-"iYA" = (
-/turf/closed/wall,
-/area/maintenance/club)
 "iYW" = (
 /obj/effect/landmark/start/lawyer,
 /obj/structure/chair/office,
@@ -33341,7 +33332,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron/dark/smooth_large,
-/area/hydroponics/garden)
+/area/maintenance/port/fore)
 "jSZ" = (
 /obj/machinery/light{
 	dir = 8
@@ -33406,7 +33397,7 @@
 	dir = 1
 	},
 /turf/open/floor/plating,
-/area/hydroponics/garden)
+/area/maintenance/port/fore)
 "jUC" = (
 /obj/effect/turf_decal/tile/red/anticorner/contrasted,
 /obj/structure/table,
@@ -33602,7 +33593,7 @@
 /area/security/brig)
 "jWE" = (
 /turf/open/floor/concrete/tile,
-/area/maintenance/club)
+/area/hydroponics/garden)
 "jWH" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer4{
 	dir = 8
@@ -33617,7 +33608,7 @@
 	dir = 10
 	},
 /turf/open/floor/concrete/tile,
-/area/maintenance/club)
+/area/hydroponics/garden)
 "jXc" = (
 /obj/effect/turf_decal/siding/white{
 	dir = 10
@@ -33671,7 +33662,7 @@
 /obj/structure/chair/fancy/bench/pew/left,
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/open/floor/grass,
-/area/maintenance/club)
+/area/hydroponics/garden)
 "jYA" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -34224,7 +34215,7 @@
 	pixel_y = 11
 	},
 /turf/open/floor/iron/dark/smooth_large,
-/area/hydroponics/garden)
+/area/maintenance/port/fore)
 "kjj" = (
 /obj/machinery/vending/boozeomat,
 /turf/closed/wall,
@@ -35149,7 +35140,7 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/concrete/tile,
-/area/maintenance/club)
+/area/hydroponics/garden)
 "kBG" = (
 /obj/effect/turf_decal/tile/red/half/contrasted,
 /obj/machinery/airalarm/directional/east,
@@ -36350,7 +36341,7 @@
 "kYX" = (
 /obj/structure/flora/tree/jungle/small,
 /turf/open/floor/plating/dirt/planetary,
-/area/maintenance/club)
+/area/hydroponics/garden)
 "kZy" = (
 /obj/effect/turf_decal/tile/blue/opposingcorners{
 	dir = 1
@@ -36782,7 +36773,7 @@
 "lfL" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer4,
 /turf/open/floor/carpet/purple,
-/area/hydroponics/garden)
+/area/maintenance/port/fore)
 "lgb" = (
 /obj/structure/rack,
 /obj/structure/window/reinforced/spawner/directional/south,
@@ -37419,7 +37410,7 @@
 	dir = 10
 	},
 /turf/open/floor/wood,
-/area/maintenance/club)
+/area/hydroponics/garden)
 "lqg" = (
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron,
@@ -37994,7 +37985,7 @@
 /area/science/xenobiology)
 "lAH" = (
 /turf/open/floor/carpet/purple,
-/area/hydroponics/garden)
+/area/maintenance/port/fore)
 "lAL" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -39121,7 +39112,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plating,
-/area/hydroponics/garden)
+/area/maintenance/port/fore)
 "lYS" = (
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
 	dir = 4
@@ -39234,7 +39225,7 @@
 	dir = 4
 	},
 /turf/open/floor/carpet/purple,
-/area/hydroponics/garden)
+/area/maintenance/port/fore)
 "mbF" = (
 /obj/machinery/holopad,
 /obj/effect/turf_decal/bot_white,
@@ -39439,7 +39430,7 @@
 /turf/open/floor/iron/dark/smooth_half{
 	dir = 1
 	},
-/area/hydroponics/garden)
+/area/maintenance/port/fore)
 "mgt" = (
 /turf/closed/wall,
 /area/crew_quarters/cryopods)
@@ -40036,7 +40027,7 @@
 /turf/open/floor/iron/dark/smooth_corner{
 	dir = 4
 	},
-/area/hydroponics/garden)
+/area/maintenance/port/fore)
 "mor" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable/yellow{
@@ -40047,7 +40038,7 @@
 	name = "Garden"
 	},
 /turf/open/floor/concrete/tile,
-/area/maintenance/club)
+/area/hallway/primary/port)
 "moB" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer2{
 	dir = 1
@@ -40462,7 +40453,7 @@
 	pixel_y = 9
 	},
 /turf/open/floor/plating,
-/area/hydroponics/garden)
+/area/maintenance/port/fore)
 "mxW" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -41111,7 +41102,7 @@
 /obj/machinery/camera/directional/south,
 /obj/machinery/firealarm/directional/south,
 /turf/open/floor/concrete/tile,
-/area/maintenance/club)
+/area/hydroponics/garden)
 "mLR" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /obj/machinery/door/airlock/arrivals_external{
@@ -41173,7 +41164,7 @@
 /obj/structure/flora/ausbushes/fullgrass,
 /obj/structure/flora/ausbushes/brflowers,
 /turf/open/floor/grass,
-/area/maintenance/club)
+/area/hydroponics/garden)
 "mNB" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer2{
 	dir = 4
@@ -42630,7 +42621,7 @@
 /turf/open/floor/iron/dark/smooth_half{
 	dir = 1
 	},
-/area/hydroponics/garden)
+/area/maintenance/port/fore)
 "nsn" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-4"
@@ -43395,7 +43386,7 @@
 	id = "casinoshutter"
 	},
 /turf/open/floor/iron,
-/area/hydroponics/garden)
+/area/hallway/primary/port)
 "nEN" = (
 /obj/structure/table/reinforced,
 /obj/item/hand_labeler{
@@ -44404,7 +44395,7 @@
 	pixel_x = 5
 	},
 /turf/open/floor/plating/asteroid,
-/area/maintenance/club)
+/area/hydroponics/garden)
 "nVY" = (
 /obj/machinery/hydroponics/constructable,
 /obj/effect/turf_decal/stripes/line{
@@ -45557,7 +45548,7 @@
 	dir = 5
 	},
 /turf/open/floor/iron/dark/smooth_large,
-/area/hydroponics/garden)
+/area/maintenance/port/fore)
 "oxC" = (
 /obj/effect/turf_decal/siding/wood/corner,
 /turf/open/floor/wood,
@@ -45859,7 +45850,7 @@
 	name = "Abandonded Casino Shutters"
 	},
 /turf/open/floor/iron/dark/smooth_large,
-/area/hydroponics/garden)
+/area/maintenance/port/fore)
 "oDS" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer2{
 	dir = 1
@@ -47236,7 +47227,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
-/area/maintenance/club)
+/area/hallway/primary/port)
 "peP" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer2{
 	dir = 4
@@ -47475,7 +47466,7 @@
 	pixel_y = -13
 	},
 /turf/open/floor/carpet/purple,
-/area/hydroponics/garden)
+/area/maintenance/port/fore)
 "pic" = (
 /obj/machinery/button/door{
 	id = "Disposal Exit";
@@ -47645,7 +47636,7 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/grass,
-/area/maintenance/club)
+/area/hydroponics/garden)
 "plX" = (
 /obj/effect/turf_decal/tile/red/opposingcorners,
 /obj/effect/turf_decal/siding/wideplating_new/dark{
@@ -48221,7 +48212,7 @@
 "pxb" = (
 /obj/machinery/holopad,
 /turf/open/floor/wood,
-/area/maintenance/club)
+/area/hydroponics/garden)
 "pxn" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer2{
 	dir = 9
@@ -48430,7 +48421,7 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/concrete/tile,
-/area/maintenance/club)
+/area/hydroponics/garden)
 "pzX" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /obj/structure/window/reinforced/spawner/directional/north,
@@ -49739,11 +49730,8 @@
 /obj/effect/turf_decal/siding/purple{
 	dir = 4
 	},
-/obj/structure/cable/yellow{
-	icon_state = "0-8"
-	},
 /turf/open/floor/iron/dark/smooth_corner,
-/area/hydroponics/garden)
+/area/maintenance/port/fore)
 "qas" = (
 /obj/structure/tank_dispenser,
 /turf/open/floor/iron/white,
@@ -50423,7 +50411,7 @@
 	pixel_x = -1
 	},
 /turf/open/floor/plating/asteroid,
-/area/maintenance/club)
+/area/hydroponics/garden)
 "qmO" = (
 /obj/machinery/camera/directional/north,
 /turf/open/floor/engine/plasma,
@@ -50613,7 +50601,7 @@
 	icon_state = "woodbucket"
 	},
 /turf/open/floor/wood,
-/area/maintenance/club)
+/area/hydroponics/garden)
 "qpr" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -53520,7 +53508,7 @@
 	},
 /obj/machinery/light/directional/south,
 /turf/open/floor/concrete/tile,
-/area/maintenance/club)
+/area/hydroponics/garden)
 "rtv" = (
 /obj/effect/landmark/start/ai,
 /obj/item/radio/intercom{
@@ -55523,7 +55511,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/hydroponics/garden)
+/area/maintenance/port/fore)
 "sfg" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer2{
 	dir = 1
@@ -55975,7 +55963,7 @@
 	bulb_colour = "#9b1d70"
 	},
 /turf/open/floor/iron/dark/smooth_large,
-/area/hydroponics/garden)
+/area/maintenance/port/fore)
 "spO" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
@@ -56076,7 +56064,7 @@
 /area/medical/virology)
 "srU" = (
 /turf/open/floor/iron/dark/smooth_large,
-/area/hydroponics/garden)
+/area/maintenance/port/fore)
 "ssu" = (
 /obj/effect/turf_decal/trimline/dark_blue/filled/line{
 	dir = 4
@@ -56162,7 +56150,7 @@
 	dir = 4
 	},
 /turf/open/floor/concrete/tile,
-/area/maintenance/club)
+/area/hydroponics/garden)
 "suF" = (
 /obj/structure/railing{
 	dir = 1
@@ -57095,7 +57083,7 @@
 	pixel_x = -21
 	},
 /turf/open/floor/plating/dirt/planetary,
-/area/maintenance/club)
+/area/hydroponics/garden)
 "sMQ" = (
 /obj/effect/decal/cleanable/oil,
 /obj/item/cigbutt,
@@ -58487,7 +58475,7 @@
 	dir = 1
 	},
 /turf/open/floor/concrete/tile,
-/area/maintenance/club)
+/area/hydroponics/garden)
 "tjr" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer2{
 	dir = 4
@@ -59450,7 +59438,7 @@
 	dir = 8
 	},
 /turf/open/floor/concrete/tile,
-/area/maintenance/club)
+/area/hydroponics/garden)
 "tAD" = (
 /obj/machinery/light{
 	dir = 4
@@ -59577,7 +59565,7 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/concrete/tile,
-/area/maintenance/club)
+/area/hydroponics/garden)
 "tCt" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-4"
@@ -60229,7 +60217,7 @@
 	dir = 1
 	},
 /turf/open/floor/wood,
-/area/maintenance/club)
+/area/hydroponics/garden)
 "tLN" = (
 /obj/structure/table,
 /obj/item/paper_bin,
@@ -60500,7 +60488,7 @@
 "tRi" = (
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
-/area/maintenance/club)
+/area/hallway/primary/port)
 "tRw" = (
 /obj/machinery/door/airlock/science{
 	name = "exploration Preparation Room";
@@ -60714,7 +60702,7 @@
 	dir = 5
 	},
 /turf/open/floor/wood,
-/area/maintenance/club)
+/area/hydroponics/garden)
 "tWV" = (
 /obj/structure/window/reinforced/spawner/directional/south,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer4{
@@ -61634,7 +61622,7 @@
 /turf/open/floor/iron/dark/smooth_half{
 	dir = 1
 	},
-/area/hydroponics/garden)
+/area/maintenance/port/fore)
 "urV" = (
 /obj/structure/table,
 /obj/effect/turf_decal/tile/blue{
@@ -62392,7 +62380,7 @@
 "uGk" = (
 /obj/effect/turf_decal/tile/monorust/intensity3,
 /turf/open/floor/plating,
-/area/hydroponics/garden)
+/area/maintenance/port/fore)
 "uGr" = (
 /obj/structure/rack,
 /obj/item/tank/internals/oxygen,
@@ -62703,7 +62691,7 @@
 	},
 /obj/item/reagent_containers/cup/bucket,
 /turf/open/floor/wood,
-/area/maintenance/club)
+/area/hydroponics/garden)
 "uMh" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -63167,7 +63155,7 @@
 /area/crew_quarters/locker)
 "uXS" = (
 /turf/closed/wall/r_wall,
-/area/maintenance/club)
+/area/hydroponics/garden)
 "uYn" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer4,
@@ -63224,7 +63212,7 @@
 	dir = 4
 	},
 /turf/open/floor/concrete/tile,
-/area/maintenance/club)
+/area/hydroponics/garden)
 "uYP" = (
 /obj/structure/table,
 /obj/item/radio/intercom/directional/west,
@@ -63479,7 +63467,7 @@
 	dir = 10
 	},
 /turf/open/floor/wood,
-/area/maintenance/club)
+/area/hydroponics/garden)
 "vef" = (
 /obj/structure/table,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
@@ -64681,7 +64669,7 @@
 /obj/effect/spawner/structure/window,
 /obj/structure/barricade/wooden/crude,
 /turf/open/floor/plating,
-/area/hydroponics/garden)
+/area/hallway/primary/port)
 "vCs" = (
 /obj/structure/closet,
 /obj/item/clothing/shoes/sneakers/white,
@@ -65444,7 +65432,7 @@
 /turf/open/floor/iron/dark/smooth_half{
 	dir = 1
 	},
-/area/hydroponics/garden)
+/area/maintenance/port/fore)
 "vPu" = (
 /obj/machinery/suit_storage_unit/standard_unit,
 /obj/effect/turf_decal/tile/black/fourcorners,
@@ -65490,7 +65478,7 @@
 	pixel_y = 9
 	},
 /turf/open/floor/carpet/purple,
-/area/hydroponics/garden)
+/area/maintenance/port/fore)
 "vPI" = (
 /obj/machinery/door/airlock/command/glass{
 	name = "Control Room";
@@ -65775,7 +65763,7 @@
 /turf/open/floor/iron/dark/smooth_half{
 	dir = 1
 	},
-/area/hydroponics/garden)
+/area/maintenance/port/fore)
 "vXK" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -66358,7 +66346,7 @@
 /turf/open/floor/iron/dark/smooth_corner{
 	dir = 8
 	},
-/area/hydroponics/garden)
+/area/maintenance/port/fore)
 "wgq" = (
 /obj/structure/table,
 /obj/item/paper_bin{
@@ -66500,7 +66488,7 @@
 /turf/open/floor/iron/dark/smooth_half{
 	dir = 1
 	},
-/area/hydroponics/garden)
+/area/maintenance/port/fore)
 "wis" = (
 /obj/structure/table/wood,
 /obj/machinery/chem_dispenser/drinks,
@@ -66618,7 +66606,7 @@
 	pixel_x = -5
 	},
 /turf/open/floor/iron/dark/smooth_large,
-/area/hydroponics/garden)
+/area/maintenance/port/fore)
 "wlB" = (
 /obj/effect/turf_decal/tile/monorust/intensity2,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer4,
@@ -69359,7 +69347,7 @@
 /obj/machinery/airalarm/directional/north,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/carpet/purple,
-/area/hydroponics/garden)
+/area/maintenance/port/fore)
 "xpS" = (
 /obj/effect/turf_decal/bot,
 /obj/structure/closet/crate,
@@ -71268,11 +71256,8 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer4,
 /obj/item/trash/sosjerky,
-/obj/structure/cable/yellow{
-	icon_state = "1-4"
-	},
 /turf/open/floor/plating,
-/area/hydroponics/garden)
+/area/maintenance/port/fore)
 "ycc" = (
 /obj/structure/chair/wood{
 	dir = 1
@@ -71369,7 +71354,7 @@
 /turf/open/floor/iron/dark/smooth_half{
 	dir = 1
 	},
-/area/hydroponics/garden)
+/area/maintenance/port/fore)
 "yev" = (
 /turf/open/floor/wood,
 /area/crew_quarters/heads/hop)
@@ -86437,13 +86422,13 @@ amC
 amC
 amC
 amC
-azF
-azF
-azF
-azF
-azF
-azF
-azF
+aBI
+aBI
+aBI
+aBI
+aBI
+aBI
+aBI
 xUo
 mmR
 asE
@@ -86694,13 +86679,13 @@ alU
 alU
 alU
 alU
-azF
+alU
 wln
 bRh
 srU
 cwT
 spI
-azF
+alU
 aIR
 dad
 niE
@@ -86957,7 +86942,7 @@ lYQ
 oxq
 kjc
 jSW
-azF
+alU
 aIQ
 ayl
 ayl
@@ -87208,15 +87193,15 @@ alU
 alU
 alU
 dsg
-azF
+alU
 qap
 seU
 nrQ
 mnX
 oDQ
-azF
-azF
-azF
+alU
+alU
+pPK
 gxN
 pan
 qKO
@@ -87465,7 +87450,7 @@ amC
 abe
 alU
 qnO
-azF
+alU
 dWw
 mbA
 dux
@@ -87722,7 +87707,7 @@ amC
 amC
 alU
 qnO
-azF
+alU
 xpI
 hdJ
 bRq
@@ -87979,7 +87964,7 @@ amC
 amC
 alU
 qnO
-azF
+alU
 phW
 vPH
 dWP
@@ -88236,7 +88221,7 @@ ali
 alU
 alU
 qnO
-azF
+alU
 gyH
 vPr
 wio
@@ -88493,15 +88478,15 @@ amC
 amC
 amC
 qnO
-azF
-azF
-azF
-azF
-azF
-azF
-azF
-azF
-azF
+alU
+alU
+alU
+alU
+alU
+alU
+alU
+alU
+pPK
 evA
 frs
 aOl
@@ -88752,13 +88737,13 @@ alU
 tyZ
 jPm
 joD
-iYA
+azF
 fQp
 dYj
 qmH
 fYH
 iDh
-iYA
+pPK
 xVm
 aNm
 aOl
@@ -89266,7 +89251,7 @@ amC
 abC
 alU
 flJ
-iYA
+azF
 jYf
 pzh
 mNA
@@ -89523,13 +89508,13 @@ amC
 amC
 alU
 flJ
-iYA
+azF
 eui
 pzh
 stF
 tAw
 rtp
-iYA
+pPK
 cQM
 gJD
 cas
@@ -89780,7 +89765,7 @@ amC
 amC
 alU
 flJ
-iYA
+azF
 hAH
 plL
 tCi
@@ -90037,7 +90022,7 @@ amC
 amC
 alU
 flJ
-iYA
+azF
 kYX
 hci
 jXa
@@ -90294,13 +90279,13 @@ amC
 amC
 alU
 flJ
-iYA
+azF
 qpl
 vdX
 bvj
 uYM
 mLM
-iYA
+pPK
 aLE
 wii
 aOl
@@ -90551,7 +90536,7 @@ axj
 alU
 alU
 flJ
-iYA
+azF
 uLT
 dVT
 jWE
@@ -90808,7 +90793,7 @@ nrr
 iiF
 iiF
 pBn
-iYA
+azF
 tLC
 pxb
 gDX
@@ -91065,13 +91050,13 @@ xHI
 alU
 aoX
 atJ
-iYA
+azF
 tWP
 fMa
 cVw
 aQf
 iVj
-uXS
+fHM
 aLE
 aLE
 aOl
@@ -91328,7 +91313,7 @@ uXS
 uXS
 uXS
 uXS
-uXS
+fHM
 jwG
 tFe
 lHn


### PR DESCRIPTION
## About The Pull Request

I made a mistake, when adjusting the Garden / Club at one point i had swap their locations while keeping room dimensions and as a result, forgot that area needs to be changed. Not only that but maintence/club the area is really labelled as Xeno Maint, so i got rid of the APC in da club and maint it apart of the greater maint area


## Why It's Good For The Game

APC names are wrong, this fixes that

## Testing Photographs and Procedure

<details>
<summary>Screenshots&Videos</summary>

<img width="676" height="346" alt="Screenshot 2025-11-10 163141" src="https://github.com/user-attachments/assets/03128d7b-f784-4ad4-90a9-448907b9a423" />


</details>

## Changelog
:cl:
fix: fixed boxstation Garden / Bar Zoning and APC names
/:cl:
