### PR TITLE
Berry New Service Door Mapping_Helpers

### DIFF
--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -8566,7 +8566,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/effect/mapping_helpers/airlock/access/all/service/kitchen,
+/obj/effect/mapping_helpers/airlock/access/any/service/kitchen,
 /turf/open/floor/iron/cafeteria,
 /area/hallway/secondary/service)
 "bqF" = (
@@ -8670,7 +8670,7 @@
 	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/mapping_helpers/airlock/access/all/service/general,
+/obj/effect/mapping_helpers/airlock/access/any/service/general,
 /obj/effect/mapping_helpers/airlock/unres{
 	dir = 4
 	},
@@ -28306,15 +28306,15 @@
 "gyo" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
-/obj/effect/mapping_helpers/airlock/unres,
 /obj/machinery/door/airlock{
 	name = "Theatre Backstage";
 	req_one_access_txt = "12;46"
 	},
-/obj/effect/mapping_helpers/airlock/access/all/service/theatre,
 /obj/structure/disposalpipe/segment{
 	dir = 2
 	},
+/obj/effect/mapping_helpers/airlock/access/any/service/theatre,
+/obj/effect/mapping_helpers/airlock/unres,
 /turf/open/floor/wood,
 /area/crew_quarters/theatre)
 "gyM" = (
@@ -30248,8 +30248,8 @@
 /obj/machinery/door/airlock{
 	name = "Bar Access"
 	},
-/obj/effect/mapping_helpers/airlock/access/all/service/bar,
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/airlock/access/any/service/bar,
 /obj/effect/mapping_helpers/airlock/access/any/service/kitchen,
 /turf/open/floor/iron,
 /area/crew_quarters/bar)
@@ -30292,8 +30292,8 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/effect/mapping_helpers/airlock/access/all/service/kitchen,
 /obj/structure/disposalpipe/segment,
+/obj/effect/mapping_helpers/airlock/access/any/service/kitchen,
 /turf/open/floor/iron/cafeteria,
 /area/crew_quarters/kitchen/coldroom)
 "hir" = (
@@ -40779,7 +40779,7 @@
 /obj/machinery/door/airlock{
 	name = "Hydroponics"
 	},
-/obj/effect/mapping_helpers/airlock/access/all/service/hydroponics,
+/obj/effect/mapping_helpers/airlock/access/any/service/hydroponics,
 /turf/open/floor/iron,
 /area/hallway/secondary/service)
 "kIN" = (
@@ -41973,7 +41973,7 @@
 /obj/machinery/door/airlock{
 	name = "Hydroponics"
 	},
-/obj/effect/mapping_helpers/airlock/access/all/service/hydroponics,
+/obj/effect/mapping_helpers/airlock/access/any/service/hydroponics,
 /turf/open/floor/iron,
 /area/hydroponics)
 "lfO" = (
@@ -48312,7 +48312,7 @@
 /obj/machinery/door/airlock{
 	name = "Hydroponics Backroom"
 	},
-/obj/effect/mapping_helpers/airlock/access/all/service/hydroponics,
+/obj/effect/mapping_helpers/airlock/access/any/service/hydroponics,
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "noC" = (
@@ -50761,11 +50761,11 @@
 /turf/open/floor/iron/white,
 /area/crew_quarters/toilet/restrooms)
 "oeJ" = (
-/obj/effect/mapping_helpers/airlock/access/all/service/theatre,
 /obj/machinery/door/airlock{
 	name = "Theatre Backstage";
 	req_one_access_txt = "12;46"
 	},
+/obj/effect/mapping_helpers/airlock/access/any/service/theatre,
 /turf/open/floor/wood,
 /area/maintenance/starboard)
 "oeP" = (
@@ -54519,8 +54519,8 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/effect/mapping_helpers/airlock/access/all/service/bar,
 /obj/structure/disposalpipe/segment,
+/obj/effect/mapping_helpers/airlock/access/any/service/bar,
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
 "ppx" = (
@@ -57708,8 +57708,8 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer4,
-/obj/effect/mapping_helpers/airlock/access/all/service/hydroponics,
 /obj/structure/disposalpipe/segment,
+/obj/effect/mapping_helpers/airlock/access/any/service/hydroponics,
 /turf/open/floor/plating,
 /area/maintenance/starboard/secondary)
 "qrR" = (
@@ -64912,7 +64912,7 @@
 /obj/machinery/door/airlock{
 	name = "Hydroponics Backroom"
 	},
-/obj/effect/mapping_helpers/airlock/access/all/service/hydroponics,
+/obj/effect/mapping_helpers/airlock/access/any/service/hydroponics,
 /turf/open/floor/iron,
 /area/hydroponics)
 "sTy" = (
@@ -66538,10 +66538,10 @@
 /obj/machinery/door/airlock{
 	name = "Bar Storage"
 	},
-/obj/effect/mapping_helpers/airlock/access/all/service/bar,
 /obj/structure/disposalpipe/segment{
 	dir = 1
 	},
+/obj/effect/mapping_helpers/airlock/access/any/service/bar,
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
 "tsL" = (

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -8566,7 +8566,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/effect/mapping_helpers/airlock/access/any/service/kitchen,
+/obj/effect/mapping_helpers/airlock/access/all/service/kitchen,
 /turf/open/floor/iron/cafeteria,
 /area/hallway/secondary/service)
 "bqF" = (
@@ -8670,7 +8670,7 @@
 	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/mapping_helpers/airlock/access/any/service/general,
+/obj/effect/mapping_helpers/airlock/access/all/service/general,
 /obj/effect/mapping_helpers/airlock/unres{
 	dir = 4
 	},
@@ -28313,7 +28313,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 2
 	},
-/obj/effect/mapping_helpers/airlock/access/any/service/theatre,
+/obj/effect/mapping_helpers/airlock/access/all/service/theatre,
 /obj/effect/mapping_helpers/airlock/unres,
 /turf/open/floor/wood,
 /area/crew_quarters/theatre)
@@ -30293,7 +30293,7 @@
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
-/obj/effect/mapping_helpers/airlock/access/any/service/kitchen,
+/obj/effect/mapping_helpers/airlock/access/all/service/kitchen,
 /turf/open/floor/iron/cafeteria,
 /area/crew_quarters/kitchen/coldroom)
 "hir" = (
@@ -40779,7 +40779,7 @@
 /obj/machinery/door/airlock{
 	name = "Hydroponics"
 	},
-/obj/effect/mapping_helpers/airlock/access/any/service/hydroponics,
+/obj/effect/mapping_helpers/airlock/access/all/service/hydroponics,
 /turf/open/floor/iron,
 /area/hallway/secondary/service)
 "kIN" = (
@@ -41973,7 +41973,7 @@
 /obj/machinery/door/airlock{
 	name = "Hydroponics"
 	},
-/obj/effect/mapping_helpers/airlock/access/any/service/hydroponics,
+/obj/effect/mapping_helpers/airlock/access/all/service/hydroponics,
 /turf/open/floor/iron,
 /area/hydroponics)
 "lfO" = (
@@ -48312,7 +48312,7 @@
 /obj/machinery/door/airlock{
 	name = "Hydroponics Backroom"
 	},
-/obj/effect/mapping_helpers/airlock/access/any/service/hydroponics,
+/obj/effect/mapping_helpers/airlock/access/all/service/hydroponics,
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "noC" = (
@@ -50765,7 +50765,7 @@
 	name = "Theatre Backstage";
 	req_one_access_txt = "12;46"
 	},
-/obj/effect/mapping_helpers/airlock/access/any/service/theatre,
+/obj/effect/mapping_helpers/airlock/access/all/service/theatre,
 /turf/open/floor/wood,
 /area/maintenance/starboard)
 "oeP" = (
@@ -54520,7 +54520,7 @@
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
-/obj/effect/mapping_helpers/airlock/access/any/service/bar,
+/obj/effect/mapping_helpers/airlock/access/all/service/bar,
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
 "ppx" = (
@@ -57709,7 +57709,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer4,
 /obj/structure/disposalpipe/segment,
-/obj/effect/mapping_helpers/airlock/access/any/service/hydroponics,
+/obj/effect/mapping_helpers/airlock/access/all/service/hydroponics,
 /turf/open/floor/plating,
 /area/maintenance/starboard/secondary)
 "qrR" = (
@@ -64912,7 +64912,7 @@
 /obj/machinery/door/airlock{
 	name = "Hydroponics Backroom"
 	},
-/obj/effect/mapping_helpers/airlock/access/any/service/hydroponics,
+/obj/effect/mapping_helpers/airlock/access/all/service/hydroponics,
 /turf/open/floor/iron,
 /area/hydroponics)
 "sTy" = (
@@ -66541,7 +66541,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 1
 	},
-/obj/effect/mapping_helpers/airlock/access/any/service/bar,
+/obj/effect/mapping_helpers/airlock/access/all/service/bar,
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
 "tsL" = (


### PR DESCRIPTION
## About The Pull Request

The new metastation service area was given mapping_helpers/airlock/... rather than vv editted access > However some, most airlocks were set to `/obj/effect/mapping_helpers/airlock/access/all/service/...` this fixes that and changes them all to `/obj/effect/mapping_helpers/airlock/access/any/service/...`

## Why It's Good For The Game

There are at times issues reported with these airlocks, which i beleive is a result of the mapping helpers. These are the inherently correct ones anyways and shouldve been used orignally, this PR fixes that, and fixes are good for game!

## Testing Photographs and Procedure

<details>
<summary>Screenshots&Videos</summary>

<img width="764" height="877" alt="Screenshot 2025-11-14 173459" src="https://github.com/user-attachments/assets/455cd800-614c-4f25-816d-e79ad395b627" />


</details>

## Changelog
:cl:
tweak: Fixes Metastation Service Access by changing mapping_helpers
/:cl:
