### PR TITLE
Fixes game assigned naming violations

### DIFF
--- a/code/__DEFINES/species.dm
+++ b/code/__DEFINES/species.dm
@@ -163,3 +163,5 @@
 		'sound/emotes/male/male_giggle_1.ogg',\
 		'sound/emotes/male/male_giggle_2.ogg',\
 		'sound/emotes/male/male_giggle_3.ogg')
+
+#define SPECIES_NAME_HUMANOID "Human"

--- a/code/modules/client/preferences/middleware/_middleware.dm
+++ b/code/modules/client/preferences/middleware/_middleware.dm
@@ -47,6 +47,10 @@
 /datum/preference_middleware/proc/pre_set_preference(mob/user, preference, value)
 	return FALSE
 
+/// Called every set_preference, returns TRUE if this handled it.
+/datum/preference_middleware/proc/post_set_preference(mob/user, preference, previous_value, value)
+	return FALSE
+
 /// Called when a character is changed.
 /datum/preference_middleware/proc/on_new_character(mob/user)
 	return

--- a/code/modules/client/preferences/middleware/species.dm
+++ b/code/modules/client/preferences/middleware/species.dm
@@ -10,6 +10,8 @@
 	var/datum/species/old_species = previous_value
 	var/datum/species/new_species = value
 
+	if (old_species == new_species)
+		return
 	if (ispath(old_species, /datum/species) && ispath(new_species, /datum/species) && old_species::name_key && old_species::name_key == new_species::name_key)
 		return
 

--- a/code/modules/client/preferences/middleware/species.dm
+++ b/code/modules/client/preferences/middleware/species.dm
@@ -6,6 +6,21 @@
 		get_asset_datum(/datum/asset/spritesheet/species),
 	)
 
+/datum/preference_middleware/species/post_set_preference(mob/user, preference, previous_value, value)
+	var/datum/species/old_species = previous_value
+	var/datum/species/new_species = value
+
+	if (ispath(old_species, /datum/species) && ispath(new_species, /datum/species) && old_species::name_key && old_species::name_key == new_species::name_key)
+		return
+
+	var/datum/preference/name/name_preference = GLOB.preference_entries[/datum/preference/name/real_name]
+	if (!istype(name_preference))
+		return
+
+	log_preferences("[preferences?.parent?.ckey]: Randomized name preference as result of species change [name_preference.type]")
+	preferences.update_preference(name_preference, name_preference.create_random_value(preferences), in_menu = TRUE)
+	preferences.update_current_character_profile()
+
 /datum/asset/spritesheet/species
 	name = "species"
 	early = TRUE

--- a/code/modules/client/preferences/preferences.dm
+++ b/code/modules/client/preferences/preferences.dm
@@ -315,9 +315,18 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 			if (isnull(requested_preference))
 				return FALSE
 
+			var/current_value = read_preference(requested_preference.type)
+
 			// SAFETY: `update_preference` performs validation checks
 			if (!update_preference(requested_preference, value))
 				return FALSE
+
+			// Might be different from what we requested
+			var/new_value = read_preference(requested_preference.type)
+
+			for (var/datum/preference_middleware/preference_middleware as anything in middleware)
+				if (preference_middleware.post_set_preference(usr, requested_preference_key, current_value, new_value))
+					return TRUE
 
 			if (istype(requested_preference, /datum/preference/name/real_name))
 				update_current_character_profile()

--- a/code/modules/mob/living/carbon/human/_species.dm
+++ b/code/modules/mob/living/carbon/human/_species.dm
@@ -180,6 +180,12 @@ GLOBAL_LIST_EMPTY(features_by_species)
 	//Should we preload this species's organs?
 	var/preload = TRUE
 
+	/// The name key for the species, if the user changes from one species
+	/// to another which has a different name key, their name will be reset
+	/// to a random name.
+	/// If null, then it will always change.
+	var/name_key = null
+
 ///////////
 // PROCS //
 ///////////

--- a/code/modules/mob/living/carbon/human/species_types/humans.dm
+++ b/code/modules/mob/living/carbon/human/species_types/humans.dm
@@ -6,6 +6,7 @@
 	use_skintones = 1
 	skinned_type = /obj/item/stack/sheet/animalhide/human
 	changesource_flags = MIRROR_BADMIN | WABBAJACK | MIRROR_MAGIC | MIRROR_PRIDE | ERT_SPAWN | RACE_SWAP | SLIME_EXTRACT
+	name_key = SPECIES_NAME_HUMANOID
 
 /datum/species/human/qualifies_for_rank(rank, list/features)
 	return TRUE	//Pure humans are always allowed in all roles.


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

fixes #13668

## About The Pull Request

What's the best way to reward players who joined the server for the first time? Having the game assign them an invalid name before bwoinking them. Not even reading the rules and noticing that their name isn't a valid Felinimanionaririum name, it's like they don't even want to play here.

## Why It's Good For The Game

New players getting bwoinked sets the stage for their gameplay experience and gives off a shitty first impression, especially considering that almost all new players are from other servers so already understand SS13 culture. They aren't new to SS13, they understand that a bwoink is bad, and they understand that if a server is bwoinking them the second they join that the server will not be for them. Lets actually make an attempt at caring about wanting players by not having the game assign a name that's going to break the rules for you.

## Testing Photographs and Procedure


https://github.com/user-attachments/assets/7e6c2dbc-310f-4ae8-9d7f-cab86986abae



## Changelog
:cl:
fix: Changing species now assigns a new name.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
