### PR TITLE
Boxstion Berry Alone Disposal Pipe Removal 

### DIFF
--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -11017,12 +11017,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
-"cpD" = (
-/obj/structure/disposalpipe/sorting/mail/destination/dormitories{
-	dir = 4
-	},
-/turf/open/space/basic,
-/area/space)
 "cpF" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -107201,7 +107195,7 @@ aaa
 aaa
 aaa
 aaa
-cpD
+aaa
 aaa
 aaa
 aaa


### PR DESCRIPTION
## About The Pull Request

In #13351 I had redone apart of the map, with disposals included getting rework done to it. Apparently, in which a stray pipe floated out into space by some miracle accident... this pr deletes it

## Why It's Good For The Game

I do not think that Dispoals needs a stray pipe in space... _unless_ : This PR Deletes a RANDOM Disposal Pipe not attacted to anything floating in space, so as much as i like space junk, this PR cleans up the map a little

## Testing Photographs and Procedure

<summary>Screenshots&Videos</summary>

<img width="740" height="645" alt="Screenshot 2025-11-19 171348" src="https://github.com/user-attachments/assets/4134feac-07c9-4f52-b29a-b1308a216eb3" /><br>
### - The highlighted pipe is the DELETED one !

</details>

## Changelog
:cl:
del: Deleted a Stray Disposal Pipe outside Boxstation Armory 
/:cl:

