### PR TITLE
ED-209 Craft Fix

### DIFF
--- a/code/datums/components/crafting/crafting_lists/robots.dm
+++ b/code/datums/components/crafting/crafting_lists/robots.dm
@@ -14,7 +14,7 @@
 		/obj/item/bodypart/leg/right/robot = 1,
 		/obj/item/stack/sheet/iron = 1,
 		/obj/item/stack/cable_coil = 1,
-		/obj/item/gun/energy/disabler = 1,
+		/obj/item/gun/ballistic/taser = 1,
 		/obj/item/stock_parts/cell = 1,
 		/obj/item/assembly/prox_sensor = 1
 		)

--- a/code/modules/mob/living/simple_animal/bot/construction.dm
+++ b/code/modules/mob/living/simple_animal/bot/construction.dm
@@ -181,7 +181,7 @@
 					if(!istype(W, /obj/item/gun/energy/laser/redtag))
 						return
 				if("")
-					if(!istype(W, /obj/item/gun/energy/disabler))
+					if(!istype(W, /obj/item/gun/ballistic/taser,))
 						return
 				else
 					return

--- a/code/modules/mob/living/simple_animal/bot/ed209bot.dm
+++ b/code/modules/mob/living/simple_animal/bot/ed209bot.dm
@@ -362,9 +362,7 @@ CREATION_TEST_IGNORE_SUBTYPES(/mob/living/simple_animal/bot/ed209)
 	drop_part(cell_type, Tsec)
 
 	if(!lasercolor)
-		var/obj/item/gun/energy/disabler/G = new (Tsec)
-		G.cell.charge = 0
-		G.update_icon()
+		var/obj/item/gun/ballistic/taser/G = new (Tsec)
 	else if(lasercolor == "b")
 		var/obj/item/gun/energy/laser/bluetag/G = new (Tsec)
 		G.cell.charge = 0


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

ED209's crafting was completely botched since we soft-removed disablers, not being able to be crafted at all
This changes it to use APS-ARC Tasers instead of disablers, doesn't change the projectile they shoot

Ive fixed both the build menu crafting and hand crafting

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

Tsunami forgot to fix this
I blame them

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

<img width="571" height="523" alt="image" src="https://github.com/user-attachments/assets/782132a9-246e-46eb-9cfd-8ea9377504bf" />



</details>

## Changelog
:cl: Isaac

fix: You can craft ED-209 Robots once again
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
