### PR TITLE
Fixed lipid extractor not recognizing occupant

### DIFF
--- a/code/game/machinery/fat_sucker.dm
+++ b/code/game/machinery/fat_sucker.dm
@@ -62,7 +62,7 @@
 	playsound(src, 'sound/machines/click.ogg', 50)
 	if(occupant)
 		var/mob/living/L = occupant
-		if(!iscarbon(L) || HAS_TRAIT(L, TRAIT_POWERHUNGRY) || !(MOB_ORGANIC in L?.mob_biotypes))
+		if(!iscarbon(L) || HAS_TRAIT(L, TRAIT_POWERHUNGRY) || !(L?.mob_biotypes & MOB_ORGANIC))
 			occupant.forceMove(drop_location())
 			set_occupant(null)
 			return


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

**Re-created after I accidentally closed my previous PR (https://github.com/BeeStation/BeeStation-Hornet/pull/13723)**

When biotypes were switched to bitfields (https://github.com/BeeStation/BeeStation-Hornet/pull/13477) code in the fat_sucker was broken, causing it to not recognize an occupant as organic anymore. This change corrects this, converting the lookup to actually checking the bit.

## Why It's Good For The Game

The lipid extractor is a fun machine, and it's very frustrating to build one and find that it can't hold anyone for an unknown reason.

## Testing Photographs and Procedure
<details>
No photos, but without this change you can stand on a lipid extractor as a human and shut the door without going inside. The machine is effectively useless.

With the change, you can use the machine as before, producing meat and slimming the user.
</details>

## Changelog
:cl:
fix: Lipid extractor not detecting occupants
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
