### PR TITLE
Fixes oversight with bolas, modifies how they work slightly

### DIFF
--- a/code/datums/status_effects/debuffs/debuffs.dm
+++ b/code/datums/status_effects/debuffs/debuffs.dm
@@ -233,6 +233,10 @@
 		carbon_owner.legcuffed = null
 		carbon_owner.update_worn_legcuffs()
 
+/datum/status_effect/bola/Destroy()
+	. = ..()
+	linked_bola = null
+
 //OTHER DEBUFFS
 /datum/status_effect/strandling //get it, strand as in durathread strand + strangling = strandling hahahahahahahahahahhahahaha i want to die
 	id = "strandling"

--- a/code/datums/status_effects/debuffs/debuffs.dm
+++ b/code/datums/status_effects/debuffs/debuffs.dm
@@ -217,6 +217,7 @@
 /datum/status_effect/bola
 	id = "bola"
 	status_type = STATUS_EFFECT_REPLACE
+	alert_type = null
 	var/obj/item/linked_bola
 
 /datum/status_effect/bola/on_creation(mob/living/new_owner, bola_duration, obj/item/bola)

--- a/code/datums/status_effects/debuffs/debuffs.dm
+++ b/code/datums/status_effects/debuffs/debuffs.dm
@@ -213,7 +213,24 @@
 	desc = "Your biological functions have halted. You could live forever this way, but it's pretty boring."
 	icon_state = "stasis"
 
-//GOLEM GANG
+//BOLA TRACKING
+/datum/status_effect/bola
+	id = "bola"
+	status_type = STATUS_EFFECT_REPLACE
+	var/obj/item/linked_bola
+
+/datum/status_effect/bola/on_creation(mob/living/new_owner, bola_duration, obj/item/bola)
+	linked_bola = bola
+	duration = bola_duration
+	return ..()
+
+/datum/status_effect/bola/on_remove()
+	var/mob/living/carbon/carbon_owner = owner
+	if(carbon_owner?.legcuffed == linked_bola)
+		var/turf/owner_turf = get_turf(carbon_owner)
+		linked_bola.forceMove(owner_turf)
+		carbon_owner.legcuffed = null
+		carbon_owner.update_worn_legcuffs()
 
 //OTHER DEBUFFS
 /datum/status_effect/strandling //get it, strand as in durathread strand + strangling = strandling hahahahahahahahahahhahahaha i want to die

--- a/code/game/objects/items/handcuffs.dm
+++ b/code/game/objects/items/handcuffs.dm
@@ -345,6 +345,12 @@
 	var/knockdown = 2 SECONDS
 	gender = NEUTER
 
+/obj/item/restraints/legcuffs/bola/Destroy()
+	. = ..()
+	if(isliving(loc))
+		var/mob/living/bola_mob = loc
+		bola_mob.remove_status_effect(/datum/status_effect/bola)
+
 /obj/item/restraints/legcuffs/bola/throw_at(atom/target, range, speed, mob/thrower, spin=1, diagonals_first = 0, datum/callback/callback, force, quickstart = TRUE)
 	if(!..())
 		return

--- a/code/game/objects/items/handcuffs.dm
+++ b/code/game/objects/items/handcuffs.dm
@@ -341,9 +341,9 @@
 	item_state = "bola"
 	lefthand_file = 'icons/mob/inhands/weapons/thrown_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/weapons/thrown_righthand.dmi'
-	breakouttime = 2 SECONDS
+	slowdown = 0 //Bolas trip the person they hit rather than slowing them down
+	var/knockdown = 2 SECONDS
 	gender = NEUTER
-	var/knockdown = 0
 
 /obj/item/restraints/legcuffs/bola/throw_at(atom/target, range, speed, mob/thrower, spin=1, diagonals_first = 0, datum/callback/callback, force, quickstart = TRUE)
 	if(!..())
@@ -361,17 +361,17 @@
   * Arguments:
   * * C - the carbon that we will try to ensnare
   */
-/obj/item/restraints/legcuffs/bola/proc/ensnare(mob/living/carbon/C)
-	if(!C.legcuffed && C.num_legs >= 2)
-		visible_message(span_danger("\The [src] ensnares [C]!"))
-		C.legcuffed = src
-		forceMove(C)
-		C.update_equipment_speed_mods()
-		C.update_worn_legcuffs()
+/obj/item/restraints/legcuffs/bola/proc/ensnare(mob/living/carbon/target)
+	if(!target.legcuffed && target.num_legs >= 2)
+		visible_message(span_danger("\The [src] ensnares [target]!"))
+		target.legcuffed = src
+		forceMove(target)
+		target.update_worn_legcuffs()
 		SSblackbox.record_feedback("tally", "handcuffs", 1, type)
-		to_chat(C, span_userdanger("\The [src] ensnares you!"))
+		to_chat(target, span_userdanger("\The [src] ensnares you!"))
 		if(knockdown)
-			C.Knockdown(knockdown)
+			target.Knockdown(knockdown)
+			target.apply_status_effect(/datum/status_effect/bola, knockdown, src) //When status effect ends, bola is automatically dropped
 		playsound(src, 'sound/effects/snap.ogg', 50, TRUE)
 
 /obj/item/restraints/legcuffs/bola/tactical//traitor variant
@@ -379,15 +379,14 @@
 	desc = "A strong bola, made with a long steel chain. It looks heavy, enough so that it could trip somebody."
 	icon_state = "bola_r"
 	item_state = "bola_r"
-	breakouttime = 7 SECONDS
-	knockdown = 2 SECONDS
+	knockdown = 7 SECONDS
 
 /obj/item/restraints/legcuffs/bola/watcher //tribal bola for tribal lizards
 	name = "watcher Bola"
 	desc = "A Bola made from the stretchy sinew of fallen watchers."
 	icon_state = "bola_watcher"
 	item_state = "bola_watcher"
-	breakouttime = 4.5 SECONDS
+	knockdown = 4.5 SECONDS
 
 /obj/item/restraints/legcuffs/bola/energy //For Security
 	name = "energy bola"
@@ -395,14 +394,12 @@
 	icon_state = "ebola"
 	item_state = "ebola"
 	hitsound = 'sound/weapons/taserhit.ogg'
-	w_class = WEIGHT_CLASS_SMALL
-	breakouttime = 6 SECONDS
+	knockdown = 6 SECONDS
 	custom_price = 100
 
 /obj/item/restraints/legcuffs/bola/energy/ensnare(mob/living/carbon/C)
-	var/obj/item/restraints/legcuffs/beartrap/B = new /obj/item/restraints/legcuffs/beartrap/energy/cyborg(get_turf(C))
-	B.spring_trap(C, ignore_movetypes = TRUE)
-	qdel(src)
+	. = ..()
+	
 
 /obj/item/restraints/legcuffs/bola/energy/emp_act(severity)
 	if(prob(25 * severity))

--- a/code/game/objects/items/handcuffs.dm
+++ b/code/game/objects/items/handcuffs.dm
@@ -409,8 +409,7 @@
 	icon_state = "gonbola"
 	icon_state_preview = "gonbola_preview"
 	item_state = "bola_r"
-	breakouttime = 30 SECONDS //Good god
-	slowdown = 0
+	knockdown = 10 SECONDS //Good god
 	var/datum/status_effect/gonbola_pacify/effectReference
 
 /obj/item/restraints/legcuffs/bola/gonbola/throw_impact(atom/hit_atom, datum/thrownthing/throwingdatum)

--- a/code/game/objects/items/handcuffs.dm
+++ b/code/game/objects/items/handcuffs.dm
@@ -394,12 +394,8 @@
 	icon_state = "ebola"
 	item_state = "ebola"
 	hitsound = 'sound/weapons/taserhit.ogg'
-	knockdown = 6 SECONDS
+	knockdown = 3 SECONDS
 	custom_price = 100
-
-/obj/item/restraints/legcuffs/bola/energy/ensnare(mob/living/carbon/C)
-	. = ..()
-	
 
 /obj/item/restraints/legcuffs/bola/energy/emp_act(severity)
 	if(prob(25 * severity))

--- a/code/modules/antagonists/cult/cult_items.dm
+++ b/code/modules/antagonists/cult/cult_items.dm
@@ -112,8 +112,7 @@ Striking a noncultist, however, will tear their flesh."}
 	desc = "A strong bola, bound with dark magic that allows it to pass harmlessly through Nar'Sien cultists. Throw it to trip and slow your victim."
 	icon_state = "bola_cult"
 	item_state = "bola_cult"
-	breakouttime = 6 SECONDS
-	knockdown = 20
+	knockdown = 6 SECONDS
 
 /obj/item/restraints/legcuffs/bola/cult/throw_impact(atom/hit_atom, datum/thrownthing/throwingdatum)
 	if(!isliving(hit_atom))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

### First an explanation of the problem:
Way back in #12602 I changed how players break out of restraints, but because this changed breakout attempts to work in 5 second increments, all bolas with less than 5 second breakout now took a full five seconds. Bolas with slightly more than 5 second breakouts now took a full ten seconds. This made bolas last much longer than intended from that point forward, most notably:
* Energy bolas are supposed to snare for 3 seconds, and instead snared for at least 5. 
* Reinforced bolas are supposed to snare for 7 seconds and instead snared for at least 10
* Watcher bolas are supposed to snare for 4.5 seconds and instead snare for at least 5 (not that different on this one)

### What this PR actually does
* All bolas have had their hardcoded slowdown removed and instead apply a knockdown for their intended duration. Knockdown is not quite as slow as their original slowdown, but it's close and much more immersive
* All bolas apply a status effect matching in duration for the knockdown, at which point the bola falls off. This means bolas no longer require players to consciously react to and break out of. The act of struggling on the ground does this on its own. 
* Energy bolas are no longer consumed upon impact and may be reused like other bolas
* Because the slowdown is applied through a knockdown, all durations are actually slightly longer than advertised since players don't start getting up from a knockdown until the duration is expired. Consider this a replacement for the time spent manually resisting. 
* Gonbola now acts like other bolas and as a result I've reduced its duration to 10 seconds because a 30 second knockdown would be excessive. Gonbolas still apply pacification in addition to being the strongest bola. 

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Unintended buffs to bolas have proven to be quite bad for the game as they've cropped back up as being incredibly oppressive. I originally went into this PR expecting to intentionally nerf them, but I'm going to settle for restoring them to the values they are supposed to have plus automating the process of removing bolas in the name of bringing our skill ceiling down a bit more. 

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

![dreamseeker_3kHvaLUdlX](https://github.com/user-attachments/assets/2ef5e080-bf11-4fa0-9998-d5d8c77ec208)

</details>

## Changelog
:cl:
fix: Unintentionally buffed bola durations have been reverted to their prior values. Energy bolas will last for 3 seconds and reinforced bolas for 7 seconds, down from being accidentally buffed to 5 and 10 respectively. 
tweak: Rather than applying a hardcoded slowdown when hit with a bola, players are knocked down for the intended escape duration and bolas will automatically fall off after the intended duration is up
tweak: Energy bolas are no longer consumed upon hitting a target
tweak: Gonbolas have had their duration reduced from 30 seconds to 10 seconds since they are also knockdown instead of just a pacification tool now. 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
