### PR TITLE
Reverts newcuffs

### DIFF
--- a/code/__DEFINES/combat.dm
+++ b/code/__DEFINES/combat.dm
@@ -97,7 +97,7 @@
 #define CLICK_CD_RAPID 2
 #define CLICK_CD_HYPER_RAPID 1
 #define CLICK_CD_CLICK_ABILITY 6
-#define CLICK_CD_BREAKOUT 20
+#define CLICK_CD_BREAKOUT 100
 #define CLICK_CD_HANDCUFFED 10
 #define CLICK_CD_RESIST 20
 #define CLICK_CD_GRABBING 10
@@ -107,6 +107,7 @@
 
 //Cuff resist speeds
 #define FAST_CUFFBREAK 1
+#define INSTANT_CUFFBREAK 2
 
 //Grab levels
 #define GRAB_PASSIVE 0

--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -447,7 +447,7 @@ GLOBAL_LIST_INIT(available_random_trauma_list, list(
 #define GRAB_PIXEL_SHIFT_AGGRESSIVE 12
 #define GRAB_PIXEL_SHIFT_NECK 16
 
-#define PULL_PRONE_SLOWDOWN 4
+#define PULL_PRONE_SLOWDOWN 1.5
 #define HUMAN_CARRY_SLOWDOWN 0.35
 
 #define SLEEP_CHECK_DEATH(X) sleep(X); if(QDELETED(src) || stat == DEAD) return;

--- a/code/_onclick/hud/alert.dm
+++ b/code/_onclick/hud/alert.dm
@@ -841,14 +841,16 @@ Recharging stations are available in robotics, the dormitory bathrooms, and the 
 	if(!istype(L) || !L.can_resist() || L != owner)
 		return
 	L.changeNext_move(CLICK_CD_RESIST)
-	return L.resist_restraints()
+	if((L.mobility_flags & MOBILITY_MOVE) && (L.last_special <= world.time))
+		return L.resist_restraints()
 
 /atom/movable/screen/alert/restrained/buckled/Click()
 	var/mob/living/L = usr
 	if(!istype(L) || !L.can_resist() || L != owner)
 		return
 	L.changeNext_move(CLICK_CD_RESIST)
-	return L.resist_buckle()
+	if(L.last_special <= world.time)
+		return L.resist_buckle()
 
 // PRIVATE = only edit, use, or override these if you're editing the system as a whole
 

--- a/code/_onclick/hud/alert.dm
+++ b/code/_onclick/hud/alert.dm
@@ -837,12 +837,12 @@ Recharging stations are available in robotics, the dormitory bathrooms, and the 
 	clickable_glow = TRUE
 
 /atom/movable/screen/alert/restrained/Click()
-	var/mob/living/L = usr
-	if(!istype(L) || !L.can_resist() || L != owner)
+	var/mob/living/living_mob = usr
+	if(!istype(living_mob) || !living_mob.can_resist() || living_mob != owner)
 		return
-	L.changeNext_move(CLICK_CD_RESIST)
-	if((L.mobility_flags & MOBILITY_MOVE) && (L.last_special <= world.time))
-		return L.resist_restraints()
+	living_mob.changeNext_move(CLICK_CD_RESIST)
+	if((living_mob.mobility_flags & MOBILITY_MOVE) && (living_mob.last_special <= world.time))
+		return living_mob.resist_restraints()
 
 /atom/movable/screen/alert/restrained/buckled/Click()
 	var/mob/living/L = usr

--- a/code/_onclick/hud/alert.dm
+++ b/code/_onclick/hud/alert.dm
@@ -828,9 +828,7 @@ Recharging stations are available in robotics, the dormitory bathrooms, and the 
 
 /atom/movable/screen/alert/restrained/handcuffed
 	name = "Handcuffed"
-	desc = "You're handcuffed and can't act. If anyone drags you, you won't be able to move. \
-		Left-click the alert to free yourself over time. \
-		Right-click the alert if you're willing to severely injure yourself to break out immediately."
+	desc = "You're handcuffed and can't act. If anyone drags you, you won't be able to move. Click the alert to free yourself."
 	clickable_glow = TRUE
 
 /atom/movable/screen/alert/restrained/legcuffed
@@ -838,20 +836,12 @@ Recharging stations are available in robotics, the dormitory bathrooms, and the 
 	desc = "You're legcuffed, which slows you down considerably. Click the alert to free yourself."
 	clickable_glow = TRUE
 
-/atom/movable/screen/alert/restrained/Click(location, control, params)
-	var/mob/living/living_mob = usr
-	if(!istype(living_mob) || !living_mob.can_resist() || living_mob != owner)
+/atom/movable/screen/alert/restrained/Click()
+	var/mob/living/L = usr
+	if(!istype(L) || !L.can_resist() || L != owner)
 		return
-
-	living_mob.changeNext_move(CLICK_CD_RESIST)
-
-	var/list/parameters = params2list(params)
-	if(LAZYACCESS(parameters, RIGHT_CLICK))
-		var/mob/living/carbon/human/human_mob = living_mob
-		if(ishuman(human_mob) && human_mob.handcuffed)
-			return human_mob.breakout_breaking_arms()
-
-	return living_mob.resist_restraints()
+	L.changeNext_move(CLICK_CD_RESIST)
+	return L.resist_restraints()
 
 /atom/movable/screen/alert/restrained/buckled/Click()
 	var/mob/living/L = usr

--- a/code/datums/status_effects/debuffs/debuffs.dm
+++ b/code/datums/status_effects/debuffs/debuffs.dm
@@ -496,27 +496,23 @@
 	deltimer(timerid)
 
 /datum/status_effect/gonbola_pacify
-	id = "gonbolaPacify"
+	id = "gondola_pacify"
 	status_type = STATUS_EFFECT_MULTIPLE
 	tick_interval = STATUS_EFFECT_NO_TICK
 	alert_type = null
 
 /datum/status_effect/gonbola_pacify/on_apply()
-	ADD_TRAIT(owner, TRAIT_PACIFISM, "gonbolaPacify")
-	ADD_TRAIT(owner, TRAIT_MUTE, "gonbolaMute")
-	ADD_TRAIT(owner, TRAIT_JOLLY, "gonbolaJolly")
+	owner.add_traits(list(TRAIT_PACIFISM, TRAIT_MUTE, TRAIT_JOLLY), TRAIT_STATUS_EFFECT(id))
 	to_chat(owner, span_notice("You suddenly feel at peace and feel no need to make any sudden or rash actions."))
 	return ..()
 
 /datum/status_effect/gonbola_pacify/on_remove()
-	REMOVE_TRAIT(owner, TRAIT_PACIFISM, "gonbolaPacify")
-	REMOVE_TRAIT(owner, TRAIT_MUTE, "gonbolaMute")
-	REMOVE_TRAIT(owner, TRAIT_JOLLY, "gonbolaJolly")
+	owner.remove_traits(list(TRAIT_PACIFISM, TRAIT_MUTE, TRAIT_JOLLY), TRAIT_STATUS_EFFECT(id))
 
 /datum/status_effect/trance
 	id = "trance"
 	status_type = STATUS_EFFECT_UNIQUE
-	duration = 300
+	duration = 30 SECONDS
 	tick_interval = 1 SECONDS
 	alert_type = /atom/movable/screen/alert/status_effect/trance
 	var/stun = TRUE

--- a/code/datums/status_effects/debuffs/debuffs.dm
+++ b/code/datums/status_effects/debuffs/debuffs.dm
@@ -213,29 +213,7 @@
 	desc = "Your biological functions have halted. You could live forever this way, but it's pretty boring."
 	icon_state = "stasis"
 
-//BOLA TRACKING
-/datum/status_effect/bola
-	id = "bola"
-	status_type = STATUS_EFFECT_REPLACE
-	alert_type = null
-	var/obj/item/linked_bola
-
-/datum/status_effect/bola/on_creation(mob/living/new_owner, bola_duration, obj/item/bola)
-	linked_bola = bola
-	duration = bola_duration
-	return ..()
-
-/datum/status_effect/bola/on_remove()
-	var/mob/living/carbon/carbon_owner = owner
-	if(carbon_owner?.legcuffed == linked_bola)
-		var/turf/owner_turf = get_turf(carbon_owner)
-		linked_bola.forceMove(owner_turf)
-		carbon_owner.legcuffed = null
-		carbon_owner.update_worn_legcuffs()
-
-/datum/status_effect/bola/Destroy()
-	. = ..()
-	linked_bola = null
+//GOLEM GANG
 
 //OTHER DEBUFFS
 /datum/status_effect/strandling //get it, strand as in durathread strand + strangling = strandling hahahahahahahahahahhahahaha i want to die

--- a/code/game/objects/items/handcuffs.dm
+++ b/code/game/objects/items/handcuffs.dm
@@ -1,5 +1,5 @@
 /obj/item/restraints
-	breakouttime = 600
+	breakouttime = 1 MINUTES
 	item_flags = ISWEAPON
 
 /obj/item/restraints/suicide_act(mob/living/carbon/user)
@@ -188,7 +188,7 @@
 	lefthand_file = 'icons/mob/inhands/equipment/security_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/security_righthand.dmi'
 	custom_materials = null
-	breakouttime = 450 //Deciseconds = 45s
+	breakouttime = 45 SECONDS
 	trashtype = /obj/item/restraints/handcuffs/cable/zipties/used
 	color = null
 
@@ -214,7 +214,7 @@
 	throwforce = 0
 	w_class = WEIGHT_CLASS_NORMAL
 	slowdown = 7
-	breakouttime = 300	//Deciseconds = 30s = 0.5 minute
+	breakouttime = 30 SECONDS
 
 /obj/item/restraints/legcuffs/beartrap
 	name = "bear trap"
@@ -308,7 +308,7 @@
 	armed = 1
 	icon_state = "e_snare"
 	trap_damage = 0
-	breakouttime = 30
+	breakouttime = 3 SECONDS
 	item_flags = DROPDEL | ISWEAPON
 	flags_1 = NONE
 
@@ -326,7 +326,7 @@
 	return ..()
 
 /obj/item/restraints/legcuffs/beartrap/energy/cyborg
-	breakouttime = 20 // Cyborgs shouldn't have a strong restraint
+	breakouttime = 2 SECONDS // Cyborgs shouldn't have a strong restraint
 
 /obj/item/restraints/legcuffs/beartrap/energy/emp_act(severity)
 	do_sparks(1, TRUE, src)
@@ -340,7 +340,7 @@
 	inhand_icon_state = "bola"
 	lefthand_file = 'icons/mob/inhands/weapons/thrown_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/weapons/thrown_righthand.dmi'
-	breakouttime = 20//easy to apply, easy to break out of
+	breakouttime = 2 SECONDS//easy to apply, easy to break out of
 	gender = NEUTER
 	var/knockdown = 0
 
@@ -378,15 +378,15 @@
 	desc = "A strong bola, made with a long steel chain. It looks heavy, enough so that it could trip somebody."
 	icon_state = "bola_r"
 	inhand_icon_state = "bola_r"
-	breakouttime = 70
-	knockdown = 20
+	breakouttime = 7 SECONDS
+	knockdown = 2 SECONDS
 
 /obj/item/restraints/legcuffs/bola/watcher //tribal bola for tribal lizards
 	name = "watcher Bola"
 	desc = "A Bola made from the stretchy sinew of fallen watchers."
 	icon_state = "bola_watcher"
 	inhand_icon_state = "bola_watcher"
-	breakouttime = 45
+	breakouttime = 4.5 SECONDS
 
 /obj/item/restraints/legcuffs/bola/energy //For Security
 	name = "energy bola"
@@ -395,7 +395,7 @@
 	inhand_icon_state = "ebola"
 	hitsound = 'sound/weapons/taserhit.ogg'
 	w_class = WEIGHT_CLASS_SMALL
-	breakouttime = 60
+	breakouttime = 6 SECONDS
 
 /obj/item/restraints/legcuffs/bola/energy/ensnare(mob/living/carbon/C)
 	var/obj/item/restraints/legcuffs/beartrap/B = new /obj/item/restraints/legcuffs/beartrap/energy/cyborg(get_turf(C))
@@ -414,7 +414,7 @@
 	icon_state = "gonbola"
 	icon_state_preview = "gonbola_preview"
 	inhand_icon_state = "bola_r"
-	breakouttime = 300
+	breakouttime = 30 SECONDS
 	slowdown = 0
 	var/datum/status_effect/gonbola_pacify/effectReference
 

--- a/code/game/objects/items/handcuffs.dm
+++ b/code/game/objects/items/handcuffs.dm
@@ -288,11 +288,9 @@
 
 	close_trap()
 	if(ignore_movetypes)
-		victim.visible_message(span_danger("\The [src] ensnares [victim]!"), \
-				span_danger("\The [src] ensnares you!"))
+		victim.visible_message(span_danger("\The [src] ensnares [victim]!"), span_danger("\The [src] ensnares you!"))
 	else
-		victim.visible_message(span_danger("[victim] triggers \the [src]."), \
-				span_danger("You trigger \the [src]!"))
+		victim.visible_message(span_danger("[victim] triggers \the [src]."), span_danger("You trigger \the [src]!"))
 	var/def_zone = BODY_ZONE_CHEST
 	if(iscarbon(victim) && (victim.body_position == STANDING_UP || hit_prone))
 		var/mob/living/carbon/carbon_victim = victim
@@ -416,15 +414,15 @@
 	inhand_icon_state = "bola_r"
 	breakouttime = 30 SECONDS
 	slowdown = 0
-	var/datum/status_effect/gonbola_pacify/effectReference
+	var/datum/status_effect/gonbola_pacify/effect_reference
 
 /obj/item/restraints/legcuffs/bola/gonbola/throw_impact(atom/hit_atom, datum/thrownthing/throwingdatum)
 	. = ..()
 	if(iscarbon(hit_atom))
 		var/mob/living/carbon/C = hit_atom
-		effectReference = C.apply_status_effect(/datum/status_effect/gonbola_pacify)
+		effect_reference = C.apply_status_effect(/datum/status_effect/gonbola_pacify)
 
 /obj/item/restraints/legcuffs/bola/gonbola/dropped(mob/user)
-	..()
-	if(effectReference)
-		QDEL_NULL(effectReference)
+	. = ..()
+	if(effect_reference)
+		QDEL_NULL(effect_reference)

--- a/code/game/objects/items/handcuffs.dm
+++ b/code/game/objects/items/handcuffs.dm
@@ -341,15 +341,9 @@
 	inhand_icon_state = "bola"
 	lefthand_file = 'icons/mob/inhands/weapons/thrown_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/weapons/thrown_righthand.dmi'
-	slowdown = 0 //Bolas trip the person they hit rather than slowing them down
-	var/knockdown = 2 SECONDS
+	breakouttime = 2 SECONDS
 	gender = NEUTER
-
-/obj/item/restraints/legcuffs/bola/Destroy()
-	. = ..()
-	if(isliving(loc))
-		var/mob/living/bola_mob = loc
-		bola_mob.remove_status_effect(/datum/status_effect/bola)
+	var/knockdown = 0
 
 /obj/item/restraints/legcuffs/bola/throw_at(atom/target, range, speed, mob/thrower, spin=1, diagonals_first = 0, datum/callback/callback, force, quickstart = TRUE)
 	if(!..())
@@ -367,17 +361,17 @@
   * Arguments:
   * * C - the carbon that we will try to ensnare
   */
-/obj/item/restraints/legcuffs/bola/proc/ensnare(mob/living/carbon/target)
-	if(!target.legcuffed && target.num_legs >= 2)
-		visible_message(span_danger("\The [src] ensnares [target]!"))
-		target.legcuffed = src
-		forceMove(target)
-		target.update_worn_legcuffs()
+/obj/item/restraints/legcuffs/bola/proc/ensnare(mob/living/carbon/C)
+	if(!C.legcuffed && C.num_legs >= 2)
+		visible_message(span_danger("\The [src] ensnares [C]!"))
+		C.legcuffed = src
+		forceMove(C)
+		C.update_equipment_speed_mods()
+		C.update_worn_legcuffs()
 		SSblackbox.record_feedback("tally", "handcuffs", 1, type)
-		to_chat(target, span_userdanger("\The [src] ensnares you!"))
+		to_chat(C, span_userdanger("\The [src] ensnares you!"))
 		if(knockdown)
-			target.Knockdown(knockdown)
-			target.apply_status_effect(/datum/status_effect/bola, knockdown, src) //When status effect ends, bola is automatically dropped
+			C.Knockdown(knockdown)
 		playsound(src, 'sound/effects/snap.ogg', 50, TRUE)
 
 /obj/item/restraints/legcuffs/bola/tactical//traitor variant
@@ -385,14 +379,15 @@
 	desc = "A strong bola, made with a long steel chain. It looks heavy, enough so that it could trip somebody."
 	icon_state = "bola_r"
 	inhand_icon_state = "bola_r"
-	knockdown = 7 SECONDS
+	breakouttime = 7 SECONDS
+	knockdown = 2 SECONDS
 
 /obj/item/restraints/legcuffs/bola/watcher //tribal bola for tribal lizards
 	name = "watcher Bola"
 	desc = "A Bola made from the stretchy sinew of fallen watchers."
 	icon_state = "bola_watcher"
 	inhand_icon_state = "bola_watcher"
-	knockdown = 4.5 SECONDS
+	breakouttime = 4.5 SECONDS
 
 /obj/item/restraints/legcuffs/bola/energy //For Security
 	name = "energy bola"
@@ -400,8 +395,14 @@
 	icon_state = "ebola"
 	inhand_icon_state = "ebola"
 	hitsound = 'sound/weapons/taserhit.ogg'
-	knockdown = 3 SECONDS
+	w_class = WEIGHT_CLASS_SMALL
+	breakouttime = 6 SECONDS
 	custom_price = 100
+
+/obj/item/restraints/legcuffs/bola/energy/ensnare(mob/living/carbon/C)
+	var/obj/item/restraints/legcuffs/beartrap/B = new /obj/item/restraints/legcuffs/beartrap/energy/cyborg(get_turf(C))
+	B.spring_trap(C, ignore_movetypes = TRUE)
+	qdel(src)
 
 /obj/item/restraints/legcuffs/bola/energy/emp_act(severity)
 	if(prob(25 * severity))
@@ -415,7 +416,8 @@
 	icon_state = "gonbola"
 	icon_state_preview = "gonbola_preview"
 	inhand_icon_state = "bola_r"
-	knockdown = 10 SECONDS //Good god
+	breakouttime = 30 SECONDS //Good god
+	slowdown = 0
 	var/datum/status_effect/gonbola_pacify/effectReference
 
 /obj/item/restraints/legcuffs/bola/gonbola/throw_impact(atom/hit_atom, datum/thrownthing/throwingdatum)

--- a/code/game/objects/items/handcuffs.dm
+++ b/code/game/objects/items/handcuffs.dm
@@ -30,7 +30,6 @@
 	custom_price = 15
 	var/cuffsound = 'sound/weapons/handcuffs.ogg'
 	var/trashtype = null //for disposable cuffs
-	var/overlay_state = "handcuff1"
 
 /obj/item/restraints/handcuffs/get_belt_overlay()
 	return mutable_appearance('icons/obj/clothing/belt_overlays.dmi', "handcuffs")

--- a/code/game/objects/items/handcuffs.dm
+++ b/code/game/objects/items/handcuffs.dm
@@ -1,5 +1,5 @@
 /obj/item/restraints
-	breakouttime = 1 MINUTES
+	breakouttime = 600
 	item_flags = ISWEAPON
 
 /obj/item/restraints/suicide_act(mob/living/carbon/user)
@@ -25,7 +25,7 @@
 	throw_speed = 3
 	throw_range = 5
 	custom_materials = list(/datum/material/iron=500)
-	breakouttime = 3 MINUTES
+	breakouttime = 1 MINUTES
 	armor_type = /datum/armor/restraints_handcuffs
 	custom_price = 15
 	var/cuffsound = 'sound/weapons/handcuffs.ogg'
@@ -101,7 +101,7 @@
 	lefthand_file = 'icons/mob/inhands/equipment/tools_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/tools_righthand.dmi'
 	custom_materials = list(/datum/material/iron=150, /datum/material/glass=75)
-	breakouttime = 1 MINUTES
+	breakouttime = 30 SECONDS
 	cuffsound = 'sound/weapons/cablecuff.ogg'
 	custom_price = 15
 
@@ -189,7 +189,7 @@
 	lefthand_file = 'icons/mob/inhands/equipment/security_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/security_righthand.dmi'
 	custom_materials = null
-	breakouttime = 2 MINUTES
+	breakouttime = 450 //Deciseconds = 45s
 	trashtype = /obj/item/restraints/handcuffs/cable/zipties/used
 	color = null
 
@@ -215,7 +215,7 @@
 	throwforce = 0
 	w_class = WEIGHT_CLASS_NORMAL
 	slowdown = 7
-	breakouttime = 30 SECONDS
+	breakouttime = 300	//Deciseconds = 30s = 0.5 minute
 
 /obj/item/restraints/legcuffs/beartrap
 	name = "bear trap"
@@ -309,7 +309,7 @@
 	armed = 1
 	icon_state = "e_snare"
 	trap_damage = 0
-	breakouttime = 3 SECONDS
+	breakouttime = 30
 	item_flags = DROPDEL | ISWEAPON
 	flags_1 = NONE
 
@@ -327,7 +327,7 @@
 	return ..()
 
 /obj/item/restraints/legcuffs/beartrap/energy/cyborg
-	breakouttime = 3 SECONDS
+	breakouttime = 20 // Cyborgs shouldn't have a strong restraint
 
 /obj/item/restraints/legcuffs/beartrap/energy/emp_act(severity)
 	do_sparks(1, TRUE, src)
@@ -341,7 +341,7 @@
 	inhand_icon_state = "bola"
 	lefthand_file = 'icons/mob/inhands/weapons/thrown_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/weapons/thrown_righthand.dmi'
-	breakouttime = 2 SECONDS
+	breakouttime = 20//easy to apply, easy to break out of
 	gender = NEUTER
 	var/knockdown = 0
 
@@ -379,15 +379,15 @@
 	desc = "A strong bola, made with a long steel chain. It looks heavy, enough so that it could trip somebody."
 	icon_state = "bola_r"
 	inhand_icon_state = "bola_r"
-	breakouttime = 7 SECONDS
-	knockdown = 2 SECONDS
+	breakouttime = 70
+	knockdown = 20
 
 /obj/item/restraints/legcuffs/bola/watcher //tribal bola for tribal lizards
 	name = "watcher Bola"
 	desc = "A Bola made from the stretchy sinew of fallen watchers."
 	icon_state = "bola_watcher"
 	inhand_icon_state = "bola_watcher"
-	breakouttime = 4.5 SECONDS
+	breakouttime = 45
 
 /obj/item/restraints/legcuffs/bola/energy //For Security
 	name = "energy bola"
@@ -396,8 +396,7 @@
 	inhand_icon_state = "ebola"
 	hitsound = 'sound/weapons/taserhit.ogg'
 	w_class = WEIGHT_CLASS_SMALL
-	breakouttime = 6 SECONDS
-	custom_price = 100
+	breakouttime = 60
 
 /obj/item/restraints/legcuffs/bola/energy/ensnare(mob/living/carbon/C)
 	var/obj/item/restraints/legcuffs/beartrap/B = new /obj/item/restraints/legcuffs/beartrap/energy/cyborg(get_turf(C))
@@ -416,7 +415,7 @@
 	icon_state = "gonbola"
 	icon_state_preview = "gonbola_preview"
 	inhand_icon_state = "bola_r"
-	breakouttime = 30 SECONDS //Good god
+	breakouttime = 300
 	slowdown = 0
 	var/datum/status_effect/gonbola_pacify/effectReference
 

--- a/code/modules/antagonists/cult/cult_items.dm
+++ b/code/modules/antagonists/cult/cult_items.dm
@@ -112,7 +112,7 @@ Striking a noncultist, however, will tear their flesh."}
 	desc = "A strong bola, bound with dark magic that allows it to pass harmlessly through Nar'Sien cultists. Throw it to trip and slow your victim."
 	icon_state = "bola_cult"
 	inhand_icon_state = "bola_cult"
-	breakouttime = 6 SECONDS
+	breakouttime = 60
 	knockdown = 20
 
 /obj/item/restraints/legcuffs/bola/cult/throw_impact(atom/hit_atom, datum/thrownthing/throwingdatum)

--- a/code/modules/antagonists/cult/cult_items.dm
+++ b/code/modules/antagonists/cult/cult_items.dm
@@ -112,7 +112,8 @@ Striking a noncultist, however, will tear their flesh."}
 	desc = "A strong bola, bound with dark magic that allows it to pass harmlessly through Nar'Sien cultists. Throw it to trip and slow your victim."
 	icon_state = "bola_cult"
 	inhand_icon_state = "bola_cult"
-	knockdown = 6 SECONDS
+	breakouttime = 6 SECONDS
+	knockdown = 20
 
 /obj/item/restraints/legcuffs/bola/cult/throw_impact(atom/hit_atom, datum/thrownthing/throwingdatum)
 	if(!isliving(hit_atom))

--- a/code/modules/antagonists/cult/cult_items.dm
+++ b/code/modules/antagonists/cult/cult_items.dm
@@ -112,8 +112,8 @@ Striking a noncultist, however, will tear their flesh."}
 	desc = "A strong bola, bound with dark magic that allows it to pass harmlessly through Nar'Sien cultists. Throw it to trip and slow your victim."
 	icon_state = "bola_cult"
 	inhand_icon_state = "bola_cult"
-	breakouttime = 60
-	knockdown = 20
+	breakouttime = 6 SECONDS
+	knockdown = 2 SECONDS
 
 /obj/item/restraints/legcuffs/bola/cult/throw_impact(atom/hit_atom, datum/thrownthing/throwingdatum)
 	if(!isliving(hit_atom))

--- a/code/modules/clothing/gloves/color.dm
+++ b/code/modules/clothing/gloves/color.dm
@@ -84,7 +84,7 @@
 	desc = "The old gloves your great grandfather stole from Engineering, many moons ago. They've seen some tough times recently."
 
 /obj/item/clothing/gloves/color/black
-	desc = "These gloves are thick and fire-resistant."
+	desc = "These gloves are fire-resistant."
 	name = "black gloves"
 	icon_state = "black"
 	inhand_icon_state = "blackgloves"

--- a/code/modules/clothing/suits/straightjacket.dm
+++ b/code/modules/clothing/suits/straightjacket.dm
@@ -5,7 +5,7 @@
 	inhand_icon_state = "straight_jacket"
 	body_parts_covered = CHEST|GROIN|LEGS|ARMS|HANDS
 	flags_inv = HIDEGLOVES|HIDESHOES|HIDEJUMPSUIT
-	equip_delay_self = 5 SECONDS
-	strip_delay = 6 SECONDS
-	breakouttime = 2 MINUTES
+	equip_delay_self = 50
+	strip_delay = 60
+	breakouttime = 3000
 	pockets = FALSE

--- a/code/modules/mob/living/carbon/alien/humanoid/humanoid.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/humanoid.dm
@@ -33,7 +33,7 @@ GLOBAL_LIST_INIT(strippable_alien_humanoid_items, create_strippable_list(list(
 
 /mob/living/carbon/alien/humanoid/cuff_resist(obj/item/I)
 	playsound(src, 'sound/voice/hiss5.ogg', 40, 1, 1)  //Alien roars when starting to break free
-	..(I, cuff_break = FAST_CUFFBREAK)
+	..(I, cuff_break = INSTANT_CUFFBREAK)
 
 /mob/living/carbon/alien/humanoid/resist_grab(moving_resist)
 	if(pulledby.grab_state)

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -330,17 +330,16 @@ CREATION_TEST_IGNORE_SELF(/mob/living/carbon)
 			to_chat(src, span_warning("You fail to break [cuffs]!"))
 
 	else if(istype(cuffs, /obj/item/restraints/handcuffs))
+
 		to_chat(src, span_notice("You attempt to wriggle your way out of [cuffs]..."))
-		while(cuffs.item_flags & BEING_REMOVED && handcuffed == cuffs)
-			cuff_breakout_attempts++ //We increment these first so that long-term progress is still made even if interrupted
-			if(!do_after(src, 5 SECONDS, timed_action_flags = IGNORE_USER_LOC_CHANGE|IGNORE_HELD_ITEM, hidden = TRUE))
-				break
-			if(cuff_breakout_attempts * 5 SECONDS >= breakouttime)
+		while(do_after(src, 5 SECONDS, timed_action_flags = IGNORE_USER_LOC_CHANGE|IGNORE_HELD_ITEM, hidden = TRUE))
+			cuff_breakout_attempts++
+			if(cuff_breakout_attempts * 5 SECONDS >= breakouttime || (prob(cuff_breakout_attempts/4)))
 				log_combat(src, src, "slipped out of [cuffs] after [cuff_breakout_attempts]/[breakouttime / (5 SECONDS)] attempts", important = FALSE)
 				. = clear_cuffs(cuffs, cuff_break)
 				break
-			else if(cuff_breakout_attempts % 10 == 0)
-				visible_message(span_warning("[src] seems to be trying to wriggle out of [cuffs]!")) //Ten second warning for zipties, three warnings for real cuffs
+			else if(prob(4))
+				visible_message(span_warning("[src] seems to be trying to wriggle out of [cuffs]!"))
 
 	else
 		to_chat(src, span_notice("You attempt to remove [cuffs]... (This will take around [DisplayTimeText(breakouttime)]"))
@@ -348,6 +347,7 @@ CREATION_TEST_IGNORE_SELF(/mob/living/carbon)
 			. = clear_cuffs(cuffs, cuff_break)
 		else
 			to_chat(src, span_warning("You fail to remove [cuffs]!"))
+
 
 	cuffs.item_flags &= ~BEING_REMOVED
 

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -260,8 +260,8 @@ CREATION_TEST_IGNORE_SELF(/mob/living/carbon)
 	var/buckle_cd = 1 MINUTES
 
 	if(handcuffed)
-		var/obj/item/restraints/O = src.get_item_by_slot(ITEM_SLOT_HANDCUFFED)
-		buckle_cd = O.breakouttime
+		resist_restraints()
+		return
 
 	visible_message(span_warning("[src] attempts to unbuckle [p_them()]self!"), span_notice("You attempt to unbuckle yourself... (This will take around [DisplayTimeText(buckle_cd)] and you need to stay still.)"))
 

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -260,8 +260,8 @@ CREATION_TEST_IGNORE_SELF(/mob/living/carbon)
 	var/buckle_cd = 1 MINUTES
 
 	if(handcuffed)
-		resist_restraints()
-		return
+		var/obj/item/restraints/O = src.get_item_by_slot(ITEM_SLOT_HANDCUFFED)
+		buckle_cd = O.breakouttime
 
 	visible_message(span_warning("[src] attempts to unbuckle [p_them()]self!"), span_notice("You attempt to unbuckle yourself... (This will take around [DisplayTimeText(buckle_cd)] and you need to stay still.)"))
 
@@ -319,36 +319,25 @@ CREATION_TEST_IGNORE_SELF(/mob/living/carbon)
 		return
 	cuffs.item_flags |= BEING_REMOVED
 	breakouttime = cuffs.breakouttime
-
-	if(cuff_break)
-		breakouttime = 5 SECONDS
-		visible_message(span_warning("[src] is trying to break [cuffs]!"))
-		to_chat(src, span_notice("You attempt to break [cuffs]... (This will take around 5 seconds)"))
-		if(do_after(src, breakouttime, timed_action_flags = IGNORE_USER_LOC_CHANGE|IGNORE_HELD_ITEM))
-			. = clear_cuffs(cuffs, cuff_break)
-		else
-			to_chat(src, span_warning("You fail to break [cuffs]!"))
-
-	else if(istype(cuffs, /obj/item/restraints/handcuffs))
-
-		to_chat(src, span_notice("You attempt to wriggle your way out of [cuffs]..."))
-		while(do_after(src, 5 SECONDS, timed_action_flags = IGNORE_USER_LOC_CHANGE|IGNORE_HELD_ITEM, hidden = TRUE))
-			cuff_breakout_attempts++
-			if(cuff_breakout_attempts * 5 SECONDS >= breakouttime || (prob(cuff_breakout_attempts/4)))
-				log_combat(src, src, "slipped out of [cuffs] after [cuff_breakout_attempts]/[breakouttime / (5 SECONDS)] attempts", important = FALSE)
-				. = clear_cuffs(cuffs, cuff_break)
-				break
-			else if(prob(4))
-				visible_message(span_warning("[src] seems to be trying to wriggle out of [cuffs]!"))
-
-	else
-		to_chat(src, span_notice("You attempt to remove [cuffs]... (This will take around [DisplayTimeText(breakouttime)]"))
-		if(do_after(src, breakouttime, timed_action_flags = IGNORE_USER_LOC_CHANGE|IGNORE_HELD_ITEM, hidden = TRUE))
+	if(!cuff_break)
+		visible_message(span_warning("[src] attempts to remove [cuffs]!"))
+		to_chat(src, span_notice("You attempt to remove [cuffs]... (This will take around [DisplayTimeText(breakouttime)] and you need to stand still.)"))
+		if(do_after(src, breakouttime, target = src, timed_action_flags = IGNORE_HELD_ITEM, hidden = TRUE))
 			. = clear_cuffs(cuffs, cuff_break)
 		else
 			to_chat(src, span_warning("You fail to remove [cuffs]!"))
 
+	else if(cuff_break == FAST_CUFFBREAK)
+		breakouttime = 5 SECONDS
+		visible_message(span_warning("[src] is trying to break [cuffs]!"))
+		to_chat(src, span_notice("You attempt to break [cuffs]... (This will take around 5 seconds and you need to stand still.)"))
+		if(do_after(src, breakouttime, target = src, timed_action_flags = IGNORE_HELD_ITEM))
+			. = clear_cuffs(cuffs, cuff_break)
+		else
+			to_chat(src, span_warning("You fail to break [cuffs]!"))
 
+	else if(cuff_break == INSTANT_CUFFBREAK)
+		. = clear_cuffs(cuffs, cuff_break)
 	cuffs.item_flags &= ~BEING_REMOVED
 
 /mob/living/carbon/proc/uncuff()
@@ -383,7 +372,7 @@ CREATION_TEST_IGNORE_SELF(/mob/living/carbon)
 	update_equipment_speed_mods() // In case cuffs ever change speed
 
 /mob/living/carbon/proc/clear_cuffs(obj/item/I, cuff_break)
-	if(!I.loc)
+	if(!I.loc || buckled)
 		return FALSE
 	if(I != handcuffed && I != legcuffed)
 		return FALSE
@@ -871,7 +860,6 @@ CREATION_TEST_IGNORE_SELF(/mob/living/carbon)
 		stop_pulling()
 		throw_alert("handcuffed", /atom/movable/screen/alert/restrained/handcuffed, new_master = src.handcuffed)
 		SEND_SIGNAL(src, COMSIG_ADD_MOOD_EVENT, "handcuffed", /datum/mood_event/handcuffed)
-		cuff_breakout_attempts = 0
 	else
 		clear_alert("handcuffed")
 		SEND_SIGNAL(src, COMSIG_CLEAR_MOOD_EVENT, "handcuffed")

--- a/code/modules/mob/living/carbon/carbon_defines.dm
+++ b/code/modules/mob/living/carbon/carbon_defines.dm
@@ -8,17 +8,16 @@
 	usable_legs = 0 //Populated on init through list/bodyparts
 	num_hands = 0 //Populated on init through list/bodyparts
 	usable_hands = 0 //Populated on init through list/bodyparts
-	//List of /obj/item/organ in the mob. They don't go in the contents for some reason I don't want to know.
+	/// List of /obj/item/organ in the mob. They don't go in the contents for some reason I don't want to know.
 	var/list/internal_organs = list()
-	//Same as above, but stores "slot ID" - "organ" pairs for easy access.
+	/// Same as above, but stores "slot ID" - "organ" pairs for easy access.
 	var/list/internal_organs_slot = list()
-	var/silent = FALSE 		//Can't talk. Value goes down every life proc. //NOTE TO FUTURE CODERS: DO NOT INITIALIZE NUMERICAL VARS AS NULL OR I WILL MURDER YOU.
-
-	///Whether or not the mob is currently handcuffed, defined as the handcuff item restraining them
-	var/obj/item/restraints/handcuffs/handcuffed = null
-	///used to track how many times the mob has tried breaking away from their handcuffs since being cuffed. Reset to zero in update_handcuffed()
-	var/cuff_breakout_attempts = 0
-	var/obj/item/legcuffed = null  //Same as handcuffs but for legs. Bear traps use this.
+	/// Can't talk. Value goes down every life proc. //NOTE TO FUTURE CODERS: DO NOT INITIALIZE NUMERICAL VARS AS NULL OR I WILL MURDER YOU.
+	var/silent = FALSE
+	/// Whether or not the mob is handcuffed
+	var/obj/item/handcuffed = null
+	/// Same as handcuffs but for legs. Bear traps use this.
+	var/obj/item/legcuffed = null
 
 	/// Measure of how disgusted we are. See DISGUST_LEVEL_GROSS and friends
 	var/disgust = 0

--- a/code/modules/mob/living/carbon/carbon_update_icons.dm
+++ b/code/modules/mob/living/carbon/carbon_update_icons.dm
@@ -187,7 +187,7 @@
 	if(handcuffed)
 		if(update_obscured)
 			update_obscured_slots(handcuffed.flags_inv)
-		overlays_standing[HANDCUFF_LAYER] = mutable_appearance('icons/mob/mob.dmi', handcuffed.overlay_state, CALCULATE_MOB_OVERLAY_LAYER(HANDCUFF_LAYER))
+		overlays_standing[HANDCUFF_LAYER] = mutable_appearance('icons/mob/mob.dmi', "handcuff1", CALCULATE_MOB_OVERLAY_LAYER(HANDCUFF_LAYER))
 		apply_overlay(HANDCUFF_LAYER)
 
 

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -820,21 +820,3 @@
 	if(M.melee_damage != 0 && !HAS_TRAIT(M, TRAIT_PACIFISM) && check_shields(M, M.melee_damage, "the [M.name]", MELEE_ATTACK, M.armour_penetration))
 		return FALSE
 	return ..()
-
-/mob/living/carbon/human/proc/breakout_breaking_arms()
-	visible_message(span_warning("[src] is fighting [handcuffed] with every ounce of their strength!"))
-	if(!do_after(src, 5 SECONDS, timed_action_flags = IGNORE_USER_LOC_CHANGE|IGNORE_HELD_ITEM, hidden = TRUE))
-		return
-
-	playsound(src, 'sound/weapons/pierce_slow.ogg', 50, TRUE)
-
-	var/obj/item/bodypart/random_arm = pick(get_bodypart(BODY_ZONE_L_ARM), get_bodypart(BODY_ZONE_R_ARM))
-	log_combat(src, src, "has forcibly broken their arm to escape [handcuffed]", important = FALSE)
-
-	if(HAS_TRAIT(src, TRAIT_EASYDISMEMBER) && !HAS_TRAIT(src, TRAIT_NODISMEMBER))
-		random_arm.dismember()
-		random_arm.receive_damage(20)
-		uncuff()
-	else
-		random_arm.receive_damage(50)
-		uncuff()


### PR DESCRIPTION
## About The Pull Request

Reverts:
- https://github.com/BeeStation/BeeStation-Hornet/pull/12602
- https://github.com/BeeStation/BeeStation-Hornet/pull/13320
- https://github.com/BeeStation/BeeStation-Hornet/pull/13642

closes #13766

## Why It's Good For The Game

Unfortunately newcuffs didn't work out. It makes securing prisoners completely unfeasible and makes security less fun. I'll repeat what I said in the comments of #13705, _"the fight for staying free should be in the fight... not when being processed"_

I get this reasoning is pretty shallow, but forgive me, I'm tired at the moment of writing this and I already know this is going to be merged regardless of what I write here. If anyone has any questions feel free to comment, additionally I'll try and fluff up the written reasoning when I'm able.

## Testing Photographs and Procedure

https://github.com/user-attachments/assets/c06fe0b2-6b0d-4e26-9b6a-0e7f5dfd85fe

## Changelog
:cl:
del: Reverted handcuffs to the previous behavior. Which means: you can no longer break your wrists to escape handcuffs and you now must stand completely still for the handcuff's escape duration to... escape.
/:cl: