### PR TITLE
Circuit Component: No Operation (No-op)

### DIFF
--- a/beestation.dme
+++ b/beestation.dme
@@ -4661,6 +4661,7 @@
 #include "code\modules\wiremod\components\utility\delay.dm"
 #include "code\modules\wiremod\components\utility\getter.dm"
 #include "code\modules\wiremod\components\utility\iterator.dm"
+#include "code\modules\wiremod\components\utility\noop.dm"
 #include "code\modules\wiremod\components\utility\router.dm"
 #include "code\modules\wiremod\components\utility\setter.dm"
 #include "code\modules\wiremod\components\utility\switchcase.dm"

--- a/code/modules/research/designs/wiremod_designs.dm
+++ b/code/modules/research/designs/wiremod_designs.dm
@@ -396,6 +396,13 @@
 	build_path = /obj/item/circuit_component/ntnet_send
 	category = list(WIREMOD_CIRCUITRY, WIREMOD_OUTPUT_COMPONENTS)
 
+/datum/design/component/noop
+	name = "No Operation Component"
+	id = "comp_noop"
+	build_path = /obj/item/circuit_component/noop
+	category = list(WIREMOD_CIRCUITRY)
+
+
 /datum/design/component/list_literal
 	name = "List Literal Component"
 	id = "comp_list_literal"

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -227,6 +227,7 @@
 		"comp_module",
 		"comp_multiplexer",
 		"comp_not",
+		"comp_noop",
 		"comp_ntnet_receive",
 		"comp_ntnet_send",
 		"comp_pathfind",

--- a/code/modules/wiremod/components/utility/noop.dm
+++ b/code/modules/wiremod/components/utility/noop.dm
@@ -10,11 +10,11 @@
 	category = "Utility"
 
 	power_usage_per_input = 0 //This does nothing, so consumes no power.
+	circuit_size = 0 //This does nothing, it should take no space.
 
 	circuit_flags = CIRCUIT_FLAG_INPUT_SIGNAL | CIRCUIT_FLAG_OUTPUT_SIGNAL
 
-	/// A comment String for the part. Does Nothing
-	var/datum/port/input/comment
+	var/datum/port/input/comment // A comment String for the part. Does Nothing
 
 
 /obj/item/circuit_component/noop/populate_ports()

--- a/code/modules/wiremod/components/utility/noop.dm
+++ b/code/modules/wiremod/components/utility/noop.dm
@@ -1,0 +1,22 @@
+/**
+ * # No Operation
+ *
+ * A block which does nothing except pass a trigger through. Useful for gathering lots of signals into one bundle.
+ * Includes a comment line so you can comment about the signal path
+ */
+/obj/item/circuit_component/noop
+	display_name = "No Operation Component"
+	desc = "Use this to gather multiple output signals into one for organization. The comment string does nothing."
+	category = "Utility"
+
+	power_usage_per_input = 0 //This does nothing, so consumes no power.
+
+	circuit_flags = CIRCUIT_FLAG_INPUT_SIGNAL | CIRCUIT_FLAG_OUTPUT_SIGNAL
+
+	/// A comment String for the part. Does Nothing
+	var/datum/port/input/comment
+
+
+/obj/item/circuit_component/noop/populate_ports()
+
+	comment = add_input_port("Comment", PORT_TYPE_STRING)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

This circuit component is simple, but a needed one. It only acts as a gathering point for signals and passes them through unimpeded. 

The name comes from the assembly instruction NOOP, which does nothing except consume a clock cycle.

This is useful for circuit organization, like such:

<img width="1212" height="469" alt="image" src="https://github.com/user-attachments/assets/ba66647f-928f-45f4-854e-a0bb4d92b852" />

If you need to reorganize, it's easier to rewire 1 connection instead of 5

## Why It's Good For The Game

Organizing circuits has always been painful. This aims to help organize it better.

Atomized for a quicker review process.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

<img width="1458" height="725" alt="noop Test" src="https://github.com/user-attachments/assets/b4c817fd-b8ad-483a-83ef-f3b59e345245" />

Speech Output:

<img width="326" height="159" alt="noop output" src="https://github.com/user-attachments/assets/fc5a6665-0b65-48d7-8c29-9389743919a8" />
</details>

## Changelog
:cl:
add: Added a No-Operation Wiremod Component which... does nothing except help organize.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
