### PR TITLE
Fixes death not slowing down bleeding, fixes blood splatters spawning excessively

### DIFF
--- a/code/modules/mob/living/blood.dm
+++ b/code/modules/mob/living/blood.dm
@@ -48,12 +48,6 @@ bleedsuppress has been replaced for is_bandaged(). Note that is_bleeding() retur
 		qdel(src)
 		return
 
-	// Add splatter effects on every tick for heavy bleeding, less frequently for light
-	if(bleed_rate >= BLEED_DEEP_WOUND)
-		owner.add_splatter_floor(owner.loc)
-	else if(time_applied >= 1 SECONDS)
-		owner.add_splatter_floor(owner.loc, TRUE)
-
 	time_applied += seconds_between_ticks SECONDS
 
 	// For light bleeding, only process healing/bleeding every 1 second
@@ -168,10 +162,6 @@ bleedsuppress has been replaced for is_bandaged(). Note that is_bleeding() retur
 		blur_eyes(1)
 		var/datum/reagent/blood = get_blood_id() //Not every race has "BLOOD" rushing from the wound
 		to_chat(src, "[span_userdanger("[blood.name] starts rushing out of the open wound!")]")
-	if(bleed_level >= BLEED_CUT)
-		add_splatter_floor(src.loc)
-	else
-		add_splatter_floor(src.loc, 1)
 
 /mob/living/carbon/human/add_bleeding(bleed_level)
 	if(HAS_TRAIT(src, TRAIT_NOBLOOD))
@@ -358,7 +348,7 @@ bleedsuppress has been replaced for is_bandaged(). Note that is_bleeding() retur
 		// See the top of this file for desmos lines
 		var/decrease_multiplier = BLEED_RATE_MULTIPLIER
 		var/obj/item/organ/heart/heart = get_organ_slot(ORGAN_SLOT_HEART)
-		if (!heart || !heart.beating || src.stat == DEAD)
+		if (!heart || !heart.beating)
 			decrease_multiplier = BLEED_RATE_MULTIPLIER_NO_HEART
 		var/blood_loss_amount = blood_volume - blood_volume * NUM_E ** (-(amt * decrease_multiplier)/BLOOD_VOLUME_NORMAL)
 		blood_volume = max(blood_volume - blood_loss_amount, 0)

--- a/code/modules/mob/living/blood.dm
+++ b/code/modules/mob/living/blood.dm
@@ -339,7 +339,7 @@ bleedsuppress has been replaced for is_bandaged(). Note that is_bleeding() retur
 		adjustOxyLoss(health_difference)
 
 /mob/living/proc/bleed(amt)
-	add_splatter_floor(src.loc, 1)
+	add_splatter_floor(src.loc, TRUE)
 
 //Makes a blood drop, leaking amt units of blood from the mob
 /mob/living/carbon/bleed(amt)
@@ -356,7 +356,7 @@ bleedsuppress has been replaced for is_bandaged(). Note that is_bleeding() retur
 			if(blood_loss_amount >= 2)
 				add_splatter_floor(src.loc)
 			else
-				add_splatter_floor(src.loc, 1)
+				add_splatter_floor(src.loc, TRUE)
 
 /mob/living/carbon/human/bleed(amt)
 	amt *= physiology.bleed_mod

--- a/code/modules/mob/living/blood.dm
+++ b/code/modules/mob/living/blood.dm
@@ -358,7 +358,7 @@ bleedsuppress has been replaced for is_bandaged(). Note that is_bleeding() retur
 		// See the top of this file for desmos lines
 		var/decrease_multiplier = BLEED_RATE_MULTIPLIER
 		var/obj/item/organ/heart/heart = get_organ_slot(ORGAN_SLOT_HEART)
-		if (!heart || !heart.beating)
+		if (!heart || !heart.beating || src.stat == DEAD)
 			decrease_multiplier = BLEED_RATE_MULTIPLIER_NO_HEART
 		var/blood_loss_amount = blood_volume - blood_volume * NUM_E ** (-(amt * decrease_multiplier)/BLOOD_VOLUME_NORMAL)
 		blood_volume = max(blood_volume - blood_loss_amount, 0)

--- a/code/modules/mob/living/blood.dm
+++ b/code/modules/mob/living/blood.dm
@@ -348,7 +348,7 @@ bleedsuppress has been replaced for is_bandaged(). Note that is_bleeding() retur
 		// See the top of this file for desmos lines
 		var/decrease_multiplier = BLEED_RATE_MULTIPLIER
 		var/obj/item/organ/heart/heart = get_organ_slot(ORGAN_SLOT_HEART)
-		if (!heart || !heart.beating)
+		if (!heart || !heart.beating || src.stat == DEAD)
 			decrease_multiplier = BLEED_RATE_MULTIPLIER_NO_HEART
 		var/blood_loss_amount = blood_volume - blood_volume * NUM_E ** (-(amt * decrease_multiplier)/BLOOD_VOLUME_NORMAL)
 		blood_volume = max(blood_volume - blood_loss_amount, 0)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
So heart.beating doesn't care about whether you're dead or not, it only cares about heart attacks, so now we check if you're dead dead.

Blood splatters were being applied by 3 procs at once for what seems like no reason so now it's only the final bleed() proc that spawns splatters.
## Why It's Good For The Game
Dying means you don't get drained to 0% blood constantly. Splatters don't get spammed.

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>

Blood slowing down after death:

<img width="373" height="249" alt="Code_ARoKkZDR4n" src="https://github.com/user-attachments/assets/5f35e90c-c4b0-4a43-bcf4-3e187f355105" />

BEFORE: Splatters being applied by 3 procs with differing bleeding values:

https://github.com/user-attachments/assets/1644b183-6dcc-4eec-aef8-c4daf7e20be6


AFTER: Splatters being applied by the proc that actually does the blood calculations:

https://github.com/user-attachments/assets/f5a04e7c-a737-4ed1-b4a7-2bd15495a4e1


<summary>Screenshots&Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>

## Changelog
:cl:
fix: Fixed death not slowing down bleeding.
fix: Fixed blood splatters spawning on every tile when subjected to heavy bleeding.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
