### PR TITLE
Suit Sensors - Missing

### DIFF
--- a/code/game/machinery/computer/crew.dm
+++ b/code/game/machinery/computer/crew.dm
@@ -101,6 +101,9 @@ GLOBAL_DATUM_INIT(crewmonitor, /datum/crewmonitor, new)
 	/// Cache of last update time for each z-level
 	var/list/last_update = list()
 
+	/// The last update for the crew-member
+	var/list/outdated_update = list()
+
 	/// Map of job to ID for sorting purposes
 	var/list/jobs = list(
 		// Note that jobs divisible by 10 are considered heads of staff, and bolded
@@ -201,7 +204,8 @@ GLOBAL_DATUM_INIT(crewmonitor, /datum/crewmonitor, new)
 		z = T.get_virtual_z_level()
 	. = list(
 		"sensors" = update_data(z, T.z),
-		"link_allowed" = isAI(user)
+		"link_allowed" = isAI(user),
+		"time" = world.time
 	)
 
 /// z represents the virtual z-level the user is on
@@ -211,6 +215,8 @@ GLOBAL_DATUM_INIT(crewmonitor, /datum/crewmonitor, new)
 		return data_by_z["[z]"]
 
 	var/list/results = list()
+
+	var/list/valid_refs = list()
 
 	for(var/mob/living/carbon/human/tracked_human as () in GLOB.suit_sensors_list)
 		if(!tracked_human)
@@ -260,6 +266,8 @@ GLOBAL_DATUM_INIT(crewmonitor, /datum/crewmonitor, new)
 			"ref" = REF(tracked_human),
 			"name" = "Unknown",
 			"ijob" = UNKNOWN_JOB_ID,
+			"last_update" = world.time,
+			"missing" = FALSE
 		)
 
 		var/obj/item/card/id/I = tracked_human.wear_id ? tracked_human.wear_id.GetID() : null
@@ -288,7 +296,23 @@ GLOBAL_DATUM_INIT(crewmonitor, /datum/crewmonitor, new)
 		// Trackability
 		entry["can_track"] = tracked_human.can_track()
 
+		/// Update the tracked entry
+		if (I?.registered_name)
+			outdated_update[I.registered_name] = entry
+			valid_refs[I.registered_name] = TRUE
+
 		results[++results.len] = entry
+
+	for (var/outdated_ref in outdated_update)
+		if (valid_refs[outdated_ref])
+			continue
+		var/list/last_results = outdated_update[outdated_ref]
+		results[++results.len] = list(
+			"ref" = REF(outdated_ref),
+			"name" = last_results["name"],
+			"last_update" = last_results["last_update"],
+			"missing" = TRUE
+		)
 
 	data_by_z["[z]"] = results
 	last_update["[z]"] = world.time

--- a/code/game/machinery/computer/crew.dm
+++ b/code/game/machinery/computer/crew.dm
@@ -297,8 +297,11 @@ GLOBAL_DATUM_INIT(crewmonitor, /datum/crewmonitor, new)
 		entry["can_track"] = tracked_human.can_track()
 
 		/// Update the tracked entry
-		if (I?.registered_name)
-			outdated_update[I.registered_name] = entry
+		if (I?.registered_name && find_record(I.registered_name, GLOB.manifest.general))
+			outdated_update[I.registered_name] = list(
+				"name" = I.registered_name,
+				"last_update" = world.time
+			)
 			valid_refs[I.registered_name] = TRUE
 
 		results[++results.len] = entry
@@ -307,8 +310,12 @@ GLOBAL_DATUM_INIT(crewmonitor, /datum/crewmonitor, new)
 		if (valid_refs[outdated_ref])
 			continue
 		var/list/last_results = outdated_update[outdated_ref]
+		// Deleted from the records, cryo'd or malicious intent. Remove the target
+		if (!find_record(last_results["name"], GLOB.manifest.general))
+			outdated_update -= outdated_ref
+			continue
 		results[++results.len] = list(
-			"ref" = REF(outdated_ref),
+			"ref" = outdated_ref,
 			"name" = last_results["name"],
 			"last_update" = last_results["last_update"],
 			"missing" = TRUE

--- a/tgui/packages/tgui/components/TimeDisplay.jsx
+++ b/tgui/packages/tgui/components/TimeDisplay.jsx
@@ -1,3 +1,4 @@
+import { toFixed } from 'common/math';
 import { Component } from 'react';
 
 // AnimatedNumber Copypaste

--- a/tgui/packages/tgui/components/TimeDisplay.jsx
+++ b/tgui/packages/tgui/components/TimeDisplay.jsx
@@ -23,13 +23,6 @@ export class TimeDisplay extends Component {
     }
   }
 
-  componentDidUpdate() {
-    if (this.props.auto !== undefined) {
-      clearInterval(this.timer);
-      this.timer = setInterval(() => this.tick(), 1000); // every 1 s
-    }
-  }
-
   tick() {
     let current = Number(this.state.value);
     if (this.props.value !== this.last_seen_value) {
@@ -38,7 +31,7 @@ export class TimeDisplay extends Component {
     }
     const mod = this.props.auto === 'up' ? 10 : -10; // Time down by default.
     const value = Math.max(0, current + mod); // one sec tick
-    this.setState({ value });
+    this.setState({ value: value });
   }
 
   componentDidMount() {
@@ -52,7 +45,7 @@ export class TimeDisplay extends Component {
   }
 
   render() {
-    const val = this.state.value;
+    const val = this.props.auto ? this.state.value : this.props.value;
     // Directly display weird stuff
     if (!isSafeNumber(val)) {
       return this.state.value || null;

--- a/tgui/packages/tgui/interfaces/CrewConsole.tsx
+++ b/tgui/packages/tgui/interfaces/CrewConsole.tsx
@@ -269,7 +269,7 @@ const CrewTableEntry = (props: CrewTableEntryProps) => {
             justifyContent: 'center',
           }}
         >
-          <Icon name="question" color="#ffffff" size={1} />
+          <Icon name="question" color="#ffffff" size={1} />{' '}
         </Table.Cell>
       </Table.Row>
     );

--- a/tgui/packages/tgui/interfaces/CrewConsole.tsx
+++ b/tgui/packages/tgui/interfaces/CrewConsole.tsx
@@ -2,7 +2,15 @@ import { BooleanLike } from 'common/react';
 import { createSearch } from 'common/string';
 
 import { useBackend, useLocalState } from '../backend';
-import { Box, Button, Icon, Input, Section, Table } from '../components';
+import {
+  Box,
+  Button,
+  Icon,
+  Input,
+  Section,
+  Table,
+  TimeDisplay,
+} from '../components';
 import { COLORS } from '../constants';
 import { Window } from '../layouts';
 
@@ -25,7 +33,7 @@ const SORT_NAMES = {
 const STAT_LIVING = 0;
 const STAT_DEAD = 4;
 
-const SORT_OPTIONS = ['health', 'ijob', 'name', 'area'];
+const SORT_OPTIONS = ['ijob', 'health', 'name', 'area'];
 
 const jobIsHead = (jobId: number) => jobId % 10 === 0;
 
@@ -68,6 +76,8 @@ const statToIcon = (life_status: number) => {
 };
 
 const healthSort = (a: CrewSensor, b: CrewSensor) => {
+  if (a.missing) return 1;
+  if (b.missing) return -1;
   if (a.life_status > b.life_status) return -1;
   if (a.life_status < b.life_status) return 1;
   if (a.health < b.health) return -1;
@@ -76,6 +86,8 @@ const healthSort = (a: CrewSensor, b: CrewSensor) => {
 };
 
 const areaSort = (a: CrewSensor, b: CrewSensor) => {
+  if (a.missing) return 1;
+  if (b.missing) return -1;
   a.area ??= '~';
   b.area ??= '~';
   if (a.area < b.area) return -1;
@@ -121,24 +133,34 @@ export const CrewConsole = () => {
   );
 };
 
-type CrewSensor = {
-  name: string;
-  assignment: string | undefined;
-  ijob: number;
-  life_status: number;
-  oxydam: number;
-  toxdam: number;
-  burndam: number;
-  brutedam: number;
-  area: string | undefined;
-  health: number;
-  can_track: BooleanLike;
-  ref: string;
-};
+type CrewSensor =
+  | {
+      name: string;
+      assignment: string | undefined;
+      ijob: number;
+      life_status: number;
+      oxydam: number;
+      toxdam: number;
+      burndam: number;
+      brutedam: number;
+      area: string | undefined;
+      health: number;
+      can_track: BooleanLike;
+      ref: string;
+      last_update: number;
+      missing: false;
+    }
+  | {
+      name: string;
+      last_update: number;
+      missing: true;
+      ref: string;
+    };
 
 type CrewConsoleData = {
   sensors: CrewSensor[];
   link_allowed: BooleanLike;
+  time: number;
 };
 
 const CrewTable = (props) => {
@@ -165,6 +187,8 @@ const CrewTable = (props) => {
       case 'name':
         return sortAsc ? +(a.name > b.name) : +(b.name > a.name);
       case 'ijob':
+        if (a.missing) return sortAsc ? 1 : -1;
+        if (b.missing) return sortAsc ? -1 : 1;
         return sortAsc ? a.ijob - b.ijob : b.ijob - a.ijob;
       case 'health':
         return sortAsc ? healthSort(a, b) : healthSort(b, a);
@@ -225,8 +249,31 @@ type CrewTableEntryProps = {
 
 const CrewTableEntry = (props: CrewTableEntryProps) => {
   const { act, data } = useBackend<CrewConsoleData>();
-  const { link_allowed } = data;
+  const { link_allowed, time } = data;
   const { sensor_data } = props;
+  if (sensor_data.missing) {
+    const { name, last_update } = sensor_data;
+    return (
+      <Table.Row className="candystripe">
+        <Table.Cell color={COLORS.department.other}>{name}</Table.Cell>
+        <Table.Cell collapsing textAlign="center">
+          <Icon name="question" color="#aaaaaa" size={1} />
+        </Table.Cell>
+        <Table.Cell collapsing textAlign="center">
+          Missing (<TimeDisplay auto="up" value={time - last_update} />)
+        </Table.Cell>
+        <Table.Cell
+          style={{
+            display: 'flex',
+            flexDirection: 'row',
+            justifyContent: 'center',
+          }}
+        >
+          <Icon name="question" color="#ffffff" size={1} />
+        </Table.Cell>
+      </Table.Row>
+    );
+  }
   const {
     name,
     assignment,
@@ -282,7 +329,13 @@ const CrewTableEntry = (props: CrewTableEntryProps) => {
           'Dead'
         )}
       </Table.Cell>
-      <Table.Cell>
+      <Table.Cell
+        style={{
+          display: 'flex',
+          flexDirection: 'row',
+          justifyContent: 'center',
+        }}
+      >
         {area !== '~' && area !== undefined ? (
           area
         ) : (


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

The crew monitoring console will now display 'missing' for anyone that goes completely offline on the sensors, but was once visible on them.

- If someone has their sensors disabled, they will show as unknown on the crew monitor.
- When someone goes missing from the network, only their name will show.
- Only people whose ID name is in the medical records will show as missing, if someone is fully deleted then they will not show as missing.

Fixes the unused time display component, since it just didn't work

## Why It's Good For The Game

It gives medical more to investigate. If someone is showing as missing then they have a mystery to solve: Are they hiding, and if so, why, or are they dead?

When someone cryos their record is removed, so it won't contain bad data for the rest of the round.

This was generally made as a result of the gamemode rework testmerge round, since that emphasises antagonists slowly whittling down the crew.

## Testing Photographs and Procedure

<img width="605" height="630" alt="image" src="https://github.com/user-attachments/assets/85847e34-2f79-47df-919f-38c09315c8ef" />

Before deleting all mobs:

<img width="598" height="855" alt="image" src="https://github.com/user-attachments/assets/740c329d-cc62-48fc-b615-05e387e4db1d" />

After deleting all mobs (Only the mob who's record exists remained):

<img width="598" height="601" alt="image" src="https://github.com/user-attachments/assets/69f84115-724e-4fb9-810e-53db15fe797a" />

## Changelog
:cl:
tweak: The crew monitoring console will now show when someone's sensors have gone offline, if they are in the crew manifest.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
