### PR TITLE
Informed jumpsuit type

### DIFF
--- a/code/__DEFINES/preferences.dm
+++ b/code/__DEFINES/preferences.dm
@@ -238,6 +238,9 @@ GLOBAL_PROTECT(undatumized_preference_tags_character)
 /// Dependant on gender to create an informed value
 #define PREFERENCE_PRIORITY_UNDERWEAR 4
 
+/// Dependant on gender to create an informed value
+#define PREFERENCE_PRIORITY_JUMPSUIT 4
+
 /// Dependant on hair colour to create an informed value
 #define PREFERENCE_PRIORITY_FACIAL_COLOR 5
 

--- a/code/modules/client/preferences/entries/character/clothing.dm
+++ b/code/modules/client/preferences/entries/character/clothing.dm
@@ -59,6 +59,8 @@
 	main_feature_name = "Jumpsuit"
 	category = PREFERENCE_CATEGORY_CLOTHING
 	should_generate_icons = TRUE
+	informed = TRUE
+	priority = PREFERENCE_PRIORITY_JUMPSUIT
 
 /datum/preference/choiced/jumpsuit_style/init_possible_values()
 	var/list/values = list()
@@ -70,6 +72,12 @@
 
 /datum/preference/choiced/jumpsuit_style/apply_to_human(mob/living/carbon/human/target, value)
 	target.jumpsuit_style = value
+
+/datum/preference/choiced/jumpsuit_style/create_informed_default_value(datum/preferences/preferences)
+	var/gender = preferences.read_character_preference(/datum/preference/choiced/gender)
+	if (gender == MALE)
+		return PREF_SUIT
+	return pick(PREF_SUIT, PREF_SKIRT)
 
 /// Socks preference
 /datum/preference/choiced/socks


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Randomised jumpsuit value will no longer spawn with jumpskirts when male.

## Why It's Good For The Game

With the rest of randomisation being quite locked down on what it can spawn, having a bearded security guy spawn in a skirt feels very out of place.

## Testing Photographs and Procedure

https://github.com/user-attachments/assets/ef0c6f64-f4eb-4eff-8686-3d896ce48439

## Changelog
:cl:
fix: Characters generated through the strict random generator will no longer spawn with jumpskirts when male.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
