### PR TITLE
Cults and nukies spawn a minimum of two players

### DIFF
--- a/code/controllers/subsystem/dynamic/dynamic_rulesets_roundstart.dm
+++ b/code/controllers/subsystem/dynamic/dynamic_rulesets_roundstart.dm
@@ -206,7 +206,7 @@
 	var/datum/team/cult/team
 
 /datum/dynamic_ruleset/roundstart/bloodcult/set_drafted_players_amount()
-	drafted_players_amount = max(FLOOR(length(SSdynamic.roundstart_candidates) / 9, 1), 1)
+	drafted_players_amount = max(FLOOR(length(SSdynamic.roundstart_candidates) / 9, 1), 2)
 
 /datum/dynamic_ruleset/roundstart/bloodcult/execute()
 	team = new
@@ -253,7 +253,7 @@
 	var/datum/team/clock_cult/main_cult
 
 /datum/dynamic_ruleset/roundstart/clockcult/set_drafted_players_amount()
-	drafted_players_amount = max(FLOOR(length(SSdynamic.roundstart_candidates) / 7, 1), 1)
+	drafted_players_amount = max(FLOOR(length(SSdynamic.roundstart_candidates) / 7, 1), 2)
 
 /datum/dynamic_ruleset/roundstart/clockcult/choose_candidates()
 	. = ..()
@@ -309,7 +309,7 @@
 	var/datum/team/nuclear/nuke_team
 
 /datum/dynamic_ruleset/roundstart/nuclear/set_drafted_players_amount()
-	drafted_players_amount = max(FLOOR(length(SSdynamic.roundstart_candidates) / 7, 1), 1)
+	drafted_players_amount = max(FLOOR(length(SSdynamic.roundstart_candidates) / 7, 1), 2)
 
 /datum/dynamic_ruleset/roundstart/nuclear/choose_candidates()
 	. = ..()


### PR DESCRIPTION
## About The Pull Request

see title

## Why It's Good For The Game

closes #13768
closes #13646

## Testing Photographs and Procedure

i can't feasibly get testing evidence- i changed a 1 to a 2.

## Changelog
:cl:
config: cults and nuclear operatives now spawn a minimum of two players
/:cl: