### PR TITLE
Fixes a config setting not working

### DIFF
--- a/code/__DEFINES/role_preferences.dm
+++ b/code/__DEFINES/role_preferences.dm
@@ -208,6 +208,8 @@ GLOBAL_LIST_INIT(other_bannable_roles, list(
 				to_chat(src, "<span class='warning'>You are banned from this role!</span>")
 			return FALSE
 	if(req_hours) //minimum living hour count
+		if(CONFIG_GET(flag/use_exp_restrictions_admin_bypass) && check_rights_for(src, R_ADMIN))
+			return TRUE
 		if((src.get_exp_living(TRUE)/60) < req_hours)
 			if(feedback)
 				to_chat(src, "<span class='warning'>You do not have enough living hours to take this role ([req_hours]hrs required)!</span>")

--- a/code/modules/client/preferences/middleware/antags.dm
+++ b/code/modules/client/preferences/middleware/antags.dm
@@ -113,6 +113,8 @@
 /datum/preference_middleware/antags/proc/get_antag_living_playtime_hours_left()
 	if(!preferences.parent)
 		return list()
+	if(CONFIG_GET(flag/use_exp_restrictions_admin_bypass) && check_rights_for(preferences.parent, R_ADMIN))
+		return list()
 	var/list/antag_living_playtime_hours_left = list()
 
 	for(var/type in GLOB.role_preference_entries)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes the use_exp_restrictions_admin_bypass not working for antagonist role checks.

## Why It's Good For The Game

The time limit on antagonists are insanely annoying when you are locally testing anything that involves antagonists without a DB setup. There is no greater sin than to make something annoying for a dev.

## Testing Photographs and Procedure

<img width="1195" height="765" alt="image" src="https://github.com/user-attachments/assets/4d1eb3b2-4a7e-417e-be3e-190222d8c3d3" />

<img width="905" height="129" alt="image" src="https://github.com/user-attachments/assets/fb9a15d4-38a5-4876-90e0-66995ae414c4" />

<img width="706" height="557" alt="image" src="https://github.com/user-attachments/assets/2da53549-6510-42e9-9d6a-4467aff86578" />

Deadmin:

<img width="748" height="258" alt="image" src="https://github.com/user-attachments/assets/eb2415cb-f0df-44b4-ad9e-be2f9934dc38" />

No events appearing despite having 100 midround points.

<img width="1189" height="111" alt="image" src="https://github.com/user-attachments/assets/67d003cd-2063-427b-bcc0-c43655c32169" />

Re-admin to show the above test actually means something:

<img width="846" height="30" alt="image" src="https://github.com/user-attachments/assets/79cab91b-a52f-4f44-8029-ea2e8e3409b2" />


## Changelog
:cl:
tweak: Admins can now bypass antagonist time restrictions when the use_exp_restrictions_admin_bypass flag is set, making local testing easier.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
