### PR TITLE
Fixes toy eswords not having an inhand icon

### DIFF
--- a/code/game/objects/items/toys.dm
+++ b/code/game/objects/items/toys.dm
@@ -293,6 +293,8 @@
 	name = "toy sword"
 	desc = "A cheap, plastic replica of an energy sword. Realistic sounds! Ages 8 and up."
 	icon_state = "e_sword"
+	base_icon_state = "e_sword"
+	inhand_icon_state = "e_sword"
 	icon = 'icons/obj/transforming_energy.dmi'
 	lefthand_file = 'icons/mob/inhands/weapons/swords_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/weapons/swords_righthand.dmi'
@@ -338,9 +340,12 @@
 
 /obj/item/toy/sword/update_icon_state()
 	. = ..()
-	var/last_part = HAS_TRAIT(src, TRAIT_TRANSFORM_ACTIVE) ? "_on[saber_color ? "_[saber_color]" : null]" : null
-	icon_state = "[initial(icon_state)][last_part]"
-	inhand_icon_state = "[initial(inhand_icon_state)][last_part]"
+	if(HAS_TRAIT(src, TRAIT_TRANSFORM_ACTIVE))
+		icon_state = "[base_icon_state]_on_[saber_color]" // "esword_on_red"
+		inhand_icon_state = icon_state
+	else
+		icon_state = base_icon_state
+		inhand_icon_state = base_icon_state
 
 /obj/item/toy/sword/multitool_act(mob/living/user, obj/item/tool)
 	if(hacked)


### PR DESCRIPTION
## About The Pull Request

see title

## Why It's Good For The Game

closes #13544

## Testing Photographs and Procedure

### Enabled

<img width="100" height="83" alt="image" src="https://github.com/user-attachments/assets/3398cb1e-1863-46c5-bd65-2dc4703c2e46" />

<img width="66" height="68" alt="image" src="https://github.com/user-attachments/assets/bd75c726-171e-4158-b42b-2b11461c59c2" />

### Disabled

<img width="69" height="89" alt="image" src="https://github.com/user-attachments/assets/f8870339-0b01-4cea-a2f8-e2e2d0b29c95" />

<img width="79" height="83" alt="image" src="https://github.com/user-attachments/assets/5a6e565d-d500-4261-b3bc-3e3c898fb19b" />

## Changelog
:cl:
fix: fixed toy eswords not having an inhand icon
/:cl:
