### PR TITLE
Adds a more visible hotspot fire type

### DIFF
--- a/code/modules/atmospherics/environmental/LINDA_fire.dm
+++ b/code/modules/atmospherics/environmental/LINDA_fire.dm
@@ -336,6 +336,13 @@
 /obj/effect/hotspot/singularity_pull(atom/singularity, current_size)
 	return
 
+/obj/effect/hotspot/bright
+	icon_state = "medium"
+
+/obj/effect/hotspot/bright/update_color()
+	..()
+	alpha = 255
+
 /datum/looping_sound/fire
 	mid_sounds = list(
 		'sound/effects/fireclip1.ogg' = 1,

--- a/code/modules/atmospherics/environmental/LINDA_fire.dm
+++ b/code/modules/atmospherics/environmental/LINDA_fire.dm
@@ -336,6 +336,7 @@
 /obj/effect/hotspot/singularity_pull(atom/singularity, current_size)
 	return
 
+//Hotspot meant for higher visibility fire
 /obj/effect/hotspot/bright
 	icon_state = "medium"
 

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/drake.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/drake.dm
@@ -269,7 +269,7 @@ Difficulty: Medium
 		if(istype(T, /turf/closed))
 			break
 		new /obj/effect/hotspot/bright(T)
-		T.hotspot_expose(700,50,1)
+		T.hotspot_expose(700, 50, 1)
 		for(var/mob/living/L in T.contents)
 			if((L in hit_list) || L == source)
 				continue
@@ -550,7 +550,7 @@ CREATION_TEST_IGNORE_SUBTYPES(/obj/effect/temp_visual/target)
 		M.gets_drilled()
 	playsound(T, "explosion", 80, 1)
 	new /obj/effect/hotspot/bright(T)
-	T.hotspot_expose(700,50,1)
+	T.hotspot_expose(700, 50, 1)
 	for(var/mob/living/L in T.contents)
 		if(istype(L, /mob/living/simple_animal/hostile/megafauna/dragon))
 			continue

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/drake.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/drake.dm
@@ -268,7 +268,7 @@ Difficulty: Medium
 	for(var/turf/T in turfs)
 		if(istype(T, /turf/closed))
 			break
-		new /obj/effect/hotspot(T)
+		new /obj/effect/hotspot/bright(T)
 		T.hotspot_expose(700,50,1)
 		for(var/mob/living/L in T.contents)
 			if((L in hit_list) || L == source)
@@ -549,8 +549,8 @@ CREATION_TEST_IGNORE_SUBTYPES(/obj/effect/temp_visual/target)
 		var/turf/closed/mineral/M = T
 		M.gets_drilled()
 	playsound(T, "explosion", 80, 1)
-	new /obj/effect/hotspot(T)
-	T.hotspot_expose(700, 50, 1)
+	new /obj/effect/hotspot/bright(T)
+	T.hotspot_expose(700,50,1)
 	for(var/mob/living/L in T.contents)
 		if(istype(L, /mob/living/simple_animal/hostile/megafauna/dragon))
 			continue

--- a/code/modules/mob/living/simple_animal/hostile/space_dragon.dm
+++ b/code/modules/mob/living/simple_animal/hostile/space_dragon.dm
@@ -313,7 +313,7 @@
 	var/list/hit_list = list()
 	hit_list += src
 	new /obj/effect/hotspot/bright(T)
-	T.hotspot_expose(700,50,1)
+	T.hotspot_expose(700, 50, 1)
 	for(var/mob/living/L in T.contents)
 		if(L.faction_check_mob(src) && L != src)
 			hit_list += L

--- a/code/modules/mob/living/simple_animal/hostile/space_dragon.dm
+++ b/code/modules/mob/living/simple_animal/hostile/space_dragon.dm
@@ -312,7 +312,7 @@
 /mob/living/simple_animal/hostile/space_dragon/proc/dragon_fire_line(turf/T)
 	var/list/hit_list = list()
 	hit_list += src
-	new /obj/effect/hotspot(T)
+	new /obj/effect/hotspot/bright(T)
 	T.hotspot_expose(700,50,1)
 	for(var/mob/living/L in T.contents)
 		if(L.faction_check_mob(src) && L != src)

--- a/code/modules/reagents/chemistry/reagents/pyrotechnic_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/pyrotechnic_reagents.dm
@@ -65,7 +65,7 @@
 		if(isfloorturf(floor))
 			for(var/turf/open/turf in RANGE_TURFS(1,floor))
 				if(!locate(/obj/effect/hotspot) in turf)
-					new /obj/effect/hotspot(floor)
+					new /obj/effect/hotspot/bright(floor)
 
 	else if(iswallturf(exposed_turf))
 		var/turf/closed/wall/wall = exposed_turf
@@ -80,7 +80,7 @@
 		exposed_mob.adjust_fire_stacks(min(reac_volume/5, 10))
 		exposed_mob.IgniteMob()
 		if(!locate(/obj/effect/hotspot) in exposed_mob.loc)
-			new /obj/effect/hotspot(exposed_mob.loc)
+			new /obj/effect/hotspot/bright(exposed_mob.loc)
 
 /datum/reagent/sorium
 	name = "Sorium"

--- a/code/modules/reagents/chemistry/recipes/pyrotechnics.dm
+++ b/code/modules/reagents/chemistry/recipes/pyrotechnics.dm
@@ -209,7 +209,7 @@
 	var/turf/T = get_turf(holder.my_atom)
 	for(var/turf/open/turf in RANGE_TURFS(1,T))
 		if(!locate(/obj/effect/hotspot) in turf)
-			new /obj/effect/hotspot(turf)
+			new /obj/effect/hotspot/bright(turf)
 	holder.chem_temp = 1000 // hot as shit
 
 /datum/chemical_reaction/reagent_explosion/methsplosion
@@ -224,7 +224,7 @@
 	var/turf/T = get_turf(holder.my_atom)
 	for(var/turf/open/turf in RANGE_TURFS(1,T))
 		if(!locate(/obj/effect/hotspot) in turf)
-			new /obj/effect/hotspot(turf)
+			new /obj/effect/hotspot/bright(turf)
 	holder.chem_temp = 1000 // hot as shit
 	..()
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Title.

This was made mostly because ash drake fire is very hard to see now since transparent and dark red is a bad combination on the dark lavaland tiles instead of being opaque and yellow as it was before.
I have also added this to space dragon's fire with the same reasoning as above, clf3 fire and meth explosion fire since they looked underwhelming.

Closes https://github.com/BeeStation/BeeStation-Hornet/issues/13504
## Why It's Good For The Game
Better visibility.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>


Removed because it contained my CID.


<summary>Screenshots&Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>

## Changelog
:cl:

tweak: Makes ash drake, space dragon, clf3 and meth fires more visible.

/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
