### PR TITLE
Cuff escapes v3

### DIFF
--- a/code/_onclick/hud/alert.dm
+++ b/code/_onclick/hud/alert.dm
@@ -829,8 +829,7 @@ Recharging stations are available in robotics, the dormitory bathrooms, and the 
 /atom/movable/screen/alert/restrained/handcuffed
 	name = "Handcuffed"
 	desc = "You're handcuffed and can't act. If anyone drags you, you won't be able to move. \
-		Left-click the alert to free yourself over time. \
-		Right-click the alert if you're willing to severely injure yourself to break out immediately."
+		Left-click the alert to attempt to free yourself."
 	clickable_glow = TRUE
 
 /atom/movable/screen/alert/restrained/legcuffed
@@ -838,19 +837,12 @@ Recharging stations are available in robotics, the dormitory bathrooms, and the 
 	desc = "You're legcuffed, which slows you down considerably. Click the alert to free yourself."
 	clickable_glow = TRUE
 
-/atom/movable/screen/alert/restrained/Click(location, control, params)
+/atom/movable/screen/alert/restrained/Click()
 	var/mob/living/living_mob = usr
 	if(!istype(living_mob) || !living_mob.can_resist() || living_mob != owner)
 		return
 
 	living_mob.changeNext_move(CLICK_CD_RESIST)
-
-	var/list/parameters = params2list(params)
-	if(LAZYACCESS(parameters, RIGHT_CLICK))
-		var/mob/living/carbon/human/human_mob = living_mob
-		if(ishuman(human_mob) && human_mob.handcuffed)
-			return human_mob.breakout_breaking_arms()
-
 	return living_mob.resist_restraints()
 
 /atom/movable/screen/alert/restrained/buckled/Click()

--- a/code/game/objects/items/handcuffs.dm
+++ b/code/game/objects/items/handcuffs.dm
@@ -25,7 +25,7 @@
 	throw_speed = 3
 	throw_range = 5
 	custom_materials = list(/datum/material/iron=500)
-	breakouttime = 3 MINUTES
+	breakouttime = 1 MINUTES
 	armor_type = /datum/armor/restraints_handcuffs
 	custom_price = 15
 	var/cuffsound = 'sound/weapons/handcuffs.ogg'
@@ -101,7 +101,7 @@
 	lefthand_file = 'icons/mob/inhands/equipment/tools_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/tools_righthand.dmi'
 	custom_materials = list(/datum/material/iron=150, /datum/material/glass=75)
-	breakouttime = 1 MINUTES
+	breakouttime = 30 SECONDS
 	cuffsound = 'sound/weapons/cablecuff.ogg'
 	custom_price = 15
 
@@ -189,7 +189,7 @@
 	lefthand_file = 'icons/mob/inhands/equipment/security_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/security_righthand.dmi'
 	custom_materials = null
-	breakouttime = 2 MINUTES
+	breakouttime = 40 SECONDS
 	trashtype = /obj/item/restraints/handcuffs/cable/zipties/used
 	color = null
 

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -820,21 +820,3 @@
 	if(M.melee_damage != 0 && !HAS_TRAIT(M, TRAIT_PACIFISM) && check_shields(M, M.melee_damage, "the [M.name]", MELEE_ATTACK, M.armour_penetration))
 		return FALSE
 	return ..()
-
-/mob/living/carbon/human/proc/breakout_breaking_arms()
-	visible_message(span_warning("[src] is fighting [handcuffed] with every ounce of their strength!"))
-	if(!do_after(src, 5 SECONDS, timed_action_flags = IGNORE_USER_LOC_CHANGE|IGNORE_HELD_ITEM, hidden = TRUE))
-		return
-
-	playsound(src, 'sound/weapons/pierce_slow.ogg', 50, TRUE)
-
-	var/obj/item/bodypart/random_arm = pick(get_bodypart(BODY_ZONE_L_ARM), get_bodypart(BODY_ZONE_R_ARM))
-	log_combat(src, src, "has forcibly broken their arm to escape [handcuffed]", important = FALSE)
-
-	if(HAS_TRAIT(src, TRAIT_EASYDISMEMBER) && !HAS_TRAIT(src, TRAIT_NODISMEMBER))
-		random_arm.dismember()
-		random_arm.receive_damage(20)
-		uncuff()
-	else
-		random_arm.receive_damage(50)
-		uncuff()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

* Partially reverts #13320  (Removes wrist breaking) 
* Partially reverts #12602  (Restores a lot of original behavior and breakout times, but not all)

### Ignore what you already know about cuffs, here's how the work as of this PR**
**While you are actively being held by your captor (or anyone else)**
* Being forcefully moved around interrupts breakout attempts again
* Because the breakout can be interrupted again, handcuffs, zip ties and cables have been mostly restored to their old breakout times: 60, 40 and 30 seconds respectively. 
* Breaking out still makes incremental progress, but those increments take twice as long with 10 seconds per step. 
* When/if you reach your final 10 second step, a message is sent to everyone nearby that you are attempting to escape. Alert officers/captors should use this opportunity stun and recuff captives to reset the cuffs.  

**While you are not being actively held by someone, and can freely run around**
* Breakout times are halved, each step of progress only taking 5 seconds each
* Progress steps do not require you to stand still

**Additional changes**
* Captives are now told their escape progress
* Captives no longer see messages only intended for captors (cleaned up so `visible_message()` procs)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Every attempt at improving cuffs has been aimed at reducing the likelihood that a captive is being held indefinitely instead of being processed. Instead they have made it much harder to actively detain people. This is the latest attempt at trying to balance the need to be able to detain people while also giving detained people a reasonable way out if they are not being processed.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

<img width="435" height="67" alt="image" src="https://github.com/user-attachments/assets/7d0197f5-f703-4070-9f02-a20f92d5debe" />

<img width="761" height="144" alt="image" src="https://github.com/user-attachments/assets/e2ce9f28-86d6-4b7a-ba08-2df7d7ace74a" />

</details>

## Changelog
:cl:
del: Removed the ability to break your own arm in order to break out of cuffs quickly.
balance: Forcefully dragging/moving cuffed players now interrupts escape attempts again, but players that are free to move around on their own will not interrupt their own progress. Keep a tight hold on your captives!
balance: Cuffs, zip ties and cables have been restored to nearly their original breakout timers again since escape attempts can be interrupted again, at 60, 40 and 30 seconds respectively.
tweak: The steps for progressing an escape from cuffs now take 10 seconds instead of just 5
tweak: Nearby players are always alerted when a cuffed player has reached their final escape step and have nearly slipped their cuffs. This serves as a 10 second warning to re-stun and re-cuff the player to reset the timer to full before they get away.
tweak: Cuffed players are now told their escape progress
fix: Fixed some messages displaying to cuffed players that were intended only for others nearby.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
