### PR TITLE
Cleans up shutter jank and QoL

### DIFF
--- a/code/__DEFINES/construction.dm
+++ b/code/__DEFINES/construction.dm
@@ -32,9 +32,11 @@
 #define AIRLOCK_ASSEMBLY_NEEDS_ELECTRONICS 1
 #define AIRLOCK_ASSEMBLY_NEEDS_SCREWDRIVER 2
 
-//blast door (de)construction states
+///The blast door is missing wires, first step of construction.
 #define BLASTDOOR_NEEDS_WIRES 0
+///The blast door needs electronics, second step of construction.
 #define BLASTDOOR_NEEDS_ELECTRONICS 1
+///The blast door is fully constructed.
 #define BLASTDOOR_FINISHED 2
 
 // default_unfasten_wrench() return defines

--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -205,8 +205,9 @@
 	return
 
 /obj/machinery/door/welder_act(mob/living/user, obj/item/tool)
-	try_to_weld(tool, user)
-	return TOOL_ACT_TOOLTYPE_SUCCESS
+	if (!user.combat_mode)
+		try_to_weld(tool, user)
+		return TOOL_ACT_TOOLTYPE_SUCCESS
 
 /obj/machinery/door/crowbar_act(mob/living/user, obj/item/tool)
 	if(user.combat_mode || HAS_TRAIT(tool, TRAIT_DOOR_PRYER))

--- a/code/game/machinery/doors/poddoor.dm
+++ b/code/game/machinery/doors/poddoor.dm
@@ -59,7 +59,7 @@
 			balloon_alert(user, "not enough cable!")
 			return
 		balloon_alert(user, "adding cables...")
-		if(!coil.use_tool(src, user, 5 SECONDS))
+		if(!coil.use_tool(src, user, 5 SECONDS, amount = amount_needed, volume = 50))
 			return TRUE
 		deconstruction = BLASTDOOR_NEEDS_ELECTRONICS
 		balloon_alert(user, "cables added")
@@ -67,7 +67,7 @@
 
 	if(deconstruction == BLASTDOOR_NEEDS_ELECTRONICS && istype(attacking_item, /obj/item/electronics/airlock))
 		balloon_alert(user, "adding electronics...")
-		if(!attacking_item.use_tool(src, user, 10 SECONDS))
+		if(!attacking_item.use_tool(src, user, 10 SECONDS, volume = 50))
 			return TRUE
 		qdel(attacking_item)
 		balloon_alert(user, "electronics added")

--- a/code/game/machinery/doors/poddoor.dm
+++ b/code/game/machinery/doors/poddoor.dm
@@ -40,7 +40,7 @@
 		if(deconstruction == BLASTDOOR_FINISHED)
 			. += span_notice("The maintenance panel is opened and the electronics could be <b>pried</b> out.")
 			. += span_notice("\The [src] could be calibrated to a blast door controller ID with a <b>multitool</b>.")
-			. += span_notice("You can scan another <b>blast door controller</b> and copy it's ID.")
+			. += span_notice("You can scan another <b>blast door controller</b> and copy its ID.")
 		else if(deconstruction == BLASTDOOR_NEEDS_ELECTRONICS)
 			. += span_notice("The <i>electronics</i> are missing and there are some <b>wires</b> sticking out.")
 		else if(deconstruction == BLASTDOOR_NEEDS_WIRES)

--- a/code/game/machinery/doors/poddoor.dm
+++ b/code/game/machinery/doors/poddoor.dm
@@ -2,8 +2,8 @@
 	name = "blast door"
 	desc = "A heavy duty blast door that opens mechanically."
 	icon = 'icons/obj/doors/blastdoors/blastdoor.dmi'
-
-	var/id = 1
+	base_icon_state = "blast"
+	icon_state = "blast_closed"
 	layer = BLASTDOOR_LAYER
 	closingLayer = CLOSED_BLASTDOOR_LAYER
 	sub_door = TRUE
@@ -14,13 +14,16 @@
 	armor_type = /datum/armor/door_poddoor
 	resistance_flags = FIRE_PROOF
 	damage_deflection = 70
+	/// The recipe for this door
 	var/datum/crafting_recipe/recipe_type = /datum/crafting_recipe/blast_doors
-	var/deconstruction = BLASTDOOR_FINISHED // deconstruction step
-	var/base_state = "blast"
+	/// The current deconstruction step
+	var/deconstruction = BLASTDOOR_FINISHED
+	/// The door's ID (used for buttons, etc to control the door)
+	var/id = null
+	/// The sound that plays when the door opens
 	var/pod_open_sound  = 'sound/machines/blastdoor.ogg'
+	/// The sound that plays when the door closes
 	var/pod_close_sound = 'sound/machines/blastdoor.ogg'
-	icon_state = "blast_closed"
-
 
 /datum/armor/door_poddoor
 	melee = 50
@@ -31,59 +34,162 @@
 	fire = 100
 	acid = 70
 
-/obj/machinery/door/poddoor/attackby(obj/item/W, mob/user, params)
-	. = ..()
-
-	if(W.tool_behaviour == TOOL_SCREWDRIVER)
-		if(density)
-			to_chat(user, span_warning("You need to open [src] before opening its maintenance panel."))
-			return
-		else if(default_deconstruction_screwdriver(user, icon_state, icon_state, W))
-			to_chat(user, span_notice("You [panel_open ? "open" : "close"] the maintenance hatch of [src]."))
-			return TRUE
-
-	if(panel_open)
-		if(W.tool_behaviour == TOOL_MULTITOOL && deconstruction == BLASTDOOR_FINISHED)
-			var/change_id = input("Set the shutters/blast door controller's ID. It must be a number between 1 and 100.", "ID", id) as num|null
-			if(change_id)
-				id = clamp(round(change_id, 1), 1, 100)
-				to_chat(user, span_notice("You change the ID to [id]."))
-
-		if(W.tool_behaviour == TOOL_CROWBAR &&deconstruction == BLASTDOOR_FINISHED)
-			to_chat(user, span_notice("You start to remove the airlock electronics."))
-			if(do_after(user, 10 SECONDS, target = src))
-				new /obj/item/electronics/airlock(loc)
-				id = null
-				deconstruction = BLASTDOOR_NEEDS_ELECTRONICS
-
-		else if(W.tool_behaviour == TOOL_WIRECUTTER && deconstruction == BLASTDOOR_NEEDS_ELECTRONICS)
-			to_chat(user, span_notice("You start to remove the internal cables."))
-			if(do_after(user, 10 SECONDS, target = src))
-				deconstruction = TRUE
-				var/datum/crafting_recipe/recipe = locate(recipe_type) in GLOB.crafting_recipes
-				var/amount = recipe.reqs[/obj/item/stack/cable_coil]
-				new /obj/item/stack/cable_coil(loc, amount)
-				deconstruction = BLASTDOOR_NEEDS_WIRES
-
-		else if(W.tool_behaviour == TOOL_WELDER && deconstruction == BLASTDOOR_NEEDS_WIRES)
-			if(!W.tool_start_check(user, amount=0))
-				return
-
-			to_chat(user, span_notice("You start tearing apart the [src]."))
-			playsound(src.loc, 'sound/items/welder.ogg', 50, 1)
-			if(do_after(user, 15 SECONDS, target = src))
-				new /obj/item/stack/sheet/plasteel(loc, 15)
-				qdel(src)
-
 /obj/machinery/door/poddoor/examine(mob/user)
 	. = ..()
 	if(panel_open)
 		if(deconstruction == BLASTDOOR_FINISHED)
 			. += span_notice("The maintenance panel is opened and the electronics could be <b>pried</b> out.")
+			. += span_notice("\The [src] could be calibrated to a blast door controller ID with a <b>multitool</b>.")
+			. += span_notice("You can scan another <b>blast door controller</b> and copy it's ID.")
 		else if(deconstruction == BLASTDOOR_NEEDS_ELECTRONICS)
 			. += span_notice("The <i>electronics</i> are missing and there are some <b>wires</b> sticking out.")
 		else if(deconstruction == BLASTDOOR_NEEDS_WIRES)
 			. += span_notice("The <i>wires</i> have been removed and it's ready to be <b>sliced apart</b>.")
+
+/obj/machinery/door/poddoor/attackby(obj/item/attacking_item, mob/living/user, params)
+	. = ..()
+	if(user.combat_mode)
+		return
+
+	if(deconstruction == BLASTDOOR_NEEDS_WIRES && istype(attacking_item, /obj/item/stack/cable_coil))
+		var/obj/item/stack/cable_coil/coil = attacking_item
+		var/datum/crafting_recipe/recipe = locate(recipe_type) in GLOB.crafting_recipes
+		var/amount_needed = recipe.reqs[/obj/item/stack/cable_coil]
+		if(coil.get_amount() < amount_needed)
+			balloon_alert(user, "not enough cable!")
+			return
+		balloon_alert(user, "adding cables...")
+		if(!coil.use_tool(src, user, 5 SECONDS))
+			return TRUE
+		deconstruction = BLASTDOOR_NEEDS_ELECTRONICS
+		balloon_alert(user, "cables added")
+		return TRUE
+
+	if(deconstruction == BLASTDOOR_NEEDS_ELECTRONICS && istype(attacking_item, /obj/item/electronics/airlock))
+		balloon_alert(user, "adding electronics...")
+		if(!attacking_item.use_tool(src, user, 10 SECONDS))
+			return TRUE
+		qdel(attacking_item)
+		balloon_alert(user, "electronics added")
+		deconstruction = BLASTDOOR_FINISHED
+		return TRUE
+
+	if(deconstruction == BLASTDOOR_FINISHED && istype(attacking_item, /obj/item/assembly/control))
+		if(density)
+			balloon_alert(user, "open the door first!")
+			return TRUE
+		if(!panel_open)
+			balloon_alert(user, "open the panel first!")
+			return TRUE
+
+		var/obj/item/assembly/control/controller_item = attacking_item
+		if(!isnull(controller_item.id))
+			id = controller_item.id
+			balloon_alert(user, "id changed to [id]")
+		return TRUE
+
+/obj/machinery/door/poddoor/screwdriver_act(mob/living/user, obj/item/tool)
+	. = ..()
+	if (user.combat_mode)
+		return
+
+	if (density)
+		balloon_alert(user, "open the door first!")
+		return TOOL_ACT_TOOLTYPE_SUCCESS
+	else if (default_deconstruction_screwdriver(user, icon_state, icon_state, tool))
+		return TOOL_ACT_TOOLTYPE_SUCCESS
+
+/obj/machinery/door/poddoor/crowbar_act(mob/living/user, obj/item/tool)
+	. = ..()
+	// We need to check our parent's return value because it has some snowflake behavior with TRAIT_DOOR_PRYER
+	if(!.)
+		return
+
+	if (machine_stat & NOPOWER)
+		// ..() will have called open()
+		return TOOL_ACT_TOOLTYPE_SUCCESS
+	if (density)
+		balloon_alert(user, "open the door first!")
+		return TOOL_ACT_TOOLTYPE_SUCCESS
+	if (!panel_open)
+		balloon_alert(user, "open the panel first!")
+		return TOOL_ACT_TOOLTYPE_SUCCESS
+	if (deconstruction != BLASTDOOR_FINISHED)
+		return
+
+	balloon_alert(user, "removing airlock electronics...")
+	if(tool.use_tool(src, user, 10 SECONDS, volume = 50))
+		new /obj/item/electronics/airlock(loc)
+		id = null
+		deconstruction = BLASTDOOR_NEEDS_ELECTRONICS
+		balloon_alert(user, "removed airlock electronics")
+	return TOOL_ACT_TOOLTYPE_SUCCESS
+
+/obj/machinery/door/poddoor/wirecutter_act(mob/living/user, obj/item/tool)
+	. = ..()
+	if (user.combat_mode)
+		return
+
+	if (density)
+		balloon_alert(user, "open the door first!")
+		return TOOL_ACT_TOOLTYPE_SUCCESS
+	if (!panel_open)
+		balloon_alert(user, "open the panel first!")
+		return TOOL_ACT_TOOLTYPE_SUCCESS
+	if (deconstruction != BLASTDOOR_NEEDS_ELECTRONICS)
+		return
+
+	balloon_alert(user, "removing internal cables...")
+	if (tool.use_tool(src, user, 10 SECONDS, volume = 50))
+		var/datum/crafting_recipe/recipe = locate(recipe_type) in GLOB.crafting_recipes
+		var/amount = recipe.reqs[/obj/item/stack/cable_coil]
+		new /obj/item/stack/cable_coil(loc, amount)
+		deconstruction = BLASTDOOR_NEEDS_WIRES
+	return TOOL_ACT_TOOLTYPE_SUCCESS
+
+/obj/machinery/door/poddoor/welder_act(mob/living/user, obj/item/tool)
+	. = ..()
+	if (user.combat_mode)
+		return
+
+	if (density)
+		balloon_alert(user, "open the door first!")
+		return TOOL_ACT_TOOLTYPE_SUCCESS
+	if (!panel_open)
+		balloon_alert(user, "open the panel first!")
+		return TOOL_ACT_TOOLTYPE_SUCCESS
+	if (deconstruction != BLASTDOOR_NEEDS_WIRES)
+		return
+
+	balloon_alert(user, "slicing apart...")
+	if(tool.use_tool(src, user, 15 SECONDS, volume = 50))
+		var/datum/crafting_recipe/recipe = locate(recipe_type) in GLOB.crafting_recipes
+		var/amount = recipe.reqs[/obj/item/stack/sheet/plasteel]
+		new /obj/item/stack/sheet/plasteel(loc, amount)
+		qdel(src)
+	return TOOL_ACT_TOOLTYPE_SUCCESS
+
+/obj/machinery/door/poddoor/multitool_act(mob/living/user, obj/item/tool)
+	. = ..()
+	if (user.combat_mode)
+		return
+
+	if (density)
+		balloon_alert(user, "open the door first!")
+		return TOOL_ACT_TOOLTYPE_SUCCESS
+	if (!panel_open)
+		balloon_alert(user, "open the panel first!")
+		return TOOL_ACT_TOOLTYPE_SUCCESS
+	if (deconstruction != BLASTDOOR_FINISHED)
+		return
+
+	var/change_id = tgui_input_number(user, "Set the shutters/blast door controller's ID. It must be a number between 1 and 100.", "Controller ID", min_value = 1, max_value = 100)
+	if (isnull(change_id) || QDELETED(src) || QDELETED(user))
+		return TOOL_ACT_TOOLTYPE_SUCCESS
+
+	id = change_id
+	balloon_alert(user, "id changed to [id]")
+	return TOOL_ACT_TOOLTYPE_SUCCESS
 
 /obj/machinery/door/poddoor/preopen
 	icon_state = "blast_open"
@@ -98,7 +204,7 @@
 
 //special poddoors that open when emergency shuttle docks at centcom
 /obj/machinery/door/poddoor/shuttledock
-	var/checkdir = 4	//door won't open if turf in this dir is `turftype`
+	var/checkdir = EAST // door won't open if turf in this dir is `turftype`
 	var/turftype = /turf/open/space
 
 /obj/machinery/door/poddoor/shuttledock/proc/check()
@@ -139,28 +245,28 @@
 
 //"BLAST" doors are obviously stronger than regular doors when it comes to BLASTS.
 /obj/machinery/door/poddoor/ex_act(severity, target)
-	if(severity == 3)
+	if(severity == EXPLODE_LIGHT)
 		return
-	..()
+	return ..()
 
 /obj/machinery/door/poddoor/do_animate(animation)
 	switch(animation)
 		if("opening")
-			flick("[base_state]_opening", src)
+			flick("[base_icon_state]_opening", src)
 			playsound(src, pod_open_sound, 30, 1)
 		if("closing")
-			flick("[base_state]_closing", src)
+			flick("[base_icon_state]_closing", src)
 			playsound(src, pod_close_sound, 30, 1)
 
 /obj/machinery/door/poddoor/update_icon()
 	if(density)
-		icon_state = "[base_state]_closed"
+		icon_state = "[base_icon_state]_closed"
 	else
-		icon_state = "[base_state]_open"
+		icon_state = "[base_icon_state]_open"
 
 /obj/machinery/door/poddoor/try_to_activate_door(obj/item/I, mob/user)
 	return
 
 /obj/machinery/door/poddoor/try_to_crowbar(obj/item/acting_object, mob/user, forced = FALSE)
 	if(machine_stat & NOPOWER)
