### PR TITLE
Syndicate Modsuit Buffs

### DIFF
--- a/code/modules/antagonists/nukeop/nukeop.dm
+++ b/code/modules/antagonists/nukeop/nukeop.dm
@@ -489,13 +489,12 @@
 	name = "Syndicate Operative - Full Kit"
 
 	glasses = /obj/item/clothing/glasses/night
+	back = /obj/item/mod/control/pre_equipped/nuclear
 	mask = /obj/item/clothing/mask/gas/syndicate
-	suit = /obj/item/clothing/suit/space/hardsuit/syndi
 	r_pocket = /obj/item/tank/internals/emergency_oxygen/engi
 	internals_slot = ITEM_SLOT_RPOCKET
 	belt = /obj/item/storage/belt/military
-	r_hand = /obj/item/gun/ballistic/shotgun/automatic/bulldog
-	l_hand = /obj/item/tank/jetpack/oxygen/harness
+	suit_store = /obj/item/gun/ballistic/shotgun/automatic/bulldog
 	backpack_contents = list(
 		/obj/item/storage/box/survival/syndie=1,\
 		/obj/item/gun/ballistic/automatic/pistol=1,\

--- a/code/modules/antagonists/role_preference/role_roundstarts.dm
+++ b/code/modules/antagonists/role_preference/role_roundstarts.dm
@@ -276,7 +276,7 @@
 	back = /obj/item/mod/control/pre_equipped/empty/syndicate
 
 /datum/outfit/nuclear_operative/post_equip(mob/living/carbon/human/H, visuals_only)
-	var/obj/item/mod/module/armor_booster/booster = locate() in H.back
+	var/obj/item/mod/module/mod_switch/booster = locate() in H.back
 	booster.active = TRUE
 	H.update_worn_back()
 
@@ -288,7 +288,7 @@
 	r_hand = /obj/item/shield/energy
 
 /datum/outfit/nuclear_operative_elite/post_equip(mob/living/carbon/human/H, visuals_only)
-	var/obj/item/mod/module/armor_booster/booster = locate() in H.back
+	var/obj/item/mod/module/mod_switch/booster = locate() in H.back
 	booster.active = TRUE
 	H.update_worn_back()
 	var/obj/item/shield/energy/shield = locate() in H.held_items

--- a/code/modules/mod/mod_theme.dm
+++ b/code/modules/mod/mod_theme.dm
@@ -1134,7 +1134,7 @@
 	slowdown_deployed = 0
 	ui_theme = "syndicate"
 	resistance_flags = FIRE_PROOF
-	inbuilt_modules = list(/obj/item/mod/module/armor_booster)
+	inbuilt_modules = list(/obj/item/mod/module/mod_switch)
 	allowed_suit_storage = list(
 		/obj/item/restraints/handcuffs,
 		/obj/item/assembly/flash,
@@ -1241,7 +1241,7 @@
 	siemens_coefficient = 0
 	slowdown_deployed = 0
 	ui_theme = "syndicate"
-	inbuilt_modules = list(/obj/item/mod/module/armor_booster)
+	inbuilt_modules = list(/obj/item/mod/module/mod_switch)
 	allowed_suit_storage = list(
 		/obj/item/restraints/handcuffs,
 		/obj/item/assembly/flash,

--- a/code/modules/mod/mod_theme.dm
+++ b/code/modules/mod/mod_theme.dm
@@ -1212,16 +1212,16 @@
 	)
 
 /datum/armor/mod_theme_syndicate
-	melee = 22.5
-	bullet = 22.5
-	laser = 15
-	energy = 30
+	melee = 40
+	bullet = 50
+	laser = 30
+	energy = 55
 	bomb = 35
 	bio = 100
 	fire = 50
-	acid = 90
-	stamina = 30
-	bleed = 55
+	acid = 100
+	stamina = 60
+	bleed = 70
 
 /datum/mod_theme/elite
 	name = "elite"
@@ -1285,16 +1285,16 @@
 	)
 
 /datum/armor/mod_theme_elite
-	melee = 35
-	bullet = 30
-	laser = 35
-	energy = 35
+	melee = 60
+	bullet = 60
+	laser = 50
+	energy = 70
 	bomb = 55
 	bio = 100
 	fire = 100
 	acid = 100
-	stamina = 45
-	bleed = 60
+	stamina = 80
+	bleed = 70
 
 /datum/mod_theme/infiltrator
 	name = "infiltrator"

--- a/code/modules/mod/mod_types.dm
+++ b/code/modules/mod/mod_types.dm
@@ -234,7 +234,7 @@
 		/obj/item/mod/module/tracking_beacon/syndicate,
 	)
 	default_pins = list(
-		/obj/item/mod/module/armor_booster,
+		/obj/item/mod/module/mod_switch,
 		/obj/item/mod/module/jetpack,
 		/obj/item/mod/module/tracking_beacon/syndicate,
 	)
