### PR TITLE
Station Self-Destruct Improvements

### DIFF
--- a/code/__DEFINES/admin.dm
+++ b/code/__DEFINES/admin.dm
@@ -45,6 +45,7 @@
 #define ADMIN_LOOKUP(user) "[key_name_admin(user)][ADMIN_QUE(user)]"
 #define ADMIN_LOOKUPFLW(user) "[key_name_admin(user)][ADMIN_QUE(user)] [ADMIN_FLW(user)]"
 #define ADMIN_SET_SD_CODE "(<a href='byond://?_src_=holder;[HrefToken(TRUE)];set_selfdestruct_code=1'>SETCODE</a>)"
+#define ADMIN_REJECT_SD_REQUEST(request) "(<a href='byond://?_src_=holder;[HrefToken(TRUE)];reject_nuke_request=[REF(request)]'>REJECT</A>))"
 #define ADMIN_FULLMONTY_NONAME(user) "[ADMIN_QUE(user)] [ADMIN_PP(user)] [ADMIN_VV(user)] [ADMIN_SM(user)] [ADMIN_FLW(user)] [ADMIN_TP(user)] [ADMIN_INDIVIDUALLOG(user)] [ADMIN_SMITE(user)]"
 #define ADMIN_FULLMONTY(user) "[key_name_admin(user)] [ADMIN_FULLMONTY_NONAME(user)]"
 #define ADMIN_JMP(src) "(<a href='byond://?_src_=holder;[HrefToken(TRUE)];adminplayerobservecoodjump=1;X=[src.x];Y=[src.y];Z=[src.z]'>JMP</a>)"

--- a/code/__DEFINES/announcements.dm
+++ b/code/__DEFINES/announcements.dm
@@ -3,5 +3,7 @@
 #define ANNOUNCEMENT_TYPE_PRIORITY "Priority"
 /// Make it sound like it's coming from the Captain
 #define ANNOUNCEMENT_TYPE_CAPTAIN "Captain"
+/// Make it sound like it's a standard station announcement
+#define ANNOUNCEMENT_TYPE_STATION "Station"
 /// Make it sound like it's coming from the Syndicate
 #define ANNOUNCEMENT_TYPE_SYNDICATE "Syndicate"

--- a/code/__HELPERS/priority_announce.dm
+++ b/code/__HELPERS/priority_announce.dm
@@ -68,6 +68,11 @@
 		if(ANNOUNCEMENT_TYPE_CAPTAIN)
 			header = MAJOR_ANNOUNCEMENT_TITLE("[JOB_NAME_CAPTAIN]'s Announcement")
 			GLOB.news_network.submit_article(text, "[JOB_NAME_CAPTAIN]'s Announcement", "Station Announcements", null)
+		if(ANNOUNCEMENT_TYPE_STATION)
+			header = MAJOR_ANNOUNCEMENT_TITLE("Station Announcement")
+			GLOB.news_network.submit_article(text, "Station Announcement", "Station Announcements", null)
+			if(length(title) > 0)
+				header += SUBHEADER_ANNOUNCEMENT_TITLE(title)
 		if(ANNOUNCEMENT_TYPE_SYNDICATE)
 			header = MAJOR_ANNOUNCEMENT_TITLE("Syndicate Announcement")
 		else

--- a/code/game/machinery/computer/communications.dm
+++ b/code/game/machinery/computer/communications.dm
@@ -223,7 +223,7 @@
 			nuke_request(reason, usr)
 			to_chat(usr, span_notice("Request sent."))
 			usr.log_message("has requested the nuclear codes from CentCom with reason \"[reason]\"", LOG_SAY)
-			priority_announce("The codes for the on-station nuclear self-destruct have been requested by [usr]. Confirmation or denial of this request will be sent shortly.", "Nuclear Self-Destruct Codes Requested", SSstation.announcer.get_rand_report_sound())
+			priority_announce("The codes for the on-station nuclear self-destruct have been requested by [usr]. Confirmation or denial of this request will be sent shortly.", "Nuclear Self-Destruct Codes Requested", SSstation.announcer.get_rand_report_sound(), ANNOUNCEMENT_TYPE_STATION)
 			playsound(src, 'sound/machines/terminal_prompt.ogg', 50, FALSE)
 			COOLDOWN_START(src, important_action_cooldown, IMPORTANT_ACTION_COOLDOWN)
 			. = TRUE

--- a/code/game/machinery/computer/communications.dm
+++ b/code/game/machinery/computer/communications.dm
@@ -223,7 +223,7 @@
 			nuke_request(reason, usr)
 			to_chat(usr, span_notice("Request sent."))
 			usr.log_message("has requested the nuclear codes from CentCom with reason \"[reason]\"", LOG_SAY)
-			priority_announce("The codes for the on-station nuclear self-destruct have been requested by [usr]. Confirmation or denial of this request will be sent shortly.", "Nuclear Self-Destruct Codes Requested", SSstation.announcer.get_rand_report_sound(), ANNOUNCEMENT_TYPE_STATION)
+			priority_announce("The codes for the on-station nuclear self-destruct have been requested by [usr].", "Nuclear Self-Destruct Codes Requested", SSstation.announcer.get_rand_report_sound(), ANNOUNCEMENT_TYPE_STATION)
 			playsound(src, 'sound/machines/terminal_prompt.ogg', 50, FALSE)
 			COOLDOWN_START(src, important_action_cooldown, IMPORTANT_ACTION_COOLDOWN)
 			. = TRUE

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -897,8 +897,6 @@
 		// notify admins and requester
 		message_admins("[key_name(src.owner)] has rejected a nuke request from [request.owner_name].")
 		log_admin("[key_name(src.owner)] rejected a nuke request from [request.owner_name].")
-		if(request.owner && request.owner.mob)
-			to_chat(request.owner.mob, span_warning("Your request for the self-destruct code has been rejected by the admins."))
 		qdel(request)
 
 	else if(href_list["jumpto"])

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -1293,7 +1293,7 @@
 				if(response)
 					log_query_debug("[usr.key] | [response]")
 		else if(answer == "no")
-		 log_query_debug("[usr.key] | Reported no server hang")
+			log_query_debug("[usr.key] | Reported no server hang")
 
 	else if(href_list["ctf_toggle"])
 		if(!check_rights(R_ADMIN))

--- a/code/modules/admin/verbs/pray.dm
+++ b/code/modules/admin/verbs/pray.dm
@@ -75,7 +75,6 @@
 /proc/nuke_request(text, mob/sender)
 	var/msg = copytext_char(sanitize(text), 1, MAX_MESSAGE_LEN)
 	GLOB.requests.nuke_request(sender.client, msg)
-	msg = span_adminnotice("<b><font color=orange>NUKE CODE REQUEST:</font>[ADMIN_FULLMONTY(sender)] [ADMIN_CENTCOM_REPLY(sender)] [ADMIN_SET_SD_CODE]:</b> [msg]")
-	to_chat(GLOB.admins, msg)
+	message_admins("[ADMIN_FULLMONTY(sender)] has requested the self-destruct codes. [ADMIN_CENTCOM_REPLY(sender)]")
 	for(var/obj/machinery/computer/communications/console in GLOB.machines)
 		console.override_cooldown()

--- a/code/modules/antagonists/nukeop/equipment/nuclearbomb.dm
+++ b/code/modules/antagonists/nukeop/equipment/nuclearbomb.dm
@@ -347,11 +347,16 @@ GLOBAL_VAR_INIT(nuke_off_station, 0)
 	switch(action)
 		if("eject_disk")
 			if(auth && auth.loc == src)
-				playsound(src, 'sound/machines/terminal_insert_disc.ogg', 50, FALSE)
-				playsound(src, 'sound/machines/nuke/general_beep.ogg', 50, FALSE)
-				auth.forceMove(get_turf(src))
-				auth = null
-				. = TRUE
+				if(!timing)
+					playsound(src, 'sound/machines/terminal_insert_disc.ogg', 50, FALSE)
+					playsound(src, 'sound/machines/nuke/general_beep.ogg', 50, FALSE)
+					auth.forceMove(get_turf(src))
+					auth = null
+					. = TRUE
+				else
+					playsound(src, 'sound/machines/nuke/angry_beep.ogg', 50, FALSE)
+					balloon_alert_to_viewers("Cannot eject disk from active nuclear device!")
+					numeric_input = "ERROR"
 			else
 				var/obj/item/I = usr.is_holding_item_of_type(/obj/item/disk/nuclear)
 				if(I && disk_check(I) && usr.transferItemToLoc(I, src))

--- a/code/modules/requests/request.dm
+++ b/code/modules/requests/request.dm
@@ -22,6 +22,8 @@
 	var/additional_information
 	/// When the request was created
 	var/timestamp
+	/// Timer id used for auto-approving requests (eg. nuke requests)
+	var/response_timer_id = null
 
 /datum/request/New(client/requestee, type, request, additional_info)
 	if (!requestee)

--- a/code/modules/requests/request_manager.dm
+++ b/code/modules/requests/request_manager.dm
@@ -284,7 +284,6 @@ GLOBAL_DATUM_INIT(requests, /datum/request_manager, new)
 	var/code = random_code(5)
 	for(var/obj/machinery/nuclearbomb/selfdestruct/SD in GLOB.nuke_list)
 		SD.r_code = code
-		SD.minimum_timer_set = 300 // Set minimum timer to 5 minutes
 
 	// Announce to admins and requester
 	message_admins(span_adminnotice("Auto-approved nuke request from [request.owner_name]: code set to [code]."))

--- a/code/modules/requests/request_manager.dm
+++ b/code/modules/requests/request_manager.dm
@@ -298,6 +298,7 @@ GLOBAL_DATUM_INIT(requests, /datum/request_manager, new)
 		Misuse of this function will trigger direct disciplinary action upon review by High Command.\n\n\
 		Authorization codes for your station have been assigned:\n\
 		=>>> [code] <<<=\n\n\
+		Per regulation, minimum detonation core timer is locked at 5 minutes.\n\n\
 		Your alert level has been set to RED automatically.\n\n\
 		--- END OF MESSAGE ---</code></center>", "Automated Message", FALSE)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This does the following:

- Nuclear code requests are now auto-accepted after 60 seconds, admins can veto it.
- Raises the self-destruct terminal's minimum time to 5 minutes
- Introduces progressive warnings as the timer goes down(of the self destruct, other nukes don't get this)
- All nuclear devices now send an announcement informing the crew of the fact a nuke has been armed, and what the remaining time is.
  - Hard to believe but we didn't do this, it just wordlessly activates delta and that's it.
 - All nuclear devices that are NOT the station's self destruct have had their maximum time reduced to 120 seconds, which lines up with the end of the song that plays.
   - This avoids the all-too-common situation of a nuke being set, and then everyone forgets about it, before it silently blows up.
- I think that was it. I added a station alert type to priority alerts that's intended to be used for stationside announcements. It made no sense that CC is telling us that we sent them a request. How silly.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

I envision a nuke-endgame sort of like CM13. Where the nuclear device becomes a more relevant part of antag planning, and last-stand vault defenses become a regular-ish feature.

This will be badass in the extreme.

It also clears up some of the uncertainty revolving around nukes and their activation in general, so that's always good.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure

https://www.youtube.com/watch?v=OVZL6vv4vu0

## Changelog
:cl:
add: Added more announcements to nuclear devices
tweak: nuke code requests are now auto-accepted
balance: the station self-destruct terminal now has a minumum time of 5 minutes
balance: all other nukes get a max time of 120 seconds.
code: added new type for announcements that fit station-specific announcements better
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
