### PR TITLE
Lings survive decapitation once more

### DIFF
--- a/code/modules/mob/living/brain/brain_item.dm
+++ b/code/modules/mob/living/brain/brain_item.dm
@@ -118,7 +118,7 @@
 	if((!gc_destroyed || (owner && !owner.gc_destroyed)) && !no_id_transfer)
 		if(brain_owner.mind)
 			transfer_identity(brain_owner)
-			if(brain_owner.mind.current)
+			if(brain_owner.mind.current && !decoy_override)
 				brain_owner.mind.transfer_to(brainmob)
 		to_chat(brainmob, span_notice("You feel slightly disoriented. That's normal when you're just a brain."))
 	brain_owner.update_hair()


### PR DESCRIPTION
## About The Pull Request
So lings losing their brain would do a `transfer_to(brainmob)`... except brainmob for lings is always null, now you're going to pass that null value into transfer_to and when it tries to access the .key for that null brainmob it runtimes and bugs lings in ways including but not limited to:
Round removed if you're decapitated
All your abilities get bricked if you lose your brain in any way, effectively round removing you if you ever die.

So now we check if the brain is a decoy first.

Closes https://github.com/BeeStation/BeeStation-Hornet/issues/13738
## Why It's Good For The Game
Really bad bug.

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>

https://github.com/user-attachments/assets/f7b7fa55-a96b-431b-bf4e-23ac15c786a7


<summary>Screenshots&Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>

## Changelog
:cl:
fix: Fixed changelings getting round removed by decapitation.
fix: Fixed changelings being incapable of using abilities without a brain.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
