### PR TITLE
Supermatter explosions now scale with time

### DIFF
--- a/code/__DEFINES/supermatter.dm
+++ b/code/__DEFINES/supermatter.dm
@@ -115,6 +115,9 @@
 /// Currently counting down to delamination. True [/obj/machinery/power/supermatter_crystal/var/final_countdown]
 #define SUPERMATTER_DELAMINATING 6
 
+/// This is the amount of time that must pass before supermatter delaminations can trigger singularity/tesla, and before explosions reach their old max power
+#define SUPERMATTER_CRITICAL_TIME (45 MINUTES) //Parenthesis are important for order of operations
+
 // SUPERMATTER FACTORS DEFINES
 // This might feel obvious, but mentioning it doesnt hurt anyone:
 // While we separate these factors into neat little boxes, order still matters in the code.

--- a/code/modules/power/supermatter/supermatter.dm
+++ b/code/modules/power/supermatter/supermatter.dm
@@ -676,7 +676,7 @@ GLOBAL_DATUM(main_supermatter_engine, /obj/machinery/power/supermatter_crystal)
 	internal_energy = max(internal_energy, 0)
 	if(internal_energy && !activation_time)
 		stack_trace("Supermatter powered for the first time without being logged. Internal energy factors: [json_encode(internal_energy_factors)]")
-		activation_time = TRUE // so we dont spam the log.
+		activation_time = world.time
 	else if(!internal_energy)
 		last_power_zap = world.time
 		last_energy_accumulation_perspective_machines = SSmachines.times_fired

--- a/code/modules/power/supermatter/supermatter.dm
+++ b/code/modules/power/supermatter/supermatter.dm
@@ -120,8 +120,8 @@ GLOBAL_DATUM(main_supermatter_engine, /obj/machinery/power/supermatter_crystal)
 	/// The key our internal radio uses
 	var/radio_key = /obj/item/encryptionkey/headset_eng
 
-	/// Boolean used to log the first activation of the SM.
-	var/activation_logged = FALSE
+	/// Variable used to log the first activation of the SM.
+	var/activation_time
 
 	/// An effect we show to admins and ghosts the percentage of delam we're at
 	var/obj/effect/countdown/supermatter/countdown
@@ -674,9 +674,9 @@ GLOBAL_DATUM(main_supermatter_engine, /obj/machinery/power/supermatter_crystal)
 	for(var/powergain_types in additive_power)
 		internal_energy += additive_power[powergain_types]
 	internal_energy = max(internal_energy, 0)
-	if(internal_energy && !activation_logged)
+	if(internal_energy && !activation_time)
 		stack_trace("Supermatter powered for the first time without being logged. Internal energy factors: [json_encode(internal_energy_factors)]")
-		activation_logged = TRUE // so we dont spam the log.
+		activation_time = TRUE // so we dont spam the log.
 	else if(!internal_energy)
 		last_power_zap = world.time
 		last_energy_accumulation_perspective_machines = SSmachines.times_fired
@@ -691,7 +691,7 @@ GLOBAL_DATUM(main_supermatter_engine, /obj/machinery/power/supermatter_crystal)
  * * how - A datum. How they powered it. Optional.
  */
 /obj/machinery/power/supermatter_crystal/proc/log_activation(who, how)
-	if(activation_logged || disable_power_change)
+	if(activation_time || disable_power_change)
 		return
 	if(!who)
 		CRASH("Supermatter activated by an unknown source")
@@ -702,7 +702,7 @@ GLOBAL_DATUM(main_supermatter_engine, /obj/machinery/power/supermatter_crystal)
 	else
 		investigate_log("has been powered for the first time by [key_name(who)][how ? " with [how]" : ""].", INVESTIGATE_ENGINES)
 		message_admins("[src] [ADMIN_JMP(src)] has been powered for the first time by [ADMIN_FULLMONTY(who)][how ? " with [how]" : ""].")
-	activation_logged = TRUE
+	activation_time = world.time
 
 /**
  * Perform calculation for the main zap power transmission rate in W/MeV.

--- a/code/modules/power/supermatter/supermatter_delamination/common_delams.dm
+++ b/code/modules/power/supermatter/supermatter_delamination/common_delams.dm
@@ -4,7 +4,7 @@
 /datum/sm_delam/singularity
 
 /datum/sm_delam/singularity/can_select(obj/machinery/power/supermatter_crystal/sm)
-	return (sm.absorbed_gasmix.total_moles() >= MOLE_PENALTY_THRESHOLD * ((world.time - sm.activation_time) / SUPERMATTER_CRITICAL_TIME))
+	return (sm.absorbed_gasmix.total_moles() >= MOLE_PENALTY_THRESHOLD / min((world.time - sm.activation_time) / SUPERMATTER_CRITICAL_TIME), 1)
 
 /datum/sm_delam/singularity/delam_progress(obj/machinery/power/supermatter_crystal/sm)
 	. = ..()
@@ -67,7 +67,7 @@
 /datum/sm_delam/tesla
 
 /datum/sm_delam/tesla/can_select(obj/machinery/power/supermatter_crystal/sm)
-	return (sm.internal_energy > POWER_PENALTY_THRESHOLD * ((world.time - sm.activation_time) / SUPERMATTER_CRITICAL_TIME))
+	return (sm.internal_energy > POWER_PENALTY_THRESHOLD / min((world.time - sm.activation_time) / SUPERMATTER_CRITICAL_TIME), 1)
 
 /datum/sm_delam/tesla/delam_progress(obj/machinery/power/supermatter_crystal/sm)
 	if(!..())

--- a/code/modules/power/supermatter/supermatter_delamination/common_delams.dm
+++ b/code/modules/power/supermatter/supermatter_delamination/common_delams.dm
@@ -4,7 +4,7 @@
 /datum/sm_delam/singularity
 
 /datum/sm_delam/singularity/can_select(obj/machinery/power/supermatter_crystal/sm)
-	return (sm.absorbed_gasmix.total_moles() >= MOLE_PENALTY_THRESHOLD / min((world.time - sm.activation_time) / SUPERMATTER_CRITICAL_TIME), 1)
+	return (sm.absorbed_gasmix.total_moles() >= MOLE_PENALTY_THRESHOLD / min(((world.time - sm.activation_time) / SUPERMATTER_CRITICAL_TIME), 1))
 
 /datum/sm_delam/singularity/delam_progress(obj/machinery/power/supermatter_crystal/sm)
 	. = ..()
@@ -67,7 +67,7 @@
 /datum/sm_delam/tesla
 
 /datum/sm_delam/tesla/can_select(obj/machinery/power/supermatter_crystal/sm)
-	return (sm.internal_energy > POWER_PENALTY_THRESHOLD / min((world.time - sm.activation_time) / SUPERMATTER_CRITICAL_TIME), 1)
+	return (sm.internal_energy > POWER_PENALTY_THRESHOLD / min(((world.time - sm.activation_time) / SUPERMATTER_CRITICAL_TIME), 1))
 
 /datum/sm_delam/tesla/delam_progress(obj/machinery/power/supermatter_crystal/sm)
 	if(!..())

--- a/code/modules/power/supermatter/supermatter_delamination/common_delams.dm
+++ b/code/modules/power/supermatter/supermatter_delamination/common_delams.dm
@@ -4,7 +4,7 @@
 /datum/sm_delam/singularity
 
 /datum/sm_delam/singularity/can_select(obj/machinery/power/supermatter_crystal/sm)
-	return (sm.absorbed_gasmix.total_moles() >= MOLE_PENALTY_THRESHOLD)
+	return (sm.absorbed_gasmix.total_moles() >= MOLE_PENALTY_THRESHOLD) && (world.time - sm.activation_time > 45 MINUTES)
 
 /datum/sm_delam/singularity/delam_progress(obj/machinery/power/supermatter_crystal/sm)
 	. = ..()
@@ -67,7 +67,7 @@
 /datum/sm_delam/tesla
 
 /datum/sm_delam/tesla/can_select(obj/machinery/power/supermatter_crystal/sm)
-	return (sm.internal_energy > POWER_PENALTY_THRESHOLD)
+	return (sm.internal_energy > POWER_PENALTY_THRESHOLD) && (world.time - sm.activation_time > 45 MINUTES)
 
 /datum/sm_delam/tesla/delam_progress(obj/machinery/power/supermatter_crystal/sm)
 	if(!..())

--- a/code/modules/power/supermatter/supermatter_delamination/common_delams.dm
+++ b/code/modules/power/supermatter/supermatter_delamination/common_delams.dm
@@ -4,7 +4,7 @@
 /datum/sm_delam/singularity
 
 /datum/sm_delam/singularity/can_select(obj/machinery/power/supermatter_crystal/sm)
-	return (sm.absorbed_gasmix.total_moles() >= MOLE_PENALTY_THRESHOLD) && (world.time - sm.activation_time > SUPERMATTER_CRITICAL_TIME)
+	return (sm.absorbed_gasmix.total_moles() >= MOLE_PENALTY_THRESHOLD * ((world.time - sm.activation_time) / SUPERMATTER_CRITICAL_TIME))
 
 /datum/sm_delam/singularity/delam_progress(obj/machinery/power/supermatter_crystal/sm)
 	. = ..()
@@ -67,7 +67,7 @@
 /datum/sm_delam/tesla
 
 /datum/sm_delam/tesla/can_select(obj/machinery/power/supermatter_crystal/sm)
-	return (sm.internal_energy > POWER_PENALTY_THRESHOLD) && (world.time - sm.activation_time > SUPERMATTER_CRITICAL_TIME)
+	return (sm.internal_energy > POWER_PENALTY_THRESHOLD * ((world.time - sm.activation_time) / SUPERMATTER_CRITICAL_TIME))
 
 /datum/sm_delam/tesla/delam_progress(obj/machinery/power/supermatter_crystal/sm)
 	if(!..())

--- a/code/modules/power/supermatter/supermatter_delamination/common_delams.dm
+++ b/code/modules/power/supermatter/supermatter_delamination/common_delams.dm
@@ -4,7 +4,7 @@
 /datum/sm_delam/singularity
 
 /datum/sm_delam/singularity/can_select(obj/machinery/power/supermatter_crystal/sm)
-	return (sm.absorbed_gasmix.total_moles() >= MOLE_PENALTY_THRESHOLD) && (world.time - sm.activation_time > 45 MINUTES)
+	return (sm.absorbed_gasmix.total_moles() >= MOLE_PENALTY_THRESHOLD) && (world.time - sm.activation_time > SUPERMATTER_CRITICAL_TIME)
 
 /datum/sm_delam/singularity/delam_progress(obj/machinery/power/supermatter_crystal/sm)
 	. = ..()
@@ -67,7 +67,7 @@
 /datum/sm_delam/tesla
 
 /datum/sm_delam/tesla/can_select(obj/machinery/power/supermatter_crystal/sm)
-	return (sm.internal_energy > POWER_PENALTY_THRESHOLD) && (world.time - sm.activation_time > 45 MINUTES)
+	return (sm.internal_energy > POWER_PENALTY_THRESHOLD) && (world.time - sm.activation_time > SUPERMATTER_CRITICAL_TIME)
 
 /datum/sm_delam/tesla/delam_progress(obj/machinery/power/supermatter_crystal/sm)
 	if(!..())

--- a/code/modules/power/supermatter/supermatter_delamination/delamination_effects.dm
+++ b/code/modules/power/supermatter/supermatter_delamination/delamination_effects.dm
@@ -82,17 +82,17 @@
 /datum/sm_delam/proc/effect_explosion(obj/machinery/power/supermatter_crystal/sm)
 	explosion(
 		epicenter = get_turf(sm),
-		devastation_range = calculate_explosion(sm) * 0.5, // max 17.5
-		heavy_impact_range = calculate_explosion(sm) + 2, // max 37
-		light_impact_range = calculate_explosion(sm) + 4, // max 39
-		flash_range = calculate_explosion(sm) + 6, //max 41
+		devastation_range = calculate_explosion(sm) * 0.5, // 17.5 at 75 MINUTES
+		heavy_impact_range = calculate_explosion(sm) + 2, // 37
+		light_impact_range = calculate_explosion(sm) + 4, // 39
+		flash_range = calculate_explosion(sm) + 6, // 41
 		adminlog = TRUE,
 		ignorecap = TRUE,
 	)
 	return TRUE
 
 /datum/sm_delam/proc/calculate_explosion(obj/machinery/power/supermatter_crystal/sm)
-	return sm.explosion_power * max(sm.gas_heat_power_generation, 0.205)
+	return sm.explosion_power * max(sm.gas_heat_power_generation, 0.205) * ((world.time - sm.activation_time) / (45 MINUTES)) //energy builds over time for explosions
 
 /// Spawns a scrung and eat the SM.
 /datum/sm_delam/proc/effect_singulo(obj/machinery/power/supermatter_crystal/sm)

--- a/code/modules/power/supermatter/supermatter_delamination/delamination_effects.dm
+++ b/code/modules/power/supermatter/supermatter_delamination/delamination_effects.dm
@@ -82,7 +82,7 @@
 /datum/sm_delam/proc/effect_explosion(obj/machinery/power/supermatter_crystal/sm)
 	explosion(
 		epicenter = get_turf(sm),
-		devastation_range = calculate_explosion(sm) * 0.5, // 17.5 at 75 MINUTES
+		devastation_range = calculate_explosion(sm) * 0.5, // 17.5 at SUPERMATTER_CRITICAL_TIME define.
 		heavy_impact_range = calculate_explosion(sm) + 2, // 37
 		light_impact_range = calculate_explosion(sm) + 4, // 39
 		flash_range = calculate_explosion(sm) + 6, // 41

--- a/code/modules/power/supermatter/supermatter_delamination/delamination_effects.dm
+++ b/code/modules/power/supermatter/supermatter_delamination/delamination_effects.dm
@@ -92,7 +92,7 @@
 	return TRUE
 
 /datum/sm_delam/proc/calculate_explosion(obj/machinery/power/supermatter_crystal/sm)
-	return sm.explosion_power * max(sm.gas_heat_power_generation, 0.205) * ((world.time - sm.activation_time) / (45 MINUTES)) //energy builds over time for explosions
+	return sm.explosion_power * max(sm.gas_heat_power_generation, 0.205) * ((world.time - sm.activation_time) / SUPERMATTER_CRITICAL_TIME) //energy builds over time for explosions
 
 /// Spawns a scrung and eat the SM.
 /datum/sm_delam/proc/effect_singulo(obj/machinery/power/supermatter_crystal/sm)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This PR: 
* Changes the supermatter variable `activation_logged` from a boolean value into `activation_time` which is the specific time a supermatter crystal was powered.
* Also adds an additional modifer to the strength of supermatter explosions based on when it was first powered. The exact modifier added is `* ((world.time - sm.activation_time) / (45 MINUTES))` Which means that a supermatter which was just activated will explode with far less force than one which has been running for a while. 
* As a result of the above formula, supermatter explosions near the start of the round will have far less devastating force... but those that have been running successfully for a long time will potentially have far **more** devastating force than they previously had, potentially blowing up half of the station if the supermatter goes near the end of a round. 
* Singularity and Tesla delaminations are also tied into a very similar formula, where the thresholds for their activation are higher until the supermatter has been active for at least 45 minutes, where the value plateaus at its original requirement. This makes it much harder to speedrun a tesla/singularity near the start of the round as well, for those rare occasions that someone fucks up **really** badly.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

This makes screwing up a supermatter engine during setup far less punishing for the rest of the station, and better enables a station to recover from having a newer engineer, or from having engine sabotage rushed early on. Many stations are damaged badly enough by supermatter explosions that recovery afterwards is not realistically possible and this prevents explosions on that scale from happening before the round has had a chance to progress to any reasonable degree. 

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

### High power explosion right after the supermatter is powered:
#### Damage is localized entirely within the immediate supermatter chamber
<img width="782" height="96" alt="image" src="https://github.com/user-attachments/assets/0a008b67-8d58-4b8f-abd7-2122cbfc9d25" />
<img width="677" height="547" alt="image" src="https://github.com/user-attachments/assets/5462a230-e09d-41d6-80a2-cb238e30d604" />

### High power explosion 20 minutes after supermatter is powered:
#### Damage is localized to the room surrounding the supermatter chamber. SMES and atmospherics are fully in tact
<img width="785" height="82" alt="image" src="https://github.com/user-attachments/assets/0da9deae-f38a-4502-9f2b-6599dad24e8d" />
<img width="1101" height="978" alt="image" src="https://github.com/user-attachments/assets/dda9ca29-4f61-4e4b-8a00-2dee2445fa0a" />

### High power explosion 40 minutes after supermatter is powered (close to current max power):
#### Most of engineering main area has suffered heavy damage. The SMES are damaged and/or disconnected and so is the gravity generator. Depending on map damage starts to vary heavily.
<img width="973" height="743" alt="image" src="https://github.com/user-attachments/assets/01196d20-67b5-4a7c-8a60-e709cda8dfb3" />

### High power explosion 120 minutes after supermatter is powered (the absolute upper limit explosion right as round is ending anyway if supermatter has been powered the whole shift):
#### Half of the station is vaporized
<img width="980" height="929" alt="image" src="https://github.com/user-attachments/assets/4c1a9dd3-f6a3-4fd5-a038-3f12911dfb87" />
</details>

## Changelog
:cl:
tweak: Supermatter delaminations now scale with how long the crystal has been powered. This means if someone who is still learning messes up during the initial setup, the explosion will be much smaller than if the engine has been running for a while before it went south. 
tweak: Supermatter crystal explosions will reach their previous maximum force after being powered for 45 minutes, but they will continue to grow after this point meaning they are only capped in power by the duration of the round. 
tweak: Tesla and Singularity delaminations have scaling requirements as well, but these values plateau to their old requirements after the supermatter has been powered for 45 minutes. 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
