### PR TITLE
Breaching slugs vs Mechs Tweak

### DIFF
--- a/code/modules/projectiles/projectile/bullets/shotgun.dm
+++ b/code/modules/projectiles/projectile/bullets/shotgun.dm
@@ -137,7 +137,7 @@
 	name = "12g breaching round"
 	desc = "A breaching round designed to destroy minor objects and windows with only a few shots, but is ineffective against other targets."
 	hitsound = 'sound/weapons/sonic_jackhammer.ogg'
-	damage = 10 //does shit damage to everything except doors and windows
+	damage = 10 //does shit damage to everything except doors, windows, structures and mechs
 	bleed_force = BLEED_SURFACE
 
 /obj/projectile/bullet/shotgun_breaching/on_hit(atom/target)
@@ -145,4 +145,28 @@
 		damage = 500
 	if (isturf(target))
 		damage = 150 // 3 shots for normal walls 8 for rwalls
+	if (ismecha(target))
+		var/obj/vehicle/sealed/mecha/targetmech = target
+		if (istype(targetmech, /obj/vehicle/sealed/mecha/combat))
+			damage = 100 // High HP, High Armor, High Damage being dealt
+		else if (istype(targetmech, /obj/vehicle/sealed/mecha/working))
+			damage = 60 // Mid HP, Low Armor, Mid Damage being dealt
+		else if (istype(targetmech, /obj/vehicle/sealed/mecha/medical/odysseus))
+			damage = 30 // Low HP, Low Armor, Low Damage being dealt
+		targetmech.visible_message(span_danger("The breaching round leaves a visible hole in the armor, leaving sparks from where it hit!"))
+		var/internaldamagetype = rand(1, 100) // Apart from the damage, we choose an additional effect to deal upon the mech.
+		switch(internaldamagetype)
+			if(1 to 15)
+				targetmech.set_internal_damage(MECHA_INT_TANK_BREACH)
+			if(16 to 30)
+				targetmech.set_internal_damage(MECHA_INT_SHORT_CIRCUIT)
+			if(31 to 45)
+				targetmech.set_internal_damage(MECHA_INT_FIRE)
+			if(46 to 60)
+				targetmech.set_internal_damage(MECHA_INT_CONTROL_LOST)
+			if(61 to 75)
+				targetmech.set_internal_damage(MECHA_INT_TEMP_CONTROL)
+			else
+				return // 25% to not apply any internal damage
+
 	..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Since https://github.com/BeeStation/BeeStation-Hornet/pull/13654 being closed, there's still a visible gap in the ways to deal with a mech, the second best option i found apart from touching ion guns was to tweak how breaching slugs affect mechs
they're slugs designed to destroy machinery, doors, windows, makes sense they can pack a punch into a mech's armor

## Why It's Good For The Game

More ways for antags and security to deal with mechs

Antags can print it via any hacked lathe and security has their own lathe.
All damage values are W.I.P and not the final values

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

<img width="479" height="337" alt="image" src="https://github.com/user-attachments/assets/a42d0e40-573d-4819-988a-213606f20417" />

Breaching Slugs

Durand received 7 shots, deflecting two of them totalling a damage of 217, being left with 183/400
Ripley received 7 shots deflecting two of them, totalling a damage of 160, being left with 40/200
Oddyseus received 7 shots, deflecting two of them, totalling a damage of 90, being left with 30/120

Laser Weaponry

<img width="471" height="347" alt="image" src="https://github.com/user-attachments/assets/e1530994-88ca-4df0-a0fb-303e499590f4" />

Durand being left 275/400 integrity by 14 laser shots, deflecting three of them
Ripley being left 68/200 integrity by 14 laser shots, deflecting three of them
Oddyseus being left 0/120  integrity by 14 laser shots, deflecting two of them and being destroyed


</details>

## Changelog
:cl: Isaac, pixelpoepleman
tweak: Mechs receive more damage by breaching slugs
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
