### PR TITLE
Change the end of round last words message

### DIFF
--- a/code/__HELPERS/roundend.dm
+++ b/code/__HELPERS/roundend.dm
@@ -867,7 +867,7 @@ GLOBAL_VAR(survivor_report) //! Contains shared survivor report for roundend rep
 	var/list/ded = SSblackbox.first_death
 	if(ded)
 		discordmsg += "First Death: [ded["name"]], [ded["role"]], at [ded["area"]]\n"
-		var/last_words = ded["last_words"] ? "Their last words were: \"[ded["last_words"]]\"\n" : "They had no last words.\n"
+		var/last_words = ded["last_words"] ? "Their last words were: \"[ded["last_words"]]\"\n" : "They died wordlessly.\n"
 		discordmsg += "[last_words]\n"
 	else
 		discordmsg += "Nobody died!\n"


### PR DESCRIPTION
## About The Pull Request

This PR changes the message shown if the first player to die that round hasn't said anything to 'died wordlessly'.

## Why It's Good For The Game

This phrase became somewhat of a meme on bee. I feel like it should have its place among 4noraisins and batong.

## Testing Photographs and Procedure


## Changelog
:cl:
tweak: Changed the discord message shown when the first player to die hasn't said anything
/:cl:

Geatish bribed me to make this PR.
