### PR TITLE
Berry Fun Cargo Blood Variety Pack Crate

### DIFF
--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -1763,10 +1763,14 @@
 
 /datum/supply_pack/medical/bloodpacks
 	name = "Blood Pack Variety Crate"
-	desc = "Contains ten different blood packs for reintroducing blood to patients."
-	cost = 700
+	desc = "Contains a variety of blood packs for reintroducing blood to patients."
+	cost = 900
 	max_supply = 4
 	contains = list(/obj/item/reagent_containers/blood/random,
+					/obj/item/reagent_containers/blood/random,
+					/obj/item/reagent_containers/blood/random,
+					/obj/item/reagent_containers/blood/random,
+					/obj/item/reagent_containers/blood/random,
 					/obj/item/reagent_containers/blood/random,
 					/obj/item/reagent_containers/blood/random,
 					/obj/item/reagent_containers/blood/random,

--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -1763,20 +1763,20 @@
 
 /datum/supply_pack/medical/bloodpacks
 	name = "Blood Pack Variety Crate"
-	desc = "Contains eight different blood packs for reintroducing blood to patients."
+	desc = "Contains ten different blood packs for reintroducing blood to patients."
 	cost = 700
 	max_supply = 4
-	contains = list(/obj/item/reagent_containers/blood,
-					/obj/item/reagent_containers/blood,
-					/obj/item/reagent_containers/blood/APlus,
-					/obj/item/reagent_containers/blood/AMinus,
-					/obj/item/reagent_containers/blood/BPlus,
-					/obj/item/reagent_containers/blood/BMinus,
-					/obj/item/reagent_containers/blood/OPlus,
-					/obj/item/reagent_containers/blood/OMinus,
-					/obj/item/reagent_containers/blood/lizard,
-					/obj/item/reagent_containers/blood/ethereal,
-					/obj/item/reagent_containers/blood/oozeling)
+	contains = list(/obj/item/reagent_containers/blood/random,
+					/obj/item/reagent_containers/blood/random,
+					/obj/item/reagent_containers/blood/random,
+					/obj/item/reagent_containers/blood/random,
+					/obj/item/reagent_containers/blood/random,
+					/obj/item/reagent_containers/blood/random,
+					/obj/item/reagent_containers/blood/random,
+					/obj/item/reagent_containers/blood/random,
+					/obj/item/reagent_containers/blood/random,
+					/obj/item/reagent_containers/blood/random,
+					/obj/item/reagent_containers/blood/random)
 	crate_name = "blood freezer"
 	crate_type = /obj/structure/closet/crate/freezer
 


### PR DESCRIPTION
### ! ONLY ONE PR CAN BE MERGED, THIS EXCITING PR #13677 or THE BORING #13676 !

## About The Pull Request

OKAY! So, for SOME REASON, Cargo blood crates have **NO IPC COOLANT** : RACISM!!!

This PR like #13676 changes that, allowing for **ALL** Blood to be distributed, **UNLIKE THAT BORING PR** this one is ENTIRELY RANDOMIZED - 10 packs of lizard blood is as possible as one of each! GAMBA!!!


## Why It's Good For The Game

Gambling is FUN!!!! I could make an argument about how i genuinely doubt how organized Central Command shipping is, but ultimately this is an OOC decision to be made, a decision which i support on account of it adding a bit more diversity to the crates, which can lead to more unique situations, where worst case, Cargo gets more interaction and MONEY!!!

## Testing Photographs and Procedure
<details>
<summary>Screenshots&Videos</summary>

<img width="581" height="67" alt="Screenshot 2025-11-20 233933" src="https://github.com/user-attachments/assets/9e0441af-c68e-4365-9ed7-ecf7730f9cb5" />
<img width="242" height="310" alt="Screenshot 2025-11-20 235558" src="https://github.com/user-attachments/assets/b2d0883e-1e7f-4058-bd6d-68ccd2fb5049" />

</details>

## Changelog
:cl:
tweak:  Cargo's blood pack crates now contain 15 random blood bags
/:cl: