### PR TITLE
Fixes shuttle not defaulting to leave when all players are disconnected.

### DIFF
--- a/code/__HELPERS/mobs.dm
+++ b/code/__HELPERS/mobs.dm
@@ -572,6 +572,12 @@ GLOBAL_LIST_EMPTY(species_list)
 		if(player.stat != DEAD && player.mind && !is_centcom_level(player.z) && !isnewplayer(player) && !isbrain(player))
 			. |= player
 
+/proc/get_living_connected_crew()
+	. = list()
+	for(var/mob/living/carbon/human/player in GLOB.mob_living_list)
+		if(player.stat != DEAD && player.mind && player.client)
+			. |= player
+
 //Gets all sentient humans that are alive
 /proc/get_living_crew()
 	. = list()

--- a/code/datums/votes/shuttle_vote.dm
+++ b/code/datums/votes/shuttle_vote.dm
@@ -30,7 +30,7 @@
 		return
 
 /datum/vote/shuttle_vote/tiebreaker(list/winners)
-	if(!length(get_living_crew())) //No Players? Shuttle
+	if(!length(get_living_connected_crew())) //No Players? Shuttle
 		return CHOICE_SHUTTLE
 
 	return length(choices_by_ckey) ? CHOICE_SHUTTLE : CHOICE_CONTINUE  //If there are no votes, continue, otherwise, prefer shuttle.


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

#13770 has flawed logic in that get living crew returns living crew, even if the player for that body has disconnected. This includes if someone ghosts without dying and isn't limited to humans. This means literally any mob that has had a mind at some point will result in the round considering there to be active players.

## Why It's Good For The Game

If everyone on the server disconnects, then we want to default to calling the shuttle.

## Testing Photographs and Procedure

<img width="585" height="550" alt="image" src="https://github.com/user-attachments/assets/baf0d123-5ced-4546-b592-025fa0c43364" />

<img width="793" height="115" alt="image" src="https://github.com/user-attachments/assets/c41461ec-1441-447a-9f08-db9990ea655c" />

<img width="190" height="257" alt="image" src="https://github.com/user-attachments/assets/99206a16-5098-4568-88c0-f10936a6e6a5" />

Body still has a mind

<img width="998" height="108" alt="image" src="https://github.com/user-attachments/assets/48858ef6-a055-4a35-aa27-97f89613b0b7" />


## Changelog
:cl:
fix: 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
