### PR TITLE
SEPUTT (Slightly Earlier Present Under The Tree)

### DIFF
--- a/code/__DEFINES/time.dm
+++ b/code/__DEFINES/time.dm
@@ -22,6 +22,7 @@
 #define EASTER					"Easter"
 #define HALLOWEEN				"Halloween"
 #define CHRISTMAS				"Christmas"
+#define CHRISTMAS_TREE			"Christmas Tree"
 #define FESTIVE_SEASON			"Festive Season"
 #define GARBAGEDAY				"Garbage Day"
 

--- a/code/modules/events/holiday/xmas.dm
+++ b/code/modules/events/holiday/xmas.dm
@@ -78,7 +78,7 @@
 
 /obj/effect/spawner/xmastree/Initialize(mapload)
 	. = ..()
-	if((CHRISTMAS in SSevents.holidays) && christmas_tree)
+	if((CHRISTMAS_TREE in SSevents.holidays) && christmas_tree)
 		new christmas_tree(get_turf(src))
 	else if((FESTIVE_SEASON in SSevents.holidays) && festive_tree)
 		new festive_tree(get_turf(src))

--- a/code/modules/holiday/holidays.dm
+++ b/code/modules/holiday/holidays.dm
@@ -541,6 +541,11 @@ Since Ramadan is an entire month that lasts 29.5 days on average, the start and 
 	for(var/mob/living/basic/pet/dog/corgi/ian/Ian in GLOB.mob_living_list)
 		Ian.place_on_head(new /obj/item/clothing/head/helmet/space/santahat(Ian))
 
+/datum/holiday/christmas_tree
+	name = CHRISTMAS_TREE //This controls the days where the xmas tree with presents spawns.
+	begin_day = 14
+	begin_month = DECEMBER
+	end_day = 28
 
 /datum/holiday/festive_season
 	name = FESTIVE_SEASON


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Makes the 3 day period of christmas presents, which most Beestationer's won't be playing Beestation, The 24th to 26th, extend to 14 day period instead, 14th to the 28th, allowing more JOYOUS activities to occur in a longer time span, while allowing more Beestationer's to actually play during the event instead of being off celebrating.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

I believe it will bring more memorable moments, allow more people to experience it and might even boost pop.

**IF YOU WANT TO KEY THIS, MAYBE MAKE A PLAYER INPUTS POLL TO ASK IF PEOPLE WANT THIS PR OR NOT!!**

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

Not needed, just check the code it is barely any lines.

</details>

## Changelog
:cl: Bieyes
tweak: Presents are now under the tree during the 14th to the 28th
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