@@ -254,7 +254,7 @@
 		/obj/item/mod/module/tracking_beacon/syndicate,
 	)
 	default_pins = list(
-		/obj/item/mod/module/armor_booster,
+		/obj/item/mod/module/mod_switch,
 		/obj/item/mod/module/jetpack/advanced,
 		/obj/item/mod/module/tracking_beacon/syndicate,
 	)
@@ -273,7 +273,7 @@
 		/obj/item/mod/module/tracking_beacon/syndicate,
 	)
 	default_pins = list(
-		/obj/item/mod/module/armor_booster,
+		/obj/item/mod/module/mod_switch,
 		/obj/item/mod/module/jetpack/advanced,
 		/obj/item/mod/module/tracking_beacon/syndicate,
 	)
@@ -295,7 +295,7 @@
 		/obj/item/mod/module/tracking_beacon/syndicate,
 	)
 	default_pins = list(
-		/obj/item/mod/module/armor_booster,
+		/obj/item/mod/module/mod_switch,
 		/obj/item/mod/module/jetpack/advanced,
 		/obj/item/mod/module/tracking_beacon/syndicate,
 	)
@@ -313,7 +313,7 @@
 		/obj/item/mod/module/flamethrower,
 	)
 	default_pins = list(
-		/obj/item/mod/module/armor_booster,
+		/obj/item/mod/module/mod_switch,
 		/obj/item/mod/module/jetpack/advanced,
 		/obj/item/mod/module/tracking_beacon/syndicate,
 		/obj/item/mod/module/flamethrower,

--- a/code/modules/mod/modules/modules_antag.dm
+++ b/code/modules/mod/modules/modules_antag.dm
@@ -47,7 +47,7 @@
 
 /obj/item/mod/module/armor_booster/on_activation()
 	playsound(src, 'sound/mecha/mechmove03.ogg', 25, TRUE, SHORT_RANGE_SOUND_EXTRARANGE)
-	balloon_alert(mod.wearer, "Combat mode Active, EVA Lost")
+	balloon_alert(mod.wearer, "Combat protocol engaged, EVA Lost")
 	/*
 	var/datum/mod_part/head_cover = mod.get_part_datum_from_slot(ITEM_SLOT_HEAD) || mod.get_part_datum_from_slot(ITEM_SLOT_MASK) || mod.get_part_datum_from_slot(ITEM_SLOT_EYES)
 	if(head_cover)
@@ -67,7 +67,7 @@
 /obj/item/mod/module/armor_booster/on_deactivation(display_message = TRUE, deleting = FALSE)
 	if(!deleting)
 		playsound(src, 'sound/mecha/mechmove03.ogg', 25, TRUE, SHORT_RANGE_SOUND_EXTRARANGE)
-		balloon_alert(mod.wearer, "Combat mode Deactivated, EVA ready")
+		balloon_alert(mod.wearer, "Combat protocol disengaged, EVA ready")
 	/*
 	var/datum/mod_part/head_cover = mod.get_part_datum_from_slot(ITEM_SLOT_HEAD) || mod.get_part_datum_from_slot(ITEM_SLOT_MASK) || mod.get_part_datum_from_slot(ITEM_SLOT_EYES)
 	if(head_cover)

--- a/code/modules/mod/modules/modules_antag.dm
+++ b/code/modules/mod/modules/modules_antag.dm
@@ -3,9 +3,9 @@
 ///Mode Switch - Switch from combat mode to EVA.
 /obj/item/mod/module/armor_booster
 	name = "\improper MOD Mode Switch Module"
-	desc = "A retrofitted series of retractable armor plates, allowing the suit to change from two versions, EVA and combat, \
-		removing the usual weight given by the armor platings, however both versions cannot be deployed at the same time, \
-		since it retracts part of the armor to make them lightweight and less bulkier on the body, while removing the ability to spacewalk."
+	desc = "A retrofitted pressurized shell which allow the suit to change between two versions, EVA and combat. \
+		Activating combat mode removes the usual weight given by the shell allowing, for greater mobility, \
+		but sacrificing the ability to safely navigate vacuums."
 	icon_state = "armor_booster"
 	module_type = MODULE_TOGGLE
 	active_power_cost = DEFAULT_CHARGE_DRAIN * 0.3

--- a/code/modules/mod/modules/modules_antag.dm
+++ b/code/modules/mod/modules/modules_antag.dm
@@ -1,12 +1,11 @@
 //Antag modules for MODsuits
 
-///Armor Booster - Grants your suit more armor and speed in exchange for EVA protection.
+///Mode Switch - Switch from combat mode to EVA.
 /obj/item/mod/module/armor_booster
-	name = "\improper MOD armor booster module"
-	desc = "A retrofitted series of retractable armor plates, allowing the suit to function as essentially power armor, \
-		giving the user incredible protection against conventional firearms, or everyday attacks in close-quarters. \
-		However, the additional plating cannot deploy alongside parts of the suit used for vacuum sealing, \
-		so this extra armor provides zero ability for extravehicular activity while deployed."
+	name = "\improper MOD Mode Switch Module"
+	desc = "A retrofitted series of retractable armor plates, allowing the suit to change from two versions, EVA and combat, \
+		removing the usual weight given by the armor platings, however both versions cannot be deployed at the same time. \
+		since it retracts part of the armor to make them lightweight and less bulkier on the body, while removing the ability to spacewalk."
 	icon_state = "armor_booster"
 	module_type = MODULE_TOGGLE
 	active_power_cost = DEFAULT_CHARGE_DRAIN * 0.3
@@ -29,10 +28,6 @@
 	space_slowdown = 0
 
 /datum/armor/mod_module_armor_boost
-	melee = 25
-	bullet = 30
-	laser = 15
-	energy = 15
 
 /obj/item/mod/module/armor_booster/on_part_activation()
 	RegisterSignal(mod, COMSIG_MOD_UPDATE_SPEED, PROC_REF(on_update_speed))
@@ -52,7 +47,7 @@
 
 /obj/item/mod/module/armor_booster/on_activation()
 	playsound(src, 'sound/mecha/mechmove03.ogg', 25, TRUE, SHORT_RANGE_SOUND_EXTRARANGE)
-	balloon_alert(mod.wearer, "armor boosted, EVA lost")
+	balloon_alert(mod.wearer, "Combat mode Active, EVA Lost")
 	/*
 	var/datum/mod_part/head_cover = mod.get_part_datum_from_slot(ITEM_SLOT_HEAD) || mod.get_part_datum_from_slot(ITEM_SLOT_MASK) || mod.get_part_datum_from_slot(ITEM_SLOT_EYES)
 	if(head_cover)
@@ -72,7 +67,7 @@
 /obj/item/mod/module/armor_booster/on_deactivation(display_message = TRUE, deleting = FALSE)
 	if(!deleting)
 		playsound(src, 'sound/mecha/mechmove03.ogg', 25, TRUE, SHORT_RANGE_SOUND_EXTRARANGE)
-		balloon_alert(mod.wearer, "armor retracts, EVA ready")
+		balloon_alert(mod.wearer, "Combat mode Deactivated, EVA ready")
 	/*
 	var/datum/mod_part/head_cover = mod.get_part_datum_from_slot(ITEM_SLOT_HEAD) || mod.get_part_datum_from_slot(ITEM_SLOT_MASK) || mod.get_part_datum_from_slot(ITEM_SLOT_EYES)
 	if(head_cover)

--- a/code/modules/mod/modules/modules_antag.dm
+++ b/code/modules/mod/modules/modules_antag.dm
@@ -1,16 +1,16 @@
 //Antag modules for MODsuits
 
 ///Mode Switch - Switch from combat mode to EVA.
-/obj/item/mod/module/armor_booster
+/obj/item/mod/module/mod_switch
 	name = "\improper MOD Mode Switch Module"
 	desc = "A retrofitted pressurized shell which allow the suit to change between two versions, EVA and combat. \
-		Activating combat mode removes the usual weight given by the shell allowing, for greater mobility, \
+		Activating combat mode removes the usual weight given by the shell allowing for greater mobility, \
 		but sacrificing the ability to safely navigate vacuums."
 	icon_state = "armor_booster"
 	module_type = MODULE_TOGGLE
 	active_power_cost = DEFAULT_CHARGE_DRAIN * 0.3
 	removable = FALSE
-	incompatible_modules = list(/obj/item/mod/module/armor_booster, /obj/item/mod/module/welding)
+	incompatible_modules = list(/obj/item/mod/module/mod_switch, /obj/item/mod/module/welding)
 	overlay_state_inactive = "module_armorbooster_off"
 	overlay_state_active = "module_armorbooster_on"
 	use_mod_colors = TRUE
@@ -22,17 +22,14 @@
 	/// List of parts of the suit that are spaceproofed, for giving them back the pressure protection.
 	var/list/spaceproofed = list()
 
-/obj/item/mod/module/armor_booster/no_speedbost
-	space_slowdown = 0
-
-/obj/item/mod/module/armor_booster/on_part_activation()
+/obj/item/mod/module/mod_switch/on_part_activation()
 	RegisterSignal(mod, COMSIG_MOD_UPDATE_SPEED, PROC_REF(on_update_speed))
 	var/obj/item/clothing/head_cover = mod.get_part_from_slot(ITEM_SLOT_HEAD) || mod.get_part_from_slot(ITEM_SLOT_MASK) || mod.get_part_from_slot(ITEM_SLOT_EYES)
 	if(istype(head_cover))
 		head_cover.flash_protect = FLASH_PROTECTION_WELDER
 	mod.update_speed()
 
-/obj/item/mod/module/armor_booster/on_part_deactivation(deleting = FALSE)
+/obj/item/mod/module/mod_switch/on_part_deactivation(deleting = FALSE)
 	if(deleting)
 		return
 	UnregisterSignal(mod, COMSIG_MOD_UPDATE_SPEED)
@@ -41,7 +38,7 @@
 		head_cover.flash_protect = initial(head_cover.flash_protect)
 	mod.update_speed()
 
-/obj/item/mod/module/armor_booster/on_activation()
+/obj/item/mod/module/mod_switch/on_activation()
 	playsound(src, 'sound/mecha/mechmove03.ogg', 25, TRUE, SHORT_RANGE_SOUND_EXTRARANGE)
 	balloon_alert(mod.wearer, "Combat Protocol engaged, EVA Lost")
 	/*
@@ -59,10 +56,10 @@
 			spaceproofed[clothing_part] = TRUE
 	mod.update_speed()
 
-/obj/item/mod/module/armor_booster/on_deactivation(display_message = TRUE, deleting = FALSE)
+/obj/item/mod/module/mod_switch/on_deactivation(display_message = TRUE, deleting = FALSE)
 	if(!deleting)
 		playsound(src, 'sound/mecha/mechmove03.ogg', 25, TRUE, SHORT_RANGE_SOUND_EXTRARANGE)
-		balloon_alert(mod.wearer, "Combat mode Deactivated, EVA ready")
+		balloon_alert(mod.wearer, "Combat Protocol disengaged, EVA ready")
 	/*
 	var/datum/mod_part/head_cover = mod.get_part_datum_from_slot(ITEM_SLOT_HEAD) || mod.get_part_datum_from_slot(ITEM_SLOT_MASK) || mod.get_part_datum_from_slot(ITEM_SLOT_EYES)
 	if(head_cover)
@@ -77,18 +74,18 @@
 	mod.update_speed()
 	spaceproofed = list()
 
-/obj/item/mod/module/armor_booster/proc/on_update_speed(datum/source, list/module_slowdowns, prevent_slowdown)
+/obj/item/mod/module/mod_switch/proc/on_update_speed(datum/source, list/module_slowdowns, prevent_slowdown)
 	SIGNAL_HANDLER
 	if (!active)
 		module_slowdowns += space_slowdown
 
-/obj/item/mod/module/armor_booster/generate_worn_overlay(mutable_appearance/standing)
+/obj/item/mod/module/mod_switch/generate_worn_overlay(mutable_appearance/standing)
 	overlay_state_inactive = "[initial(overlay_state_inactive)]-[mod.skin]"
 	overlay_state_active = "[initial(overlay_state_active)]-[mod.skin]"
 	return ..()
 
 /*
-/obj/item/mod/module/armor_booster/proc/seal_helmet(datum/source, datum/mod_part/part)
+/obj/item/mod/module/mod_switch/proc/seal_helmet(datum/source, datum/mod_part/part)
 	var/datum/mod_part/head_cover = mod.get_part_datum_from_slot(ITEM_SLOT_HEAD) || mod.get_part_datum_from_slot(ITEM_SLOT_MASK) || mod.get_part_datum_from_slot(ITEM_SLOT_EYES)
 	if(part != head_cover)
 		return
@@ -98,13 +95,13 @@
 		REMOVE_TRAIT(mod.wearer, TRAIT_HEAD_INJURY_BLOCKED, REF(src))
 */
 
-/obj/item/mod/module/armor_booster/on_install()
+/obj/item/mod/module/mod_switch/on_install()
 	RegisterSignal(mod, COMSIG_MOD_GET_VISOR_OVERLAY, PROC_REF(on_visor_overlay))
 
-/obj/item/mod/module/armor_booster/on_uninstall(deleting)
+/obj/item/mod/module/mod_switch/on_uninstall(deleting)
 	UnregisterSignal(mod, COMSIG_MOD_GET_VISOR_OVERLAY)
 
-/obj/item/mod/module/armor_booster/proc/on_visor_overlay(datum/source,  mutable_appearance/standing, list/overrides)
+/obj/item/mod/module/mod_switch/proc/on_visor_overlay(datum/source,  mutable_appearance/standing, list/overrides)
 	SIGNAL_HANDLER
 	if (active)
 		overrides += mutable_appearance(overlay_icon_file, "module_armorbooster_visor-[mod.skin]", layer = standing.layer + 0.1)
@@ -492,7 +489,7 @@
 	complexity = 0
 	removable = FALSE
 	idle_power_cost = DEFAULT_CHARGE_DRAIN * 0
-	incompatible_modules = list(/obj/item/mod/module/infiltrator, /obj/item/mod/module/armor_booster, /obj/item/mod/module/welding)
+	incompatible_modules = list(/obj/item/mod/module/infiltrator, /obj/item/mod/module/mod_switch, /obj/item/mod/module/welding)
 	required_slots = list(ITEM_SLOT_FEET, ITEM_SLOT_HEAD, ITEM_SLOT_OCLOTHING)
 
 /obj/item/mod/module/infiltrator/on_install()

--- a/code/modules/mod/modules/modules_antag.dm
+++ b/code/modules/mod/modules/modules_antag.dm
@@ -4,7 +4,7 @@
 /obj/item/mod/module/armor_booster
 	name = "\improper MOD Mode Switch Module"
 	desc = "A retrofitted series of retractable armor plates, allowing the suit to change from two versions, EVA and combat, \
-		removing the usual weight given by the armor platings, however both versions cannot be deployed at the same time. \
+		removing the usual weight given by the armor platings, however both versions cannot be deployed at the same time, \
 		since it retracts part of the armor to make them lightweight and less bulkier on the body, while removing the ability to spacewalk."
 	icon_state = "armor_booster"
 	module_type = MODULE_TOGGLE

--- a/code/modules/mod/modules/modules_antag.dm
+++ b/code/modules/mod/modules/modules_antag.dm
@@ -19,15 +19,11 @@
 	var/remove_pressure_protection = TRUE
 	/// Slowdown added to the control unit while this module is disabled
 	var/space_slowdown = 0.5
-	/// Armor values added to the suit parts.
-	var/datum/armor/armor_mod = /datum/armor/mod_module_armor_boost
 	/// List of parts of the suit that are spaceproofed, for giving them back the pressure protection.
 	var/list/spaceproofed = list()
 
 /obj/item/mod/module/armor_booster/no_speedbost
 	space_slowdown = 0
-
-/datum/armor/mod_module_armor_boost
 
 /obj/item/mod/module/armor_booster/on_part_activation()
 	RegisterSignal(mod, COMSIG_MOD_UPDATE_SPEED, PROC_REF(on_update_speed))
@@ -47,7 +43,7 @@
 
 /obj/item/mod/module/armor_booster/on_activation()
 	playsound(src, 'sound/mecha/mechmove03.ogg', 25, TRUE, SHORT_RANGE_SOUND_EXTRARANGE)
-	balloon_alert(mod.wearer, "Combat protocol engaged, EVA Lost")
+	balloon_alert(mod.wearer, "Combat Protocol engaged, EVA Lost")
 	/*
 	var/datum/mod_part/head_cover = mod.get_part_datum_from_slot(ITEM_SLOT_HEAD) || mod.get_part_datum_from_slot(ITEM_SLOT_MASK) || mod.get_part_datum_from_slot(ITEM_SLOT_EYES)
 	if(head_cover)
@@ -55,7 +51,6 @@
 		seal_helmet(mod, head_cover)
 	*/
 	for(var/obj/item/part as anything in mod.get_parts(all = TRUE))
-		part.set_armor(part.get_armor().add_other_armor(armor_mod))
 		if(!remove_pressure_protection || !isclothing(part))
 			continue
 		var/obj/item/clothing/clothing_part = part
@@ -67,14 +62,13 @@
 /obj/item/mod/module/armor_booster/on_deactivation(display_message = TRUE, deleting = FALSE)
 	if(!deleting)
 		playsound(src, 'sound/mecha/mechmove03.ogg', 25, TRUE, SHORT_RANGE_SOUND_EXTRARANGE)
-		balloon_alert(mod.wearer, "Combat protocol disengaged, EVA ready")
+		balloon_alert(mod.wearer, "Combat mode Deactivated, EVA ready")
 	/*
 	var/datum/mod_part/head_cover = mod.get_part_datum_from_slot(ITEM_SLOT_HEAD) || mod.get_part_datum_from_slot(ITEM_SLOT_MASK) || mod.get_part_datum_from_slot(ITEM_SLOT_EYES)
 	if(head_cover)
 		UnregisterSignal(mod, COMSIG_MOD_PART_SEALED)
 	*/
 	for(var/obj/item/part as anything in mod.get_parts(all = TRUE))
-		part.set_armor(part.get_armor().subtract_other_armor(armor_mod))
 		if(!remove_pressure_protection || !isclothing(part))
 			continue
 		var/obj/item/clothing/clothing_part = part

--- a/code/modules/mod/modules/modules_engineering.dm
+++ b/code/modules/mod/modules/modules_engineering.dm
@@ -8,7 +8,7 @@
 		immunity against extremities such as spot and arc welding, solar eclipses, and handheld flashlights."
 	icon_state = "welding"
 	complexity = 1
-	incompatible_modules = list(/obj/item/mod/module/welding, /obj/item/mod/module/armor_booster)
+	incompatible_modules = list(/obj/item/mod/module/welding, /obj/item/mod/module/mod_switch)
 	overlay_state_inactive = "module_welding"
 	required_slots = list(ITEM_SLOT_HEAD|ITEM_SLOT_EYES|ITEM_SLOT_MASK)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Losing armor for being in EVA mode was weird, renames the armor booster module in favor of Mod Switch Module
As the name implies, it's main use right now is changing from EVA to Combat

In EVA you're spaceproof but slower
In COMBAT mode you are not spaceproof but are faster



## Why It's Good For The Game

Nukies wont get obliterated while in EVA anymore

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

<img width="369" height="270" alt="image" src="https://github.com/user-attachments/assets/6f14e167-efeb-469d-b018-3fba98982769" />

<img width="332" height="199" alt="image" src="https://github.com/user-attachments/assets/61a2d602-611d-425a-a705-e8e7d9a1374e" />

<img width="1140" height="596" alt="image" src="https://github.com/user-attachments/assets/d161555d-0c55-44b6-9b20-182ed29f9638" />



</details>

## Changelog

:cl: Isaac

balance: Syndicate Modsuits now have it's full armor, regardless if it's in EVA or Combat
balance: Lone Operative now starts with the modsuit
/:cl: 

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
