### PR TITLE
Nerf ninja invis

### DIFF
--- a/code/datums/status_effects/buffs.dm
+++ b/code/datums/status_effects/buffs.dm
@@ -750,7 +750,6 @@
 
 /datum/status_effect/cloaked/on_remove()
 	owner.remove_alt_appearance(REF(src))
-	UnregisterSignal(owner, list(COMSIG_MOVABLE_MOVED, COMSIG_MOB_APPLY_DAMAGE, COMSIG_ATOM_BUMPED))
 	animate(owner, time = 0.5 SECONDS, alpha = 255)
 
 /datum/status_effect/cloaked/proc/bump_alpha()

--- a/code/datums/status_effects/buffs.dm
+++ b/code/datums/status_effects/buffs.dm
@@ -700,7 +700,7 @@
 	id = "invisibility"
 	alert_type = /atom/movable/screen/alert/status_effect/cloaked
 	tick_interval = 2
-	duration = STATUS_EFFECT_PERMANENT
+	duration = 40 SECONDS
 	show_duration = TRUE
 	var/can_see_self = FALSE
 
@@ -718,6 +718,12 @@
 		can_see_self = TRUE
 	if (owner.alpha > 100 && can_see_self)
 		owner.remove_alt_appearance(REF(src))
+	// Check for restoring the duration
+	var/turf/location = get_turf(owner)
+	if (location.get_lumcount() < 0.7)
+		var/time_left = duration - world.time
+		var/new_time = min(time_left + 2 SECONDS, initial(duration))
+		duration = world.time + new_time
 
 /datum/status_effect/cloaked/on_apply()
 	if(!..())
@@ -735,6 +741,7 @@
 	RegisterSignal(owner, COMSIG_ATOM_HULK_ATTACK, PROC_REF(terminate_effect))
 	RegisterSignal(owner, COMSIG_ATOM_ATTACK_PAW, PROC_REF(terminate_effect))
 	RegisterSignal(owner, COMSIG_CARBON_CUFF_ATTEMPTED, PROC_REF(terminate_effect))
+	RegisterSignal(owner, COMSIG_MOB_ABILITY_STARTED, PROC_REF(terminate_effect))
 	return TRUE
 
 /datum/status_effect/cloaked/on_remove()

--- a/code/datums/status_effects/buffs.dm
+++ b/code/datums/status_effects/buffs.dm
@@ -699,16 +699,17 @@
 /datum/status_effect/cloaked
 	id = "invisibility"
 	alert_type = /atom/movable/screen/alert/status_effect/cloaked
-	tick_interval = 2
+	tick_interval = STATUS_EFFECT_AUTO_TICK
 	duration = 40 SECONDS
 	show_duration = TRUE
 	var/can_see_self = FALSE
+	var/last_time_update = 0
 
-/datum/status_effect/cloaked/tick()
+/datum/status_effect/cloaked/tick(delta_time)
 	if(owner.on_fire)
 		terminate_effect()
 		return
-	owner.alpha = max(owner.alpha - 10, 0)
+	owner.alpha = max(owner.alpha - 50 * delta_time, 0)
 	if (owner.alpha <= 100 && !can_see_self)
 		// Make it so the user can always see themselves while cloaked
 		var/mutable_appearance/self_appearance = mutable_appearance('icons/hud/actions/actions_minor_antag.dmi', "ninja_cloak")
@@ -720,10 +721,13 @@
 		owner.remove_alt_appearance(REF(src))
 	// Check for restoring the duration
 	var/turf/location = get_turf(owner)
-	if (location.get_lumcount() < 0.7)
+	if (location.get_lumcount() < LIGHTING_TILE_IS_DARK)
 		var/time_left = duration - world.time
-		var/new_time = min(time_left + 2 SECONDS, initial(duration))
+		// Calculate how much real time has passed
+		// Add on tick interval + 1 to make it never stutter when increasing
+		var/new_time = min(time_left + ((world.time - last_time_update) / (1 SECONDS)) * 2 SECONDS, initial(duration))
 		duration = world.time + new_time
+	last_time_update = world.time
 
 /datum/status_effect/cloaked/on_apply()
 	if(!..())

--- a/code/modules/mod/modules/modules_ninja.dm
+++ b/code/modules/mod/modules/modules_ninja.dm
@@ -101,7 +101,7 @@
 		using the nanites already hosted in the wearer's suit to transmute into monomolecular shuriken. \
 		While these lack the intense bleeding edge of conventional throwing stars, \
 		they have been set to electrify fleeing targets; and branded with the Spider Clan symbol."
-	dispense_type = /obj/item/throwing_star/ninja
+	dispense_type = /obj/item/throwing_star/stamina/ninja
 	cooldown_time = 0.5 SECONDS
 
 /obj/item/throwing_star/ninja

--- a/code/modules/mod/modules/modules_ninja.dm
+++ b/code/modules/mod/modules/modules_ninja.dm
@@ -101,12 +101,12 @@
 		using the nanites already hosted in the wearer's suit to transmute into monomolecular shuriken. \
 		While these lack the intense bleeding edge of conventional throwing stars, \
 		they have been set to electrify fleeing targets; and branded with the Spider Clan symbol."
-	dispense_type = /obj/item/throwing_star/stamina/ninja
+	dispense_type = /obj/item/throwing_star/ninja
 	cooldown_time = 0.5 SECONDS
 
-/obj/item/throwing_star/stamina/ninja
+/obj/item/throwing_star/ninja
 	name = "ninja throwing star"
-	throwforce = 10
+	throwforce = 18
 
 ///Hacker - This module hooks onto your right-clicks with empty hands and causes ninja actions.
 /obj/item/mod/module/hacker

--- a/code/modules/mod/modules/modules_ninja.dm
+++ b/code/modules/mod/modules/modules_ninja.dm
@@ -104,9 +104,9 @@
 	dispense_type = /obj/item/throwing_star/stamina/ninja
 	cooldown_time = 0.5 SECONDS
 
-/obj/item/throwing_star/ninja
+/obj/item/throwing_star/stamina/ninja
 	name = "ninja throwing star"
-	throwforce = 18
+	throwforce = 10
 
 ///Hacker - This module hooks onto your right-clicks with empty hands and causes ninja actions.
 /obj/item/mod/module/hacker


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

- Ninja invisibility is now limited to 40 seconds, but that timer increases while in the dark.
- Ninja invisibility disables when any other ability is activated.

## Why It's Good For The Game

Ninja invisibility is far too overpowered, and you have to limit yourself to have fun as ninja. This PR makes it so that you can't just slice someone's arms off from invisibility, and that the station has some way (maintaining light) to weaken your capabilities. The length is still long enough that you can reasonably stalk people.

## Testing Photographs and Procedure

https://github.com/user-attachments/assets/17a38830-c3a4-4c10-b97c-03aa429ec117

## Changelog
:cl:
balance: Ninja invisibility is now limited to 40 seconds, but that timer increases while in the dark.
balance: Ninja invisibility disables when any other ability is activated.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
