### PR TITLE
No midround ghost role repeats

### DIFF
--- a/code/controllers/subsystem/dynamic/dynamic_rulesets_midround_ghost.dm
+++ b/code/controllers/subsystem/dynamic/dynamic_rulesets_midround_ghost.dm
@@ -8,6 +8,7 @@
 
 /datum/dynamic_ruleset/midround/ghost
 	abstract_type = /datum/dynamic_ruleset/midround/ghost
+	ruleset_flags = CANNOT_REPEAT
 
 	/// List of possible locations for this antag to spawn
 	var/list/spawn_locations = list()
@@ -159,7 +160,6 @@
 	minimum_players_required = 20
 	weight = 4
 	use_spawn_locations = FALSE
-	ruleset_flags = CANNOT_REPEAT
 
 	var/datum/team/nuclear/team
 	var/has_made_leader = FALSE
@@ -194,7 +194,6 @@
 	minimum_players_required = 13
 	weight = 4
 	use_spawn_locations = FALSE
-	ruleset_flags = CANNOT_REPEAT
 
 /datum/dynamic_ruleset/midround/ghost/blob/get_poll_icon()
 	var/icon/blob_icon = icon('icons/mob/blob.dmi', icon_state = "blob_core")
@@ -219,7 +218,6 @@
 	points_cost = 50
 	minimum_players_required = 20
 	weight = 4
-	ruleset_flags = CANNOT_REPEAT
 
 /datum/dynamic_ruleset/midround/ghost/xenomorph_infestation/get_poll_icon()
 	return /mob/living/carbon/alien/larva
@@ -263,7 +261,6 @@
 	points_cost = 40
 	weight = 4
 	minimum_players_required = 10
-	ruleset_flags = CANNOT_REPEAT
 
 /datum/dynamic_ruleset/midround/ghost/space_dragon/get_poll_icon()
 	return /mob/living/simple_animal/hostile/space_dragon
@@ -292,7 +289,6 @@
 	antag_datum = /datum/antagonist/ninja
 	points_cost = 40
 	weight = 4
-	ruleset_flags = CANNOT_REPEAT
 
 /datum/dynamic_ruleset/midround/ghost/ninja/get_poll_icon()
 	return /obj/item/energy_katana
@@ -516,7 +512,6 @@
 	antag_datum = /datum/antagonist/swarmer
 	points_cost = 40
 	weight = 4
-	ruleset_flags = CANNOT_REPEAT
 
 	var/announce_probability = 25
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Midround ghost roles are now banned from repeating.

## Why It's Good For The Game

Having 2 morphs or 2 revenants really sucks. If we are going to be an insanely long round that ends up spawning a lot, at least make what it spawns more diverse so one of them has a chance at ending the round before it goes bad.

## Testing Photographs and Procedure

<img width="1181" height="303" alt="image" src="https://github.com/user-attachments/assets/7d8dd5b6-8b1d-45ca-9808-6ba394b9fc19" />

Unfortunately kind of hard to test locally, however this is only a simple flag change.

## Changelog
:cl:
tweak: All midround ghost roles can only execute once per-round.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