-		open(1)
+		open(TRUE)

--- a/code/game/machinery/doors/shutters.dm
+++ b/code/game/machinery/doors/shutters.dm
@@ -3,16 +3,15 @@
 	name = "shutters"
 	desc = "Heavy duty metal shutters that open mechanically."
 	icon = 'icons/obj/doors/blastdoors/shutters.dmi'
+	base_icon_state = "shut"
+	icon_state = "shut_closed"
 	layer = SHUTTER_LAYER
 	closingLayer = SHUTTER_LAYER
 	damage_deflection = 20
 	armor_type = /datum/armor/poddoor_shutters
 	recipe_type = /datum/crafting_recipe/shutters
-	base_state = "shut"
-	icon_state = "shut_closed"
 	pod_open_sound  = 'sound/machines/shutter_open.ogg'
 	pod_close_sound = 'sound/machines/shutter_close.ogg'
-
 
 /datum/armor/poddoor_shutters
 	melee = 20
@@ -29,17 +28,20 @@
 	z_flags = NONE // reset zblock
 	opacity = FALSE
 
+/obj/machinery/door/poddoor/shutters/preopen/deconstructed
+	deconstruction = BLASTDOOR_NEEDS_WIRES
+
 /obj/machinery/door/poddoor/shutters/indestructible
 	name = "hardened shutters"
 	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | UNACIDABLE | ACID_PROOF
 
-/obj/machinery/door/poddoor/shutters/bumpopen()
+/obj/machinery/door/poddoor/shutters/bumpopen(mob/user)
 	return
 
 /obj/machinery/door/poddoor/shutters/radiation
 	name = "radiation shutters"
 	desc = "Depleted uranium-lined shutters with a radiation hazard symbol. Whilst this won't stop you getting irradiated, especially by a supermatter crystal, it will stop the majority of radiation."
-	base_state = "rad"
+	base_icon_state = "rad"
 	icon_state = "rad_closed"
 	rad_insulation = RAD_EXTREME_INSULATION
 	recipe_type = /datum/crafting_recipe/radshutters
@@ -62,7 +64,7 @@
 /obj/machinery/door/poddoor/shutters/window
 	name = "windowed shutters"
 	desc = "A shutter with a thick see-through polycarbonate window."
-	base_state = "win"
+	base_icon_state = "win"
 	icon_state = "win_closed"
 	opacity = FALSE
 	glass = TRUE

--- a/code/game/objects/items/stacks/sheets/mineral/metals_recipes.dm
+++ b/code/game/objects/items/stacks/sheets/mineral/metals_recipes.dm
@@ -130,6 +130,7 @@ GLOBAL_LIST_INIT(plasteel_recipes, list ( \
 	new/datum/stack_recipe("bomb assembly", /obj/machinery/syndicatebomb/empty, 10, time = 5, crafting_flags = NONE, category = CAT_CHEMISTRY),
 	new/datum/stack_recipe("dock tile", /obj/item/stack/tile/dock, 1, 4, 20, crafting_flags = NONE, category = CAT_TILES),
 	new/datum/stack_recipe("dry dock tile", /obj/item/stack/tile/drydock, 2, 4, 20, crafting_flags = NONE, category = CAT_TILES),
+	new/datum/stack_recipe("shutter assembly", /obj/machinery/door/poddoor/shutters/preopen/deconstructed, 5, time = 5 SECONDS, crafting_flags = CRAFT_ONE_PER_TURF, category = CAT_DOORS),
 	null, \
 	new /datum/stack_recipe_list("airlock assemblies", list( \
 		new/datum/stack_recipe("high security airlock assembly", /obj/structure/door_assembly/door_assembly_highsecurity, 4, crafting_flags = CRAFT_CHECK_DENSITY | CRAFT_ONE_PER_TURF | CRAFT_ON_SOLID_GROUND, time = 5 SECONDS, category = CAT_DOORS),

--- a/code/game/objects/items/wall_mounted.dm
+++ b/code/game/objects/items/wall_mounted.dm
@@ -91,3 +91,4 @@
 	custom_price = 20
 	custom_materials = list(/datum/material/iron=50, /datum/material/glass=50)
 	grind_results = list(/datum/reagent/iron = 10, /datum/reagent/silicon = 10)
+	usesound = 'sound/items/deconstruct.ogg'

--- a/code/modules/assembly/doorcontrol.dm
+++ b/code/modules/assembly/doorcontrol.dm
@@ -3,21 +3,39 @@
 	desc = "A small electronic device able to control a blast door remotely."
 	icon_state = "control"
 	attachable = TRUE
+	/// The ID of the blast door electronics to match to the ID of the blast door being used.
 	var/id = null
-	var/can_change_id = 0
-	var/cooldown = FALSE //Door cooldowns
+	/// Cooldown of the door's controller. Updates when pressed (activate())
+	var/cooldown = FALSE
+	/// Should we toggle open/close of doors based on their current state
 	var/sync_doors = TRUE
 
 /obj/item/assembly/control/examine(mob/user)
 	. = ..()
-	if(id)
+	if (!isnull(id))
 		. += span_notice("Its channel ID is '[id]'.")
+	else
+		. += span_notice("It has no channel ID set. You can set it with a multitool or by scanning another controller.")
 
-/obj/item/assembly/control/multitool_act(mob/living/user)
-	var/change_id = input("Set the shutters/blast door controller's ID. It must be a number between 1 and 100.", "ID", id) as num|null
-	if(change_id)
-		id = clamp(round(change_id, 1), 1, 100)
-		to_chat(user, span_notice("You change the ID to [id]."))
+/obj/item/assembly/control/add_context_self(datum/screentip_context/context, mob/user)
+	context.add_left_click_item_action("Copy ID", /obj/item/assembly/control)
+
+/obj/item/assembly/control/attackby(obj/item/attacking_item, mob/user, params)
+	. = ..()
+	if (istype(attacking_item, /obj/item/assembly/control))
+		var/obj/item/assembly/control/other_controller = attacking_item
+		if(!isnull(other_controller.id))
+			id = other_controller.id
+			balloon_alert(user, "id changed to [id]")
+			return TRUE
+
+/obj/item/assembly/control/multitool_act(mob/living/user, obj/item/tool)
+	var/change_id = tgui_input_number(user, "Set the shutters/blast door controller's ID. It must be a number between 1 and 100.", "Controller ID", min_value = 1, max_value = 100)
+	if (isnull(change_id) || QDELETED(src) || QDELETED(user))
+		return
+
+	id = change_id
+	balloon_alert(user, "id changed to [id]")
 
 /obj/item/assembly/control/activate()
 	var/openclose

--- a/code/modules/assembly/doorcontrol.dm
+++ b/code/modules/assembly/doorcontrol.dm
@@ -12,7 +12,7 @@
 
 /obj/item/assembly/control/examine(mob/user)
 	. = ..()
-	if (!isnull(id))
+	if (!isnull(id)) // We check for null here instead of just the value so 0 displays as a valid ID
 		. += span_notice("Its channel ID is '[id]'.")
 	else
 		. += span_notice("It has no channel ID set. You can set it with a multitool or by scanning another controller.")


### PR DESCRIPTION
## About The Pull Request

Ports two /tg/ prs and a bunch of small little improvements of my own.

- https://github.com/tgstation/tgstation/pull/82939
- https://github.com/tgstation/tgstation/pull/84713

## Why It's Good For The Game

Mechanics shouldn't be janky and a headache to use.

closes #13558

## Testing Photographs and Procedure

https://github.com/user-attachments/assets/b4c836e1-0cb3-4b8a-8adb-7a74f5ee50fc

## Changelog
:cl: mrmanlikesbt, JohnFulpWillard, 00-Steven
add: shutter frames can now be made with plasteel in-hand instead of having to use the crafting menu
fix: fixed some jankiness with constructing shutters and blast doors
fix: fixed not being able to deconstruct shutters and blast doors
qol: you can now use a blast door controller on shutters with their panel open to set their ID more easily
qol: you can now copy a blast door controller's ID to another one by hitting it with it 
/:cl:
