### PR TITLE
Fixes improper to_chat and sound effect when cauterizing someone's bleeding

### DIFF
--- a/code/modules/mob/living/carbon/human/_species.dm
+++ b/code/modules/mob/living/carbon/human/_species.dm
@@ -1919,8 +1919,8 @@ GLOBAL_LIST_EMPTY(features_by_species)
 			H.force_say(user)
 	else if (I.damtype == BURN && H.is_bleeding())
 		H.cauterise_wounds(AMOUNT_TO_BLEED_INTENSITY(I.force / 3))
-		to_chat(user, span_userdanger("The heat from [I] cauterizes your bleeding!"))
-		playsound(src, 'sound/surgery/cautery2.ogg', 70)
+		to_chat(H, span_userdanger("The heat from [I] cauterizes your bleeding!"))
+		playsound(H, 'sound/surgery/cautery2.ogg', 70)
 	return TRUE
 
 /datum/species/proc/apply_damage(damage, damagetype = BRUTE, def_zone = null, blocked, mob/living/carbon/human/H, forced = FALSE, spread_damage = FALSE)


### PR DESCRIPTION
## About The Pull Request

The `to_chat()` was being sent to the person applying the cauterization, this behavior is incorrect. Additionally, the sound effect was being played on `src`, which was a datum in this instance. 

## Why It's Good For The Game

closes #13184

## Testing Photographs and Procedure

https://github.com/user-attachments/assets/d7804b77-4970-4238-95ac-9cb6261f272b

## Changelog
:cl:
fix: fixed cauterizing someone with a hot item sending a message to the wrong person and not playing a sound effect
/:cl:
