### PR TITLE
Fixes blood freezers having fake ethereal blood in them

### DIFF
--- a/code/modules/reagents/reagent_containers/blood_pack.dm
+++ b/code/modules/reagents/reagent_containers/blood_pack.dm
@@ -78,12 +78,6 @@
 /obj/item/reagent_containers/blood/synthetic
 	blood_type = "Coolant"
 
-/obj/item/reagent_containers/blood/ethereal
-	labelled = 1
-	name = "blood pack - LE"
-	blood_type = "LE"
-	unique_blood = /datum/reagent/consumable/liquidelectricity
-
 /obj/item/reagent_containers/blood/oozeling
 	labelled = 1
 	name = "blood pack - OZ"


### PR DESCRIPTION
## About The Pull Request

the blood pack was redefined with improper vars

## Why It's Good For The Game

closes #13747

## Testing Photographs and Procedure

https://github.com/user-attachments/assets/c60ff7cf-62df-4501-9752-94b7fdbbec67

## Changelog
:cl:
fix: blood freezers are no longer stocked with fake ethereal blood
/:cl:
