### PR TITLE
Fix oozeling limb regeneration potentially crashing the server

### DIFF
--- a/code/__DEFINES/do_afters.dm
+++ b/code/__DEFINES/do_afters.dm
@@ -3,3 +3,4 @@
 #define DOAFTER_SOURCE_SURVIVALPEN "doafter_survivalpen"
 #define DOAFTER_SOURCE_GETTING_UP "doafter_gettingup"
 #define DOAFTER_SOURCE_CLIMBING_LADDER "doafter_climbingladder"
+#define DOAFTER_SOURCE_REGEN_LIMBS "doafter_regen_limbs"

--- a/code/modules/mob/living/carbon/human/species_types/oozelings.dm
+++ b/code/modules/mob/living/carbon/human/species_types/oozelings.dm
@@ -171,9 +171,8 @@
 			if(!do_after(H, 3 SECONDS, target = H, interaction_key = DOAFTER_SOURCE_REGEN_LIMBS))
 				to_chat(H, span_warning("...but you must stay still in order to focus on regenerating!"))
 				return
-			var/healed_limb = pick(limbs_to_heal)
+			var/healed_limb = pick_n_take(limbs_to_heal)
 			H.regenerate_limb(healed_limb)
-			limbs_to_heal -= healed_limb
 			H.blood_volume -= 80
 			H.nutrition -= 20
 		return

--- a/code/modules/mob/living/carbon/human/species_types/oozelings.dm
+++ b/code/modules/mob/living/carbon/human/species_types/oozelings.dm
@@ -163,11 +163,13 @@
 			H.blood_volume -= 80*limbs_to_heal.len
 			H.nutrition -= 20*limbs_to_heal.len
 			to_chat(H, span_notice("...and after a moment you finish reforming!"))
+		else
+			to_chat(H, span_warning("...but you must stay still in order to focus on regenerating!"))
 		return
 	if(H.blood_volume >= 80)//We can partially heal some limbs
 		while(H.blood_volume >= BLOOD_VOLUME_OKAY+80 && LAZYLEN(limbs_to_heal))
 			if(!do_after(H, 3 SECONDS, target = H, interaction_key = DOAFTER_SOURCE_REGEN_LIMBS))
-				to_chat(H, span_warning("...but there is not enough of you to fix everything! You must attain more blood volume to heal completely!"))
+				to_chat(H, span_warning("...but you must stay still in order to focus on regenerating!"))
 				return
 			var/healed_limb = pick(limbs_to_heal)
 			H.regenerate_limb(healed_limb)

--- a/code/modules/mob/living/carbon/human/species_types/oozelings.dm
+++ b/code/modules/mob/living/carbon/human/species_types/oozelings.dm
@@ -150,13 +150,15 @@
 
 /datum/action/innate/regenerate_limbs/on_activate()
 	var/mob/living/carbon/human/H = owner
+	if(DOING_INTERACTION(H, DOAFTER_SOURCE_REGEN_LIMBS))
+		return
 	var/list/limbs_to_heal = H.get_missing_limbs()
 	if(!LAZYLEN(limbs_to_heal))
 		to_chat(H, span_notice("You feel intact enough as it is."))
 		return
 	to_chat(H, span_notice("You focus intently on your missing [limbs_to_heal.len >= 2 ? "limbs" : "limb"]..."))
 	if(H.blood_volume >= 80*limbs_to_heal.len+BLOOD_VOLUME_OKAY)
-		if(do_after(H, 60, target = H))
+		if(do_after(H, 6 SECONDS, target = H, interaction_key = DOAFTER_SOURCE_REGEN_LIMBS))
 			H.regenerate_limbs()
 			H.blood_volume -= 80*limbs_to_heal.len
 			H.nutrition -= 20*limbs_to_heal.len
@@ -164,13 +166,14 @@
 		return
 	if(H.blood_volume >= 80)//We can partially heal some limbs
 		while(H.blood_volume >= BLOOD_VOLUME_OKAY+80 && LAZYLEN(limbs_to_heal))
-			if(do_after(H, 30, target = H))
-				var/healed_limb = pick(limbs_to_heal)
-				H.regenerate_limb(healed_limb)
-				limbs_to_heal -= healed_limb
-				H.blood_volume -= 80
-				H.nutrition -= 20
-			to_chat(H, span_warning("...but there is not enough of you to fix everything! You must attain more blood volume to heal completely!"))
+			if(!do_after(H, 3 SECONDS, target = H, interaction_key = DOAFTER_SOURCE_REGEN_LIMBS))
+				to_chat(H, span_warning("...but there is not enough of you to fix everything! You must attain more blood volume to heal completely!"))
+				return
+			var/healed_limb = pick(limbs_to_heal)
+			H.regenerate_limb(healed_limb)
+			limbs_to_heal -= healed_limb
+			H.blood_volume -= 80
+			H.nutrition -= 20
 		return
 	to_chat(H, span_warning("...but there is not enough of you to go around! You must attain more blood volume to heal!"))
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

this makes it so the regen limb loop just stops if the `do_after` is canceled.

also makes it use interaction keys so that you can't start as many loops as you want.

## Why It's Good For The Game

crash bad

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>

## Changelog
:cl:
fix: Fixed oozeling limb regeneration potentially crashing the server.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
