### PR TITLE
Fixes Mjolnir not being two handed

### DIFF
--- a/code/game/objects/items/mjolnir.dm
+++ b/code/game/objects/items/mjolnir.dm
@@ -133,7 +133,7 @@ CREATION_TEST_IGNORE_SUBTYPES(/obj/structure/anchored_mjolnir)
 	desc = "A weapon worthy of a god, able to strike with the force of a lightning bolt. It crackles with barely contained energy."
 	icon_state = "mjollnir"
 	nodamage = FALSE
-	damage = 0
+	damage = 30
 	range = 40
 	projectile_phasing = NONE
 	projectile_piercing = (ALL & (~PASSCLOSEDTURF))

--- a/code/game/objects/items/mjolnir.dm
+++ b/code/game/objects/items/mjolnir.dm
@@ -14,6 +14,10 @@
 	w_class = WEIGHT_CLASS_HUGE
 	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | UNACIDABLE | ACID_PROOF | FREEZE_PROOF
 
+/obj/item/mjolnir/Initialize(mapload)
+	. = ..()
+	AddComponent(/datum/component/two_handed, force_multiplier=5, icon_wielded="mjollnir1", attacksound="sparks")
+
 /obj/item/mjolnir/update_icon_state()
 	icon_state = "mjollnir0"
 	return ..()
@@ -143,7 +147,6 @@ CREATION_TEST_IGNORE_SUBTYPES(/obj/projectile/mjolnir)
 	contained = contained_hammer
 	if (contained_hammer)
 		contained_hammer.forceMove(src)
-	AddComponent(/datum/component/two_handed, force_multiplier=5, icon_wielded="mjollnir1", attacksound="sparks")
 
 /obj/projectile/mjolnir/Destroy()
 	if (contained)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

See title.

## Why It's Good For The Game

izafix

## Testing Photographs and Procedure

https://github.com/user-attachments/assets/3df9200b-bd03-4a33-ab82-9c76272cdbc1

## Changelog
:cl:
fix: Fixed mjolnir not being two handed
balance: Set the mjolnir projectile's damage to 30 (this was reverted ~3 years ago)
/:cl:
