### PR TITLE
APCs have 50% more power + tweaks to automatic shutdowns. 

### DIFF
--- a/code/modules/mapping/mapping_helpers.dm
+++ b/code/modules/mapping/mapping_helpers.dm
@@ -495,10 +495,6 @@ CREATION_TEST_IGNORE_SUBTYPES(/obj/effect/mapping_helpers)
 		return
 	if(target.cut_ai_wire)
 		target.wires.cut(WIRE_AI)
-	if(target.cell_5k)
-		target.install_cell_5k()
-	if(target.cell_10k)
-		target.install_cell_10k()
 	if(target.unlocked)
 		target.unlock()
 	if(target.syndicate_access)
@@ -509,8 +505,6 @@ CREATION_TEST_IGNORE_SUBTYPES(/obj/effect/mapping_helpers)
 		target.set_no_charge()
 	if(target.full_charge)
 		target.set_full_charge()
-	if(target.cell_5k && target.cell_10k)
-		CRASH("Tried to combine non-combinable cell_5k and cell_10k APC helpers!")
 	if(target.syndicate_access && target.away_general_access)
 		CRASH("Tried to combine non-combinable syndicate_access and away_general_access APC helpers!")
 	if(target.no_charge && target.full_charge)
@@ -530,26 +524,6 @@ CREATION_TEST_IGNORE_SUBTYPES(/obj/effect/mapping_helpers)
 		var/area/apc_area = get_area(target)
 		log_mapping("[src] at [AREACOORD(src)] [(apc_area.type)] tried to mend the AI wire on the [target] but it's already cut!")
 	target.cut_ai_wire = TRUE
-
-/obj/effect/mapping_helpers/apc/cell_5k
-	name = "apc 5k cell helper"
-	icon_state = "apc_5k_cell_helper"
-
-/obj/effect/mapping_helpers/apc/cell_5k/payload(obj/machinery/power/apc/target)
-	if(target.cell_5k)
-		var/area/apc_area = get_area(target)
-		log_mapping("[src] at [AREACOORD(src)] [(apc_area.type)] tried to change [target]'s cell to cell_5k but it's already changed!")
-	target.cell_5k = TRUE
-
-/obj/effect/mapping_helpers/apc/cell_10k
-	name = "apc 10k cell helper"
-	icon_state = "apc_10k_cell_helper"
-
-/obj/effect/mapping_helpers/apc/cell_10k/payload(obj/machinery/power/apc/target)
-	if(target.cell_10k)
-		var/area/apc_area = get_area(target)
-		log_mapping("[src] at [AREACOORD(src)] [(apc_area.type)] tried to change [target]'s cell to cell_10k but it's already changed!")
-	target.cell_10k = TRUE
 
 /obj/effect/mapping_helpers/apc/syndicate_access
 	name = "apc syndicate access helper"

--- a/code/modules/power/apc/apc_main.dm
+++ b/code/modules/power/apc/apc_main.dm
@@ -41,9 +41,9 @@
 	///Reference to our internal cell
 	var/obj/item/stock_parts/cell/cell
 	///Initial cell charge %
-	var/start_charge = 90
+	var/start_charge = 100
 	///Type of cell we start with
-	var/cell_type = /obj/item/stock_parts/cell/high	//Base cell has 100 kW. Enter the path of a different cell you want to use. cell determines charge rates, max capacity, ect. These can also be changed with other APC vars, but isn't recommended to minimize the risk of accidental usage of dirty editted APCs
+	var/cell_type = /obj/item/stock_parts/cell/high/plus	//Base cell has 150 kW. Enter the path of a different cell you want to use. cell determines charge rates, max capacity, ect. These can also be changed with other APC vars, but isn't recommended to minimize the risk of accidental usage of dirty editted APCs
 	///State of the cover (closed, opened, removed)
 	var/opened = APC_COVER_CLOSED
 	///Is the APC shorted and not working?
@@ -128,10 +128,6 @@
 	var/syndicate_access = FALSE
 	/// Used for apc helper called away_general_access to make apc's required access away_general_access.
 	var/away_general_access = FALSE
-	/// Used for apc helper called cell_5k to install 5k cell into apc.
-	var/cell_5k = FALSE
-	/// Used for apc helper called cell_10k to install 10k cell into apc.
-	var/cell_10k = FALSE
 	/// Used for apc helper called no_charge to make apc's charge at 0% meter.
 	var/no_charge = FALSE
 	/// Used for apc helper called full_charge to make apc's charge at 100% meter.
@@ -414,16 +410,6 @@
 /obj/machinery/power/apc/proc/report()
 	return "[area.name] : [equipment]/[lighting]/[environ] ([lastused_equip+lastused_light+lastused_environ]) : [cell? cell.percent() : "N/C"] ([charging])"
 
-///Used for cell_5k apc helper, which installs 5k cell into apc.
-/obj/machinery/power/apc/proc/install_cell_5k()
-	cell_type = /obj/item/stock_parts/cell/upgraded/plus
-	cell = new cell_type(src)
-
-/// Used for cell_10k apc helper, which installs 10k cell into apc.
-/obj/machinery/power/apc/proc/install_cell_10k()
-	cell_type = /obj/item/stock_parts/cell/high
-	cell = new cell_type(src)
-
 /// Used for unlocked apc helper, which unlocks the apc.
 /obj/machinery/power/apc/proc/unlock()
 	locked = FALSE
@@ -577,12 +563,12 @@
 	// The following math salad handles channel activation based on cell percent and if its charge plus surplus can meet the channels demand
 	// TODO: Not having it require cell
 	lighting = update_channel(lighting, light_power_req,
-		(cell.percent() > 65 && (surplus() + cell.charge - (environ_power_req + equip_power_req)) > light_power_req),
+		(cell.percent() > 95 && (surplus() + cell.charge - (environ_power_req + equip_power_req)) > light_power_req),
 		(environ_power_req + equip_power_req),
 		TRUE) // only lighting triggers alarms
 
 	equipment = update_channel(equipment, equip_power_req,
-		(cell.percent() >= 50 && (surplus() + cell.charge - environ_power_req) > equip_power_req), environ_power_req, FALSE)
+		(cell.percent() >= 15 && (surplus() + cell.charge - environ_power_req) > equip_power_req), environ_power_req, FALSE)
 
 	environ = update_channel(environ, environ_power_req,
 		(cell.percent() > 15 && (surplus() + cell.charge) > environ_power_req), 0, FALSE)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

* Tweaks the values at which APCs shut off certain things:
  * Lights now automatically switch to emergency power at 95% instead of 65%
  * Non atmospheric equipment now automatically shuts off at 15% instead of 50%
  * Atmospherics are unchanged and still automatically shut off at 15%
* Removes outdated and unused mapping helpers and associated procs intended for giving APCs extra charge.
* APCs now start with 100% charge instead of 90% charge
* APCs now start with high-capacity+ cells, instead of ordinary high capacity cells
* Closes #13639 hopefully


<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

* **APC Shutoff thresholds** - Emergency lighting serves as an immediate warning that an APC has lost the main grid connection and also cuts down on power drain so that vital machinery can function for longer, albeit in the dark. The threshold for non-atmopsheric equipment being much lower is for the same reason - so equipment functions for much longer, right up until the APC shuts off all power to the room unless forced online to drain the final 15%. 
* **Mapping helpers** - These helpers are completely unused and would no longer function as intended if someone did use them. I'm also strictly against overriding the power cell default values instead of overriding the power cell itself. Having an ordinary looking power cell that's actually 2.5x better than a bluespace cell was a not a fun issue to discover we had previously. 
* **APCs starting with 100% charge** - So the station isn't in emergency lighting as soon as the round starts, and also cuts down a bit on roundstart powernet calculations. 
* **APCs starting with better cells** - These are the best available roundstart cells, and as a result are the best that make any sense to be installed. Between the threshold changes and these power cell changes, I'm hoping that this PR can resolve the complaint/discussion from #13639

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

<img width="627" height="207" alt="image" src="https://github.com/user-attachments/assets/39aa919f-bed4-4ab0-a53d-d0001818a7df" />

<img width="619" height="216" alt="image" src="https://github.com/user-attachments/assets/65a87ee3-3e21-40ff-8d16-f4f23e492cd6" />


</details>

## Changelog
:cl:
tweak: When an APC loses its powernet connection connection, department lights will switch to emergency mode almost immediately to conserve power to be spent on keeping the area operational for longer.
tweak: An APC without an active connection will now continue to power departmental equipment until it reaches 15% charge, instead of shutting off vital machinery at 50% charge. 
tweak: APCs now hold 50% more maximum charge at roundstart, and start with 100% charge instead of 90%. 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
