### PR TITLE
Shuttle Transfer Vote with Zero Votes Defaults to Continue Round

### DIFF
--- a/code/datums/votes/shuttle_vote.dm
+++ b/code/datums/votes/shuttle_vote.dm
@@ -30,7 +30,10 @@
 		return
 
 /datum/vote/shuttle_vote/tiebreaker(list/winners)
-	return CHOICE_SHUTTLE //In the event of an even 50/50 split, we prefer to evacuate
+	if(!length(choices_by_ckey))
+		return CHOICE_CONTINUE //In the event of a tie on zero votes, continue.
+	else
+		return CHOICE_SHUTTLE //In the event of an even 50/50 split, we prefer to evacuate
 
 #undef CHOICE_SHUTTLE
 #undef CHOICE_CONTINUE

--- a/code/datums/votes/shuttle_vote.dm
+++ b/code/datums/votes/shuttle_vote.dm
@@ -30,7 +30,7 @@
 		return
 
 /datum/vote/shuttle_vote/tiebreaker(list/winners)
-	if(!living_player_count()) //No Players? Shuttle
+	if(!length(get_living_station_crew())) //No Players? Shuttle
 		return CHOICE_SHUTTLE
 
 	return length(choices_by_ckey) ? CHOICE_SHUTTLE : CHOICE_CONTINUE  //If there are no votes, continue, otherwise, prefer shuttle.

--- a/code/datums/votes/shuttle_vote.dm
+++ b/code/datums/votes/shuttle_vote.dm
@@ -30,7 +30,7 @@
 		return
 
 /datum/vote/shuttle_vote/tiebreaker(list/winners)
-	if(!length(get_living_station_crew())) //No Players? Shuttle
+	if(!length(get_living_crew())) //No Players? Shuttle
 		return CHOICE_SHUTTLE
 
 	return length(choices_by_ckey) ? CHOICE_SHUTTLE : CHOICE_CONTINUE  //If there are no votes, continue, otherwise, prefer shuttle.

--- a/code/datums/votes/shuttle_vote.dm
+++ b/code/datums/votes/shuttle_vote.dm
@@ -30,10 +30,10 @@
 		return
 
 /datum/vote/shuttle_vote/tiebreaker(list/winners)
-	if(!length(choices_by_ckey))
-		return CHOICE_CONTINUE //In the event of a tie on zero votes, continue.
-	else
-		return CHOICE_SHUTTLE //In the event of an even 50/50 split, we prefer to evacuate
+	if(!living_player_count()) //No Players? Shuttle
+		return CHOICE_SHUTTLE
+
+	return length(choices_by_ckey) ? CHOICE_SHUTTLE : CHOICE_CONTINUE  //If there are no votes, continue, otherwise, prefer shuttle.
 
 #undef CHOICE_SHUTTLE
 #undef CHOICE_CONTINUE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

The previous PR set a simple majority for the transfer vote, preferring to transfer if tied.

If nobody voted though, the shuttle would automatically be called, because of a tie.

This PR makes it so if there are zero votes, the round will continue, because nobody has a strong enough opinion to vote (or they are all caught up in some shenanigans and missed the vote).

## Why It's Good For The Game

If people are enjoying the round enough to not vote, the shuttle should not be called.

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

<img width="843" height="430" alt="image" src="https://github.com/user-attachments/assets/ce91177e-58bf-4d6c-8c56-6f387a45390d" />

</details>

## Changelog
:cl:
tweak: Transfer shuttle will not be called when there are zero votes in the poll.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
