### PR TITLE
Fixes runtime when re-aquiring parallax cache

### DIFF
--- a/code/_onclick/hud/parallax.dm
+++ b/code/_onclick/hud/parallax.dm
@@ -15,12 +15,12 @@
 
 	if(!length(C.parallax_layers_cached))
 		C.parallax_layers_cached = list()
-		C.parallax_layers_cached += new /atom/movable/screen/parallax_layer/layer_1(null, src)
-		C.parallax_layers_cached += new /atom/movable/screen/parallax_layer/layer_2(null, src)
-		C.parallax_layers_cached += new /atom/movable/screen/parallax_layer/planet(null, src)
+		C.parallax_layers_cached += new /atom/movable/screen/parallax_layer/layer_1(null, null, C.view)
+		C.parallax_layers_cached += new /atom/movable/screen/parallax_layer/layer_2(null, null, C.view)
+		C.parallax_layers_cached += new /atom/movable/screen/parallax_layer/planet(null, null, C.view)
 		if(SSparallax.random_layer)
-			C.parallax_layers_cached += new SSparallax.random_layer(null, src)
-		C.parallax_layers_cached += new /atom/movable/screen/parallax_layer/layer_3(null, src)
+			C.parallax_layers_cached += new SSparallax.random_layer(null, null, C.view)
+		C.parallax_layers_cached += new /atom/movable/screen/parallax_layer/layer_3(null, null, C.view)
 
 	C.parallax_layers = C.parallax_layers_cached.Copy()
 
@@ -267,20 +267,13 @@
 
 CREATION_TEST_IGNORE_SUBTYPES(/atom/movable/screen/parallax_layer)
 
-/atom/movable/screen/parallax_layer/Initialize(mapload, datum/hud/hud_owner)
+/atom/movable/screen/parallax_layer/Initialize(mapload, datum/hud/hud_owner, view)
 	. = ..()
 	// Parallax layers are independent of hud, they care about client
-	// Not doing this will just create a bunch of hard deletes
+	// This ensures we never have a hud_owner set
 	set_new_hud(hud_owner = null)
 
-	var/client/boss = hud_owner?.mymob?.client
-
-	if(!boss) // If this typepath all starts to harddel your culprit is likely this
-		return INITIALIZE_HINT_QDEL
-
-	// I do not want to know bestie
-	var/view = boss.view || world.view
-	update_o(view)
+	update_o(view || world.view)
 
 /atom/movable/screen/parallax_layer/proc/update_o(view)
 	if (!view)
@@ -329,7 +322,7 @@ CREATION_TEST_IGNORE_SUBTYPES(/atom/movable/screen/parallax_layer)
 
 CREATION_TEST_IGNORE_SUBTYPES(/atom/movable/screen/parallax_layer/random/space_gas)
 
-/atom/movable/screen/parallax_layer/random/space_gas/Initialize(mapload, datum/hud/hud_owner)
+/atom/movable/screen/parallax_layer/random/space_gas/Initialize(mapload, datum/hud/hud_owner, view)
 	. = ..()
 	src.add_atom_colour(SSparallax.assign_random_parallax_colour(), ADMIN_COLOUR_PRIORITY)
 

--- a/code/_onclick/hud/parallax.dm
+++ b/code/_onclick/hud/parallax.dm
@@ -15,12 +15,12 @@
 
 	if(!length(C.parallax_layers_cached))
 		C.parallax_layers_cached = list()
-		C.parallax_layers_cached += new /atom/movable/screen/parallax_layer/layer_1(null, C.view)
-		C.parallax_layers_cached += new /atom/movable/screen/parallax_layer/layer_2(null, C.view)
-		C.parallax_layers_cached += new /atom/movable/screen/parallax_layer/planet(null, C.view)
+		C.parallax_layers_cached += new /atom/movable/screen/parallax_layer/layer_1(null, src)
+		C.parallax_layers_cached += new /atom/movable/screen/parallax_layer/layer_2(null, src)
+		C.parallax_layers_cached += new /atom/movable/screen/parallax_layer/planet(null, src)
 		if(SSparallax.random_layer)
-			C.parallax_layers_cached += new SSparallax.random_layer
-		C.parallax_layers_cached += new /atom/movable/screen/parallax_layer/layer_3(null, C.view)
+			C.parallax_layers_cached += new SSparallax.random_layer(null, src)
+		C.parallax_layers_cached += new /atom/movable/screen/parallax_layer/layer_3(null, src)
 
 	C.parallax_layers = C.parallax_layers_cached.Copy()
 
@@ -267,10 +267,19 @@
 
 CREATION_TEST_IGNORE_SUBTYPES(/atom/movable/screen/parallax_layer)
 
-/atom/movable/screen/parallax_layer/Initialize(mapload, view)
+/atom/movable/screen/parallax_layer/Initialize(mapload, datum/hud/hud_owner)
 	. = ..()
-	if (!view)
-		view = world.view
+	// Parallax layers are independent of hud, they care about client
+	// Not doing this will just create a bunch of hard deletes
+	set_new_hud(hud_owner = null)
+
+	var/client/boss = hud_owner?.mymob?.client
+
+	if(!boss) // If this typepath all starts to harddel your culprit is likely this
+		return INITIALIZE_HINT_QDEL
+
+	// I do not want to know bestie
+	var/view = boss.view || world.view
 	update_o(view)
 
 /atom/movable/screen/parallax_layer/proc/update_o(view)
@@ -320,7 +329,7 @@ CREATION_TEST_IGNORE_SUBTYPES(/atom/movable/screen/parallax_layer)
 
 CREATION_TEST_IGNORE_SUBTYPES(/atom/movable/screen/parallax_layer/random/space_gas)
 
-/atom/movable/screen/parallax_layer/random/space_gas/Initialize(mapload, view)
+/atom/movable/screen/parallax_layer/random/space_gas/Initialize(mapload, datum/hud/hud_owner)
 	. = ..()
 	src.add_atom_colour(SSparallax.assign_random_parallax_colour(), ADMIN_COLOUR_PRIORITY)
 


### PR DESCRIPTION
## About The Pull Request

yada, yada. byond did it's thing. `/atom/movable/screen/parallax_layer/Initialize()` had different proc arguments than it's parent which caused the runtime. I went ahead and made the code a tiny bit less awful as well.

## Why It's Good For The Game

better code, less runtimes

## Testing Photographs and Procedure

<img width="590" height="424" alt="image" src="https://github.com/user-attachments/assets/5ad14b2e-6735-4dd5-9ba2-921d305fd4d3" />

<img width="1016" height="506" alt="image" src="https://github.com/user-attachments/assets/c3840af8-2557-405a-8c6f-9230069336fb" />

## Changelog
:cl:
fix: fixed a runtime when re-aquiring a client's parallax cache
/:cl:
