### PR TITLE
Upper limit to supermatter explosions

### DIFF
--- a/code/modules/power/supermatter/supermatter_delamination/delamination_effects.dm
+++ b/code/modules/power/supermatter/supermatter_delamination/delamination_effects.dm
@@ -92,7 +92,7 @@
 	return TRUE
 
 /datum/sm_delam/proc/calculate_explosion(obj/machinery/power/supermatter_crystal/sm)
-	return sm.explosion_power * max(sm.gas_heat_power_generation, 0.205) * min(((world.time - sm.activation_time) / SUPERMATTER_CRITICAL_TIME), 3) //energy builds over time for explosions
+	return sm.explosion_power * max(sm.gas_heat_power_generation, 0.205) * min(((world.time - sm.activation_time) / SUPERMATTER_CRITICAL_TIME), 2) //energy builds over time for explosions
 
 /// Spawns a scrung and eat the SM.
 /datum/sm_delam/proc/effect_singulo(obj/machinery/power/supermatter_crystal/sm)

--- a/code/modules/power/supermatter/supermatter_delamination/delamination_effects.dm
+++ b/code/modules/power/supermatter/supermatter_delamination/delamination_effects.dm
@@ -92,7 +92,7 @@
 	return TRUE
 
 /datum/sm_delam/proc/calculate_explosion(obj/machinery/power/supermatter_crystal/sm)
-	return sm.explosion_power * max(sm.gas_heat_power_generation, 0.205) * ((world.time - sm.activation_time) / SUPERMATTER_CRITICAL_TIME) //energy builds over time for explosions
+	return sm.explosion_power * max(sm.gas_heat_power_generation, 0.205) * min(((world.time - sm.activation_time) / SUPERMATTER_CRITICAL_TIME), 3) //energy builds over time for explosions
 
 /// Spawns a scrung and eat the SM.
 /datum/sm_delam/proc/effect_singulo(obj/machinery/power/supermatter_crystal/sm)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This puts an upper limit on supermatter explosions to 2x the limit that existed before #13628
Supermatters will reach their highest potential after being powered for 90 minutes.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

When #13628 was first made, rounds were limited to two hours and some change, and that time limit acted as an upper limit on the destruction the supermatter could do. With rounds now being limited to four hours, the supermatter could potentially destroy the entire station z-level if the right conditions are met. 

I don't really want this to be rushed into being merged, but since I'm about to potentially lose access to coding for a bit, I wanted to pre-empt this being a disaster rather than a loved feature now that rounds have a much higher maximum length. 

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

Here is boxstation bridge with an explosion very slightly stronger than the theoretical maximum this PR provides. 

<img width="978" height="931" alt="image" src="https://github.com/user-attachments/assets/867d83ed-1c6f-47a2-a931-a676ab8f6384" />

</details>

## Changelog
:cl:
tweak: Supermatter crystals now have an upper limit on their explosive force, achieved after 90 minutes of being powered. 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
