### PR TITLE
Disables respawning logic by default

### DIFF
--- a/config/config.txt
+++ b/config/config.txt
@@ -227,7 +227,7 @@ DEFAULT_NO_VOTE
 ## 0 = Cannot respawn (default)
 ## 1 = Can respawn
 ## 2 = Can respawn if choosing a different character
-ALLOW_RESPAWN 2
+ALLOW_RESPAWN 0
 
 ## Respawn delay(in deciseconds), which doesn't allow to return to lobby, default 5 minutes
 RESPAWN_DELAY 3000


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Disables respawning logic for the default config. This is extremely annoying when you want to test something because it will not let you rejoin the round.

## Why It's Good For The Game

When playing locally, you probably don't want the respawn logic enabled since it just gets in the way of testing. Any downstreams can manually configure the config to get the results they want.

## Testing Photographs and Procedure

N/A Config Change

## Changelog
:cl:
config: The default (local) config no longer has respawning enabled.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
