### PR TITLE
Changes taser hand behaviour

### DIFF
--- a/code/modules/projectiles/projectile/energy/stun.dm
+++ b/code/modules/projectiles/projectile/energy/stun.dm
@@ -349,6 +349,7 @@
 		RegisterSignal(firer, COMSIG_QDELETING, PROC_REF(end_tase))
 	RegisterSignal(firer, COMSIG_MOB_EQUIPPED_ITEM, PROC_REF(check_hands))
 	RegisterSignal(firer, COMSIG_MOB_UNEQUIPPED_ITEM, PROC_REF(check_hands))
+	RegisterSignal(firer, COMSIG_MOB_DROPPED_ITEM, PROC_REF(check_hands))
 
 	RegisterSignal(firer, COMSIG_MOB_CLICKON, PROC_REF(user_cancel_tase))
 	RegisterSignal(firer, COMSIG_MOVABLE_MOVED, PROC_REF(recalculate_distance))
@@ -412,8 +413,11 @@
 	SIGNAL_HANDLER
 	if(QDELING(src))
 		return
-	// We don't care about switching hands, only about item equips
-	if (item.item_flags & ABSTRACT)
+	if (!isliving(firer))
+		end_tase()
+		return
+	var/mob/living/living_firer = firer
+	if (taser in living_firer.held_items)
 		return
 	end_tase()
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

- Tasers will correctly end their tasing when dropped / put into a backpack.
- Tasers will correctly continue tasing when a different item is picked up/dropped.

## Why It's Good For The Game

If you have an item in your hand, you can use it while tasing. If you pickup or drop an item that is in your hand, then you cancel the tase. This behaviour is inconsistent and was intended to go into the original PR. It was explained but forgotten in the code and changelog.

Obviously, putting a taser in your bag should not make it able to continue tasing.

## Testing Photographs and Procedure

https://github.com/user-attachments/assets/7669dfad-bc4f-4833-83f9-2274aad94efa

## Changelog
:cl:
fix: Fixes taser continuing to fire even after being put in your backpack.
balance: Fixes tasers unequipping when pulling out items in your second hand.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
