### PR TITLE
Fixes various cult related runtimes, fixes cultist antag HUDs not appearing

### DIFF
--- a/code/datums/status_effects/buffs.dm
+++ b/code/datums/status_effects/buffs.dm
@@ -144,9 +144,9 @@
 	if(!QDELETED(GLOB.narsie))
 		return //if Nar'Sie is alive, don't even worry about it
 	var/area/area = get_area(owner)
-	for(var/datum/mind/M in get_antag_minds(/datum/antagonist/cult))
-		if(isliving(M))
-			var/mob/living/cultist_body = M.current
+	for(var/datum/mind/cult_mind in get_antag_minds(/datum/antagonist/cult))
+		if(isliving(cult_mind))
+			var/mob/living/cultist_body = cult_mind.current
 			SEND_SOUND(cultist_body, sound('sound/hallucinations/veryfar_noise.ogg'))
 			to_chat(cultist_body, span_cultlarge("The Cult's Master, [owner], has fallen in \the [area]!"))
 

--- a/code/datums/status_effects/buffs.dm
+++ b/code/datums/status_effects/buffs.dm
@@ -144,9 +144,9 @@
 	if(!QDELETED(GLOB.narsie))
 		return //if Nar'Sie is alive, don't even worry about it
 	var/area/area = get_area(owner)
-	for(var/datum/antagonist/cult/cultist in GLOB.antagonists)
-		if(isliving(cultist.owner))
-			var/mob/living/cultist_body = cultist.owner.current
+	for(var/datum/mind/M in get_antag_minds(/datum/antagonist/cult))
+		if(isliving(M))
+			var/mob/living/cultist_body = M.current
 			SEND_SOUND(cultist_body, sound('sound/hallucinations/veryfar_noise.ogg'))
 			to_chat(cultist_body, span_cultlarge("The Cult's Master, [owner], has fallen in \the [area]!"))
 

--- a/code/datums/status_effects/buffs.dm
+++ b/code/datums/status_effects/buffs.dm
@@ -145,7 +145,7 @@
 		return //if Nar'Sie is alive, don't even worry about it
 	var/area/area = get_area(owner)
 	for(var/datum/mind/cult_mind in get_antag_minds(/datum/antagonist/cult))
-		if(isliving(cult_mind))
+		if(isliving(cult_mind.current))
 			var/mob/living/cultist_body = cult_mind.current
 			SEND_SOUND(cultist_body, sound('sound/hallucinations/veryfar_noise.ogg'))
 			to_chat(cultist_body, span_cultlarge("The Cult's Master, [owner], has fallen in \the [area]!"))

--- a/code/modules/antagonists/clock_cult/clockwork_massive.dm
+++ b/code/modules/antagonists/clock_cult/clockwork_massive.dm
@@ -289,9 +289,9 @@ CREATION_TEST_IGNORE_SUBTYPES(/obj/eldritch/ratvar)
 					SEND_SOUND(world, 'sound/magic/demon_dies.ogg')
 					to_chat(world, span_ratvar("You were a fool for underestimating me..."))
 					qdel(ratvar_target)
-					for(var/datum/mind/M in get_antag_minds(/datum/antagonist/cult))
-						to_chat(M, span_userdanger("You feel a stabbing pain in your chest... This can't be happening!"))
-						M.current?.dust()
+					for(var/datum/mind/cult_mind in get_antag_minds(/datum/antagonist/cult))
+						to_chat(cult_mind, span_userdanger("You feel a stabbing pain in your chest... This can't be happening!"))
+						cult_mind.current?.dust()
 				return
 
 /obj/eldritch/ratvar/consume(atom/A)

--- a/code/modules/antagonists/clock_cult/clockwork_massive.dm
+++ b/code/modules/antagonists/clock_cult/clockwork_massive.dm
@@ -289,9 +289,9 @@ CREATION_TEST_IGNORE_SUBTYPES(/obj/eldritch/ratvar)
 					SEND_SOUND(world, 'sound/magic/demon_dies.ogg')
 					to_chat(world, span_ratvar("You were a fool for underestimating me..."))
 					qdel(ratvar_target)
-					for(var/datum/antagonist/cult/cultist in GLOB.antagonists)
-						to_chat(cultist.owner, span_userdanger("You feel a stabbing pain in your chest... This can't be happening!"))
-						cultist.owner.current?.dust()
+					for(var/datum/mind/M in get_antag_minds(/datum/antagonist/cult))
+						to_chat(M, span_userdanger("You feel a stabbing pain in your chest... This can't be happening!"))
+						M.current?.dust()
 				return
 
 /obj/eldritch/ratvar/consume(atom/A)

--- a/code/modules/antagonists/cult/cult.dm
+++ b/code/modules/antagonists/cult/cult.dm
@@ -63,7 +63,7 @@
 	add_objectives()
 	if(give_equipment)
 		equip_cultist(TRUE)
-	add_antag_hud(ANTAG_HUD_CULT, "cultist", current)
+	add_antag_hud(ANTAG_HUD_CULT, "cult", current)
 	current.log_message("has been converted to the cult of Nar'Sie!", LOG_ATTACK, color="#960000")
 
 	if(cult_team.blood_target && cult_team.blood_target_image && current.client)

--- a/code/modules/antagonists/cult/cult_items.dm
+++ b/code/modules/antagonists/cult/cult_items.dm
@@ -530,9 +530,9 @@ Striking a noncultist, however, will tear their flesh."}
 	if(istype(A, /obj/item))
 
 		var/list/cultists = list()
-		for(var/datum/mind/M in get_antag_minds(/datum/antagonist/cult))
-			if(M.current?.stat != DEAD)
-				cultists |= M.current
+		for(var/datum/mind/cult_mind in get_antag_minds(/datum/antagonist/cult))
+			if(cult_mind.current?.stat != DEAD)
+				cultists |= cult_mind.current
 		var/mob/living/cultist_to_receive = input(user, "Who do you wish to call to [src]?", "Followers of the Geometer") as null|anything in (cultists - user)
 		if(!Adjacent(user) || !src || QDELETED(src) || user.incapacitated())
 			return

--- a/code/modules/antagonists/cult/cult_items.dm
+++ b/code/modules/antagonists/cult/cult_items.dm
@@ -530,9 +530,9 @@ Striking a noncultist, however, will tear their flesh."}
 	if(istype(A, /obj/item))
 
 		var/list/cultists = list()
-		for(var/datum/antagonist/cult/cultist in GLOB.antagonists)
-			if(cultist.owner?.current?.stat != DEAD)
-				cultists |= cultist.owner.current
+		for(var/datum/mind/M in get_antag_minds(/datum/antagonist/cult))
+			if(M.current?.stat != DEAD)
+				cultists |= M.current
 		var/mob/living/cultist_to_receive = input(user, "Who do you wish to call to [src]?", "Followers of the Geometer") as null|anything in (cultists - user)
 		if(!Adjacent(user) || !src || QDELETED(src) || user.incapacitated())
 			return

--- a/code/modules/antagonists/cult/narsie.dm
+++ b/code/modules/antagonists/cult/narsie.dm
@@ -50,11 +50,9 @@ GLOBAL_DATUM(narsie, /obj/eldritch/narsie)
 		var/datum/objective/eldergod/summon_objective = locate() in cult_team.objectives
 		if(summon_objective)
 			summon_objective.summoned = TRUE
-	for(var/datum/antagonist/cult/cultist in GLOB.antagonists)
-		if(!cultist.owner)
-			continue
-		if(isliving(cultist.owner.current))
-			var/mob/living/L = cultist.owner.current
+	for(var/datum/mind/M in get_antag_minds(/datum/antagonist/cult))
+		if(isliving(M.current))
+			var/mob/living/L = M.current
 			L.narsie_act()
 	for(var/mob/living/carbon/player in GLOB.player_list)
 		if(player.stat != DEAD && is_station_level(player.loc?.z) && !IS_CULTIST(player))

--- a/code/modules/antagonists/cult/narsie.dm
+++ b/code/modules/antagonists/cult/narsie.dm
@@ -50,9 +50,9 @@ GLOBAL_DATUM(narsie, /obj/eldritch/narsie)
 		var/datum/objective/eldergod/summon_objective = locate() in cult_team.objectives
 		if(summon_objective)
 			summon_objective.summoned = TRUE
-	for(var/datum/mind/M in get_antag_minds(/datum/antagonist/cult))
-		if(isliving(M.current))
-			var/mob/living/L = M.current
+	for(var/datum/mind/cult_mind in get_antag_minds(/datum/antagonist/cult))
+		if(isliving(cult_mind.current))
+			var/mob/living/L = cult_mind.current
 			L.narsie_act()
 	for(var/mob/living/carbon/player in GLOB.player_list)
 		if(player.stat != DEAD && is_station_level(player.loc?.z) && !IS_CULTIST(player))

--- a/code/modules/antagonists/cult/narsie.dm
+++ b/code/modules/antagonists/cult/narsie.dm
@@ -51,6 +51,8 @@ GLOBAL_DATUM(narsie, /obj/eldritch/narsie)
 		if(summon_objective)
 			summon_objective.summoned = TRUE
 	for(var/datum/antagonist/cult/cultist in GLOB.antagonists)
+		if(!cultist.owner)
+			continue
 		if(isliving(cultist.owner.current))
 			var/mob/living/L = cultist.owner.current
 			L.narsie_act()

--- a/code/modules/antagonists/cult/runes.dm
+++ b/code/modules/antagonists/cult/runes.dm
@@ -790,9 +790,9 @@ CREATION_TEST_IGNORE_SUBTYPES(/obj/effect/rune/wall)
 /obj/effect/rune/summon/invoke(list/invokers)
 	var/mob/living/user = invokers[1]
 	var/list/cultists = list()
-	for(var/datum/mind/M in get_antag_minds(/datum/antagonist/cult))
-		if(M.current?.stat != DEAD && !(M.current in invokers))
-			cultists |= M.current
+	for(var/datum/mind/cult_mind in get_antag_minds(/datum/antagonist/cult))
+		if(cult_mind.current?.stat != DEAD && !(cult_mind.current in invokers))
+			cultists |= cult_mind.current
 	var/mob/living/cultist_to_summon = input(user, "Who do you wish to call to [src]?", "Followers of the Geometer") as null|anything in cultists
 	var/held_in_place = FALSE
 	if(iscarbon(cultist_to_summon))

--- a/code/modules/antagonists/cult/runes.dm
+++ b/code/modules/antagonists/cult/runes.dm
@@ -790,9 +790,9 @@ CREATION_TEST_IGNORE_SUBTYPES(/obj/effect/rune/wall)
 /obj/effect/rune/summon/invoke(list/invokers)
 	var/mob/living/user = invokers[1]
 	var/list/cultists = list()
-	for(var/datum/antagonist/cult/cultist in GLOB.antagonists)
-		if(cultist?.owner?.current?.stat != DEAD && !(cultist.owner.current in invokers))
-			cultists |= cultist.owner.current
+	for(var/datum/mind/M in get_antag_minds(/datum/antagonist/cult))
+		if(M.current?.stat != DEAD && !(M.current in invokers))
+			cultists |= M.current
 	var/mob/living/cultist_to_summon = input(user, "Who do you wish to call to [src]?", "Followers of the Geometer") as null|anything in cultists
 	var/held_in_place = FALSE
 	if(iscarbon(cultist_to_summon))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Title.
Prevents a bunch of null.current runtimes.
GLOB.antagonist contains antag datums with null values and things go bad when you don't check if that antag datum has a mind.
The pieces of code that don't directly make use of the antag datum have been changed to only use the mind datum.

Fixes cultists not getting their antag HUDs because the game was looking for the icon "cultist" when trying to assign them which doesn't exist, instead of "cult"

Closes https://github.com/BeeStation/BeeStation-Hornet/issues/13644

## Why It's Good For The Game
Fix

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

Everything in these screenshots would produce a null.current runtime previously.

<img width="1038" height="356" alt="dreamseeker_LLNM3F1GgK" src="https://github.com/user-attachments/assets/88035af3-68c6-4dee-b0dd-8ac82d318556" />

<img width="842" height="321" alt="dreamseeker_xpPyaUxj9N" src="https://github.com/user-attachments/assets/55e2c920-d940-4adf-ba0f-c88bb78f32b7" />

Antag HUDs show up
<img width="336" height="228" alt="dreamseeker_KObtU2AJBf" src="https://github.com/user-attachments/assets/93226844-374f-471d-afc7-9a3ea57a50a3" />


Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>

## Changelog
:cl:

fix: Summon Cultist rune works again
fix: Cultist torch now works again
fix: Blood cultists get dusted if Rat'Var wins again
fix: Cultist leader's location on death gets announced again
fix: Cultists can see eachother's antag HUD icons again
code: Nar'Sie doesn't runtime on spawn

/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
