### PR TITLE
Fix Artifact Traits - Porous & Haunted

### DIFF
--- a/code/modules/xenoarchaeology/traits/majors/porous.dm
+++ b/code/modules/xenoarchaeology/traits/majors/porous.dm
@@ -7,8 +7,8 @@
 	label_desc = "Porous: The artifact seems to contain porous components. Triggering these components will cause the artifact to exchange one gas with another."
 	cooldown = XENOA_TRAIT_COOLDOWN_SAFE
 	flags = XENOA_BLUESPACE_TRAIT | XENOA_URANIUM_TRAIT | XENOA_BANANIUM_TRAIT | XENOA_PEARL_TRAIT
-	register_targets = FALSE
 	weight = 15
+	register_targets = FALSE
 	///Possible target gasses
 	var/list/target_gasses = list(
 		/datum/gas/oxygen = 6,
@@ -37,25 +37,29 @@
 	choosen_target = pick_weight(target_gasses)
 	choosen_exchange = pick_weight(exchange_gasses)
 
+/datum/xenoartifact_trait/major/gas/register_parent(datum/source)
+	. = ..()
+	if(!component_parent?.parent)
+		return
+	setup_generic_item_hint()
+
 /datum/xenoartifact_trait/major/gas/trigger(datum/source, _priority, atom/override)
 	. = ..()
 	if(!.)
 		return
-	var/turf/T = get_turf(component_parent.parent)
-	var/datum/gas_mixture/air = T.return_air()
-	if(!air)
+	var/turf/open/T = get_turf(component_parent.parent)
+	var/datum/gas_mixture/air = T.air
+	if(!istype(T) || !air)
 		return
-	var/input_id = initial(choosen_target.id)
-	var/output_id = initial(choosen_exchange.id)
-	var/moles = min(air.total_moles(input_id), max_moles)
-	if(!input_id || !output_id || !moles)
+	var/moles = min(air.total_moles(choosen_target), max_moles)
+	if(!moles)
 		return
-	SET_MOLES(input_id, air, -moles)
-	SET_MOLES(output_id, air, moles)
+	SET_MOLES(choosen_target, air, -moles)
+	SET_MOLES(choosen_exchange, air, moles)
 
 /datum/xenoartifact_trait/major/gas/get_dictionary_hint()
 	. = ..()
-	return list(XENOA_TRAIT_HINT_RANDOMISED)
+	return list(XENOA_TRAIT_HINT_RANDOMISED, XENOA_TRAIT_HINT_DETECT("gas analyzer, which will also reveal what gasses the artifact exchanges."))
 
 /datum/xenoartifact_trait/major/gas/do_hint(mob/user, atom/item)
 	if(istype(item, /obj/item/analyzer))

--- a/code/modules/xenoarchaeology/traits/minors/haunted.dm
+++ b/code/modules/xenoarchaeology/traits/minors/haunted.dm
@@ -68,11 +68,12 @@
 		return
 	//Find a target
 	for(var/atom/target in oview(component_parent.target_range, get_turf(component_parent?.parent)))
-		if(!isliving(target))
+		if(!isliving(target) || iscameramob(target) || isobserver(target)) //We can't register cameras or observers, but we shouldn't waste an activation
 			continue
 		component_parent.register_target(target, TRUE)
 		component_parent.trigger(TRUE)
 		return
+	component_parent.trigger(TRUE)
 
 //Instant variant, no move delay. Can only move when not seen
 /datum/xenoartifact_trait/minor/haunted/instant

--- a/code/modules/xenoarchaeology/traits/minors/haunted.dm
+++ b/code/modules/xenoarchaeology/traits/minors/haunted.dm
@@ -68,6 +68,8 @@
 		return
 	//Find a target
 	for(var/atom/target in oview(component_parent.target_range, get_turf(component_parent?.parent)))
+		if(!isliving(target))
+			continue
 		component_parent.register_target(target, TRUE)
 		component_parent.trigger(TRUE)
 		return

--- a/code/modules/xenoarchaeology/traits/minors/haunted.dm
+++ b/code/modules/xenoarchaeology/traits/minors/haunted.dm
@@ -71,7 +71,6 @@
 		if(!isliving(target) || iscameramob(target) || isobserver(target)) //We can't register cameras or observers, but we shouldn't waste an activation
 			continue
 		component_parent.register_target(target, TRUE)
-		component_parent.trigger(TRUE)
 		return
 	component_parent.trigger(TRUE)
 

--- a/code/modules/xenoarchaeology/traits/minors/haunted.dm
+++ b/code/modules/xenoarchaeology/traits/minors/haunted.dm
@@ -71,8 +71,7 @@
 		if(!isliving(target) || iscameramob(target) || isobserver(target)) //We can't register cameras or observers, but we shouldn't waste an activation
 			continue
 		component_parent.register_target(target, TRUE)
-		component_parent.trigger(TRUE)
-		return
+		break
 	component_parent.trigger(TRUE)
 
 //Instant variant, no move delay. Can only move when not seen

--- a/code/modules/xenoarchaeology/traits/minors/haunted.dm
+++ b/code/modules/xenoarchaeology/traits/minors/haunted.dm
@@ -68,7 +68,7 @@
 		return
 	//Find a target
 	for(var/atom/target in oview(component_parent.target_range, get_turf(component_parent?.parent)))
-		if(!isliving(target)) //We can't register cameras or observers, but we shouldn't waste an activation
+		if(!isliving(target))
 			continue
 		component_parent.register_target(target, TRUE)
 		break

--- a/code/modules/xenoarchaeology/traits/minors/haunted.dm
+++ b/code/modules/xenoarchaeology/traits/minors/haunted.dm
@@ -68,7 +68,7 @@
 		return
 	//Find a target
 	for(var/atom/target in oview(component_parent.target_range, get_turf(component_parent?.parent)))
-		if(!isliving(target) || iscameramob(target) || isobserver(target)) //We can't register cameras or observers, but we shouldn't waste an activation
+		if(!isliving(target)) //We can't register cameras or observers, but we shouldn't waste an activation
 			continue
 		component_parent.register_target(target, TRUE)
 		break

--- a/code/modules/xenoarchaeology/traits/minors/haunted.dm
+++ b/code/modules/xenoarchaeology/traits/minors/haunted.dm
@@ -71,6 +71,7 @@
 		if(!isliving(target) || iscameramob(target) || isobserver(target)) //We can't register cameras or observers, but we shouldn't waste an activation
 			continue
 		component_parent.register_target(target, TRUE)
+		component_parent.trigger(TRUE)
 		return
 	component_parent.trigger(TRUE)
 


### PR DESCRIPTION
## About The Pull Request

Fixes the porous artifact trait. This trait started run timing at some point, very bad, stopped it from working.
Additionally adds tool hints. This was in the previous version of xenoarch 1.0, but it wasn't ported due to error-cohol.

Additionally 'fixes' the haunted trait. This trait would select the first valid target it could, which would usually be the floor, which is bad. It will now select the first living valid target it can.

## Why It's Good For The Game

Bugs & runtimes r bad

## Testing Photographs and Procedure
<summary>Screenshots&Videos</summary>
<details>

<img width="215" height="372" alt="image" src="https://github.com/user-attachments/assets/2fe19c2c-aed6-42ea-aa46-30b3ae3705fb" />

<img width="658" height="18" alt="image" src="https://github.com/user-attachments/assets/8c3de8f6-9f46-454c-810c-4a470abc3eaa" />

</details>

## Changelog
:cl: @DrDuckedGoose code @aramix273 sleuthing help, feedback, and suggestions
fix: Fixed runtime in artifact trait code, for the porous trait.
tweak: The haunted artifact trait will now exclusively target living mobs.
/:cl:
