### PR TITLE
Fixes unintended behavior change with abductor baton

### DIFF
--- a/code/modules/antagonists/abductor/equipment/abduction_gear.dm
+++ b/code/modules/antagonists/abductor/equipment/abduction_gear.dm
@@ -522,6 +522,10 @@ Congratulations! You are now trained for invasive xenobiology research!"}
 	if(!isliving(target))
 		return FALSE
 
+	//Turn the baton on if it isn't, no sense in letting abductors accidentally bonk people
+	if(damtype != STAMINA)
+		attack_self(user)
+
 	//Standard attack logic if the basic stun is being used
 	if(mode == BATON_STUN)
 		return ..()
@@ -539,9 +543,11 @@ Congratulations! You are now trained for invasive xenobiology research!"}
 			ProbeAttack(living_target, user)
 
 /obj/item/melee/baton/abductor/attack_self(mob/living/user)
-	toggle(user)
+	//If it isn't on, turn it on.
 	if(damtype != STAMINA)
 		return ..()
+	//If it's already on, cycle the baton to a new mode
+	toggle(user)
 
 /obj/item/melee/baton/abductor/proc/SleepAttack(mob/living/L,mob/living/user)
 	playsound(src, active_hitsound, 50, TRUE, -1)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
* Closes #13691
* Abductor batons turn on automatically when used by ayys again
* Adjusted the abductor baton attack_self so that only toggles what mode it's on if it isn't being turned on

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
I accidentally changed the default behavior of abductor batons - they used to turn on automatically when used by an abductor and now they don't. This has led to abductors bonking people instead of one-hit stunning them. As hilarious as this is to witness, it's not a great experience for the abductor who expects their baton to work out of the box. 

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

![dreamseeker_nWNIfHtppn](https://github.com/user-attachments/assets/4926cf52-f5e0-42f4-9362-a34642131fbc)

</details>

## Changelog
:cl:
fix: Abductor batons turn themselves on automatically when used again. No more accidentally bonking your abduction targets. 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
