### PR TITLE
19x15 Screen Size

### DIFF
--- a/beestation.dme
+++ b/beestation.dme
@@ -2707,6 +2707,7 @@
 #include "code\modules\client\preferences\entries\player\roundend.dm"
 #include "code\modules\client\preferences\entries\player\runechat.dm"
 #include "code\modules\client\preferences\entries\player\scaling_method.dm"
+#include "code\modules\client\preferences\entries\player\screen_size.dm"
 #include "code\modules\client\preferences\entries\player\screentips.dm"
 #include "code\modules\client\preferences\entries\player\sound.dm"
 #include "code\modules\client\preferences\entries\player\tgui.dm"

--- a/code/__DEFINES/preferences.dm
+++ b/code/__DEFINES/preferences.dm
@@ -17,6 +17,10 @@
 #define SCALING_METHOD_DISTORT "distort"
 #define SCALING_METHOD_BLUR "blur"
 
+#define SCREEN_SIZE_TINY "15x15"
+#define SCREEN_SIZE_SMALL "17x15"
+#define SCREEN_SIZE_NORMAL "19x15"
+
 #define PARALLAX_DELAY_DEFAULT world.tick_lag
 #define PARALLAX_DELAY_MED     1
 #define PARALLAX_DELAY_LOW     2

--- a/code/controllers/configuration/entries/general.dm
+++ b/code/controllers/configuration/entries/general.dm
@@ -580,9 +580,6 @@
 	config_entry_value = -1
 	min_val = 0
 
-/datum/config_entry/string/default_view
-	config_entry_value = "15x15"
-
 /datum/config_entry/flag/log_pictures
 
 /datum/config_entry/flag/picture_logging_camera

--- a/code/datums/mocking/client.dm
+++ b/code/datums/mocking/client.dm
@@ -4,7 +4,7 @@
 	var/datum/preferences/prefs
 
 	/// The view of the client, similar to /client/var/view
-	var/view = "17x15"
+	var/view = "19x15"
 
 	var/typing_indicators
 

--- a/code/datums/view.dm
+++ b/code/datums/view.dm
@@ -30,11 +30,8 @@
 	return ..()
 
 /datum/view_data/proc/setDefault(string)
-	var/list/current_size = getviewsize(default)
 	default = string
-	// New default, apply
-	if (current_size[1] == width && current_size[2] == height)
-		apply()
+	apply()
 
 /datum/view_data/proc/afterViewChange()
 	if(isZooming())

--- a/code/datums/view.dm
+++ b/code/datums/view.dm
@@ -30,8 +30,11 @@
 	return ..()
 
 /datum/view_data/proc/setDefault(string)
+	var/list/current_size = getviewsize(default)
 	default = string
-	apply()
+	// New default, apply
+	if (current_size[1] == width && current_size[2] == height)
+		apply()
 
 /datum/view_data/proc/afterViewChange()
 	if(isZooming())
@@ -145,5 +148,8 @@
 	// New players on the menu get the size of the lobby art
 	if(istype(M, /mob/dead/new_player))
 		return SStitle.lobby_screen_size
+	// Get the client's view size
+	if (M.client)
+		return M.client.prefs.read_player_preference(/datum/preference/choiced/screen_size)
 	// Otherwise, they get the default view
-	return CONFIG_GET(string/default_view)
+	return world.view

--- a/code/game/objects/items/binoculars.dm
+++ b/code/game/objects/items/binoculars.dm
@@ -62,6 +62,6 @@
 	if(user && user.client)
 		user.regenerate_icons()
 		var/client/C = user.client
-		C.change_view(CONFIG_GET(string/default_view))
+		C.view_size.resetToDefault()
 		user.client.pixel_x = 0
 		user.client.pixel_y = 0

--- a/code/modules/client/preferences/entries/player/screen_size.dm
+++ b/code/modules/client/preferences/entries/player/screen_size.dm
@@ -14,4 +14,4 @@
 	// Can't change it here
 	if (istype(client.mob, /mob/dead/new_player))
 		return
-	client.view_size?.setDefault(value)
+	client.view_size?.resetToDefault(value)

--- a/code/modules/client/preferences/entries/player/screen_size.dm
+++ b/code/modules/client/preferences/entries/player/screen_size.dm
@@ -1,0 +1,17 @@
+/// The scaling method to show the world in, e.g. nearest neighbor
+/datum/preference/choiced/screen_size
+	category = PREFERENCE_CATEGORY_GAME_PREFERENCES
+	db_key = "screen_size"
+	preference_type = PREFERENCE_PLAYER
+
+/datum/preference/choiced/screen_size/create_default_value()
+	return SCREEN_SIZE_NORMAL
+
+/datum/preference/choiced/screen_size/init_possible_values()
+	return list(SCREEN_SIZE_NORMAL, SCREEN_SIZE_SMALL, SCREEN_SIZE_TINY)
+
+/datum/preference/choiced/screen_size/apply_to_client(client/client, value)
+	// Can't change it here
+	if (istype(client.mob, /mob/dead/new_player))
+		return
+	client.view_size?.setDefault(value)

--- a/code/modules/client/preferences/preferences.dm
+++ b/code/modules/client/preferences/preferences.dm
@@ -315,14 +315,14 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 			if (isnull(requested_preference))
 				return FALSE
 
-			var/current_value = read_character_preference(requested_preference.type)
+			var/current_value = requested_preference.preference_type == PREFERENCE_PLAYER ? read_player_preference(requested_preference.type) : read_character_preference(requested_preference.type)
 
 			// SAFETY: `update_preference` performs validation checks
 			if (!update_preference(requested_preference, value))
 				return FALSE
 
 			// Might be different from what we requested
-			var/new_value = read_character_preference(requested_preference.type)
+			var/new_value = requested_preference.preference_type == PREFERENCE_PLAYER ? read_player_preference(requested_preference.type) : read_character_preference(requested_preference.type)
 
 			for (var/datum/preference_middleware/preference_middleware as anything in middleware)
 				if (preference_middleware.post_set_preference(usr, requested_preference_key, current_value, new_value))

--- a/code/world.dm
+++ b/code/world.dm
@@ -5,7 +5,7 @@
 	mob = /mob/dead/new_player/pre_auth
 	turf = /turf/open/space/basic
 	area = /area/space
-	view = "17x15"
+	view = "19x15"
 	hub = "Exadv1.spacestation13"
 	hub_password = "kMZy3U5jJHSiBQjr"
 	name = "BeeStation 13"

--- a/config/config.txt
+++ b/config/config.txt
@@ -547,12 +547,6 @@ DISABLE_HIGH_POP_MC_MODE_AMOUNT 100
 ## Uncomment to set the number of /world/Reboot()s before the DreamDaemon restarts itself. 0 means restart every round. Requires tgstation server tools.
 ROUNDS_UNTIL_HARD_RESTART 3
 
-##Default screen resolution, in tiles.
-##	By default, this is 15x15, which gets simplified to 7 by BYOND, as it is a 1:1 screen ratio.
-##	For reference, Goonstation uses a resolution of 21x15 for it's widescreen mode.
-##	Do note that changing this value will affect the title screen. The title screen will have to be updated manually if this is changed.
-DEFAULT_VIEW 17x15
-
 ## Name your perpetual currency here
 ## This is used within the metashop and earned by playing the game.
 METACURRENCY_NAME BeeCoin

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/game_preferences/screen_size.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/game_preferences/screen_size.tsx
@@ -1,0 +1,15 @@
+import { createDropdownInput, Feature } from '../base';
+
+export const screen_size: Feature<string> = {
+  name: 'View Size',
+  category: 'GRAPHICS',
+  subcategory: 'Scaling',
+  description:
+    'The amount of tiles that you can see, there is no benefit to decreasing the amount of tiles that you can view, and exists to support ultra-thin monitors.',
+  component: createDropdownInput({
+    '15x15': 'Tiny (15x15)',
+    '17x15': 'Small (17x15)',
+    '19x15': 'Normal (19x15)',
+  }),
+  important: true,
+};


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

- Increases the screen size to 19x15, the standard for practically all space station 13 servers in 2025.
- Adds a new preference for screen size.

## Why It's Good For The Game

This actually doesn't feel that much different than 17x15, but just feels a slight bit like the server has a higher quality. It generally just feels nicer to play, and the time has long gone to call this a modernization, it's more getting us up to date with the servers of 2022.

This also removes the default size config setting, since it wasn't that useful and isn't really necessary. It no longer has any use when we give players the option to change the view size.

## Testing Photographs and Procedure

https://github.com/user-attachments/assets/5152cd62-fab6-4b4a-94a3-590175e05e6e

Something to note is that the implementation of `/datum/view_data` is absolutely dreadful, setting your view radius will make the binoculars reset to the normal view (if you do it during gameplay), but this won't impact anyone and would require a huge rework of how we handle view sizes to properly correct (all for a setting that nobody is going to change).

## Changelog
:cl:
tweak: Increases the view range from 17x15 to 19x15.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
