### PR TITLE
Cryoing no longer requires alerting admins

### DIFF
--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -258,7 +258,7 @@ GLOBAL_LIST_EMPTY(cryopod_computers)
 
 		//Offer special roles to ghosts and pause processing while we do
 		var/datum/antagonist/A = mob_occupant.mind.has_antag_datum(/datum/antagonist)
-		if(A || (mob_occupant.mind.assigned_role in SSdepartment.get_jobs_by_dept_id(DEPT_NAME_COMMAND)))
+		if(A)
 			ghost_offering = TRUE
 			INVOKE_ASYNC(src, PROC_REF(offering_to_ghosts), mob_occupant)
 			return

--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -229,6 +229,7 @@ GLOBAL_LIST_EMPTY(cryopod_computers)
 
 /obj/machinery/cryopod/open_machine()
 	..()
+	ghost_offering = FALSE
 	icon_state = "cryopod-open"
 	set_density(TRUE)
 	name = initial(name)
@@ -258,8 +259,8 @@ GLOBAL_LIST_EMPTY(cryopod_computers)
 		//Offer special roles to ghosts and pause processing while we do
 		var/datum/antagonist/A = mob_occupant.mind.has_antag_datum(/datum/antagonist)
 		if(A || (mob_occupant.mind.assigned_role in SSdepartment.get_jobs_by_dept_id(DEPT_NAME_COMMAND)))
-			INVOKE_ASYNC(src, PROC_REF(offering_to_ghosts), mob_occupant)
 			ghost_offering = TRUE
+			INVOKE_ASYNC(src, PROC_REF(offering_to_ghosts), mob_occupant)
 			return
 		//This is not a role that needs to be offered, despawn them.
 		despawn_occupant()
@@ -270,11 +271,10 @@ GLOBAL_LIST_EMPTY(cryopod_computers)
 		open_machine()
 	else
 		despawn_occupant()
-	ghost_offering = FALSE
-
 
 // This function can not be undone; do not call this unless you are sure
 /obj/machinery/cryopod/proc/despawn_occupant()
+	ghost_offering = FALSE
 	//Last chance to find this computer if it exists
 	if(!control_computer_weakref)
 		find_control_computer(urgent = TRUE)

--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -154,8 +154,9 @@ GLOBAL_LIST_EMPTY(cryopod_computers)
 	var/on_store_name = "Cryogenic Oversight"
 
 	// 5 minutes-ish safe period before being despawned.
-	var/time_till_despawn = 5 * 600 // This is reduced to 30 seconds if a player manually enters cryo
-	var/despawn_world_time = null          // Used to keep track of the safe period.
+	var/time_till_despawn = 5 MINUTES // Players are ghosted immediately if they manually chose to enter cryo
+	var/despawn_world_time = null // Used to keep track of the safe period.
+	var/ghost_offering = FALSE //Sets to true when the occupant is currently being offered to ghosts, to pause despawning them
 
 	var/datum/weakref/control_computer_weakref
 	var/last_no_computer_message = 0
@@ -220,8 +221,8 @@ GLOBAL_LIST_EMPTY(cryopod_computers)
 		var/mob/living/mob_occupant = occupant
 		if(mob_occupant && mob_occupant.stat != DEAD)
 			to_chat(occupant, span_boldnotice("You feel cool air surround you. You go numb as your senses turn inward."))
-		if(mob_occupant.client)//if they're logged in
-			despawn_world_time = world.time + (time_till_despawn * 0.1) // This gives them 30 seconds
+		if(mob_occupant.client)
+			despawn_world_time = world.time //If they are logged in and actively chose to cryo themselves, they are immediately offered
 		else
 			despawn_world_time = world.time + time_till_despawn
 	icon_state = "cryopod"
@@ -241,26 +242,43 @@ GLOBAL_LIST_EMPTY(cryopod_computers)
 	container_resist(user)
 
 /obj/machinery/cryopod/process()
-	if(!occupant)
+	if(!occupant || ghost_offering)
 		return
 
 	var/mob/living/mob_occupant = occupant
 	if(mob_occupant)
-		// Eject dead people
-		if(mob_occupant.stat == DEAD)
+		// Eject people that are incapacitated
+		if(mob_occupant.stat)
 			open_machine()
 
+		//The grace period isn't up yet
 		if(!(world.time > despawn_world_time))
 			return
 
-		if(!mob_occupant.client && mob_occupant.stat < 2) //Occupant is living and has no client.
-			if(!control_computer_weakref)
-				find_control_computer(urgent = TRUE)//better hope you found it this time
+		//Offer special roles to ghosts and pause processing while we do
+		var/datum/antagonist/A = mob_occupant.mind.has_antag_datum(/datum/antagonist)
+		if(A || (mob_occupant.mind.assigned_role in SSdepartment.get_jobs_by_dept_id(DEPT_NAME_COMMAND)))
+			INVOKE_ASYNC(src, PROC_REF(offering_to_ghosts), mob_occupant)
+			ghost_offering = TRUE
+			return
+		//This is not a role that needs to be offered, despawn them.
+		despawn_occupant()
 
-			despawn_occupant()
+/obj/machinery/cryopod/proc/offering_to_ghosts(mob/living/mob_occupant)
+	mob_occupant.SetUnconscious(30 SECONDS, TRUE)
+	if(offer_control(mob_occupant))
+		open_machine()
+	else
+		despawn_occupant()
+	ghost_offering = FALSE
+
 
 // This function can not be undone; do not call this unless you are sure
 /obj/machinery/cryopod/proc/despawn_occupant()
+	//Last chance to find this computer if it exists
+	if(!control_computer_weakref)
+		find_control_computer(urgent = TRUE)
+
 	var/mob/living/mob_occupant = occupant
 
 	if(mob_occupant.mind && mob_occupant.mind.assigned_role)
@@ -378,21 +396,6 @@ GLOBAL_LIST_EMPTY(cryopod_computers)
 		if(alert(target,"Would you like to enter cryosleep?",,"Yes","No") != "Yes")
 			return
 
-	var/generic_plsnoleave_message = " Please adminhelp before leaving the round, even if there are no administrators online!"
-
-	if(target == user && world.time - target.client.cryo_warned > 5 MINUTES)//if we haven't warned them in the last 5 minutes
-		var/caught = FALSE
-		var/datum/antagonist/A = target.mind.has_antag_datum(/datum/antagonist)
-		if(target.mind.assigned_role in SSdepartment.get_jobs_by_dept_id(DEPT_NAME_COMMAND))
-			alert("You're a Head of Staff![generic_plsnoleave_message]")
-			caught = TRUE
-		if(A)
-			alert("You're a [A.name]![generic_plsnoleave_message]")
-			caught = TRUE
-		if(caught)
-			target.client.cryo_warned = world.time
-			return
-
 	if(!target || user.incapacitated() || !target.Adjacent(user) || !Adjacent(user) || (!ishuman(user) && !iscyborg(user)) || !istype(user.loc, /turf) || target.buckled)
 		return
 		//rerun the checks in case of shenanigans
@@ -407,7 +410,6 @@ GLOBAL_LIST_EMPTY(cryopod_computers)
 		return
 	close_machine(target)
 
-	to_chat(target, span_boldnotice("If you ghost, log out or close your client now, your character will shortly be permanently removed from the round."))
 	name = "[name] ([occupant.name])"
 	if((world.time - SSticker.round_start_time) < 5 MINUTES)
 		message_admins("[span_danger("[key_name_admin(target)], the [target.job] entered a stasis pod. (<A HREF='BYOND://?_src_=holder;[HrefToken()];adminplayerobservecoodjump=1;X=[x];Y=[y];Z=[z]'>JMP</a>")])")

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -437,7 +437,7 @@
 	var/mob/dead/observer/candidate = SSpolling.poll_ghosts_one_choice(
 		question = poll_message,
 		check_jobban = ban_key,
-		poll_time = 10 SECONDS,
+		poll_time = 30 SECONDS,
 		jump_target = M,
 		alert_pic = M,
 	)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Players are no longer stopped and told they are required to alert admins when they are leaving a round via cryo

Players are now automatically offered to ghosts when playing antagonist roles and attempting to cryo

Using cryo to evade security officers or other conflict is metagaming, and players who accept the prompt to enter a cryopod can no longer change their minds, they can instead respawn. Once the cryopod takes a willing person it will not give them back unless a new ghost takes the role. 

(Unchanged from current behavior) Players cannot be placed into cryopods by another player if their client is connected. 

Players which are placed into cryopods while they are disconnected may still freely leave the cryopod if they reconnect within the grace period (currently set to 5 minutes). 

Cryo smites still immediately remove players from the round without offering them because they are a conscious administrative action.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Cuts down on both player and admin expectations by automating a system that should always be happening anyway. 

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

<img width="798" height="183" alt="image" src="https://github.com/user-attachments/assets/74ef5406-b229-45d4-b006-71ae758e9fdf" />

<img width="785" height="190" alt="image" src="https://github.com/user-attachments/assets/72be34cb-72b1-46b5-9bbd-f9580b1ed629" />

I did further testing than this, but the screenshots were lost. This system notably does not work with the cryo smites because they were coded in a fairly janky way. If an admin is available to cryo smite, they are also available to offer the body to ghosts directly instead

</details>

## Changelog
:cl:
tweak: Going to cryo no longer requires notifying admins for any roles.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
