### PR TITLE
Restores optional input text to "spawn" admin verb

### DIFF
--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -487,7 +487,7 @@
 
 ////////////////////////////////////////////////////////////////////////////////////////////////ADMIN HELPER PROCS
 
-/datum/admins/proc/spawn_atom()
+/datum/admins/proc/spawn_atom(input as null|text)
 	set category = "Debug"
 	set desc = "(atom path) Spawn an atom"
 	set name = "Spawn"
@@ -495,7 +495,9 @@
 	if(!check_rights(R_SPAWN))
 		return
 
-	var/chosen = pick_closest_path(tgui_input_text(usr, "Spawn an atom:", "Spawn"))
+	if (!input)
+		input = tgui_input_text(usr, "Spawn an atom:", "Spawn")
+	var/chosen = pick_closest_path(input)
 	if(!chosen)
 		return
 	var/turf/T = get_turf(usr)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

during #12720, spawn verb was changed to use tgui prompts instead of windows dialogues as part of tguification attempts
however, this introduced a slight functionality loss in that the verb would no longer accept text parameters
this is slightly inconvenient as it affects workflow of users, but it also seems to be unintended
the likely explanation is that using a "text" parameter would have forced the user to provide a text, meaning that if it's missing, it would spawn a windows dialog, which was probably against the scope of #12720 - ultimately, two separate prompts were used, first for figuring input, second for actually searching for it
fortunately, we can use "null|text" to make the text parameter optional, then treat the null case ourselves by only then spawning the first input dialog
 
## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->
this PR restores the previous workflow used by admins where if they knew exactly what they're spawning, they could skip one or both of the input dialogues, which should improve quality of life, while also keeping behavior where unspecified input is treated friendly by providing prompts

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

Test case: following prompts were used
```
spawn crystal/blue
spawn crystal/inexistent
spawn
spawn crystal/bluespace
```


https://github.com/user-attachments/assets/b6dbbc63-2d25-4759-9dc2-481a2e9f3cae

perceived jank could be explained by either wine simulation on linux or mp4 video compression artifacts

</details>

## Changelog
:cl: Aramix
admin: "spawn" verb optionally accepts input text from command bar once again
/:cl: