### PR TITLE
Unrandomises default backpack choice

### DIFF
--- a/code/modules/client/preferences/entries/character/clothing.dm
+++ b/code/modules/client/preferences/entries/character/clothing.dm
@@ -52,6 +52,9 @@
 /datum/preference/choiced/backpack/apply_to_human(mob/living/carbon/human/target, value)
 	target.backbag = value
 
+/datum/preference/choiced/backpack/create_default_value()
+	return DBACKPACK
+
 /// Jumpsuit preference
 /datum/preference/choiced/jumpsuit_style
 	db_key = "jumpsuit_style"

--- a/code/modules/client/preferences/entries/character/clothing.dm
+++ b/code/modules/client/preferences/entries/character/clothing.dm
@@ -52,9 +52,6 @@
 /datum/preference/choiced/backpack/apply_to_human(mob/living/carbon/human/target, value)
 	target.backbag = value
 
-/datum/preference/choiced/backpack/create_random_value(datum/preferences/preferences)
-	return pick(get_choices())
-
 /datum/preference/choiced/backpack/create_default_value()
 	return DBACKPACK
 

--- a/code/modules/client/preferences/entries/character/clothing.dm
+++ b/code/modules/client/preferences/entries/character/clothing.dm
@@ -52,6 +52,9 @@
 /datum/preference/choiced/backpack/apply_to_human(mob/living/carbon/human/target, value)
 	target.backbag = value
 
+/datum/preference/choiced/backpack/create_random_value(datum/preferences/preferences)
+	return pick(get_choices())
+
 /datum/preference/choiced/backpack/create_default_value()
 	return DBACKPACK
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

You will always be spawned with the standard department backpack by default.

## Why It's Good For The Game

It is insanely annoying in testing to be assigned duffel bag in your prefs which then constantly tries to equip you with it, making you slow. Just give us the normal backpack choice and let people change it if they want.

## Testing Photographs and Procedure

https://github.com/user-attachments/assets/86541fab-21e1-4027-9a39-8dc29bf66eac

Something to note is that it will always pick the departmental backpack even when using fully random characters. This is because the randomisation choice just creates a new initial value and there is no way in the preference system to ask for hard randomisation. This is fine, since it means we will always get a best pick and players are free to change it manually.

## Changelog
:cl:
tweak: The default backpack choice will always be departmental backpack now.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
