### PR TITLE
Reagent dispenser lag hotfix

### DIFF
--- a/code/modules/reagents/reagent_dispenser.dm
+++ b/code/modules/reagents/reagent_dispenser.dm
@@ -119,7 +119,7 @@
 		if(!fuel_amt)
 			visible_message(span_danger("\The [src] ruptures!"))
 		// Leave it up to future terrorists to figure out the best way to mix reagents with fuel for a useful boom here
-		chem_splash(loc, 2 + (reagents.total_volume + fuel_amt) / 1000, list(reagents), extra_heat=(fuel_amt / 50), adminlog=(fuel_amt<25))
+		chem_splash(loc, min(2 + (reagents.total_volume + fuel_amt) / 1000, 6), list(reagents), extra_heat=(fuel_amt / 50), adminlog=(fuel_amt<25))
 
 	if(fuel_amt) // with that done, actually explode
 		visible_message(span_danger("\The [src] explodes!"))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

fixes #13753

Under certain conditions, reagent dispensers can have a lot of reagent units. This is bad when you have linear scaling on reagent dispersion range and a really inefficient algorithm for dispersion which scales with something like O(n^2).

## Why It's Good For The Game

Hotfixes a lag issue.

## Testing Photographs and Procedure

<img width="334" height="132" alt="image" src="https://github.com/user-attachments/assets/186f34ae-db3f-4bf8-b602-34bff2006745" />

<img width="654" height="771" alt="image" src="https://github.com/user-attachments/assets/80a85675-3031-4680-9fbd-b917fec4618a" />

No lag

## Changelog
:cl:
fix: Fixes a lag issue caused by reagent containers detonating under certain conditions.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
