### PR TITLE
Hotfixes player preferences not working

### DIFF
--- a/code/modules/client/preferences/preferences.dm
+++ b/code/modules/client/preferences/preferences.dm
@@ -315,14 +315,14 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 			if (isnull(requested_preference))
 				return FALSE
 
-			var/current_value = read_character_preference(requested_preference.type)
+			var/current_value = requested_preference.preference_type == PREFERENCE_PLAYER ? read_player_preference(requested_preference.type) : read_character_preference(requested_preference.type)
 
 			// SAFETY: `update_preference` performs validation checks
 			if (!update_preference(requested_preference, value))
 				return FALSE
 
 			// Might be different from what we requested
-			var/new_value = read_character_preference(requested_preference.type)
+			var/new_value = requested_preference.preference_type == PREFERENCE_PLAYER ? read_player_preference(requested_preference.type) : read_character_preference(requested_preference.type)
 
 			for (var/datum/preference_middleware/preference_middleware as anything in middleware)
 				if (preference_middleware.post_set_preference(usr, requested_preference_key, current_value, new_value))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Player preferences are currently not functioning. This fixes that.

## Why It's Good For The Game

Hotfix non-functioning code.

## Testing Photographs and Procedure

<img width="630" height="161" alt="image" src="https://github.com/user-attachments/assets/2a001110-d77c-4166-9630-a7edd7c5a424" />

It now works, previously it would crash on the line above.

## Changelog
:cl:
fix: Fixes player preferences not working.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
