### PR TITLE
Ensures that all PDAs have at least 90 minutes of battery life when not using any particular programs

### DIFF
--- a/code/modules/modular_computers/computers/item/computer.dm
+++ b/code/modules/modular_computers/computers/item/computer.dm
@@ -104,6 +104,8 @@ GLOBAL_LIST_EMPTY(TabletMessengers) // a list of all active messengers, similar 
 	var/default_virus_defense = ANTIVIRUS_NONE
 	/// Multiplier for power usage
 	var/power_usage_multiplier = 1
+	/// People looking at the computer
+	var/list/computer_users = list()
 
 /datum/armor/item_modular_computer
 	bullet = 20

--- a/code/modules/modular_computers/computers/item/computer_power.dm
+++ b/code/modules/modular_computers/computers/item/computer_power.dm
@@ -127,7 +127,7 @@
 		if(H.enabled)
 			power_usage += H.power_usage
 
-	if (active_program && length(viewers) > 0)
+	if (active_program && length(computer_users) > 0)
 		power_usage += active_program.power_consumption
 
 	return power_usage * power_usage_multiplier

--- a/code/modules/modular_computers/computers/item/computer_power.dm
+++ b/code/modules/modular_computers/computers/item/computer_power.dm
@@ -127,7 +127,7 @@
 		if(H.enabled)
 			power_usage += H.power_usage
 
-	if (active_program)
+	if (active_program && length(viewers) > 0)
 		power_usage += active_program.power_consumption
 
 	return power_usage * power_usage_multiplier

--- a/code/modules/modular_computers/computers/item/computer_ui.dm
+++ b/code/modules/modular_computers/computers/item/computer_ui.dm
@@ -40,6 +40,8 @@
 
 	ui = SStgui.try_update_ui(user, src, ui)
 	if(!ui)
+		// Register the user as a viewer
+		computer_users |= REF(user)
 		if(active_program)
 			ui = new(user, src, active_program.tgui_id, active_program.filedesc)
 			ui.set_autoupdate(TRUE)
@@ -66,6 +68,7 @@
 /obj/item/modular_computer/ui_close(mob/user, datum/tgui/tgui)
 	if(active_program)
 		active_program.on_ui_close(user, tgui)
+	computer_users -= REF(user)
 
 /obj/item/modular_computer/ui_assets(mob/user)
 	var/list/data = list()

--- a/code/modules/modular_computers/computers/item/role_tablet_presets.dm
+++ b/code/modules/modular_computers/computers/item/role_tablet_presets.dm
@@ -240,6 +240,8 @@
 
 /obj/item/modular_computer/tablet/pda/preset/syndicate/Initialize(mapload)
 	. = ..()
+	forget_component(all_components[MC_CELL])
+	install_component(new /obj/item/computer_hardware/battery/huge)
 	var/obj/item/computer_hardware/network_card/network_card = all_components[MC_NET]
 	if(istype(network_card))
 		forget_component(network_card)

--- a/code/modules/modular_computers/computers/item/role_tablet_presets.dm
+++ b/code/modules/modular_computers/computers/item/role_tablet_presets.dm
@@ -1,10 +1,11 @@
 /obj/item/modular_computer/tablet/pda/preset	//This needs to exist or else we can't really have empty PDA shells!
+	var/cell_type = /obj/item/computer_hardware/battery/tiny
 
 /obj/item/modular_computer/tablet/pda/preset/Initialize(mapload)
 	. = ..()
 	install_component(new /obj/item/computer_hardware/hard_drive/micro)
 	install_component(new /obj/item/computer_hardware/processor_unit/small)
-	install_component(new /obj/item/computer_hardware/battery/tiny)
+	install_component(new cell_type)
 	install_component(new /obj/item/computer_hardware/network_card)
 	install_component(new /obj/item/computer_hardware/card_slot)
 	install_component(new /obj/item/computer_hardware/identifier)
@@ -134,7 +135,7 @@
 	icon_state = "pda-science"
 	init_ringtone = "boom"
 
-/obj/item/modular_computer/tablet/pda/science/Initialize(mapload)
+/obj/item/modular_computer/tablet/pda/preset/science/Initialize(mapload)
 	. = ..()
 	install_component(new /obj/item/computer_hardware/radio_card)
 
@@ -237,11 +238,10 @@
 	device_theme = THEME_SYNDICATE
 	theme_locked = TRUE
 	default_virus_defense = ANTIVIRUS_BEST
+	cell_type = /obj/item/computer_hardware/battery/huge
 
 /obj/item/modular_computer/tablet/pda/preset/syndicate/Initialize(mapload)
 	. = ..()
-	forget_component(all_components[MC_CELL])
-	install_component(new /obj/item/computer_hardware/battery/huge)
 	var/obj/item/computer_hardware/network_card/network_card = all_components[MC_NET]
 	if(istype(network_card))
 		forget_component(network_card)

--- a/code/modules/modular_computers/computers/item/role_tablet_presets.dm
+++ b/code/modules/modular_computers/computers/item/role_tablet_presets.dm
@@ -238,6 +238,7 @@
 	device_theme = THEME_SYNDICATE
 	theme_locked = TRUE
 	default_virus_defense = ANTIVIRUS_BEST
+	max_hardware_size = WEIGHT_CLASS_SMALL
 	cell_type = /obj/item/computer_hardware/battery/large
 
 /obj/item/modular_computer/tablet/pda/preset/syndicate/Initialize(mapload)

--- a/code/modules/modular_computers/computers/item/role_tablet_presets.dm
+++ b/code/modules/modular_computers/computers/item/role_tablet_presets.dm
@@ -238,7 +238,7 @@
 	device_theme = THEME_SYNDICATE
 	theme_locked = TRUE
 	default_virus_defense = ANTIVIRUS_BEST
-	cell_type = /obj/item/computer_hardware/battery/huge
+	cell_type = /obj/item/computer_hardware/battery/large
 
 /obj/item/modular_computer/tablet/pda/preset/syndicate/Initialize(mapload)
 	. = ..()

--- a/code/modules/modular_computers/hardware/battery_module.dm
+++ b/code/modules/modular_computers/hardware/battery_module.dm
@@ -96,7 +96,7 @@ CREATION_TEST_IGNORE_SUBTYPES(/obj/item/computer_hardware/battery)
 	desc = "A tiny power cell, commonly seen in low-end portable microcomputers."
 	icon_state = "cell_micro"
 	w_class = WEIGHT_CLASS_TINY
-	maxcharge = 40 KILOWATT
+	maxcharge = 60 KILOWATT
 	chargerate_divide = 4
 	custom_price = PAYCHECK_EASY
 	rating = PART_TIER_1
@@ -105,7 +105,7 @@ CREATION_TEST_IGNORE_SUBTYPES(/obj/item/computer_hardware/battery)
 	name = "micro battery"
 	desc = "A small power cell, commonly seen in most portable microcomputers."
 	icon_state = "cell_micro"
-	maxcharge = 60 KILOWATT
+	maxcharge = 80 KILOWATT
 	w_class = WEIGHT_CLASS_TINY
 	custom_price = PAYCHECK_EASY * 2
 	rating = PART_TIER_2

--- a/code/modules/modular_computers/hardware/battery_module.dm
+++ b/code/modules/modular_computers/hardware/battery_module.dm
@@ -96,7 +96,7 @@ CREATION_TEST_IGNORE_SUBTYPES(/obj/item/computer_hardware/battery)
 	desc = "A tiny power cell, commonly seen in low-end portable microcomputers."
 	icon_state = "cell_micro"
 	w_class = WEIGHT_CLASS_TINY
-	maxcharge = 60 KILOWATT
+	maxcharge = 75 KILOWATT
 	chargerate_divide = 4
 	custom_price = PAYCHECK_EASY
 	rating = PART_TIER_1
@@ -105,7 +105,7 @@ CREATION_TEST_IGNORE_SUBTYPES(/obj/item/computer_hardware/battery)
 	name = "micro battery"
 	desc = "A small power cell, commonly seen in most portable microcomputers."
 	icon_state = "cell_micro"
-	maxcharge = 80 KILOWATT
+	maxcharge = 90 KILOWATT
 	w_class = WEIGHT_CLASS_TINY
 	custom_price = PAYCHECK_EASY * 2
 	rating = PART_TIER_2
@@ -117,7 +117,7 @@ CREATION_TEST_IGNORE_SUBTYPES(/obj/item/computer_hardware/battery)
 	icon = 'icons/obj/module.dmi'
 	icon_state = "cell_mini"
 	w_class = WEIGHT_CLASS_SMALL
-	maxcharge = 100 KILOWATT
+	maxcharge = 110 KILOWATT
 	/// rating affects the size of the explosion created by the detonation of the battery (trough Power Cell Controler hacking)
 	rating = PART_TIER_3
 	custom_price = PAYCHECK_MEDIUM

--- a/code/modules/modular_computers/hardware/network_card.dm
+++ b/code/modules/modular_computers/hardware/network_card.dm
@@ -95,7 +95,7 @@
 	name = "ultra-advanced network card"
 	desc = "A prototype card that mimics hardline connectivity using unstable bluespace channels. Impervious to relay interference."
 	signal_level = SIGNAL_NO_RELAY
-	power_usage = 25 // Watts per second
+	power_usage = 10 // Watts per second
 	icon_state = "no-relay"
 	custom_price = 100
 	identification_string = "x_net_card"

--- a/code/modules/modular_computers/hardware/printer.dm
+++ b/code/modules/modular_computers/hardware/printer.dm
@@ -1,7 +1,7 @@
 /obj/item/computer_hardware/printer
 	name = "printer"
 	desc = "Computer-integrated printer with paper recycling module."
-	power_usage = 10 // Watts per second
+	power_usage = 50 // Watts per second
 	icon_state = "printer"
 	w_class = WEIGHT_CLASS_NORMAL
 	device_type = MC_PRINT
@@ -115,7 +115,7 @@
 /obj/item/computer_hardware/printer/mini
 	name = "miniprinter"
 	desc = "A small printer with paper recycling module."
-	power_usage = 50
+	power_usage = 2
 	icon_state = "printer_mini"
 	w_class = WEIGHT_CLASS_TINY
 	stored_paper = 5

--- a/code/modules/unit_tests/_unit_tests.dm
+++ b/code/modules/unit_tests/_unit_tests.dm
@@ -65,6 +65,7 @@
 #include "organs.dm"
 #include "orphaned_genturf.dm"
 #include "outfit_sanity.dm"
+#include "pda_power.dm"
 #include "preference_species.dm"
 #include "preferences.dm"
 #include "projectiles.dm"

--- a/code/modules/unit_tests/pda_power.dm
+++ b/code/modules/unit_tests/pda_power.dm
@@ -10,6 +10,6 @@
 			continue
 		var/time_left = (power_held / power_consumption) SECONDS
 		if (time_left < 90 MINUTES)
-			errors += "PDA with path [pda_path] only had [time_left / (1 MINUTES)] of power when running no programs. It needs at least 90 minutes of runtime as to not frustrate players and to be a reasonably usable item."
+			errors += "PDA with path [pda_path] only had [time_left / (1 MINUTES)] minutes of power when running no programs. It needs at least 90 minutes of runtime as to not frustrate players and to be a reasonably usable item."
 	if (length(errors))
 		TEST_FAIL(jointext(errors, "\n"))

--- a/code/modules/unit_tests/pda_power.dm
+++ b/code/modules/unit_tests/pda_power.dm
@@ -1,8 +1,15 @@
 /datum/unit_test/pda_power_consumption/Run()
+	var/list/errors = list()
 	for (var/pda_path in subtypesof(/obj/item/modular_computer/tablet/pda))
 		var/obj/item/modular_computer/tablet/pda/pda = allocate(pda_path)
+		pda.enabled = TRUE
 		var/power_held = pda.get_power()
-		TEST_ASSERT_EQUAL(pda.handle_power(1), TRUE, "The PDA tyoe [pda_path] failed its handle_power call when spawned.")
-		var/power_consumption = pda.last_power_usage
+		var/power_consumption = pda.calculate_power()
+		if (!power_consumption)
+			errors += "PDA of path [pda_path] has 0 power consumption when turned on."
+			continue
 		var/time_left = (power_held / power_consumption) SECONDS
-		TEST_ASSERT_TRUE(time_left > 90 MINUTES, "PDA with path [pda_path] only had [time_left / (1 MINUTES)] of power when running no programs. It needs at least 90 minutes of runtime as to not frustrate players and to be a reasonably usable item.")
+		if (time_left < 90 MINUTES)
+			errors += "PDA with path [pda_path] only had [time_left / (1 MINUTES)] of power when running no programs. It needs at least 90 minutes of runtime as to not frustrate players and to be a reasonably usable item."
+	if (length(errors))
+		TEST_FAIL(jointext(errors, "\n"))

--- a/code/modules/unit_tests/pda_power.dm
+++ b/code/modules/unit_tests/pda_power.dm
@@ -1,0 +1,8 @@
+/datum/unit_test/pda_power_consumption/Run()
+	for (var/pda_path in subtypesof(/obj/item/modular_computer/tablet/pda))
+		var/obj/item/modular_computer/tablet/pda/pda = allocate(pda_path)
+		var/power_held = pda.get_power()
+		TEST_ASSERT_EQUAL(pda.handle_power(1), TRUE, "The PDA tyoe [pda_path] failed its handle_power call when spawned.")
+		var/power_consumption = pda.last_power_usage
+		var/time_left = (power_held / power_consumption) SECONDS
+		TEST_ASSERT_TRUE(time_left > 90 MINUTES, "PDA with path [pda_path] only had [time_left / (1 MINUTES)] of power when running no programs. It needs at least 90 minutes of runtime as to not frustrate players and to be a reasonably usable item.")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

I have tried to fix this so many times, but PDAs keep being useless due to having their battery get eaten up in 15 minutes. When you fail to fix something twice, a unit test is only fair.

The active program no longer consumes power when nobody is actually looking at it, to remove a gotcha that results in accidental battery drain.

## Why It's Good For The Game

The PDA has totally a useless battery right now which makes it impossible to balance important programs into it. It isn't fun to have the PDA last for 10 minutes and is just frustrating to have it feel like its randomly not booting up. Since the PDA is used for important things and will be used for important things in the future (programs + uplink), players need to not be punished for simply interacting with it.

## Testing Photographs and Procedure

<img width="555" height="79" alt="image" src="https://github.com/user-attachments/assets/1954fa25-adfe-4ac8-8da9-bb5420f85622" />

<img width="569" height="93" alt="image" src="https://github.com/user-attachments/assets/8529d4da-67ef-4915-9393-498e12c028be" />

<img width="484" height="674" alt="image" src="https://github.com/user-attachments/assets/c03e7556-7896-41b7-8056-7c63de9ad6ef" />


## Changelog
:cl:
fix: Supply PDAs no longer run out of power after 10 minutes of use.
fix: Fixes the science PDA not getting its components installed correctly.
tweak: All PDAs now last at least 90 minutes without any programs opened.
balance: PDAs will no longer consume power from active programs when not observed.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
