### PR TITLE
Berry Inclusive Cargo Blood Pack Variety 

### DIFF
--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -1763,11 +1763,10 @@
 
 /datum/supply_pack/medical/bloodpacks
 	name = "Blood Pack Variety Crate"
-	desc = "Contains eight different blood packs for reintroducing blood to patients."
+	desc = "Contains ten different blood packs for reintroducing blood to patients."
 	cost = 700
 	max_supply = 4
-	contains = list(/obj/item/reagent_containers/blood,
-					/obj/item/reagent_containers/blood,
+	contains = list(/obj/item/reagent_containers/blood/synthetic,
 					/obj/item/reagent_containers/blood/APlus,
 					/obj/item/reagent_containers/blood/AMinus,
 					/obj/item/reagent_containers/blood/BPlus,
@@ -1776,7 +1775,8 @@
 					/obj/item/reagent_containers/blood/OMinus,
 					/obj/item/reagent_containers/blood/lizard,
 					/obj/item/reagent_containers/blood/ethereal,
-					/obj/item/reagent_containers/blood/oozeling)
+					/obj/item/reagent_containers/blood/oozeling,
+					/obj/item/reagent_containers/blood/random)
 	crate_name = "blood freezer"
 	crate_type = /obj/structure/closet/crate/freezer
 


### PR DESCRIPTION
### ! Only One Can be Merged, THE BORING #13676  or EXCITING #13677 !

## About The Pull Request

There I was, fighting a Gorillia with one hand, winning a Nascar race with me toes, and looking through Beediscord with my free hand, turn my peepers towards # Questions and notice someone mentioning that IPC's use Coolant instead of Oil nowadays, and that their blood didnt come in the cargo pack.

A TRAGEDY!!! 

Nanotrasen should atleast TRY to be inclusive : I took a look at the code and revised the Crate Code - Removing **TWO EMPTY BLOODBAGS** which exist for as much reason as a Godzillia Beauty Pagent. NO REASON!! Adjusting the text accomodating to mention its now 10 bags of blood - with one of each kind with one gamba bag because 9 is uneven and the devils number.


## Why It's Good For The Game

I do not think NT should hate the clankers despite whatever personal opinion may be - and they are, crew at the end of day, and should be given the same considerations as other races.

Now, notably, this PR is **NOT** good for the game in comparison to #TBD - This PR is better then base game, probably, maybe, but is NOT as fun as the Full-Gamba version of this PR previously linked


## Testing Photographs and Procedure

<details>
<summary>Screenshots&Videos</summary>

<img width="581" height="67" alt="Screenshot 2025-11-20 233933" src="https://github.com/user-attachments/assets/6fad6abb-ab78-45cc-953f-6b2351290a66" />
<img width="253" height="308" alt="Screenshot 2025-11-20 234209" src="https://github.com/user-attachments/assets/279fab4e-7cf1-43af-978b-b6c33dbd14e3" />


</details>

## Changelog
:cl:
tweak: Adjusts Cargo's Blood Pack Variety Crate Contents
/:cl:
