### PR TITLE
Fixes the yellow crystalline pylon not updating a cell's icon + minor cleanup

### DIFF
--- a/code/modules/research/xenobiology/crossbreeding/_structures.dm
+++ b/code/modules/research/xenobiology/crossbreeding/_structures.dm
@@ -223,18 +223,17 @@ GLOBAL_LIST_EMPTY(bluespace_slime_crystals)
 	. = ..()
 	set_light(3)
 
-/obj/structure/slime_crystal/yellow/attacked_by(obj/item/I, mob/living/user)
-	if(istype(I,/obj/item/stock_parts/cell))
-		var/obj/item/stock_parts/cell/cell = I
-		//Punishment for greed
-		if(cell.charge == cell.maxcharge)
-			to_chat(span_danger(" You try to charge the cell, but it is already fully energized. You are not sure if this was a good idea..."))
-			cell.explode()
-			return
-		to_chat(user, span_notice("You charged the [I.name] on [name]!"))
-		cell.give(cell.maxcharge)
+/obj/structure/slime_crystal/yellow/attacked_by(obj/item/stock_parts/cell/cell, mob/living/user)
+	if(!istype(cell))
+		return ..()
+	if(cell.charge == cell.maxcharge) // Punishment for greed
+		to_chat(user, span_danger("You try to charge [cell], but it is already fully energized. You are not sure if this was a good idea..."))
+		cell.explode()
 		return
-	return ..()
+	to_chat(user, span_notice("You charge [cell] on [src]!"))
+	cell.give(cell.maxcharge)
+	cell.update_appearance()
+
 /obj/structure/slime_crystal/darkpurple
 	colour = SLIME_TYPE_DARK_PURPLE
 


### PR DESCRIPTION
## About The Pull Request

This is basically just https://github.com/IrisSS13/IrisStation/pull/759 I found the same issue in there to also be here so decided to fix dat

- Cleaned up a bit of code using early returns
- Fixed cells recharged by the pylon not updating their sprite
- Fixed the to_chat message when you explode a cell on the pylon not having a user set

## Why It's Good For The Game

> Cleaned up a bit of code using early returns
- Cleaner code be better.
> Fixed cells recharged by the pylon not updating their sprite
- Yeah apparently that was a thing, somehow did not manage to find a single issue about it on beestation only getting the info about it on iris.
> Fixed the to_chat message when you explode a cell on the pylon not having a user set
- This one is fair to not notice, very subtle.

## Testing Photographs and Procedure

<details>
<summary>Le funky screenshots showing that the cell is in fact charged</summary>

<img width="1600" height="845" alt="image" src="https://github.com/user-attachments/assets/78a1dd90-8408-4ac6-861f-e78549a5daf1" />

<img width="1600" height="845" alt="image" src="https://github.com/user-attachments/assets/960d1b8b-a71c-43bd-9a17-dff88bed7e5c" />

</details>

## Changelog
:cl:
fix: fixed cells not properly updating their sprites on being charged with a yellow slime pylon
fix: fixed a message thats supposed to show up when you blow yourself up with the yellow slime pylon
/:cl:
