### PR TITLE
Github: Repo actions

### DIFF
--- a/.github/workflows/repo_actions.yml
+++ b/.github/workflows/repo_actions.yml
@@ -1,0 +1,20 @@
+name: Execute Management Actions
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize, edited]  # triggers when PR is opened or updated
+  issue_comment:
+    types: [created]
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
+      - name: Run local action
+        uses: BeeStation/Repo-Actions
+        with:
+          githubToken: ${{ secrets.GITHUB_TOKEN }}
+          tagLabels: Administration, Balance/Rebalance, Feature, Fix, Mapping, Port, Refactor, Quality Of Life, Removal, Revert, Tweak, UI


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Repo-actions is an in-house action which can execute a variety of useful modules:
- Size module: Labels PRs based on their size, making it easy to see at a glance which PRs will be a quick review.
- Time estimator module: Comments on PRs indicating the average time which PRs of similar sizes took to be merged, meaning the author can have some expectations about PR merge delay.
- Review module: Labels PRs based on waiting for review, changes requested, or author requested reviews. Will automatically determine the correct label based on existing review state.
- Label module: Labels PRs based on keywords found in the body of the PR

It isn't totally fully complete yet, and there are a few things I'll probably modify in the future

## Why It's Good For The Game

We can keep editing this and it provides some useful functionality.

## Testing Photographs and Procedure

It takes a long time to execute at first, but then the build gets cached and it goes faster. You can see this working on the PRs on repo-actions, not sure if it will work in this PR or only until its merged.

## Changelog
:cl:
code: Implements repo-actions for managing PRs on github.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
