### PR TITLE
APC improvements - Fix missing cell runtime error and add RPED support

### DIFF
--- a/code/modules/power/apc/apc_main.dm
+++ b/code/modules/power/apc/apc_main.dm
@@ -564,15 +564,15 @@
 	// Now checks for cell presence to avoid runtime errors when calling percent() on a null
 	if (cell)
 		lighting = update_channel(lighting, light_power_req,
-		  (cell.percent() > 95 && (surplus() + cell.charge - (environ_power_req + equip_power_req)) > light_power_req),
-		  (environ_power_req + equip_power_req),
-		  TRUE) // only lighting triggers alarms
+			(cell.percent() > 95 && (surplus() + cell.charge - (environ_power_req + equip_power_req)) > light_power_req),
+			(environ_power_req + equip_power_req),
+			TRUE) // only lighting triggers alarms
       
 		equipment = update_channel(equipment, equip_power_req,
-		  (cell.percent() >= 15 && (surplus() + cell.charge - environ_power_req) > equip_power_req), environ_power_req, FALSE)
-      
+			(cell.percent() >= 15 && (surplus() + cell.charge - environ_power_req) > equip_power_req), environ_power_req, FALSE)
+
 		environ = update_channel(environ, environ_power_req,
-		  (cell.percent() > 15 && (surplus() + cell.charge) > environ_power_req), 0, FALSE)
+			(cell.percent() > 15 && (surplus() + cell.charge) > environ_power_req), 0, FALSE)
 	else
 		lighting = autoset(lighting, AUTOSET_FORCE_OFF)
 		equipment = autoset(equipment, AUTOSET_FORCE_OFF)

--- a/code/modules/power/apc/apc_main.dm
+++ b/code/modules/power/apc/apc_main.dm
@@ -567,7 +567,7 @@
 			(cell.percent() > 95 && (surplus() + cell.charge - (environ_power_req + equip_power_req)) > light_power_req),
 			(environ_power_req + equip_power_req),
 			TRUE) // only lighting triggers alarms
-      
+
 		equipment = update_channel(equipment, equip_power_req,
 			(cell.percent() >= 15 && (surplus() + cell.charge - environ_power_req) > equip_power_req), environ_power_req, FALSE)
 

--- a/code/modules/research/stock_parts.dm
+++ b/code/modules/research/stock_parts.dm
@@ -28,12 +28,15 @@ If you create T5+ please take a pass at gene_modder.dm [L40]. Max_values MUST fi
 	if(ismachinery(attacked_object))
 		var/obj/machinery/attacked_machinery = attacked_object
 
-		if(!attacked_machinery.component_parts)
+		if(!attacked_machinery.component_parts && !istype(attacked_machinery, /obj/machinery/power/apc)) // Check for APC specifically since it has no component_parts
 			return ..()
 
 		if(works_from_distance)
 			user.Beam(attacked_machinery, icon_state = "rped_upgrade", time = 5)
-		attacked_machinery.exchange_parts(user, src)
+		if (!istype(attacked_machinery, /obj/machinery/power/apc) || astype(attacked_machinery, /obj/machinery/power/apc).cell) // If this is an APC, only exchange if it has a cell
+			attacked_machinery.exchange_parts(user, src)
+		else // Otherwise we need to bo attackby since APCs don't exist as a machine frame before assembly
+			attacked_machinery.attackby(src, user)
 		return TRUE
 
 	var/obj/structure/frame/machine/attacked_frame = attacked_object
@@ -56,7 +59,7 @@ If you create T5+ please take a pass at gene_modder.dm [L40]. Max_values MUST fi
 	if(ismachinery(attacked_object))
 		var/obj/machinery/attacked_machinery = attacked_object
 
-		if(!attacked_machinery.component_parts)
+		if(!attacked_machinery.component_parts && !istype(attacked_machinery, /obj/machinery/power/apc)) // Check for APC specifically since it has no component_parts
 			return ..()
 
 		if(works_from_distance)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

APC improvements - Enable RPED interaction and reduce runtime errors during channel activation when no cell is present

## Why It's Good For The Game

Reducing unhandled errors is always good. Without this change, an APC with no cell was getting caught up every cycle when it went to recalculate which channels should be active because of how it was calling percent() on a null.

APCs stand out as something that should be RPED-compatible. They have a power cell which can be upgraded, and using an RPED makes this much easier while avoiding power net disruptions. This will allow engineers or scientists to make the station's powernet more durable with bigger backups in each APC.

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

Without this change, an RPED would not interact with an APC in any state, mainly due to the fact that they are machines but do not have a component_parts list.

**Now an RPED can insert a cell into an APC that needs one**
<img width="952" height="465" alt="AllowsAddingWhenEmpty" src="https://github.com/user-attachments/assets/cb0b4e11-aff9-4dab-bece-4e2824dd9f0c" />

**But not if there's no connector! (Follows the same rules as if you were interacting by hand)**
<img width="835" height="466" alt="StillChecksForConnector" src="https://github.com/user-attachments/assets/69a03387-ff69-48c9-bad3-5a8af46ce095" />

**If the APC is closed and you're using a regular RPED, you get the usual message examining the contents**
<img width="975" height="463" alt="AllowsExaminingParts" src="https://github.com/user-attachments/assets/232406ec-d21e-4e25-bd0d-b075fef63cb0" />

**Unlocking/opening the cover allows upgrading the cell in place without disrupting power**
<img width="974" height="460" alt="AllowsReplacingWhenOpen" src="https://github.com/user-attachments/assets/e0197176-fa73-4637-9bef-e2261c75d1d3" />

**A bluespace RPED will let you interact/upgrade when the cover is closed just like other machines**
<img width="1091" height="460" alt="BSWorksWithCoverClosed" src="https://github.com/user-attachments/assets/9f1d5c4a-4f89-46c3-94b2-18c519df3f8a" />


</details>

## Changelog
:cl:
add: Added the ability to use an RPED with APCs
fix: fixed some runtime errors that occur with APCs that have no cell
/:cl:
