### PR TITLE
Adds a reboot timer to the statpanel

### DIFF
--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -85,6 +85,9 @@ SUBSYSTEM_DEF(ticker)
 	var/mode_result = "undefined"
 	var/end_state = "undefined"
 
+	/// ID of round reboot timer, if it exists
+	var/reboot_timer = null
+
 /datum/controller/subsystem/ticker/Initialize()
 	var/list/byond_sound_formats = list(
 		"mid"  = TRUE,
@@ -817,11 +820,10 @@ SUBSYSTEM_DEF(ticker)
 		else // Not enough time, play it anyway
 			PlayRoundEndSound()
 
-	sleep(delay - (world.time - start_wait))
+	reboot_timer = addtimer(CALLBACK(src, PROC_REF(reboot_callback), reason, end_string), delay - (world.time - start_wait), TIMER_STOPPABLE)
 
-	if(delay_end && !skip_delay)
-		to_chat(world, span_boldannounce("Reboot was cancelled by an admin."))
-		return
+/// Sends a few messages and then reboots the world
+/datum/controller/subsystem/ticker/proc/reboot_callback(reason, end_string)
 	if(end_string)
 		end_state = end_string
 
@@ -835,6 +837,21 @@ SUBSYSTEM_DEF(ticker)
 	log_game(span_boldannounce("Rebooting World. [reason]"))
 
 	world.Reboot()
+
+/**
+ * Deletes the current reboot timer and nulls the var
+ *
+ * Arguments:
+ * * user - the user that cancelled the reboot, may be null
+ */
+/datum/controller/subsystem/ticker/proc/cancel_reboot(mob/user)
+	if(!reboot_timer)
+		to_chat(user, span_warning("There is no pending reboot!"))
+		return FALSE
+	to_chat(world, span_boldannounce("An admin has delayed the round end."))
+	deltimer(reboot_timer)
+	reboot_timer = null
+	return TRUE
 
 /datum/controller/subsystem/ticker/Shutdown()
 	gather_newscaster() //called here so we ensure the log is created even upon admin reboot

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -312,6 +312,15 @@
 	SSticker.force_ending = ADMIN_FORCE_END_ROUND
 	SSblackbox.record_feedback("tally", "admin_verb", 1, "End Round") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 
+/datum/admins/proc/cancel_reboot()
+	set name = "Cancel Reboot"
+	set desc = "Cancels a pending world reboot."
+	set category = "Server"
+	if(!SSticker.cancel_reboot(usr))
+		return
+	log_admin("[key_name(usr)] cancelled the pending world reboot.")
+	message_admins("[key_name_admin(usr)] cancelled the pending world reboot.")
+
 /datum/admins/proc/announce()
 	set category = "Admin"
 	set name = "Announce"
@@ -488,6 +497,8 @@
 		SSticker.admin_delay_notice = input(usr, "Enter a reason for delaying the round end", "Round Delay Reason") as null|text
 		if(isnull(SSticker.admin_delay_notice))
 			return
+		if(SSticker.reboot_timer)
+			SSticker.cancel_reboot(usr)
 		for(var/client/admin in GLOB.admins)
 			if(check_rights(R_FUN) && !GLOB.battle_royale && admin.tgui_panel && SSticker.current_state == GAME_STATE_FINISHED)
 				admin.tgui_panel.give_br_popup()

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -312,15 +312,6 @@
 	SSticker.force_ending = ADMIN_FORCE_END_ROUND
 	SSblackbox.record_feedback("tally", "admin_verb", 1, "End Round") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 
-/datum/admins/proc/cancel_reboot()
-	set name = "Cancel Reboot"
-	set desc = "Cancels a pending world reboot."
-	set category = "Server"
-	if(!SSticker.cancel_reboot(usr))
-		return
-	log_admin("[key_name(usr)] cancelled the pending world reboot.")
-	message_admins("[key_name_admin(usr)] cancelled the pending world reboot.")
-
 /datum/admins/proc/announce()
 	set category = "Admin"
 	set name = "Announce"

--- a/code/modules/mob/mob_stat.dm
+++ b/code/modules/mob/mob_stat.dm
@@ -262,6 +262,15 @@
 		var/ETA = SSshuttle.emergency.getModeStr()
 		if(ETA)
 			tab_data[ETA] = GENERATE_STAT_TEXT(SSshuttle.emergency.getTimerStr())
+
+	if(SSticker.reboot_timer)
+		var/reboot_time = timeleft(SSticker.reboot_timer)
+		if(reboot_time)
+			tab_data["Reboot"] = DisplayTimeText(reboot_time, 1)
+	// admin must have delayed round end
+	else if(SSticker.ready_for_reboot)
+		tab_data["Reboot"] = "DELAYED"
+
 	return tab_data
 
 /mob/proc/get_stat_tab_master_controller()

--- a/code/modules/mob/mob_stat.dm
+++ b/code/modules/mob/mob_stat.dm
@@ -257,19 +257,21 @@
 	if(SSticker.round_start_time)
 		tab_data["Security Level"] = GENERATE_STAT_TEXT("[capitalize(SSsecurity_level.get_current_level_as_text())]")
 
-	tab_data["divider_3"] = GENERATE_STAT_DIVIDER
+	if(SSticker.reboot_timer)
+		tab_data["divider_3"] = GENERATE_STAT_BLANK
+		var/reboot_time = timeleft(SSticker.reboot_timer)
+		if(reboot_time)
+			tab_data["Reboot"] = GENERATE_STAT_TEXT(DisplayTimeText(reboot_time, 1))
+	// admin must have delayed round end
+	else if(SSticker.ready_for_reboot)
+		tab_data["divider_3"] = GENERATE_STAT_BLANK
+		tab_data["Reboot"] = GENERATE_STAT_TEXT("DELAYED")
+
+	tab_data["divider_4"] = GENERATE_STAT_DIVIDER
 	if(SSshuttle.emergency)
 		var/ETA = SSshuttle.emergency.getModeStr()
 		if(ETA)
 			tab_data[ETA] = GENERATE_STAT_TEXT(SSshuttle.emergency.getTimerStr())
-
-	if(SSticker.reboot_timer)
-		var/reboot_time = timeleft(SSticker.reboot_timer)
-		if(reboot_time)
-			tab_data["Reboot"] = DisplayTimeText(reboot_time, 1)
-	// admin must have delayed round end
-	else if(SSticker.ready_for_reboot)
-		tab_data["Reboot"] = "DELAYED"
 
 	return tab_data
 


### PR DESCRIPTION
## About The Pull Request

Adds an entry to the stat panel displaying how much time until the server reboots. If roundend is delayed, it will display "DELAYED"

Port of: https://github.com/tgstation/tgstation/pull/88438

## Why It's Good For The Game

Nice QoL addition. Lets me know how much time left I have to EORG until the round reboots

## Testing Photographs and Procedure

<img width="455" height="278" alt="image" src="https://github.com/user-attachments/assets/814aa6ba-96ba-4c5d-b736-d484ed2ae285" />

<img width="585" height="389" alt="image" src="https://github.com/user-attachments/assets/eefbd36b-dc46-4c2e-884f-46253cc67e3e" />

<img width="390" height="305" alt="image" src="https://github.com/user-attachments/assets/32f26637-60f0-4276-9a04-9e2121fe920e" />

## Changelog
:cl: mrmanlikesbt, TealSeer
qol: Added a reboot timer in the statpanel
/:cl:
