### PR TITLE
Adds QoL and map changelog entries and combines soundadd/sounddel and imageadd/imagedel

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -25,12 +25,12 @@ add: Added new things
 add: Added more things
 del: Removed old things
 tweak: tweaked a few things
+qol: made something easier to use
 balance: rebalanced something
 fix: fixed a few things
-soundadd: added a new sound thingy
-sounddel: removed an old sound thingy
-imageadd: added some icons and images
-imagedel: deleted some icons and images
+sound: added/modified/removed audio or sound effects
+image: added/modified/removed some icons or images
+map: added/modified/removed map content
 spellcheck: fixed a few typos
 code: changed some code
 refactor: refactored some code

--- a/tgui/packages/tgui/interfaces/Changelog.tsx
+++ b/tgui/packages/tgui/interfaces/Changelog.tsx
@@ -38,6 +38,7 @@ const icons = {
   soundadd: { icon: 'tg-sound-plus', color: 'green' },
   sounddel: { icon: 'tg-sound-minus', color: 'red' },
   spellcheck: { icon: 'spell-check', color: 'green' },
+  map: { icon: 'map', color: 'green' },
   tgs: { icon: 'toolbox', color: 'purple' },
   tweak: { icon: 'wrench', color: 'green' },
   unknown: { icon: 'info-circle', color: 'label' },

--- a/tools/WebhookProcessor/github_webhook_processor.php
+++ b/tools/WebhookProcessor/github_webhook_processor.php
@@ -850,6 +850,7 @@ function checkchangelog($payload, $compile = true) {
 				if($item != 'made something easier to use') {
 					$tags[] = 'Quality of Life';
 					$currentchangelogblock[] = array('type' => 'qol', 'body' => $item);
+				}
 			case 'sound':
 				if($item != 'added/modified/removed audio or sound effects') {
 					$tags[] = 'Sound';

--- a/tools/WebhookProcessor/github_webhook_processor.php
+++ b/tools/WebhookProcessor/github_webhook_processor.php
@@ -646,6 +646,7 @@ function get_pr_code_friendliness($payload, $oldbalance = null){
 		'Refactor' => 10,
 		'Code Improvement' => 2,
 		'Grammar and Formatting' => 1,
+		'Quality of Life' => 1,
 		'Priority: High' => 15,
 		'Priority: CRITICAL' => 20,
 		'Unit Tests' => 6,
@@ -845,17 +846,14 @@ function checkchangelog($payload, $compile = true) {
 					$currentchangelogblock[] = array('type' => 'tweak', 'body' => $item);
 				}
 				break;
-			case 'soundadd':
-				if($item != 'added a new sound thingy') {
+			case 'qol':
+				if($item != 'made something easier to use') {
+					$tags[] = 'Quality of Life';
+					$currentchangelogblock[] = array('type' => 'qol', 'body' => $item);
+			case 'sound':
+				if($item != 'added/modified/removed audio or sound effects') {
 					$tags[] = 'Sound';
-					$currentchangelogblock[] = array('type' => 'soundadd', 'body' => $item);
-				}
-				break;
-			case 'sounddel':
-				if($item != 'removed an old sound thingy') {
-					$tags[] = 'Sound';
-					$tags[] = 'Removal';
-					$currentchangelogblock[] = array('type' => 'sounddel', 'body' => $item);
+					$currentchangelogblock[] = array('type' => 'sound', 'body' => $item);
 				}
 				break;
 			case 'add':
@@ -874,17 +872,10 @@ function checkchangelog($payload, $compile = true) {
 					$currentchangelogblock[] = array('type' => 'rscdel', 'body' => $item);
 				}
 				break;
-			case 'imageadd':
-				if($item != 'added some icons and images') {
+			case 'image':
+				if($item != 'added/modified/removed some icons or images') {
 					$tags[] = 'Sprites';
-					$currentchangelogblock[] = array('type' => 'imageadd', 'body' => $item);
-				}
-				break;
-			case 'imagedel':
-				if($item != 'deleted some icons and images') {
-					$tags[] = 'Sprites';
-					$tags[] = 'Removal';
-					$currentchangelogblock[] = array('type' => 'imagedel', 'body' => $item);
+					$currentchangelogblock[] = array('type' => 'image', 'body' => $item);
 				}
 				break;
 			case 'typo':

--- a/tools/changelog/ss13_genchangelog.py
+++ b/tools/changelog/ss13_genchangelog.py
@@ -59,6 +59,9 @@ validPrefixes = [
     "config",
     "admin",
     "server",
+    "sound",
+    "image",
+    "map",
 ]
 
 


### PR DESCRIPTION
## About The Pull Request

All in the title

Attributions:
- https://github.com/tgstation/tgstation/pull/56890 (partial, just the addition of the QoL tag)
- https://github.com/tgstation/tgstation/pull/74865
- https://github.com/tgstation/tgstation/pull/76608
- https://github.com/tgstation/tgstation/pull/87034
- https://github.com/tgstation/tgstation/pull/87063

## Why It's Good For The Game

Often I find myself doing QoL changes that don't really constitute as tweaks/additions, so I always go back in forth with which category to put them in. This PR gives me, and probably others, a solution.

I added the mapping changelog entry because "larger" mapping changes don't work out that well with the add/del/tweak entries. For example, in my MetaStation service remap port I was gutting the old department, replacing it with the new version, and still making tiny tweaks in the surrounding areas to accommodate the changes. It would be so much easier to have a single mapping changelog entry for this.

I merged the imageadd/imagedel and soundadd/sounddel tags because it's stupid when four entries can be converted to two without much change. Not much more to say than that.

## Testing Photographs and Procedure

<img width="413" height="394" alt="Screenshot 2025-11-18 014215" src="https://github.com/user-attachments/assets/8c1f2ab6-62da-4430-9910-bd10cdad85be" />

## Changelog

no user facing changes