### PR TITLE
Stops overclocked volume pumps from working inside walls

### DIFF
--- a/code/modules/atmospherics/machinery/components/binary_devices/volume_pump.dm
+++ b/code/modules/atmospherics/machinery/components/binary_devices/volume_pump.dm
@@ -72,10 +72,17 @@
 	var/datum/gas_mixture/air1 = airs[1]
 	var/datum/gas_mixture/air2 = airs[2]
 
-// Pump mechanism just won't do anything if the pressure is too high/too low unless you overclock it.
+	// Pump mechanism just won't do anything if the pressure is too high/too low unless you overclock it.
 
 	var/input_starting_pressure = air1.return_pressure()
 	var/output_starting_pressure = air2.return_pressure()
+
+	if(overclocked)
+		var/turf/turf = loc
+		if(isclosedturf(turf))
+			balloon_alert_to_viewers("jammed! turning on safeties.")
+			overclocked = FALSE
+			update_appearance(UPDATE_ICON)
 
 	if((input_starting_pressure < VOLUME_PUMP_MINIMUM_OUTPUT_PRESSURE) || ((output_starting_pressure > VOLUME_PUMP_MAX_OUTPUT_PRESSURE))&&!overclocked)
 		return

--- a/code/modules/atmospherics/machinery/components/binary_devices/volume_pump.dm
+++ b/code/modules/atmospherics/machinery/components/binary_devices/volume_pump.dm
@@ -80,7 +80,7 @@
 	if(overclocked)
 		var/turf/turf = loc
 		if(isclosedturf(turf))
-			balloon_alert_to_viewers("jammed! turning on safeties.")
+			balloon_alert_to_viewers("jammed!")
 			overclocked = FALSE
 			update_appearance(UPDATE_ICON)
 

--- a/code/modules/atmospherics/machinery/components/binary_devices/volume_pump.dm
+++ b/code/modules/atmospherics/machinery/components/binary_devices/volume_pump.dm
@@ -156,6 +156,10 @@
 
 /obj/machinery/atmospherics/components/binary/volume_pump/multitool_act(mob/living/user, obj/item/I)
 	if(!overclocked)
+		var/turf/turf = loc
+		if(isclosedturf(turf))
+			to_chat(user, "The pump is sealed inside a closed space, you can't safely disable its pressure limits here.")
+			return TRUE
 		overclocked = TRUE
 		to_chat(user, "The pump makes a grinding noise and air starts to hiss out as you disable its pressure limits.")
 		update_icon()


### PR DESCRIPTION
## About The Pull Request

Port of: https://github.com/tgstation/tgstation/pull/94007

Volume pumps can be overlocked to ignore their pressure limit, as a consequence they leak gas into the surrounding area. This does not check for if the surrounding area cannot contain gas, i.e: walls

## Why It's Good For The Game

<img width="692" height="272" alt="image" src="https://github.com/user-attachments/assets/8160d1a5-1081-415e-8a86-4ce05f57ccfe" />

## Testing Photographs and Procedure

https://github.com/user-attachments/assets/6c7e4ead-908c-45e6-8127-3b89131e4980

## Changelog
:cl: mrmanlikesbt, Pickle-Coding
del: Volume pumps can no longer be overclocked on closed turfs
/:cl:
