### PR TITLE
The dynamic panel now checks for R_DEBUG instead of R_FUN

### DIFF
--- a/code/controllers/subsystem/dynamic/dynamic_panel.dm
+++ b/code/controllers/subsystem/dynamic/dynamic_panel.dm
@@ -416,7 +416,7 @@
 			return TRUE
 
 /datum/dynamic_panel/ui_status(mob/user, datum/ui_state/state)
-	return check_rights_for(user.client, R_FUN) ? UI_INTERACTIVE : UI_CLOSE
+	return check_rights_for(user.client, R_DEBUG) ? UI_INTERACTIVE : UI_CLOSE
 
 /datum/dynamic_panel/ui_interact(mob/user, datum/tgui/ui)
 	ui = SStgui.try_update_ui(user, src, ui)

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -112,7 +112,6 @@ GLOBAL_LIST_INIT(admin_verbs_fun, list(
 	/client/proc/spawnhuman,
 	/client/proc/debug_spell_requirements,
 	/datum/admins/proc/station_traits_panel,
-	/datum/admins/proc/dynamic_panel,
 	))
 GLOBAL_PROTECT(admin_verbs_fun)
 GLOBAL_LIST_INIT(admin_verbs_spawn, list(
@@ -219,6 +218,7 @@ GLOBAL_PROTECT(admin_verbs_debug)
 	/client/proc/cmd_clear_smart_asset_cache,
 	/client/proc/view_runtimes,
 	/client/proc/debug_hallucination_weighted_list_per_type,
+	/datum/admins/proc/dynamic_panel,
 	)
 
 GLOBAL_LIST_INIT(admin_verbs_possess, list(/proc/possess, GLOBAL_PROC_REF(release)))


### PR DESCRIPTION
## About The Pull Request

See title.

## Why It's Good For The Game

The dynamic panel is very much a debug panel and considering how trivially easy it is to affect dynamic through VV, there's no reason R_DEBUG shouldn't get it. The main thing I need from the dynamic panel are the delta graphs. It made my life so much more difficult whenever bacon was out of town for a week and let me edit the configs, but I couldn't see the results in a readable format because I couldn't access the panel.

## Testing Photographs and Procedure

don't think testing evidence is really applicable here

## Changelog
:cl:
admin: Use of the dynamic panel now checks for debug perms instead of fun perms
/:cl:
