### PR TITLE
Fixes stupid stupid subsystem dependencies mistake

### DIFF
--- a/code/__DEFINES/MC.dm
+++ b/code/__DEFINES/MC.dm
@@ -26,7 +26,7 @@
 
 /// Returns true if the MC is initialized and running.
 /// Optional argument init_stage controls what stage the mc must have initializted to count as initialized. Defaults to INITSTAGE_MAX if not specified.
-#define MC_RUNNING(INIT_STAGE...) (Master && Master.processing > 0 && Master.current_runlevel && Master.init_stage_completed == (max(min(INITSTAGE_MAX, ##INIT_STAGE), 1)))
+#define MC_RUNNING(INIT_STAGE...) (Master && Master.processing > 0 && Master.current_runlevel && Master.init_stage_completed >= (max(min(INITSTAGE_MAX, ##INIT_STAGE), 1)))
 
 #define MC_LOOP_RTN_NEWSTAGES 1
 #define MC_LOOP_RTN_GRACEFUL_EXIT 2


### PR DESCRIPTION
## About The Pull Request

I forgot to change one singular character in the `MC_RUNNING` macro when porting dependencies, luckily this macro is only used in 5 other places other than the voting subsystem and they are all relatively unimportant than if it had been in the master controller or something.

## Why It's Good For The Game

Wow. It seems like I'm having to make fixes for every single one of the PRs I developed/worked on at 3 in the morning while sleep deprived. I wonder why

## Testing Photographs and Procedure

<img width="372" height="113" alt="Screenshot 2025-11-10 204017" src="https://github.com/user-attachments/assets/c27e6306-603d-4ef7-9033-ea0af7ee9a88" />

## Changelog
:cl:
fix: Fixed the dynamic storyteller vote not being sent at roundstart
/:cl:
