### PR TITLE
Fixes monkey ai runtime

### DIFF
--- a/code/datums/ai/monkey/monkey_controller.dm
+++ b/code/datums/ai/monkey/monkey_controller.dm
@@ -57,18 +57,17 @@ have ways of interacting with a specific mob and control it.
 	return ..() //Run parent at end
 
 /datum/ai_controller/monkey/UnpossessPawn(destroy)
-	if(isnull(pawn))
-		return
+	if(!isnull(pawn))
+		UnregisterSignal(pawn, list(
+			COMSIG_ATOM_WAS_ATTACKED,
+			COMSIG_ATOM_BULLET_ACT,
+			COMSIG_ATOM_HITBY,
+			COMSIG_LIVING_START_PULL,
+			COMSIG_LIVING_TRY_SYRINGE,
+			COMSIG_CARBON_CUFF_ATTEMPTED,
+			COMSIG_MOB_MOVESPEED_UPDATED,
+		))
 
-	UnregisterSignal(pawn, list(
-		COMSIG_ATOM_WAS_ATTACKED,
-		COMSIG_ATOM_BULLET_ACT,
-		COMSIG_ATOM_HITBY,
-		COMSIG_LIVING_START_PULL,
-		COMSIG_LIVING_TRY_SYRINGE,
-		COMSIG_CARBON_CUFF_ATTEMPTED,
-		COMSIG_MOB_MOVESPEED_UPDATED,
-	))
 	qdel(GetComponent(/datum/component/connect_loc_behalf))
 	return ..() //Run parent at end
 

--- a/code/datums/ai/monkey/monkey_controller.dm
+++ b/code/datums/ai/monkey/monkey_controller.dm
@@ -57,8 +57,18 @@ have ways of interacting with a specific mob and control it.
 	return ..() //Run parent at end
 
 /datum/ai_controller/monkey/UnpossessPawn(destroy)
-	UnregisterSignal(pawn, list(COMSIG_ATOM_WAS_ATTACKED, COMSIG_ATOM_BULLET_ACT, COMSIG_ATOM_HITBY, COMSIG_LIVING_START_PULL,\
-	COMSIG_LIVING_TRY_SYRINGE,  COMSIG_CARBON_CUFF_ATTEMPTED, COMSIG_MOB_MOVESPEED_UPDATED))
+	if(isnull(pawn))
+		return
+
+	UnregisterSignal(pawn, list(
+		COMSIG_ATOM_WAS_ATTACKED,
+		COMSIG_ATOM_BULLET_ACT,
+		COMSIG_ATOM_HITBY,
+		COMSIG_LIVING_START_PULL,
+		COMSIG_LIVING_TRY_SYRINGE,
+		COMSIG_CARBON_CUFF_ATTEMPTED,
+		COMSIG_MOB_MOVESPEED_UPDATED,
+	))
 	qdel(GetComponent(/datum/component/connect_loc_behalf))
 	return ..() //Run parent at end
 


### PR DESCRIPTION
## About The Pull Request

The runtime is caused because the monkey ai_controller overrides `UnpossessPawn()` in which (according to the parent), `pawn` can be null, causing said runtime. So, I just added a null check for `pawn` like in the parent proc. There was also something weird going on with the 

```
proc name: UnregisterSignal (/datum/proc/UnregisterSignal)
usr: somebody's ckey/somebody's name
usr.loc: (Chapel (182, 140, 2))
src: /datum/ai_controller/monkey (/datum/ai_controller/monkey)
call stack:
/datum/ai_controller/monkey (/datum/ai_controller/monkey): UnregisterSignal(null, /list (/list))
/datum/ai_controller/monkey (/datum/ai_controller/monkey): UnpossessPawn(0)
/datum/ai_controller/monkey (/datum/ai_controller/monkey): Destroy(0)
qdel(/datum/ai_controller/monkey (/datum/ai_controller/monkey), 0)
the brain (/obj/item/organ/brain): Destroy(0)
the brain (/obj/item/organ/brain): Destroy(0)
the brain (/obj/item/organ/brain): Destroy(0)
the brain (/obj/item/organ/brain): Destroy(0)
the brain (/obj/item/organ/brain): Destroy(0)
the brain (/obj/item/organ/brain): Destroy(0)
...
/datum/component/religious_too... (/datum/component/religious_tool): AttemptActions(the Altar of the Gods (/obj/structure/altar_of_gods), the brain (/obj/item/organ/brain), somebody's name (/mob/living/carbon/human), "icon-x=20;icon-y=17;left=1;but...")
```

## Why It's Good For The Game

waiter waiter!!! more slop please!

## Testing Photographs and Procedure

At first I thought this was caused by deleting a monkey's brain and then deleting the monkey, but apparently not. IDK how to actually reproduce this, but it will fix the runtime, I pinky promise.

## Changelog
:cl:
fix: fixed monkeys sometimes runtiming when their AI controller is deleted
/:cl: