### PR TITLE
Better Telecoms Presets

### DIFF
--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -8405,7 +8405,7 @@
 /turf/open/floor/iron,
 /area/hallway/secondary/service)
 "bWB" = (
-/obj/machinery/telecomms/processor/preset_four,
+/obj/machinery/telecomms/server/medical,
 /turf/open/floor/circuit/green/telecomms,
 /area/tcommsat/server)
 "bWC" = (
@@ -8416,9 +8416,6 @@
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
 	dir = 4
 	},
-/obj/structure/cable/yellow{
-	icon_state = "2-4"
-	},
 /obj/machinery/light{
 	dir = 1
 	},
@@ -8428,7 +8425,7 @@
 /turf/open/floor/iron/dark/telecomms,
 /area/tcommsat/server)
 "bWD" = (
-/obj/machinery/telecomms/server/presets/medical,
+/obj/machinery/telecomms/server/exploration,
 /turf/open/floor/circuit/green/telecomms,
 /area/tcommsat/server)
 "bWE" = (
@@ -8438,6 +8435,9 @@
 	},
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
 	},
 /turf/open/floor/iron/dark/telecomms,
 /area/tcommsat/server)
@@ -8452,11 +8452,11 @@
 	name = "Telecomms Server APC";
 	pixel_y = 24
 	},
-/obj/structure/cable/yellow{
-	icon_state = "0-8"
-	},
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "0-4"
 	},
 /turf/open/floor/iron/dark/telecomms,
 /area/tcommsat/server)
@@ -8475,6 +8475,9 @@
 	},
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 10
+	},
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
 	},
 /turf/open/floor/iron/dark/telecomms,
 /area/tcommsat/server)
@@ -8645,22 +8648,19 @@
 /obj/effect/turf_decal/siding/wideplating_new/dark{
 	dir = 8
 	},
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple,
 /turf/open/floor/iron/dark/telecomms,
 /area/tcommsat/server)
 "bXA" = (
-/obj/machinery/telecomms/server/presets/science,
+/obj/machinery/telecomms/server/science,
 /turf/open/floor/circuit/green/telecomms,
 /area/tcommsat/server)
 "bXB" = (
-/obj/machinery/telecomms/processor/preset_one,
+/obj/machinery/telecomms/bus/leadership,
 /turf/open/floor/circuit/green/telecomms,
 /area/tcommsat/server)
 "bXC" = (
-/obj/machinery/telecomms/server/presets/common,
+/obj/machinery/telecomms/processor/discovery,
 /turf/open/floor/circuit/green/telecomms,
 /area/tcommsat/server)
 "bXF" = (
@@ -8788,9 +8788,6 @@
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
 	dir = 8
 	},
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple,
 /turf/open/floor/iron/dark/telecomms,
 /area/tcommsat/server)
@@ -8799,7 +8796,7 @@
 /turf/open/floor/circuit/green/telecomms,
 /area/tcommsat/server)
 "bYC" = (
-/obj/machinery/telecomms/bus/preset_one,
+/obj/machinery/telecomms/processor/leadership,
 /turf/open/floor/circuit/green/telecomms,
 /area/tcommsat/server)
 "bYH" = (
@@ -8908,9 +8905,6 @@
 	},
 /obj/effect/turf_decal/siding/wideplating_new/dark/corner,
 /obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
 /obj/machinery/atmospherics/pipe/heat_exchanging/manifold{
 	dir = 8
 	},
@@ -8920,6 +8914,9 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer4{
 	dir = 6
 	},
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
 /turf/open/floor/iron/dark/telecomms,
 /area/tcommsat/server)
 "bZp" = (
@@ -8928,22 +8925,16 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
 /turf/open/floor/iron/dark/telecomms,
 /area/tcommsat/server)
 "bZq" = (
-/obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
-/obj/structure/cable/yellow{
-	icon_state = "0-8"
-	},
+/obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/tcommsat/computer)
 "bZr" = (
@@ -9370,7 +9361,7 @@
 /turf/open/floor/iron/dark/telecomms,
 /area/tcommsat/server)
 "cch" = (
-/obj/machinery/telecomms/bus/preset_two,
+/obj/machinery/telecomms/processor/support,
 /turf/open/floor/circuit/green/telecomms,
 /area/tcommsat/server)
 "cco" = (
@@ -9465,11 +9456,11 @@
 /turf/open/floor/iron/dark/telecomms,
 /area/tcommsat/server)
 "cdd" = (
-/obj/machinery/telecomms/server/presets/security,
+/obj/machinery/telecomms/server/supply,
 /turf/open/floor/circuit/green/telecomms,
 /area/tcommsat/server)
 "cde" = (
-/obj/machinery/telecomms/processor/preset_two,
+/obj/machinery/telecomms/bus/support,
 /turf/open/floor/circuit/green/telecomms,
 /area/tcommsat/server)
 "cdf" = (
@@ -9552,7 +9543,7 @@
 /turf/open/floor/iron/dark/telecomms,
 /area/tcommsat/server)
 "cea" = (
-/obj/machinery/telecomms/server/presets/command,
+/obj/machinery/telecomms/server/service,
 /turf/open/floor/circuit/green/telecomms,
 /area/tcommsat/server)
 "ceb" = (
@@ -10656,7 +10647,7 @@
 /turf/open/floor/engine/air,
 /area/engine/atmos)
 "cmj" = (
-/obj/machinery/telecomms/server/presets/service,
+/obj/machinery/telecomms/bus/logistics,
 /turf/open/floor/circuit/green/telecomms,
 /area/tcommsat/server)
 "cmq" = (
@@ -12312,13 +12303,16 @@
 /obj/item/radio/intercom{
 	pixel_y = -35
 	},
-/obj/effect/landmark/event_spawn,
 /obj/effect/turf_decal/tile/yellow/half/contrasted{
 	dir = 8
 	},
 /obj/effect/turf_decal/siding/white{
 	dir = 1
 	},
+/obj/machinery/power/smes{
+	charge = 5e+006
+	},
+/obj/structure/cable/yellow,
 /turf/open/floor/iron,
 /area/tcommsat/computer)
 "cBL" = (
@@ -14028,11 +14022,11 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
 /turf/open/floor/iron/dark/telecomms,
 /area/tcommsat/server)
 "cSG" = (
@@ -15216,14 +15210,14 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
 /obj/effect/turf_decal/siding/white{
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/smart/simple/general/hidden{
 	dir = 5
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
 	},
 /turf/open/floor/iron,
 /area/tcommsat/computer)
@@ -16438,6 +16432,9 @@
 	dir = 8
 	},
 /obj/effect/landmark/navigate_destination,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
 /turf/open/floor/iron/dark,
 /area/tcommsat/computer)
 "dJs" = (
@@ -21615,7 +21612,7 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "fBP" = (
-/obj/machinery/telecomms/receiver/preset_right,
+/obj/machinery/telecomms/receiver/mission,
 /turf/open/floor/circuit/telecomms,
 /area/tcommsat/server)
 "fCc" = (
@@ -22659,6 +22656,9 @@
 	dir = 5
 	},
 /obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /turf/open/floor/iron/dark,
@@ -22927,6 +22927,9 @@
 	},
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
 /turf/open/floor/iron/dark/telecomms,
 /area/tcommsat/server)
 "fZM" = (
@@ -28004,7 +28007,7 @@
 /turf/open/floor/catwalk_floor,
 /area/maintenance/starboard/aft)
 "hQg" = (
-/obj/machinery/telecomms/bus/preset_three,
+/obj/machinery/telecomms/server/command,
 /turf/open/floor/circuit/green/telecomms,
 /area/tcommsat/server)
 "hQC" = (
@@ -28369,7 +28372,6 @@
 /area/medical/exam_room)
 "hWo" = (
 /obj/structure/window/reinforced/spawner/directional/north,
-/obj/machinery/telecomms/server/presets/exploration,
 /obj/machinery/camera/directional/west,
 /turf/open/floor/circuit/telecomms/server,
 /area/quartermaster/exploration_dock)
@@ -28757,12 +28759,12 @@
 /turf/open/floor/iron/dark,
 /area/hallway/secondary/command)
 "ifn" = (
-/obj/machinery/telecomms/message_server/preset,
 /obj/machinery/airalarm/directional/west{
 	pixel_x = -23
 	},
 /obj/effect/mapping_helpers/airalarm/tlv_no_checks,
-/turf/open/floor/circuit/green/telecomms,
+/obj/machinery/telecomms/broadcaster/operations,
+/turf/open/floor/circuit/telecomms,
 /area/tcommsat/server)
 "ifH" = (
 /obj/effect/turf_decal/tile/neutral/anticorner/contrasted{
@@ -31461,6 +31463,14 @@
 /obj/structure/chair/office{
 	dir = 8
 	},
+/obj/effect/landmark/event_spawn,
+/obj/structure/cable/yellow{
+	icon_state = "0-4"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/power/terminal,
 /turf/open/floor/iron/dark,
 /area/tcommsat/computer)
 "jhK" = (
@@ -33692,9 +33702,6 @@
 /turf/open/floor/iron/dark,
 /area/crew_quarters/theatre/backstage)
 "jYJ" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
@@ -33709,6 +33716,9 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer4{
 	dir = 8
+	},
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
 	},
 /turf/open/floor/iron/dark,
 /area/tcommsat/computer)
@@ -33925,7 +33935,7 @@
 /turf/open/floor/engine/vacuum,
 /area/maintenance/disposal/incinerator)
 "kcG" = (
-/obj/machinery/telecomms/processor/preset_three,
+/obj/machinery/telecomms/server/security,
 /turf/open/floor/circuit/green/telecomms,
 /area/tcommsat/server)
 "kcK" = (
@@ -39078,11 +39088,11 @@
 /obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer4{
 	dir = 8
 	},
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
 /obj/effect/turf_decal/siding/white{
 	dir = 10
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
 	},
 /turf/open/floor/iron,
 /area/tcommsat/computer)
@@ -39833,7 +39843,7 @@
 /turf/open/floor/wood/big,
 /area/storage/art)
 "mlV" = (
-/obj/machinery/telecomms/broadcaster/preset_right,
+/obj/machinery/telecomms/receiver/operations,
 /turf/open/floor/circuit/telecomms,
 /area/tcommsat/server)
 "mmg" = (
@@ -46540,9 +46550,6 @@
 	dir = 4
 	},
 /obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
@@ -46552,10 +46559,6 @@
 /obj/effect/turf_decal/siding/wideplating_new/dark/corner{
 	dir = 8
 	},
-/obj/machinery/door/airlock/engineering/glass{
-	name = "Server Room";
-	req_access_txt = "61"
-	},
 /obj/machinery/atmospherics/pipe/heat_exchanging/junction{
 	dir = 8
 	},
@@ -46564,6 +46567,16 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer4{
 	dir = 8
+	},
+/obj/structure/cable/yellow{
+	icon_state = "2-4"
+	},
+/obj/machinery/door/airlock/engineering/glass{
+	name = "Server Room";
+	req_access_txt = "61"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
 	},
 /turf/open/floor/iron/dark,
 /area/tcommsat/computer)
@@ -46679,9 +46692,6 @@
 /area/tcommsat/computer)
 "oVe" = (
 /obj/machinery/telecomms/hub/preset,
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
 /turf/open/floor/circuit/telecomms,
 /area/tcommsat/server)
 "oVg" = (
@@ -48475,7 +48485,7 @@
 /turf/open/floor/iron/dark,
 /area/storage/tech)
 "pAC" = (
-/obj/machinery/telecomms/server/presets/supply,
+/obj/machinery/telecomms/processor/logistics,
 /turf/open/floor/circuit/green/telecomms,
 /area/tcommsat/server)
 "pAE" = (
@@ -51167,9 +51177,6 @@
 /turf/open/floor/iron,
 /area/security/brig)
 "qBN" = (
-/obj/machinery/power/terminal{
-	dir = 8
-	},
 /obj/effect/turf_decal/siding/wideplating_new/dark{
 	dir = 4
 	},
@@ -51177,9 +51184,6 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
-/obj/structure/cable/yellow{
-	icon_state = "0-4"
-	},
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple,
 /turf/open/floor/iron/dark/telecomms,
 /area/tcommsat/server)
@@ -52971,7 +52975,6 @@
 /turf/open/floor/iron/grid,
 /area/medical/patients_rooms)
 "riO" = (
-/obj/machinery/telecomms/receiver/preset_exploration,
 /obj/machinery/power/apc/auto_name/directional/east{
 	pixel_x = 24
 	},
@@ -53988,12 +53991,6 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "rCa" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "2-8"
-	},
 /obj/effect/turf_decal/siding/white{
 	dir = 8
 	},
@@ -54005,6 +54002,9 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer4{
 	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
 	},
 /turf/open/floor/iron,
 /area/tcommsat/computer)
@@ -54429,7 +54429,6 @@
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
 "rKw" = (
-/obj/machinery/telecomms/hub/preset/exploration,
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 10
 	},
@@ -54907,7 +54906,7 @@
 /turf/open/floor/iron/techmaint,
 /area/quartermaster/office)
 "rSr" = (
-/obj/machinery/telecomms/server/presets/engineering,
+/obj/machinery/telecomms/bus/discovery,
 /turf/open/floor/circuit/green/telecomms,
 /area/tcommsat/server)
 "rSI" = (
@@ -54954,7 +54953,7 @@
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
 "rTt" = (
-/obj/machinery/telecomms/bus/preset_four,
+/obj/machinery/telecomms/server/engineering,
 /turf/open/floor/circuit/green/telecomms,
 /area/tcommsat/server)
 "rTJ" = (
@@ -56338,13 +56337,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/ai_monitored/security/armory)
-"szx" = (
-/obj/machinery/telecomms/bus/preset_exploration,
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 4
-	},
-/turf/open/floor/circuit/green/telecomms/mainframe,
-/area/quartermaster/exploration_dock)
 "szA" = (
 /obj/structure/barricade/wooden/crude,
 /obj/machinery/door/airlock/maintenance{
@@ -56363,12 +56355,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-8"
-	},
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple,
 /turf/open/floor/iron/dark/telecomms,
 /area/tcommsat/server)
@@ -56694,7 +56680,6 @@
 /turf/open/floor/iron,
 /area/security/checkpoint/science)
 "sGv" = (
-/obj/machinery/telecomms/processor/preset_exploration,
 /obj/machinery/airalarm{
 	pixel_x = -22;
 	dir = 8
@@ -57730,7 +57715,6 @@
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "sWW" = (
-/obj/machinery/telecomms/broadcaster/preset_exploration,
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 4
 	},
@@ -59834,9 +59818,6 @@
 /area/medical/exam_room)
 "tGF" = (
 /obj/machinery/ntnet_relay,
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
 /turf/open/floor/circuit/telecomms,
 /area/tcommsat/server)
 "tGR" = (
@@ -60113,11 +60094,8 @@
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "tKV" = (
-/obj/machinery/telecomms/broadcaster/preset_left,
-/obj/structure/cable/yellow{
-	icon_state = "2-4"
-	},
-/turf/open/floor/circuit/telecomms,
+/obj/machinery/telecomms/broadcaster/mission,
+/turf/open/floor/circuit/green/telecomms,
 /area/tcommsat/server)
 "tKW" = (
 /obj/effect/landmark/blobstart,
@@ -61875,14 +61853,11 @@
 /turf/open/floor/iron/dark,
 /area/crew_quarters/heads/hos)
 "uwI" = (
-/obj/machinery/power/smes{
-	charge = 5e+006
-	},
-/obj/structure/cable/yellow,
 /obj/machinery/light{
 	dir = 8
 	},
-/turf/open/floor/circuit/telecomms,
+/obj/machinery/telecomms/server/common,
+/turf/open/floor/circuit/green/telecomms,
 /area/tcommsat/server)
 "uwR" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer4{
@@ -62208,6 +62183,9 @@
 	},
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
 /turf/open/floor/iron/dark/telecomms,
 /area/tcommsat/server)
 "uDi" = (
@@ -66674,9 +66652,9 @@
 /turf/open/floor/iron/dark,
 /area/storage/tools)
 "wnw" = (
-/obj/machinery/telecomms/receiver/preset_left,
 /obj/machinery/camera/directional/west,
-/turf/open/floor/circuit/telecomms,
+/obj/machinery/telecomms/message_server/preset,
+/turf/open/floor/circuit/green/telecomms,
 /area/tcommsat/server)
 "wnL" = (
 /obj/effect/turf_decal/tile/blue{
@@ -67829,6 +67807,9 @@
 "wMu" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
 	},
 /turf/open/floor/iron/dark,
 /area/tcommsat/computer)
@@ -96498,8 +96479,8 @@ lRI
 bVI
 bWD
 bXA
-bYB
 tKV
+bYB
 uwI
 wnw
 ifn
@@ -123968,7 +123949,7 @@ aaa
 aaa
 aaa
 xkR
-szx
+sWW
 miD
 sWW
 xkR

--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -9608,7 +9608,7 @@
 	dir = 8
 	},
 /obj/item/multitool{
-	pixel_x = 6
+	pixel_x = 5
 	},
 /obj/machinery/firealarm{
 	dir = 1;

--- a/_maps/map_files/CardinalStation/CardinalStation.dmm
+++ b/_maps/map_files/CardinalStation/CardinalStation.dmm
@@ -1301,6 +1301,15 @@
 	dir = 8
 	},
 /area/security/main)
+"amR" = (
+/obj/effect/turf_decal/siding/wideplating_new/dark{
+	dir = 8
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/turf/open/floor/iron/dark/smooth_large,
+/area/tcommsat/computer)
 "and" = (
 /obj/structure/platform/wood/corner{
 	dir = 8
@@ -1462,9 +1471,6 @@
 	},
 /obj/effect/turf_decal/tile/dark/fourcorners,
 /obj/effect/turf_decal/tile/monorust,
-/obj/structure/cable/cyan{
-	icon_state = "4-8"
-	},
 /obj/effect/turf_decal/guideline/guideline_in/darkblue{
 	dir = 1
 	},
@@ -3402,8 +3408,8 @@
 	},
 /area/ai_monitored/storage/eva)
 "aKD" = (
-/obj/machinery/telecomms/server/presets/supply,
 /obj/effect/turf_decal/bot_white,
+/obj/machinery/telecomms/bus/leadership,
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/tcommsat/server)
 "aKI" = (
@@ -6103,6 +6109,11 @@
 /obj/machinery/camera/directional/north,
 /turf/open/floor/iron/ameridiner,
 /area/science/robotics/mechbay)
+"bjf" = (
+/obj/effect/turf_decal/bot_white,
+/obj/machinery/telecomms/processor/leadership,
+/turf/open/floor/circuit/telecomms/mainframe,
+/area/tcommsat/server)
 "bjg" = (
 /obj/effect/turf_decal/siding/dark,
 /obj/structure/cable/yellow{
@@ -6699,11 +6710,6 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/engine,
 /area/ai_monitored/turret_protected/aisat/foyer)
-"boU" = (
-/obj/machinery/telecomms/receiver/preset_right,
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/circuit/telecomms/mainframe,
-/area/tcommsat/server)
 "boX" = (
 /obj/effect/turf_decal/trimline/blue/filled/warning{
 	dir = 1
@@ -16610,9 +16616,6 @@
 	},
 /obj/effect/turf_decal/tile/dark/fourcorners,
 /obj/effect/turf_decal/tile/monorust,
-/obj/structure/cable/cyan{
-	icon_state = "1-2"
-	},
 /obj/effect/turf_decal/guideline/guideline_in/darkblue{
 	dir = 4
 	},
@@ -16791,11 +16794,6 @@
 	dir = 1
 	},
 /area/security/main)
-"dpL" = (
-/obj/machinery/telecomms/server/presets/common,
-/obj/effect/turf_decal/bot_white,
-/turf/open/floor/circuit/telecomms/mainframe,
-/area/tcommsat/server)
 "dpM" = (
 /obj/structure/chair{
 	dir = 1
@@ -16949,11 +16947,11 @@
 /obj/effect/turf_decal/siding/wideplating_new/dark{
 	dir = 6
 	},
-/obj/item/kirbyplants{
-	icon_state = "plant-22";
-	pixel_y = 8
-	},
 /obj/structure/railing/perspective/black,
+/obj/machinery/power/smes{
+	charge = 5e+006
+	},
+/obj/structure/cable/yellow,
 /turf/open/floor/iron/dark/smooth_large,
 /area/tcommsat/computer)
 "drB" = (
@@ -19446,13 +19444,9 @@
 /turf/open/floor/iron/tech,
 /area/security/main)
 "dUn" = (
-/obj/machinery/telecomms/server/presets/security,
-/obj/effect/turf_decal/bot_white,
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/turf/open/floor/circuit/telecomms/mainframe,
-/area/tcommsat/server)
+/obj/effect/spawner/room/tenxten,
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "dUs" = (
 /obj/structure/flora/ausbushes/sparsegrass{
 	pixel_x = 5
@@ -20978,11 +20972,14 @@
 /turf/open/floor/plating,
 /area/hallway/upper/primary/port)
 "elW" = (
-/obj/machinery/telecomms/server/presets/service,
 /obj/effect/turf_decal/bot_white,
+/obj/structure/cable/yellow{
+	icon_state = "2-4"
+	},
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
+/obj/machinery/telecomms/server/engineering,
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/tcommsat/server)
 "elY" = (
@@ -21843,9 +21840,10 @@
 /turf/open/floor/iron/white,
 /area/science/research)
 "eww" = (
-/obj/effect/landmark/event_spawn,
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
+/obj/effect/turf_decal/bot_white,
+/obj/machinery/telecomms/processor/logistics,
+/turf/open/floor/circuit/telecomms/mainframe,
+/area/tcommsat/server)
 "ewx" = (
 /obj/machinery/light/floor{
 	pixel_x = 16
@@ -26742,11 +26740,6 @@
 /obj/machinery/light/directional/south,
 /turf/open/floor/iron/dark,
 /area/crew_quarters/fitness)
-"fAr" = (
-/obj/machinery/telecomms/processor/preset_one,
-/obj/effect/turf_decal/bot_white,
-/turf/open/floor/circuit/telecomms/mainframe,
-/area/tcommsat/server)
 "fAs" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/yellow{
@@ -30758,8 +30751,8 @@
 /turf/open/floor/plating,
 /area/medical/booth)
 "goL" = (
-/obj/machinery/telecomms/server/presets/command,
 /obj/effect/turf_decal/bot_white,
+/obj/machinery/telecomms/bus/support,
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/tcommsat/server)
 "goM" = (
@@ -30842,10 +30835,10 @@
 	},
 /area/hallway/primary/central)
 "gps" = (
-/obj/machinery/telecomms/broadcaster/preset_left,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/obj/machinery/telecomms/receiver/operations,
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/tcommsat/server)
 "gpD" = (
@@ -40632,7 +40625,7 @@
 /turf/open/floor/plating,
 /area/tcommsat/server)
 "inF" = (
-/obj/effect/landmark/xeno_spawn,
+/obj/effect/landmark/event_spawn,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "inO" = (
@@ -45341,6 +45334,13 @@
 "jlL" = (
 /turf/open/floor/catwalk_floor/iron,
 /area/maintenance/department/engine)
+"jlS" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/telecomms/broadcaster/operations,
+/turf/open/floor/circuit/telecomms/mainframe,
+/area/tcommsat/server)
 "jmb" = (
 /obj/structure/closet/firecloset,
 /obj/effect/turf_decal/siding/white{
@@ -46794,9 +46794,6 @@
 	},
 /obj/effect/turf_decal/tile/dark/fourcorners,
 /obj/effect/turf_decal/tile/monorust,
-/obj/structure/cable/cyan{
-	icon_state = "4-8"
-	},
 /obj/effect/turf_decal/guideline/guideline_in/darkblue{
 	dir = 1
 	},
@@ -47068,7 +47065,6 @@
 	},
 /area/maintenance/department/engine/atmos)
 "jEA" = (
-/obj/machinery/telecomms/bus/preset_exploration,
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 4;
 	hide = 0
@@ -49455,13 +49451,6 @@
 	},
 /turf/open/floor/iron/dark/smooth_edge,
 /area/science/robotics/lab)
-"kce" = (
-/obj/machinery/telecomms/receiver/preset_left,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/circuit/telecomms/mainframe,
-/area/tcommsat/server)
 "kck" = (
 /obj/machinery/holopad{
 	pixel_y = -16
@@ -50633,17 +50622,6 @@
 /obj/effect/turf_decal/trimline/red/warning_offset,
 /turf/open/floor/iron/white,
 /area/security/brig/medbay)
-"kmY" = (
-/obj/machinery/telecomms/server/presets/engineering,
-/obj/effect/turf_decal/bot_white,
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-8"
-	},
-/turf/open/floor/circuit/telecomms/mainframe,
-/area/tcommsat/server)
 "knd" = (
 /obj/effect/mapping_helpers/Mapper_Comment{
 	desc = "A soulful solution to the disposals mass driver shooting things at the AI sat - BarteG";
@@ -57638,9 +57616,6 @@
 	},
 /obj/effect/turf_decal/tile/dark/fourcorners,
 /obj/effect/turf_decal/tile/monorust,
-/obj/structure/cable/cyan{
-	icon_state = "2-8"
-	},
 /obj/effect/turf_decal/guideline/guideline_in_alt/darkblue{
 	dir = 8
 	},
@@ -58406,6 +58381,9 @@
 	dir = 1
 	},
 /obj/machinery/light/small/directional/west,
+/obj/structure/cable/yellow{
+	icon_state = "2-4"
+	},
 /turf/open/floor/iron/tech/grid,
 /area/tcommsat/computer)
 "lTm" = (
@@ -62015,8 +61993,11 @@
 /turf/open/floor/iron/tech/grid,
 /area/engine/engine_room)
 "mHM" = (
-/obj/machinery/telecomms/bus/preset_three,
 /obj/effect/turf_decal/bot_white,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/telecomms/server/security,
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/tcommsat/server)
 "mHP" = (
@@ -62753,8 +62734,9 @@
 /turf/open/floor/iron/edge,
 /area/hallway/primary/starboard)
 "mOw" = (
-/obj/machinery/telecomms/processor/preset_four,
 /obj/effect/turf_decal/bot_white,
+/obj/machinery/telecomms/processor/discovery,
+/obj/machinery/telecomms/bus/discovery,
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/tcommsat/server)
 "mOA" = (
@@ -70493,6 +70475,9 @@
 /area/science/robotics/mechbay)
 "ord" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
 /turf/open/floor/iron/dark/smooth_large,
 /area/tcommsat/computer)
 "org" = (
@@ -70526,6 +70511,11 @@
 	},
 /turf/open/floor/iron/showroomfloor,
 /area/medical/genetics/cloning)
+"ory" = (
+/obj/effect/turf_decal/bot_white,
+/obj/machinery/telecomms/bus/discovery,
+/turf/open/floor/circuit/telecomms/mainframe,
+/area/tcommsat/server)
 "orW" = (
 /obj/machinery/light/small/directional/north,
 /obj/effect/landmark/xeno_spawn,
@@ -71671,6 +71661,9 @@
 	dir = 4
 	},
 /obj/effect/landmark/navigate_destination,
+/obj/structure/cable/cyan{
+	icon_state = "1-4"
+	},
 /turf/open/floor/iron/dark/textured_large,
 /area/tcommsat/computer)
 "oGh" = (
@@ -72643,6 +72636,12 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer4{
 	dir = 1
 	},
+/obj/structure/cable/cyan{
+	icon_state = "0-2"
+	},
+/obj/machinery/power/terminal{
+	dir = 4
+	},
 /turf/open/floor/iron/dark/smooth_large,
 /area/tcommsat/computer)
 "oPc" = (
@@ -73501,11 +73500,11 @@
 /turf/open/floor/wood,
 /area/crew_quarters/fitness/recreation)
 "oYN" = (
-/obj/machinery/telecomms/bus/preset_one,
 /obj/effect/turf_decal/bot_white,
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
+/obj/machinery/telecomms/server/medical,
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/tcommsat/server)
 "oYU" = (
@@ -74034,6 +74033,14 @@
 /obj/item/clothing/shoes/sneakers/white,
 /turf/open/floor/iron/white,
 /area/medical/medbay/aft)
+"pcM" = (
+/obj/effect/turf_decal/bot_white,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/telecomms/server/exploration,
+/turf/open/floor/circuit/telecomms/mainframe,
+/area/tcommsat/server)
 "pcW" = (
 /obj/effect/turf_decal/stripes/white{
 	dir = 1
@@ -74511,7 +74518,6 @@
 /turf/open/floor/iron,
 /area/janitor)
 "phw" = (
-/obj/machinery/telecomms/hub/preset/exploration,
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 5
 	},
@@ -76211,8 +76217,8 @@
 /turf/open/space/basic,
 /area/space)
 "pzV" = (
-/obj/machinery/telecomms/broadcaster/preset_right,
 /obj/effect/turf_decal/stripes/line,
+/obj/machinery/telecomms/receiver/mission,
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/tcommsat/server)
 "pzZ" = (
@@ -79137,6 +79143,11 @@
 /obj/effect/turf_decal/tile/neutral/opposingcorners,
 /turf/open/floor/iron/dark,
 /area/engine/atmos)
+"qez" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/telecomms/broadcaster/mission,
+/turf/open/floor/circuit/telecomms/mainframe,
+/area/tcommsat/server)
 "qeH" = (
 /turf/closed/wall,
 /area/storage/tools)
@@ -79621,6 +79632,9 @@
 	dir = 4
 	},
 /obj/structure/reagent_dispensers/water_cooler,
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
+	},
 /turf/open/floor/iron/dark/smooth_large,
 /area/tcommsat/computer)
 "qiR" = (
@@ -80322,13 +80336,7 @@
 /turf/open/floor/catwalk_floor/iron,
 /area/maintenance/department/eva)
 "qra" = (
-/obj/machinery/power/smes{
-	charge = 5e+006
-	},
-/obj/structure/cable/yellow{
-	icon_state = "0-2"
-	},
-/obj/structure/cable/yellow,
+/obj/machinery/telecomms/server/common,
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/tcommsat/server)
 "qrm" = (
@@ -82587,7 +82595,6 @@
 /turf/open/floor/catwalk_floor/iron,
 /area/maintenance/department/chapel)
 "qOE" = (
-/obj/machinery/telecomms/processor/preset_three,
 /obj/effect/turf_decal/bot_white,
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -82595,6 +82602,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
+/obj/machinery/telecomms/server/science,
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/tcommsat/server)
 "qOF" = (
@@ -84188,11 +84196,8 @@
 /turf/open/floor/plating,
 /area/maintenance/department/chapel)
 "reU" = (
-/obj/machinery/telecomms/bus/preset_four,
 /obj/effect/turf_decal/bot_white,
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
+/obj/machinery/telecomms/bus/logistics,
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/tcommsat/server)
 "reY" = (
@@ -84488,9 +84493,6 @@
 	},
 /obj/effect/turf_decal/tile/dark/fourcorners,
 /obj/effect/turf_decal/tile/monorust,
-/obj/structure/cable/cyan{
-	icon_state = "1-4"
-	},
 /obj/effect/turf_decal/guideline/guideline_in/darkblue{
 	dir = 5
 	},
@@ -84948,14 +84950,8 @@
 /turf/open/floor/carpet/black,
 /area/maintenance/club)
 "roe" = (
-/obj/machinery/telecomms/processor/preset_two,
 /obj/effect/turf_decal/bot_white,
-/obj/structure/cable/yellow{
-	icon_state = "2-4"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
+/obj/machinery/telecomms/processor/support,
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/tcommsat/server)
 "rol" = (
@@ -86392,9 +86388,6 @@
 /obj/effect/turf_decal/tile/dark/fourcorners,
 /obj/effect/turf_decal/tile/monorust{
 	alpha = 255
-	},
-/obj/structure/cable/cyan{
-	icon_state = "1-4"
 	},
 /obj/effect/turf_decal/guideline/guideline_in/darkblue{
 	dir = 5
@@ -88240,9 +88233,6 @@
 /obj/effect/turf_decal/siding/wideplating_new/dark/corner{
 	dir = 4
 	},
-/obj/structure/cable/cyan{
-	icon_state = "4-8"
-	},
 /obj/machinery/atmospherics/pipe/smart/simple/general/hidden{
 	dir = 8
 	},
@@ -88258,7 +88248,7 @@
 	dir = 4
 	},
 /obj/structure/cable/yellow{
-	icon_state = "1-2"
+	icon_state = "1-4"
 	},
 /turf/open/floor/iron/dark/textured_half{
 	dir = 1
@@ -88445,14 +88435,14 @@
 /obj/effect/turf_decal/siding/wideplating_new/dark/corner{
 	dir = 8
 	},
-/obj/structure/cable/cyan{
-	icon_state = "4-8"
-	},
 /obj/machinery/atmospherics/pipe/smart/simple/general/hidden{
 	dir = 8
 	},
 /obj/structure/cable/cyan{
 	icon_state = "2-4"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-8"
 	},
 /turf/open/floor/iron/dark/textured_large,
 /area/tcommsat/computer)
@@ -89060,11 +89050,6 @@
 	dir = 1
 	},
 /area/hallway/upper/primary/port)
-"seY" = (
-/obj/machinery/telecomms/server/presets/medical,
-/obj/effect/turf_decal/bot_white,
-/turf/open/floor/circuit/telecomms/mainframe,
-/area/tcommsat/server)
 "seZ" = (
 /obj/effect/turf_decal/siding/white{
 	dir = 1
@@ -90751,6 +90736,10 @@
 /obj/machinery/atmospherics/pipe/smart/simple/general/hidden{
 	dir = 5
 	},
+/obj/item/kirbyplants{
+	icon_state = "plant-22";
+	pixel_y = 8
+	},
 /turf/open/floor/iron/dark/smooth_large,
 /area/tcommsat/computer)
 "szg" = (
@@ -92064,6 +92053,9 @@
 /obj/effect/turf_decal/siding/wideplating_new/dark{
 	dir = 9
 	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
 /turf/open/floor/iron/dark/smooth_large,
 /area/tcommsat/computer)
 "sOi" = (
@@ -92320,6 +92312,17 @@
 /obj/machinery/camera/directional/north,
 /turf/open/floor/prison/dark,
 /area/hydroponics)
+"sQq" = (
+/obj/effect/turf_decal/bot_white,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-8"
+	},
+/obj/machinery/telecomms/server/command,
+/turf/open/floor/circuit/telecomms/mainframe,
+/area/tcommsat/server)
 "sQy" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/dark/fourcorners/contrasted,
@@ -94705,6 +94708,10 @@
 /obj/machinery/atmospherics/pipe/layer_manifold/yellow/visible,
 /turf/closed/wall/r_wall,
 /area/engine/atmos)
+"tpY" = (
+/obj/effect/landmark/xeno_spawn,
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "tqd" = (
 /obj/structure/railing/perspective/gray/corner{
 	dir = 8
@@ -95388,7 +95395,6 @@
 /turf/open/floor/plating,
 /area/crew_quarters/heads/hop)
 "twA" = (
-/obj/machinery/telecomms/server/presets/exploration,
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 6
 	},
@@ -97263,9 +97269,6 @@
 	},
 /obj/effect/turf_decal/tile/dark/fourcorners,
 /obj/effect/turf_decal/tile/monorust,
-/obj/structure/cable/cyan{
-	icon_state = "4-8"
-	},
 /obj/effect/turf_decal/guideline/guideline_in/darkblue{
 	dir = 1
 	},
@@ -101230,12 +101233,6 @@
 	},
 /obj/effect/turf_decal/tile/dark/fourcorners,
 /obj/effect/turf_decal/tile/monorust,
-/obj/machinery/power/terminal{
-	dir = 8
-	},
-/obj/structure/cable/cyan{
-	icon_state = "0-2"
-	},
 /obj/effect/mapping_helpers/make_non_slip,
 /obj/effect/turf_decal/guideline/guideline_in/darkblue{
 	dir = 4
@@ -104458,7 +104455,6 @@
 /turf/open/floor/grass/no_border,
 /area/hallway/primary/central)
 "vlu" = (
-/obj/machinery/telecomms/broadcaster/preset_exploration,
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 9
 	},
@@ -106897,6 +106893,14 @@
 	},
 /turf/open/floor/iron/dark,
 /area/security/main)
+"vJb" = (
+/obj/effect/turf_decal/bot_white,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/telecomms/server/supply,
+/turf/open/floor/circuit/telecomms/mainframe,
+/area/tcommsat/server)
 "vJc" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable{
@@ -107406,7 +107410,6 @@
 /turf/closed/wall/r_wall,
 /area/science/lab)
 "vNL" = (
-/obj/machinery/telecomms/server/presets/science,
 /obj/effect/turf_decal/bot_white,
 /obj/structure/cable/yellow{
 	icon_state = "2-4"
@@ -107414,6 +107417,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
+/obj/machinery/telecomms/server/service,
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/tcommsat/server)
 "vNU" = (
@@ -107970,7 +107974,6 @@
 /turf/open/floor/wood,
 /area/crew_quarters/locker)
 "vUd" = (
-/obj/machinery/telecomms/processor/preset_exploration,
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 4;
 	hide = 0
@@ -112011,7 +112014,6 @@
 /turf/open/floor/iron/techmaint,
 /area/science/robotics/mechbay)
 "wMj" = (
-/obj/machinery/telecomms/receiver/preset_exploration,
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 10
 	},
@@ -116017,11 +116019,6 @@
 	},
 /turf/open/floor/iron/smooth,
 /area/construction/mining/aux_base)
-"xFu" = (
-/obj/machinery/telecomms/bus/preset_two,
-/obj/effect/turf_decal/bot_white,
-/turf/open/floor/circuit/telecomms/mainframe,
-/area/tcommsat/server)
 "xFy" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -116239,9 +116236,6 @@
 	},
 /obj/effect/turf_decal/tile/dark/fourcorners,
 /obj/effect/turf_decal/tile/monorust,
-/obj/structure/cable/cyan{
-	icon_state = "4-8"
-	},
 /obj/effect/turf_decal/guideline/guideline_in/darkblue{
 	dir = 1
 	},
@@ -118359,10 +118353,6 @@
 /obj/machinery/light/dim/directional/west,
 /turf/open/floor/iron/sepia,
 /area/crew_quarters/theatre)
-"yev" = (
-/obj/effect/spawner/room/tenxten,
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
 "yeB" = (
 /mob/living/carbon/monkey,
 /obj/effect/turf_decal/siding/dark_green,
@@ -142879,7 +142869,7 @@ cti
 cti
 cti
 cti
-yev
+dUn
 bjH
 nzj
 hyT
@@ -143902,8 +143892,8 @@ cti
 cti
 cti
 cti
+tpY
 inF
-eww
 cti
 cti
 cti
@@ -146468,15 +146458,15 @@ xml
 jDr
 hyT
 gns
-kmY
-dpL
-pzV
+qOE
+mOw
+qez
 xPr
 uFb
 rBX
-gps
-aKD
-elW
+jlS
+eww
+vJb
 nne
 hyT
 hyT
@@ -146725,15 +146715,15 @@ qRO
 jDr
 nzj
 ecs
-reU
-mOw
+pcM
+ory
 gKi
 qXi
 jIE
 tQc
 epz
-xFu
-roe
+goL
+vNL
 nss
 nzj
 nzj
@@ -147239,14 +147229,14 @@ yiS
 jDr
 nzj
 gns
-qOE
-mHM
+sQq
+aKD
 gKi
 xSl
 ltH
 xHG
 epz
-fAr
+reU
 oYN
 xvV
 nzj
@@ -147496,15 +147486,15 @@ pLs
 jDr
 hyT
 ecs
-dUn
-goL
-boU
+mHM
+bjf
+pzV
 caq
 xNw
 jAO
-kce
-seY
-vNL
+gps
+roe
+elW
 nss
 hyT
 hyT
@@ -148529,7 +148519,7 @@ bOJ
 nfS
 gNk
 cyF
-cyF
+amR
 bZw
 jJT
 plp

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -2937,14 +2937,12 @@
 /turf/open/floor/iron,
 /area/maintenance/starboard/aft)
 "auF" = (
-/obj/structure/sign/warning/electricshock{
-	pixel_y = -32
+/obj/structure/table/glass,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/edges/borderfloor,
-/obj/effect/turf_decal/trimline/dark/warning{
-	dir = 1
-	},
-/turf/open/floor/iron/telecomms,
+/obj/item/folder/yellow,
+/turf/open/floor/circuit/green/telecomms/mainframe,
 /area/tcommsat/server)
 "auM" = (
 /obj/structure/disposalpipe/segment{
@@ -5615,10 +5613,13 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 1
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/machinery/door/airlock/command{
+	name = "Telecomms Server Room";
+	req_access_txt = "61"
 	},
-/turf/open/floor/carpet/grimy,
+/obj/machinery/door/firedoor,
+/turf/open/floor/catwalk_floor/iron_smooth,
 /area/tcommsat/computer)
 "aKd" = (
 /obj/machinery/power/terminal,
@@ -8053,11 +8054,9 @@
 /turf/open/floor/plating,
 /area/quartermaster/miningoffice)
 "bep" = (
-/obj/machinery/telecomms/server/presets/science,
-/obj/effect/turf_decal/tile/purple/anticorner/contrasted{
-	dir = 4
-	},
-/turf/open/floor/iron/white/telecomms,
+/obj/effect/turf_decal/tile/yellow/anticorner/contrasted,
+/obj/machinery/telecomms/bus/support,
+/turf/open/floor/iron/dark/telecomms,
 /area/tcommsat/server)
 "beu" = (
 /obj/machinery/light/small{
@@ -10382,9 +10381,16 @@
 /turf/open/floor/iron,
 /area/engine/atmos)
 "bvc" = (
-/obj/machinery/telecomms/server/presets/service,
-/obj/effect/turf_decal/tile/green/anticorner/contrasted,
-/turf/open/floor/iron/telecomms,
+/obj/effect/turf_decal/edges/borderfloor,
+/obj/effect/turf_decal/trimline/dark/warning{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/heat_exchanging/junction{
+	dir = 1
+	},
+/turf/open/floor/catwalk_floor/iron_smooth{
+	initial_gas_mix = "n2=100;TEMP=80"
+	},
 /area/tcommsat/server)
 "bve" = (
 /obj/machinery/portable_atmospherics/pump,
@@ -13849,16 +13855,18 @@
 /turf/open/floor/wood,
 /area/crew_quarters/heads/hop)
 "bWX" = (
-/turf/open/floor/circuit/green/telecomms/mainframe,
-/area/tcommsat/server)
-"bWY" = (
-/obj/machinery/telecomms/receiver/preset_right,
-/turf/open/floor/circuit/green/telecomms/mainframe,
+/obj/effect/turf_decal/tile/red/anticorner/contrasted{
+	dir = 4
+	},
+/obj/machinery/telecomms/server/security,
+/turf/open/floor/iron/dark/telecomms,
 /area/tcommsat/server)
 "bXa" = (
-/obj/machinery/telecomms/receiver/preset_left,
-/turf/open/floor/circuit/green/telecomms/mainframe,
-/area/tcommsat/server)
+/obj/machinery/atmospherics/components/unary/thermomachine/freezer/on{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/hallway/secondary/command)
 "bXc" = (
 /obj/machinery/computer/communications{
 	dir = 4
@@ -13917,10 +13925,8 @@
 /turf/open/floor/plating,
 /area/bridge)
 "bXu" = (
-/obj/machinery/telecomms/server/presets/security,
-/obj/effect/turf_decal/tile/red/anticorner/contrasted{
-	dir = 4
-	},
+/obj/effect/turf_decal/tile/red/anticorner/contrasted,
+/obj/machinery/telecomms/processor/leadership,
 /turf/open/floor/iron/dark/telecomms,
 /area/tcommsat/server)
 "bXy" = (
@@ -14836,11 +14842,10 @@
 /turf/open/floor/wood,
 /area/crew_quarters/heads/hop)
 "ccI" = (
-/obj/structure/table/glass,
+/obj/machinery/telecomms/hub/preset,
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/item/folder/yellow,
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
@@ -15048,29 +15053,16 @@
 /turf/open/floor/iron/dark/side,
 /area/ai_monitored/security/armory)
 "cev" = (
-/obj/machinery/telecomms/broadcaster/preset_left,
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
+/obj/machinery/atmospherics/pipe/smart/simple/general/hidden{
+	dir = 9
 	},
-/turf/open/floor/circuit/telecomms/mainframe,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
 /area/tcommsat/server)
 "cex" = (
 /obj/machinery/telecomms/message_server/preset,
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
-	},
-/turf/open/floor/circuit/green/telecomms/mainframe,
-/area/tcommsat/server)
-"cez" = (
-/obj/machinery/telecomms/hub/preset,
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "2-4"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-4"
 	},
 /turf/open/floor/circuit/green/telecomms/mainframe,
 /area/tcommsat/server)
@@ -15082,11 +15074,18 @@
 /turf/open/floor/circuit/green/telecomms/mainframe,
 /area/tcommsat/server)
 "ceB" = (
-/obj/machinery/telecomms/broadcaster/preset_right,
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 8
 	},
-/turf/open/floor/circuit/telecomms/mainframe,
+/obj/machinery/power/terminal{
+	dir = 1
+	},
+/obj/structure/cable/yellow{
+	icon_state = "0-2"
+	},
+/turf/open/floor/catwalk_floor/iron_smooth{
+	initial_gas_mix = "n2=100;TEMP=80"
+	},
 /area/tcommsat/server)
 "ceD" = (
 /obj/effect/turf_decal/siding/wideplating_new/dark/corner,
@@ -16504,23 +16503,24 @@
 /area/crew_quarters/heads/hop)
 "coe" = (
 /turf/closed/wall,
-/area/tcommsat/server)
+/area/hallway/secondary/command)
 "cof" = (
 /obj/effect/turf_decal/delivery,
 /obj/machinery/atmospherics/components/unary/thermomachine/freezer/on{
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/tcommsat/server)
+/area/hallway/secondary/command)
 "coi" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/xeno_spawn,
 /obj/effect/turf_decal/stripes/line{
-	dir = 5
+	dir = 6
 	},
-/obj/machinery/portable_thermomachine,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 8
+	},
 /turf/open/floor/iron,
-/area/tcommsat/server)
+/area/hallway/secondary/command)
 "cok" = (
 /obj/structure/rack,
 /obj/item/storage/toolbox/emergency,
@@ -16772,20 +16772,6 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/secondary/command)
-"cpM" = (
-/obj/structure/table,
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 26
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/delivery,
-/obj/item/book/manual/wiki/tcomms,
-/obj/item/wrench,
-/obj/item/screwdriver{
-	pixel_y = 5
-	},
-/turf/open/floor/iron,
-/area/tcommsat/server)
 "cpN" = (
 /obj/structure/rack,
 /obj/item/tank/internals/oxygen,
@@ -22790,14 +22776,11 @@
 /turf/open/floor/iron/white/corner,
 /area/crew_quarters/fitness/recreation)
 "dan" = (
-/obj/structure/cable/yellow,
-/obj/machinery/power/smes{
-	charge = 5e+006
+/obj/machinery/atmospherics/pipe/smart/simple/general/hidden{
+	dir = 10
 	},
-/obj/effect/turf_decal/edges/borderfloor{
-	dir = 4
-	},
-/turf/open/floor/iron/telecomms,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
 /area/tcommsat/server)
 "dar" = (
 /obj/structure/table/reinforced,
@@ -26179,11 +26162,9 @@
 /turf/closed/wall,
 /area/medical/morgue)
 "dCQ" = (
-/obj/machinery/telecomms/processor/preset_four,
-/obj/effect/turf_decal/tile/green/anticorner/contrasted{
-	dir = 4
-	},
-/turf/open/floor/iron/telecomms,
+/obj/effect/turf_decal/tile/green/anticorner/contrasted,
+/obj/machinery/telecomms/server/service,
+/turf/open/floor/iron/dark/telecomms,
 /area/tcommsat/server)
 "dCR" = (
 /obj/machinery/light{
@@ -30048,15 +30029,18 @@
 /turf/open/floor/iron/white,
 /area/crew_quarters/cryopods)
 "ejl" = (
-/obj/machinery/holopad,
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold/general/hidden{
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/smart/simple/general/hidden{
+	dir = 9
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/obj/machinery/light,
 /turf/open/floor/iron,
-/area/tcommsat/server)
+/area/hallway/secondary/command)
 "ejo" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer4{
@@ -32556,9 +32540,19 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/machinery/telecomms/server/presets/exploration,
-/turf/open/floor/circuit/green/telecomms/mainframe,
-/area/tcommsat/server)
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
+/obj/machinery/door/airlock/command{
+	name = "Telecomms Server Room";
+	req_access_txt = "61"
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/smart/simple/general/hidden{
+	dir = 4
+	},
+/turf/open/floor/catwalk_floor/iron_smooth,
+/area/hallway/secondary/command)
 "eTe" = (
 /obj/effect/turf_decal/tile/blue,
 /obj/machinery/light,
@@ -33123,11 +33117,9 @@
 /turf/open/floor/iron,
 /area/hallway/primary/port)
 "fcr" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 6
 	},
 /turf/open/floor/catwalk_floor/iron_smooth{
 	initial_gas_mix = "n2=100;TEMP=80"
@@ -34380,17 +34372,6 @@
 /obj/item/paicard,
 /turf/open/floor/carpet/grimy,
 /area/bridge/showroom/corporate)
-"fxl" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 9
-	},
-/turf/open/floor/catwalk_floor/iron_smooth{
-	initial_gas_mix = "n2=100;TEMP=80"
-	},
-/area/tcommsat/server)
 "fxp" = (
 /obj/machinery/vending/coffee,
 /turf/open/floor/iron/dark,
@@ -36421,16 +36402,8 @@
 /turf/open/floor/iron,
 /area/maintenance/port/fore)
 "gaw" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/effect/turf_decal/edges/borderfloor{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/dark/warning{
-	dir = 8
-	},
-/turf/open/floor/iron/telecomms,
+/obj/machinery/telecomms/broadcaster/mission,
+/turf/open/floor/circuit/green/telecomms/mainframe,
 /area/tcommsat/server)
 "gaz" = (
 /obj/structure/closet/firecloset,
@@ -36441,15 +36414,19 @@
 /turf/open/floor/iron/dark,
 /area/security/main)
 "gaA" = (
-/obj/machinery/camera/directional/east{
-	c_tag = "Telecomms - Cooling Room";
-	name = "telecomms camera"
-	},
-/obj/effect/turf_decal/delivery,
 /obj/structure/table,
-/obj/effect/decal/cleanable/cobweb/cobweb2,
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 26
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/delivery,
+/obj/item/book/manual/wiki/tcomms,
+/obj/item/wrench,
+/obj/item/screwdriver{
+	pixel_y = 5
+	},
 /turf/open/floor/iron,
-/area/tcommsat/server)
+/area/hallway/secondary/command)
 "gaT" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Library Access"
@@ -40223,12 +40200,12 @@
 /turf/open/floor/iron/dark/smooth_corner,
 /area/security/main)
 "hgU" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/smart/simple/general/hidden{
-	dir = 4
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
 	},
-/turf/open/floor/plating,
-/area/tcommsat/server)
+/turf/open/floor/iron,
+/area/hallway/secondary/command)
 "hgY" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/line{
@@ -40826,9 +40803,10 @@
 /turf/open/floor/iron/dark,
 /area/security/main)
 "hpl" = (
-/obj/machinery/telecomms/processor/preset_one,
-/obj/effect/turf_decal/tile/purple/anticorner/contrasted,
-/turf/open/floor/iron/white/telecomms,
+/obj/effect/turf_decal/tile/neutral/anticorner/contrasted{
+	dir = 4
+	},
+/turf/open/floor/iron/telecomms,
 /area/tcommsat/server)
 "hpo" = (
 /obj/structure/cable/yellow{
@@ -41130,9 +41108,9 @@
 /turf/open/floor/iron,
 /area/maintenance/solars/starboard/fore)
 "hvk" = (
-/obj/machinery/telecomms/processor/preset_three,
-/obj/effect/turf_decal/tile/blue/anticorner/contrasted{
-	dir = 8
+/obj/machinery/telecomms/server/engineering,
+/obj/effect/turf_decal/tile/yellow/anticorner/contrasted{
+	dir = 4
 	},
 /turf/open/floor/iron/dark/telecomms,
 /area/tcommsat/server)
@@ -41584,17 +41562,6 @@
 	},
 /turf/open/floor/iron,
 /area/engine/atmos)
-"hEN" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 5
-	},
-/turf/open/floor/catwalk_floor/iron_smooth{
-	initial_gas_mix = "n2=100;TEMP=80"
-	},
-/area/tcommsat/server)
 "hFh" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
 /obj/structure/disposalpipe/segment{
@@ -41734,15 +41701,12 @@
 /area/medical/medbay/aft)
 "hGZ" = (
 /obj/structure/cable/yellow{
-	icon_state = "4-8"
+	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 9
-	},
-/turf/open/floor/catwalk_floor/iron_smooth{
-	initial_gas_mix = "n2=100;TEMP=80"
-	},
-/area/tcommsat/server)
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer4,
+/turf/open/floor/iron,
+/area/hallway/secondary/command)
 "hHr" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
 /turf/open/floor/plating,
@@ -41976,8 +41940,10 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer2,
 /obj/effect/landmark/navigate_destination,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 1
+	},
 /turf/open/floor/carpet/grimy,
 /area/tcommsat/computer)
 "hLe" = (
@@ -42744,16 +42710,12 @@
 /turf/open/floor/iron/white,
 /area/medical/genetics)
 "hVx" = (
-/obj/machinery/light,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
 /obj/machinery/atmospherics/pipe/smart/simple/general/hidden{
 	dir = 9
 	},
-/turf/open/floor/iron,
-/area/tcommsat/server)
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/hallway/secondary/command)
 "hVM" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
@@ -46285,11 +46247,12 @@
 /turf/open/floor/wood,
 /area/vacant_room/commissary)
 "jgF" = (
-/obj/machinery/telecomms/processor/preset_two,
-/obj/effect/turf_decal/tile/brown/anticorner/contrasted{
-	dir = 1
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
 	},
-/turf/open/floor/iron/telecomms,
+/obj/effect/turf_decal/tile/green/opposingcorners,
+/obj/machinery/telecomms/server/exploration,
+/turf/open/floor/iron/dark/telecomms,
 /area/tcommsat/server)
 "jgM" = (
 /obj/machinery/computer/security/labor{
@@ -50998,11 +50961,12 @@
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
 "kGh" = (
-/obj/machinery/telecomms/bus/preset_two,
-/obj/effect/turf_decal/tile/neutral/anticorner/contrasted{
-	dir = 4
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
 	},
-/turf/open/floor/iron/telecomms,
+/obj/effect/turf_decal/tile/purple/anticorner/contrasted,
+/obj/machinery/telecomms/server/science,
+/turf/open/floor/iron/dark/telecomms,
 /area/tcommsat/server)
 "kGA" = (
 /obj/effect/landmark/xeno_spawn,
@@ -51575,7 +51539,7 @@
 /turf/open/floor/iron/dark,
 /area/security/main)
 "kSY" = (
-/obj/machinery/telecomms/broadcaster/preset_exploration,
+/obj/machinery/telecomms/receiver/operations,
 /turf/open/floor/circuit/green/telecomms/mainframe,
 /area/tcommsat/server)
 "kSZ" = (
@@ -51721,11 +51685,14 @@
 /turf/open/floor/iron,
 /area/security/checkpoint/escape)
 "kVI" = (
-/obj/machinery/telecomms/bus/preset_four,
 /obj/effect/turf_decal/tile/brown/anticorner/contrasted{
-	dir = 1
+	dir = 8
 	},
-/turf/open/floor/iron/telecomms,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/telecomms/server/supply,
+/turf/open/floor/iron/dark/telecomms,
 /area/tcommsat/server)
 "kWi" = (
 /obj/effect/turf_decal/tile/red/half/contrasted{
@@ -51859,18 +51826,14 @@
 /turf/open/floor/iron,
 /area/crew_quarters/locker)
 "kZj" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/delivery,
-/obj/machinery/atmospherics/components/unary/portables_connector{
+/obj/effect/turf_decal/tile/green/anticorner/contrasted{
 	dir = 4
 	},
-/obj/machinery/portable_atmospherics/canister/plasma,
-/obj/effect/mapping_helpers/atmos_auto_connect,
-/obj/machinery/airalarm{
-	dir = 8;
-	pixel_x = -22
+/obj/machinery/telecomms/bus/logistics,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark/telecomms,
 /area/tcommsat/server)
 "kZP" = (
 /obj/structure/cable/yellow{
@@ -55955,11 +55918,11 @@
 /turf/open/floor/iron,
 /area/maintenance/port)
 "moh" = (
-/obj/machinery/telecomms/server/presets/engineering,
-/obj/effect/turf_decal/tile/brown/anticorner/contrasted{
-	dir = 8
+/obj/effect/turf_decal/tile/blue/anticorner/contrasted{
+	dir = 1
 	},
-/turf/open/floor/iron/telecomms,
+/obj/machinery/telecomms/server/medical,
+/turf/open/floor/iron/dark/telecomms,
 /area/tcommsat/server)
 "moo" = (
 /obj/structure/table/reinforced,
@@ -57032,10 +56995,10 @@
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
 "mHo" = (
-/obj/machinery/telecomms/server/presets/command,
 /obj/effect/turf_decal/tile/blue/anticorner/contrasted{
-	dir = 1
+	dir = 8
 	},
+/obj/machinery/telecomms/bus/leadership,
 /turf/open/floor/iron/dark/telecomms,
 /area/tcommsat/server)
 "mHs" = (
@@ -57426,12 +57389,10 @@
 /turf/open/floor/prison,
 /area/security/prison)
 "mNo" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/smart/simple/general/hidden{
-	dir = 9
-	},
-/turf/open/floor/plating,
-/area/tcommsat/server)
+/obj/effect/turf_decal/delivery,
+/obj/machinery/portable_thermomachine,
+/turf/open/floor/iron,
+/area/hallway/secondary/command)
 "mNy" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -57838,12 +57799,8 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 8
-	},
-/turf/open/floor/catwalk_floor/iron_smooth{
-	initial_gas_mix = "n2=100;TEMP=80"
-	},
+/obj/machinery/telecomms/server/common,
+/turf/open/floor/circuit/telecomms/mainframe,
 /area/tcommsat/server)
 "mUn" = (
 /obj/machinery/light{
@@ -58839,16 +58796,19 @@
 /turf/open/floor/iron/dark,
 /area/security/detectives_office)
 "njs" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/delivery,
+/obj/machinery/atmospherics/components/unary/portables_connector{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 10
+/obj/machinery/portable_atmospherics/canister/plasma,
+/obj/effect/mapping_helpers/atmos_auto_connect,
+/obj/machinery/airalarm{
+	dir = 8;
+	pixel_x = -22
 	},
-/turf/open/floor/catwalk_floor/iron_smooth{
-	initial_gas_mix = "n2=100;TEMP=80"
-	},
-/area/tcommsat/server)
+/turf/open/floor/iron,
+/area/hallway/secondary/command)
 "njx" = (
 /obj/effect/turf_decal/siding/wood,
 /obj/effect/turf_decal/siding/wood{
@@ -59380,15 +59340,11 @@
 /turf/open/floor/iron/techmaint,
 /area/security/prison/shielded)
 "nrO" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
+/obj/effect/turf_decal/tile/blue/anticorner/contrasted{
+	dir = 1
 	},
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer4{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer2,
-/turf/open/floor/iron,
+/obj/machinery/telecomms/server/command,
+/turf/open/floor/iron/dark/telecomms,
 /area/tcommsat/server)
 "nrX" = (
 /obj/structure/table/reinforced,
@@ -59435,19 +59391,11 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+/obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/machinery/door/airlock/command{
-	name = "Telecomms Server Room";
-	req_access_txt = "61"
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/smart/simple/general/hidden{
-	dir = 4
-	},
-/turf/open/floor/catwalk_floor/iron_smooth,
-/area/tcommsat/server)
+/turf/open/floor/iron,
+/area/hallway/secondary/command)
 "nsR" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/bot,
@@ -59572,18 +59520,22 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
+/obj/machinery/holopad,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer2{
+	dir = 10
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer4{
+	dir = 6
+	},
 /turf/open/floor/iron,
-/area/tcommsat/server)
+/area/hallway/secondary/command)
 "nvg" = (
-/obj/machinery/telecomms/server/presets/medical,
 /obj/effect/turf_decal/tile/blue/anticorner/contrasted{
-	dir = 1
+	dir = 8
 	},
-/turf/open/floor/iron/white/telecomms,
+/obj/machinery/telecomms/processor/support,
+/turf/open/floor/iron/dark/telecomms,
 /area/tcommsat/server)
 "nvn" = (
 /obj/effect/turf_decal/tile/blue/opposingcorners{
@@ -61007,15 +60959,6 @@
 	},
 /turf/open/floor/iron/grid/steel,
 /area/medical/virology)
-"nPQ" = (
-/obj/effect/turf_decal/edges/borderfloor{
-	dir = 6
-	},
-/obj/effect/turf_decal/tile/techfloor{
-	dir = 1
-	},
-/turf/open/floor/iron/telecomms,
-/area/tcommsat/server)
 "nPV" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-8"
@@ -61346,13 +61289,6 @@
 /obj/machinery/power/energy_accumulator/tesla_coil,
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
-"nUN" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/machinery/telecomms/hub/preset/exploration,
-/turf/open/floor/circuit/green/telecomms/mainframe,
-/area/tcommsat/server)
 "nUP" = (
 /obj/effect/spawner/randomvend/cola,
 /obj/structure/sign/poster/official/ian{
@@ -61833,9 +61769,14 @@
 /turf/open/floor/iron,
 /area/quartermaster/storage)
 "oek" = (
-/obj/machinery/telecomms/server/presets/common,
-/obj/effect/turf_decal/tile/neutral/anticorner/contrasted,
-/turf/open/floor/iron/telecomms,
+/obj/effect/turf_decal/tile/brown/anticorner/contrasted{
+	dir = 1
+	},
+/obj/machinery/telecomms/processor/logistics,
+/obj/structure/cable/yellow{
+	icon_state = "2-4"
+	},
+/turf/open/floor/iron/dark/telecomms,
 /area/tcommsat/server)
 "oes" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
@@ -64815,16 +64756,9 @@
 /turf/open/floor/iron,
 /area/engine/storage_shared)
 "pcR" = (
-/obj/structure/cable/yellow{
-	icon_state = "2-8"
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 9
 	},
-/obj/machinery/power/terminal{
-	dir = 4
-	},
-/obj/structure/cable/yellow{
-	icon_state = "0-8"
-	},
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
 /turf/open/floor/catwalk_floor/iron_smooth{
 	initial_gas_mix = "n2=100;TEMP=80"
 	},
@@ -66664,12 +66598,12 @@
 /turf/open/floor/iron,
 /area/maintenance/starboard/aft)
 "pJZ" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
+/obj/machinery/atmospherics/pipe/smart/manifold/general/hidden{
+	dir = 8
 	},
-/obj/machinery/telecomms/processor/preset_exploration,
-/turf/open/floor/circuit/green/telecomms/mainframe,
-/area/tcommsat/server)
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/hallway/secondary/command)
 "pKb" = (
 /obj/effect/landmark/blobstart,
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
@@ -67418,9 +67352,16 @@
 /turf/open/floor/wood,
 /area/quartermaster/exploration_prep)
 "pYa" = (
-/obj/machinery/telecomms/bus/preset_three,
-/obj/effect/turf_decal/tile/red/anticorner/contrasted,
-/turf/open/floor/iron/dark/telecomms,
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/techfloor{
+	dir = 1
+	},
+/obj/effect/turf_decal/edges/borderfloor{
+	dir = 6
+	},
+/turf/open/floor/iron/telecomms,
 /area/tcommsat/server)
 "pYb" = (
 /obj/effect/decal/cleanable/dirt,
@@ -67530,10 +67471,9 @@
 /turf/open/floor/iron,
 /area/science/research)
 "qaA" = (
-/obj/structure/cable/yellow{
-	icon_state = "2-4"
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 5
 	},
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
 /turf/open/floor/catwalk_floor/iron_smooth{
 	initial_gas_mix = "n2=100;TEMP=80"
 	},
@@ -71506,7 +71446,7 @@
 /turf/open/floor/iron,
 /area/quartermaster/sorting)
 "rlk" = (
-/obj/machinery/telecomms/receiver/preset_exploration,
+/obj/machinery/telecomms/receiver/mission,
 /turf/open/floor/circuit/green/telecomms/mainframe,
 /area/tcommsat/server)
 "rlp" = (
@@ -74558,18 +74498,15 @@
 /turf/open/floor/iron,
 /area/crew_quarters/fitness/recreation)
 "seJ" = (
-/obj/structure/cable/yellow,
-/obj/machinery/power/apc/auto_name/directional/west{
-	pixel_x = -24
+/obj/machinery/camera/directional/east{
+	c_tag = "Telecomms - Cooling Room";
+	name = "telecomms camera"
 	},
-/obj/effect/turf_decal/edges/borderfloor{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/dark/warning{
-	dir = 4
-	},
-/turf/open/floor/iron/telecomms,
-/area/tcommsat/server)
+/obj/effect/decal/cleanable/cobweb/cobweb2,
+/obj/effect/turf_decal/delivery,
+/obj/structure/table,
+/turf/open/floor/iron,
+/area/hallway/secondary/command)
 "seN" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -76997,8 +76934,8 @@
 /turf/open/floor/iron,
 /area/construction/mining/aux_base)
 "sQH" = (
-/obj/item/kirbyplants/random,
-/turf/open/floor/carpet/grimy,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
 /area/tcommsat/computer)
 "sQX" = (
 /obj/machinery/computer/security/mining{
@@ -80690,13 +80627,6 @@
 	},
 /turf/open/floor/iron,
 /area/maintenance/aft)
-"ucF" = (
-/obj/machinery/telecomms/bus/preset_one,
-/obj/effect/turf_decal/tile/blue/anticorner/contrasted{
-	dir = 8
-	},
-/turf/open/floor/iron/white/telecomms,
-/area/tcommsat/server)
 "ucV" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/airalarm/directional/west{
@@ -81532,16 +81462,8 @@
 /turf/open/floor/iron,
 /area/engine/gravity_generator)
 "uqZ" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/effect/turf_decal/edges/borderfloor{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/dark/warning{
-	dir = 4
-	},
-/turf/open/floor/iron/telecomms,
+/obj/machinery/telecomms/broadcaster/operations,
+/turf/open/floor/circuit/green/telecomms/mainframe,
 /area/tcommsat/server)
 "urb" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer4,
@@ -84060,8 +83982,13 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/machinery/telecomms/bus/preset_exploration,
-/turf/open/floor/circuit/green/telecomms/mainframe,
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-8"
+	},
+/turf/open/floor/iron/telecomms,
 /area/tcommsat/server)
 "vht" = (
 /obj/effect/decal/cleanable/dirt,
@@ -84786,18 +84713,17 @@
 /turf/open/space,
 /area/space/nearstation)
 "vtr" = (
-/obj/structure/cable/yellow{
-	icon_state = "2-4"
-	},
-/obj/machinery/camera/directional/west{
-	c_tag = "Telecomms - Chamber Port";
-	name = "telecomms camera"
+/obj/machinery/power/apc/auto_name/directional/west{
+	pixel_x = -24
 	},
 /obj/effect/turf_decal/edges/borderfloor{
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/dark/warning{
 	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "0-4"
 	},
 /turf/open/floor/iron/telecomms,
 /area/tcommsat/server)
@@ -85257,10 +85183,17 @@
 /turf/open/floor/iron/dark,
 /area/security/main)
 "vzo" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
+/obj/effect/turf_decal/tile/purple/opposingcorners{
+	dir = 1
 	},
-/turf/open/floor/iron/telecomms,
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/machinery/telecomms/bus/discovery,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/turf/open/floor/iron/dark/telecomms,
 /area/tcommsat/server)
 "vzs" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
@@ -86004,12 +85937,8 @@
 /turf/open/floor/iron,
 /area/engine/atmos)
 "vMN" = (
-/obj/machinery/telecomms/server/presets/supply,
-/obj/effect/turf_decal/tile/brown/anticorner/contrasted{
-	dir = 8
-	},
-/turf/open/floor/iron/telecomms,
-/area/tcommsat/server)
+/turf/open/floor/iron,
+/area/hallway/secondary/command)
 "vMR" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/tile/purple/half/contrasted,
@@ -88053,18 +87982,6 @@
 	},
 /turf/open/floor/iron,
 /area/crew_quarters/heads/chief)
-"wsP" = (
-/obj/structure/cable/yellow{
-	icon_state = "2-8"
-	},
-/obj/effect/turf_decal/edges/borderfloor{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/dark/warning{
-	dir = 8
-	},
-/turf/open/floor/iron/telecomms,
-/area/tcommsat/server)
 "wsU" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -88268,14 +88185,11 @@
 /turf/open/floor/iron,
 /area/crew_quarters/locker)
 "wuT" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
+/obj/machinery/atmospherics/pipe/smart/simple/general/hidden{
+	dir = 6
 	},
-/obj/effect/turf_decal/edges/borderfloor,
-/obj/effect/turf_decal/trimline/dark/warning{
-	dir = 1
-	},
-/turf/open/floor/iron/telecomms,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
 /area/tcommsat/server)
 "wuY" = (
 /obj/effect/decal/cleanable/dirt,
@@ -88371,12 +88285,14 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 5
+/obj/effect/turf_decal/tile/purple/anticorner/contrasted{
+	dir = 4
 	},
-/turf/open/floor/catwalk_floor/iron_smooth{
-	initial_gas_mix = "n2=100;TEMP=80"
+/obj/machinery/telecomms/processor/discovery,
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
 	},
+/turf/open/floor/iron/dark/telecomms,
 /area/tcommsat/server)
 "wwe" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer4,
@@ -88389,12 +88305,14 @@
 /turf/open/floor/iron/white,
 /area/science/research)
 "wwj" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/smart/manifold/general/hidden{
-	dir = 1
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
 	},
-/turf/open/floor/plating,
-/area/tcommsat/server)
+/obj/machinery/atmospherics/pipe/smart/manifold/general/hidden{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/hallway/secondary/command)
 "wwm" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
 /obj/structure/disposalpipe/segment,
@@ -89936,16 +89854,13 @@
 /turf/open/floor/iron/dark,
 /area/aisat)
 "wSs" = (
+/obj/machinery/power/smes{
+	charge = 5e+006
+	},
 /obj/structure/cable/yellow{
-	icon_state = "1-2"
+	icon_state = "0-8"
 	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/obj/machinery/door/airlock/command{
-	name = "Telecomms Server Room";
-	req_access_txt = "61"
-	},
-/obj/machinery/door/firedoor,
-/turf/open/floor/catwalk_floor/iron_smooth,
+/turf/open/floor/circuit/telecomms/mainframe,
 /area/tcommsat/server)
 "wSx" = (
 /obj/effect/turf_decal/stripes/line{
@@ -90777,17 +90692,17 @@
 /turf/open/floor/iron/freezer,
 /area/security/prison)
 "xhU" = (
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -26
+/obj/machinery/camera/directional/west{
+	c_tag = "Telecomms - Chamber Port";
+	name = "telecomms camera"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+/obj/effect/turf_decal/edges/borderfloor{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/dark/warning{
+	dir = 4
+	},
+/turf/open/floor/iron/telecomms,
 /area/tcommsat/server)
 "xhW" = (
 /obj/structure/closet/l3closet/security,
@@ -131794,14 +131709,14 @@ bIH
 kSY
 rCs
 aBl
-aBl
+xhU
 vtr
-seJ
 aBl
 aBl
-uqZ
 oww
+uqZ
 bUG
+aaa
 aaa
 aaa
 cqY
@@ -132051,14 +131966,14 @@ bKH
 bUG
 sAN
 cSI
-cSI
+vCq
 fcr
 qaA
-wvZ
-pJZ
-eSz
-wuT
-gRj
+cSI
+ljn
+bUG
+bUG
+aad
 aad
 aad
 cqZ
@@ -132306,16 +132221,16 @@ tqw
 hWT
 qmu
 bUH
-bWX
+moh
 nvg
-ucF
-mUm
-cev
 ibC
+mUm
+ibC
+oek
 kVI
-vMN
-auF
-bUG
+gRj
+aaa
+aaa
 aaa
 aaa
 cqY
@@ -132563,18 +132478,18 @@ pJH
 nRv
 xcL
 bUI
-bWX
+hvk
 bep
-hpl
-mUm
+ibC
 qDD
 ibC
+kZj
 dCQ
-bvc
-ljn
 bUG
 coe
 coe
+coe
+cqY
 cqY
 pVh
 gih
@@ -132820,20 +132735,20 @@ siD
 pMI
 hXC
 bUI
-bWY
+sAN
 cSI
-cSI
-mUm
+ibC
 cex
 qxk
-dzh
-dzh
+fcr
 eWL
 cmE
+bXa
+njs
 cof
-kZj
 cqY
 csw
+css
 dpO
 cvt
 cwL
@@ -133078,19 +132993,19 @@ pMI
 sQH
 bUI
 bUI
-bUI
 vCq
-hGZ
+pcR
 qDD
 cSI
-cSI
+qDD
 bUI
-bUI
+dan
+pJZ
 wwj
 ejl
-hVx
 cra
 css
+vMN
 meH
 lBw
 cwM
@@ -133333,21 +133248,21 @@ unR
 xke
 hLc
 aKc
-wSs
 nbB
 qUN
 fWG
+auF
 ccI
-cez
 cgm
-vzo
+vgZ
 fkm
 nbB
+eSz
 nsJ
 nuO
-nrO
 qRA
 eZC
+hGZ
 vkf
 cvv
 cwN
@@ -133592,19 +133507,19 @@ rca
 sQH
 bUI
 bUI
-bUI
 qxk
-hEN
+qaA
 qDD
-cSI
-cSI
+hpl
+qDD
 bUI
-bUI
+wuT
+hVx
 hgU
 coi
-xhU
 cqY
 csy
+vMN
 suO
 krD
 cwO
@@ -133848,19 +133763,19 @@ jbk
 pMI
 kiV
 bUI
-bXa
+sAN
 cSI
-cSI
-mUm
+ibC
 ceA
 vCq
-dzh
-dzh
-eWL
+fcr
+bvc
+cev
+seJ
 mNo
 gaA
-cpM
 cqY
+csE
 csE
 mwf
 cvx
@@ -134105,18 +134020,18 @@ xxB
 mEw
 jyh
 bUI
-bWX
+nrO
 mHo
-hvk
-mUm
+ibC
 qDD
 ibC
+vzo
 jgF
-moh
-ljn
 bUG
 coe
 coe
+coe
+cqY
 cqY
 csA
 mqp
@@ -134364,14 +134279,14 @@ mmS
 bUG
 bWX
 bXu
-pYa
-mUm
-ceB
 ibC
+wSs
+ceB
+wvZ
 kGh
-oek
-auF
-bUG
+gRj
+aaa
+aaa
 aaa
 aaa
 cqY
@@ -134621,14 +134536,14 @@ bKH
 bUG
 sAN
 cSI
-cSI
-njs
+qxk
+dzh
 pcR
-fxl
-vgZ
-nUN
-wuT
-gRj
+cSI
+ljn
+bUG
+bUG
+aad
 aad
 aad
 cqZ
@@ -134879,13 +134794,13 @@ rlk
 wKv
 wcs
 wcs
-wsP
-dan
+wcs
 nxE
 pzx
+pYa
 gaw
-nPQ
 bUG
+aaa
 aaa
 aaa
 cqY

--- a/_maps/map_files/EchoStation/EchoStation.dmm
+++ b/_maps/map_files/EchoStation/EchoStation.dmm
@@ -264,7 +264,7 @@
 /area/science/robotics)
 "aiE" = (
 /obj/structure/cable{
-	icon_state = "1-2"
+	icon_state = "1-4"
 	},
 /turf/open/floor/engine{
 	initial_gas_mix = "n2=100;TEMP=80";
@@ -753,6 +753,10 @@
 	},
 /turf/open/floor/carpet/royalblue,
 /area/crew_quarters/heads/captain)
+"aqz" = (
+/obj/machinery/telecomms/receiver/operations,
+/turf/open/space/basic,
+/area/paradise)
 "aqH" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 1
@@ -1355,6 +1359,10 @@
 /obj/machinery/computer/records/security,
 /turf/open/floor/iron,
 /area/bridge)
+"aGJ" = (
+/obj/machinery/telecomms/hub/preset,
+/turf/open/space/basic,
+/area/paradise)
 "aGO" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -1366,10 +1374,10 @@
 	},
 /area/hallway/primary/central)
 "aHp" = (
-/obj/machinery/telecomms/processor/preset_three,
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
+/obj/machinery/telecomms/server/service,
 /turf/open/floor/circuit/green/telecomms/mainframe,
 /area/tcommsat/server)
 "aHq" = (
@@ -1999,6 +2007,10 @@
 /obj/machinery/computer/crew,
 /turf/open/floor/iron,
 /area/bridge)
+"aTi" = (
+/obj/machinery/telecomms/server/supply,
+/turf/open/space/basic,
+/area/paradise)
 "aTx" = (
 /obj/machinery/atmospherics/pipe/smart/simple/general/visible,
 /turf/closed/wall/r_wall,
@@ -2598,12 +2610,10 @@
 /turf/open/floor/iron/dark,
 /area/crew_quarters/heads/hos)
 "bhk" = (
-/obj/machinery/telecomms/broadcaster/preset_right{
-	density = 0
-	},
 /obj/effect/turf_decal/stripes/closeup{
 	dir = 1
 	},
+/obj/machinery/telecomms/processor/logistics,
 /turf/open/floor/circuit/green/telecomms/mainframe,
 /area/tcommsat/server)
 "bhE" = (
@@ -5727,7 +5737,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
-/obj/machinery/telecomms/processor/preset_two,
+/obj/machinery/telecomms/broadcaster/mission,
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/tcommsat/server)
 "cLW" = (
@@ -6261,8 +6271,8 @@
 /turf/open/floor/glass/reinforced,
 /area/bridge)
 "dev" = (
-/obj/machinery/telecomms/bus/preset_three,
 /obj/effect/turf_decal/stripes/closeup,
+/obj/machinery/telecomms/processor/support,
 /turf/open/floor/circuit/green/telecomms/mainframe,
 /area/tcommsat/server)
 "dez" = (
@@ -8407,7 +8417,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},
-/obj/machinery/telecomms/server/presets/security,
+/obj/machinery/telecomms/server/security,
 /turf/open/floor/circuit/green/telecomms/mainframe,
 /area/tcommsat/server)
 "eqC" = (
@@ -8746,6 +8756,10 @@
 "eyu" = (
 /turf/closed/wall,
 /area/maintenance/department/crew_quarters/bar)
+"eyH" = (
+/obj/machinery/telecomms/server/science,
+/turf/open/space/basic,
+/area/paradise)
 "eyQ" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable/yellow{
@@ -9129,10 +9143,10 @@
 /turf/open/floor/plating,
 /area/maintenance/department/medical/central)
 "eHa" = (
-/obj/machinery/telecomms/bus/preset_four,
 /obj/effect/turf_decal/stripes/closeup{
 	dir = 6
 	},
+/obj/machinery/telecomms/bus/logistics,
 /turf/open/floor/circuit/green/telecomms/mainframe,
 /area/tcommsat/server)
 "eHd" = (
@@ -10812,6 +10826,8 @@
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer2{
 	dir = 4
 	},
+/obj/effect/turf_decal/box,
+/obj/machinery/holopad,
 /turf/open/floor/engine{
 	initial_gas_mix = "n2=100;TEMP=80";
 	name = "mainframe floor"
@@ -10820,8 +10836,8 @@
 "fxn" = (
 /obj/machinery/light,
 /obj/machinery/camera/directional/south,
-/obj/machinery/telecomms/server/presets/supply,
 /obj/effect/turf_decal/stripes/closeup,
+/obj/machinery/telecomms/bus/support,
 /turf/open/floor/circuit/green/telecomms/mainframe,
 /area/tcommsat/server)
 "fxp" = (
@@ -10920,7 +10936,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},
-/obj/machinery/telecomms/server/presets/medical,
+/obj/machinery/telecomms/server/medical,
 /turf/open/floor/circuit/green/telecomms/mainframe,
 /area/tcommsat/server)
 "fBU" = (
@@ -11148,12 +11164,10 @@
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/aisat/maint)
 "fHX" = (
-/obj/machinery/telecomms/broadcaster/preset_left{
-	density = 0
-	},
 /obj/effect/turf_decal/stripes/closeup{
 	dir = 1
 	},
+/obj/machinery/telecomms/bus/discovery,
 /turf/open/floor/circuit/green/telecomms/mainframe,
 /area/tcommsat/server)
 "fIy" = (
@@ -12555,13 +12569,13 @@
 /turf/open/floor/plating/asteroid/basalt/planetary,
 /area/engine/atmos)
 "gpR" = (
-/obj/machinery/telecomms/processor/preset_one,
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
 /obj/machinery/light{
 	dir = 1
 	},
+/obj/machinery/telecomms/server/science,
 /turf/open/floor/circuit/green/telecomms/mainframe,
 /area/tcommsat/server)
 "gqv" = (
@@ -12925,6 +12939,10 @@
 	},
 /turf/open/floor/iron/dark,
 /area/ai_monitored/security/armory)
+"gBE" = (
+/obj/machinery/telecomms/server/engineering,
+/turf/open/space/basic,
+/area/paradise)
 "gBH" = (
 /obj/item/kirbyplants/random{
 	pixel_y = 22
@@ -13341,6 +13359,10 @@
 "gMG" = (
 /turf/closed/wall/r_wall,
 /area/crew_quarters/heads/hor)
+"gMO" = (
+/obj/machinery/telecomms/broadcaster/operations,
+/turf/open/space/basic,
+/area/paradise)
 "gMP" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -14461,6 +14483,10 @@
 	},
 /turf/open/floor/iron,
 /area/security/brig)
+"hsP" = (
+/obj/machinery/blackbox_recorder,
+/turf/open/space/basic,
+/area/paradise)
 "hth" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -26
@@ -15033,6 +15059,10 @@
 	},
 /turf/open/floor/iron/dark,
 /area/hallway/primary/central)
+"hGh" = (
+/obj/machinery/telecomms/server/common,
+/turf/open/space/basic,
+/area/paradise)
 "hGq" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/spawner/lootdrop/glowstick/lit,
@@ -15497,8 +15527,8 @@
 /turf/open/floor/iron,
 /area/maintenance/department/chapel)
 "hTE" = (
-/obj/machinery/telecomms/message_server/preset,
 /obj/effect/turf_decal/stripes/closeup,
+/obj/machinery/telecomms/processor/leadership,
 /turf/open/floor/circuit/green/telecomms/mainframe,
 /area/tcommsat/server)
 "hTM" = (
@@ -15865,6 +15895,10 @@
 /obj/structure/window/reinforced/spawner/directional/south,
 /turf/open/floor/engine,
 /area/science/xenobiology)
+"iff" = (
+/obj/machinery/telecomms/processor/support,
+/turf/open/space/basic,
+/area/paradise)
 "ifj" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable/yellow,
@@ -17561,6 +17595,10 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plating,
 /area/maintenance/department/medical/central)
+"iYP" = (
+/obj/machinery/ntnet_relay,
+/turf/open/space/basic,
+/area/paradise)
 "iYQ" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/light/small{
@@ -20089,15 +20127,12 @@
 /turf/open/floor/iron/dark/textured_large,
 /area/engine/atmos)
 "kqK" = (
-/obj/machinery/telecomms/server/presets/common,
-/obj/machinery/power/apc/auto_name/directional/west{
-	pixel_x = -24
+/obj/machinery/telecomms/message_server/preset,
+/obj/effect/turf_decal/stripes{
+	dir = 8
 	},
-/obj/effect/turf_decal/stripes/closeup{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "0-4"
+/obj/effect/turf_decal/stripes/corner{
+	dir = 5
 	},
 /turf/open/floor/circuit/green/telecomms/mainframe,
 /area/tcommsat/server)
@@ -21517,8 +21552,10 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/machinery/telecomms/receiver/preset_left{
-	density = 0
+/obj/machinery/telecomms/receiver/operations,
+/obj/machinery/power/apc/auto_name/directional/east,
+/obj/structure/cable{
+	icon_state = "0-8"
 	},
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/tcommsat/server)
@@ -25100,6 +25137,10 @@
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer2,
 /turf/open/floor/iron,
 /area/science/robotics)
+"nbM" = (
+/obj/machinery/telecomms/processor/discovery,
+/turf/open/space/basic,
+/area/paradise)
 "nbW" = (
 /turf/closed/wall,
 /area/paradise)
@@ -25946,6 +25987,10 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/maintenance/disposal/incinerator)
+"nAJ" = (
+/obj/machinery/telecomms/server/command,
+/turf/open/space/basic,
+/area/paradise)
 "nBT" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer2{
 	dir = 8
@@ -28239,7 +28284,6 @@
 /turf/open/floor/iron/showroomfloor,
 /area/crew_quarters/fitness/recreation)
 "oOM" = (
-/obj/structure/cable,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -28715,10 +28759,10 @@
 /turf/open/floor/iron/dark,
 /area/security/brig)
 "pac" = (
-/obj/machinery/telecomms/bus/preset_one,
 /obj/effect/turf_decal/stripes/closeup{
 	dir = 4
 	},
+/obj/machinery/telecomms/processor/discovery,
 /turf/open/floor/circuit/green/telecomms/mainframe,
 /area/tcommsat/server)
 "pag" = (
@@ -30889,9 +30933,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/machinery/telecomms/receiver/preset_right{
-	density = 0
-	},
+/obj/machinery/telecomms/receiver/mission,
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/tcommsat/server)
 "qlb" = (
@@ -31023,6 +31065,10 @@
 /obj/effect/landmark/start/lawyer,
 /turf/open/floor/plating,
 /area/library/abandoned)
+"qqV" = (
+/obj/machinery/telecomms/server/security,
+/turf/open/space/basic,
+/area/paradise)
 "qqZ" = (
 /obj/structure/lattice,
 /obj/structure/railing{
@@ -31470,7 +31516,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
-/obj/machinery/telecomms/processor/preset_four,
+/obj/machinery/telecomms/broadcaster/operations,
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/tcommsat/server)
 "qEu" = (
@@ -31580,6 +31626,10 @@
 /obj/structure/flora/ausbushes/lavendergrass,
 /turf/open/floor/plating/asteroid/planetary,
 /area/quartermaster/storage)
+"qJN" = (
+/obj/machinery/telecomms/broadcaster/mission,
+/turf/open/space/basic,
+/area/paradise)
 "qJS" = (
 /turf/closed/wall/r_wall,
 /area/crew_quarters/cafeteria)
@@ -31837,7 +31887,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},
-/obj/machinery/telecomms/server/presets/command,
+/obj/machinery/telecomms/server/command,
 /turf/open/floor/circuit/green/telecomms/mainframe,
 /area/tcommsat/server)
 "qSC" = (
@@ -32532,11 +32582,11 @@
 /turf/open/floor/iron,
 /area/maintenance/department/cargo)
 "rhA" = (
-/obj/machinery/telecomms/bus/preset_two,
 /obj/effect/turf_decal/stripes/closeup,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/machinery/telecomms/bus/leadership,
 /turf/open/floor/circuit/green/telecomms/mainframe,
 /area/tcommsat/server)
 "ris" = (
@@ -34165,6 +34215,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/mineral/random/air,
 /area/paradise)
+"sac" = (
+/obj/machinery/telecomms/message_server/preset,
+/turf/open/space/basic,
+/area/paradise)
 "sap" = (
 /obj/docking_port/stationary{
 	dir = 8;
@@ -35028,6 +35082,10 @@
 /obj/structure/window/reinforced/plasma/spawner/directional/east,
 /turf/open/floor/engine/plasma,
 /area/engine/atmos)
+"suC" = (
+/obj/machinery/telecomms/bus/support,
+/turf/open/space/basic,
+/area/paradise)
 "suO" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating,
@@ -37010,7 +37068,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},
-/obj/machinery/telecomms/server/presets/science,
+/obj/machinery/telecomms/server/engineering,
 /turf/open/floor/circuit/green/telecomms/mainframe,
 /area/tcommsat/server)
 "tzP" = (
@@ -37361,6 +37419,10 @@
 	},
 /turf/open/floor/iron/dark,
 /area/science/robotics)
+"tJn" = (
+/obj/machinery/telecomms/server/service,
+/turf/open/space/basic,
+/area/paradise)
 "tJo" = (
 /obj/structure/closet/firecloset,
 /obj/effect/turf_decal/delivery,
@@ -37510,7 +37572,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
-/obj/machinery/telecomms/server/presets/engineering,
+/obj/machinery/telecomms/server/exploration,
 /turf/open/floor/circuit/green/telecomms/mainframe,
 /area/tcommsat/server)
 "tMA" = (
@@ -38201,6 +38263,9 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/hallway/primary/aft)
+"udO" = (
+/turf/open/space/basic,
+/area/paradise)
 "ueQ" = (
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron/white,
@@ -38721,19 +38786,14 @@
 /area/engine/engineering)
 "utp" = (
 /obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+/obj/machinery/telecomms/server/common,
+/obj/effect/turf_decal/stripes/end{
 	dir = 4
 	},
-/turf/open/floor/engine{
-	initial_gas_mix = "n2=100;TEMP=80";
-	name = "mainframe floor"
-	},
+/turf/open/floor/circuit/green/telecomms/mainframe,
 /area/tcommsat/server)
 "utH" = (
 /obj/structure/cable{
@@ -38964,6 +39024,10 @@
 	},
 /turf/open/floor/plating,
 /area/crew_quarters/theatre/backstage)
+"uyR" = (
+/obj/machinery/telecomms/processor/logistics,
+/turf/open/space/basic,
+/area/paradise)
 "uzi" = (
 /obj/structure/railing{
 	dir = 8
@@ -41861,6 +41925,10 @@
 	},
 /turf/open/floor/iron,
 /area/janitor)
+"vWt" = (
+/obj/machinery/telecomms/receiver/mission,
+/turf/open/space/basic,
+/area/paradise)
 "vWW" = (
 /obj/machinery/computer/xenoarchaeology_console{
 	dir = 8
@@ -42027,12 +42095,10 @@
 	icon_state = "4-8"
 	},
 /obj/effect/landmark/blobstart,
-/obj/machinery/holopad,
-/obj/effect/turf_decal/box,
 /obj/machinery/atmospherics/pipe/heat_exchanging/manifold{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer2{
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 4
 	},
 /turf/open/floor/engine{
@@ -42183,6 +42249,10 @@
 /obj/effect/landmark/start/warden,
 /turf/open/floor/iron/dark,
 /area/security/warden)
+"wgC" = (
+/obj/machinery/telecomms/server/exploration,
+/turf/open/space/basic,
+/area/paradise)
 "wgG" = (
 /obj/item/kirbyplants/random,
 /obj/machinery/firealarm/directional/west,
@@ -43255,6 +43325,10 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
+"wMF" = (
+/obj/machinery/telecomms/server/medical,
+/turf/open/space/basic,
+/area/paradise)
 "wML" = (
 /obj/machinery/door/airlock/highsecurity{
 	name = "Secure Tech Storage";
@@ -43597,6 +43671,10 @@
 /obj/machinery/camera/directional/north,
 /turf/open/floor/iron,
 /area/bridge)
+"wWl" = (
+/obj/machinery/telecomms/processor/leadership,
+/turf/open/space/basic,
+/area/paradise)
 "wWF" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -43643,6 +43721,10 @@
 /obj/effect/turf_decal/tile/purple/fourcorners/contrasted,
 /turf/open/floor/iron/white,
 /area/science/lab)
+"wYG" = (
+/obj/machinery/telecomms/bus/leadership,
+/turf/open/space/basic,
+/area/paradise)
 "wYP" = (
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "Medbay Maintenance";
@@ -43887,7 +43969,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
-/obj/machinery/telecomms/server/presets/service,
+/obj/machinery/telecomms/server/supply,
 /turf/open/floor/circuit/green/telecomms/mainframe,
 /area/tcommsat/server)
 "xfN" = (
@@ -43949,6 +44031,10 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/closed/wall/r_wall,
 /area/quartermaster/warehouse)
+"xhW" = (
+/obj/machinery/telecomms/bus/discovery,
+/turf/open/space/basic,
+/area/paradise)
 "xhX" = (
 /obj/effect/mapping_helpers/airlock/unres{
 	dir = 8
@@ -45790,6 +45876,10 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
 /turf/open/floor/wood/broken,
 /area/chapel/office)
+"yjj" = (
+/obj/machinery/telecomms/bus/logistics,
+/turf/open/space/basic,
+/area/paradise)
 "yjm" = (
 /obj/structure/flora/grass/jungle/b,
 /turf/open/floor/plating/asteroid/planetary,
@@ -122399,10 +122489,10 @@ bhk
 eHa
 rqF
 mGR
-mGR
-mGR
-mGR
-mGR
+wMF
+iff
+uyR
+aTi
 mGR
 mGR
 mGR
@@ -122656,10 +122746,10 @@ sFy
 dev
 rqF
 mGR
-mGR
-mGR
-mGR
-mGR
+gBE
+suC
+yjj
+tJn
 xqF
 xqF
 xqF
@@ -122913,10 +123003,10 @@ vsf
 fxn
 rqF
 mGR
-mGR
-mGR
-mGR
-mGR
+aqz
+hsP
+udO
+gMO
 xqF
 fst
 fst
@@ -123170,10 +123260,10 @@ xfA
 aHp
 rqF
 mGR
-mGR
-mGR
-mGR
-mGR
+udO
+hGh
+aGJ
+udO
 xqF
 fst
 fst
@@ -123427,10 +123517,10 @@ tzw
 fBN
 rqF
 mGR
-mGR
-mGR
-mGR
-mGR
+vWt
+sac
+iYP
+qJN
 xqF
 fst
 fst
@@ -123684,10 +123774,10 @@ aiE
 oOM
 rqF
 mGR
-mGR
-mGR
-mGR
-mGR
+nAJ
+wYG
+xhW
+wgC
 xqF
 xqF
 xqF
@@ -123941,10 +124031,10 @@ lfe
 qEd
 rqF
 mGR
-mGR
-mGR
-mGR
-mGR
+qqV
+wWl
+nbM
+eyH
 mGR
 mGR
 mGR

--- a/_maps/map_files/FlandStation/FlandStation.dmm
+++ b/_maps/map_files/FlandStation/FlandStation.dmm
@@ -57463,9 +57463,6 @@
 	},
 /turf/open/floor/iron/techmaint,
 /area/science/shuttle)
-"oJz" = (
-/turf/open/space/basic,
-/area/tcommsat/server)
 "oJD" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/glowstick/lit,
@@ -58692,9 +58689,6 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
 /turf/open/floor/iron/dark,
 /area/engine/engine_smes)
-"pbv" = (
-/turf/open/space/basic,
-/area/maintenance/starboard/fore)
 "pbw" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 8
@@ -147617,12 +147611,12 @@ joS
 mVm
 uhU
 nHC
-oJz
-oJz
-oJz
-oJz
-oJz
-pbv
+kGA
+kGA
+kGA
+kGA
+kGA
+kGA
 qul
 qlJ
 rAq

--- a/_maps/map_files/FlandStation/FlandStation.dmm
+++ b/_maps/map_files/FlandStation/FlandStation.dmm
@@ -8099,10 +8099,10 @@
 	icon_state = "0-4"
 	},
 /obj/structure/cable/yellow,
-/turf/open/floor/engine{
-	initial_gas_mix = "n2=100;TEMP=80";
-	name = "mainframe floor"
-	},
+/obj/machinery/blackbox_recorder,
+/obj/effect/turf_decal/stripes/box,
+/obj/effect/turf_decal/stripes/red/box,
+/turf/open/floor/iron/dark/telecomms,
 /area/tcommsat/server)
 "cds" = (
 /obj/structure/tank_dispenser/oxygen,
@@ -32944,6 +32944,7 @@
 /obj/effect/decal/remains/human,
 /obj/effect/decal/cleanable/blood/old,
 /obj/item/clothing/mask/joy,
+/obj/machinery/telecomms/server/security,
 /turf/open/floor/plating,
 /area/quartermaster/exploration_prep)
 "itG" = (
@@ -38760,15 +38761,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/maintenance/department/science)
-"jUs" = (
-/obj/machinery/telecomms/hub/preset/exploration,
-/obj/effect/turf_decal/stripes/box,
-/obj/effect/turf_decal/stripes/red/box,
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/open/floor/iron/dark/telecomms,
-/area/tcommsat/server)
 "jUE" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -43106,9 +43098,6 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
-/obj/machinery/light/small{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 9
 	},
@@ -44661,8 +44650,8 @@
 /turf/open/floor/iron/showroomfloor,
 /area/crew_quarters/cryopods)
 "loM" = (
-/obj/machinery/telecomms/server/presets/supply,
 /obj/effect/turf_decal/stripes/closeup,
+/obj/machinery/telecomms/server/science,
 /turf/open/floor/circuit/green/telecomms/mainframe,
 /area/tcommsat/server)
 "loY" = (
@@ -50862,6 +50851,7 @@
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/closet,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "mVq" = (
@@ -51775,10 +51765,8 @@
 /turf/open/floor/iron/techmaint,
 /area/maintenance/department/engine)
 "nix" = (
-/obj/machinery/telecomms/bus/preset_one,
-/obj/effect/turf_decal/stripes/end{
-	dir = 4
-	},
+/obj/effect/turf_decal/stripes/closeup,
+/obj/machinery/telecomms/server/supply,
 /turf/open/floor/circuit/green/telecomms/mainframe,
 /area/tcommsat/server)
 "niA" = (
@@ -53688,7 +53676,6 @@
 /turf/open/floor/iron,
 /area/engine/atmos)
 "nHC" = (
-/obj/structure/closet,
 /obj/effect/spawner/lootdrop/maintenance/two,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
@@ -54394,13 +54381,13 @@
 /turf/open/floor/iron/dark,
 /area/tcommsat/computer)
 "nUp" = (
-/obj/machinery/telecomms/receiver/preset_exploration,
 /obj/effect/turf_decal/stripes/end{
 	dir = 8
 	},
 /obj/machinery/light/small{
 	dir = 1
 	},
+/obj/machinery/telecomms/receiver/operations,
 /turf/open/floor/circuit/green/telecomms/mainframe,
 /area/tcommsat/server)
 "nUr" = (
@@ -54502,12 +54489,12 @@
 /turf/open/floor/iron/grid/steel,
 /area/engine/atmos)
 "nVA" = (
-/obj/machinery/telecomms/processor/preset_exploration,
 /obj/effect/turf_decal/stripes/closeup,
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple,
+/obj/machinery/telecomms/server/engineering,
 /turf/open/floor/circuit/green/telecomms/mainframe,
 /area/tcommsat/server)
 "nVD" = (
@@ -54551,22 +54538,19 @@
 /turf/closed/wall/r_wall,
 /area/security/execution/education)
 "nWo" = (
-/obj/machinery/telecomms/server/presets/exploration,
 /obj/effect/turf_decal/stripes/end{
 	dir = 4
 	},
+/obj/machinery/telecomms/server/medical,
 /turf/open/floor/circuit/green/telecomms/mainframe,
 /area/tcommsat/server)
 "nWr" = (
 /turf/open/floor/holofloor/plating,
 /area/holodeck/prison)
 "nWt" = (
-/obj/machinery/telecomms/processor/preset_one,
-/obj/effect/turf_decal/stripes/end{
-	dir = 8
-	},
-/turf/open/floor/circuit/green/telecomms/mainframe,
-/area/tcommsat/server)
+/obj/machinery/telecomms/server/security,
+/turf/closed/wall,
+/area/quartermaster/exploration_prep)
 "nWR" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/red/corner,
@@ -54636,9 +54620,10 @@
 /turf/open/floor/iron/dark,
 /area/storage/tech)
 "nXG" = (
-/obj/machinery/telecomms/server/presets/medical,
-/obj/effect/turf_decal/stripes/closeup,
-/turf/open/floor/circuit/green/telecomms/mainframe,
+/turf/open/floor/engine{
+	initial_gas_mix = "n2=100;TEMP=80";
+	name = "mainframe floor"
+	},
 /area/tcommsat/server)
 "nXH" = (
 /obj/machinery/door/airlock/maintenance{
@@ -54734,22 +54719,23 @@
 /turf/open/floor/iron/grid/steel,
 /area/crew_quarters/dorms)
 "nZg" = (
-/obj/machinery/telecomms/server/presets/science,
 /obj/effect/turf_decal/stripes/closeup,
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple,
+/obj/machinery/telecomms/server/service,
 /turf/open/floor/circuit/green/telecomms/mainframe,
 /area/tcommsat/server)
 "nZh" = (
-/obj/machinery/blackbox_recorder,
-/obj/effect/turf_decal/stripes/box,
-/obj/effect/turf_decal/stripes/red/box,
+/obj/effect/turf_decal/stripes/end{
+	dir = 4
+	},
+/obj/machinery/telecomms/broadcaster/operations,
 /obj/machinery/light/small{
 	dir = 1
 	},
-/turf/open/floor/iron/dark/telecomms,
+/turf/open/floor/circuit/green/telecomms/mainframe,
 /area/tcommsat/server)
 "nZl" = (
 /obj/structure/lattice/catwalk/over,
@@ -57239,10 +57225,10 @@
 /turf/open/floor/plating,
 /area/maintenance/department/medical)
 "oHl" = (
-/obj/machinery/telecomms/receiver/preset_left,
 /obj/effect/turf_decal/stripes/closeup{
 	dir = 4
 	},
+/obj/machinery/telecomms/processor/support,
 /turf/open/floor/circuit/green/telecomms/mainframe,
 /area/tcommsat/server)
 "oHz" = (
@@ -57255,10 +57241,10 @@
 /turf/open/floor/engine,
 /area/science/storage)
 "oHE" = (
-/obj/machinery/telecomms/broadcaster/preset_right,
 /obj/effect/turf_decal/stripes/closeup{
 	dir = 8
 	},
+/obj/machinery/telecomms/bus/support,
 /turf/open/floor/circuit/green/telecomms/mainframe,
 /area/tcommsat/server)
 "oHJ" = (
@@ -57305,11 +57291,14 @@
 /turf/open/floor/iron/freezer,
 /area/crew_quarters/toilet/restrooms)
 "oIc" = (
-/obj/machinery/telecomms/processor/preset_two,
 /obj/effect/turf_decal/stripes/end{
 	dir = 8
 	},
-/turf/open/floor/circuit/green/telecomms/mainframe,
+/obj/machinery/ntnet_relay,
+/obj/effect/turf_decal/stripes/red/end{
+	dir = 8
+	},
+/turf/open/floor/iron/dark/telecomms,
 /area/tcommsat/server)
 "oIm" = (
 /obj/effect/turf_decal/box,
@@ -57321,9 +57310,14 @@
 	},
 /area/docking/arrival)
 "oIu" = (
-/obj/machinery/telecomms/server/presets/engineering,
-/obj/effect/turf_decal/stripes/closeup,
-/turf/open/floor/circuit/green/telecomms/mainframe,
+/obj/effect/turf_decal/stripes/end{
+	dir = 4
+	},
+/obj/machinery/telecomms/message_server/preset,
+/obj/effect/turf_decal/stripes/red/end{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/telecomms,
 /area/tcommsat/server)
 "oIy" = (
 /obj/structure/rack,
@@ -57344,8 +57338,10 @@
 /turf/open/floor/iron/tiled,
 /area/medical/virology)
 "oIz" = (
-/obj/machinery/telecomms/server/presets/common,
-/obj/effect/turf_decal/stripes/closeup,
+/obj/machinery/telecomms/bus/discovery,
+/obj/effect/turf_decal/stripes/closeup{
+	dir = 4
+	},
 /turf/open/floor/circuit/green/telecomms/mainframe,
 /area/tcommsat/server)
 "oIE" = (
@@ -57451,9 +57447,9 @@
 /turf/open/floor/wood,
 /area/security/detectives_office)
 "oJq" = (
-/obj/machinery/telecomms/bus/preset_two,
-/obj/effect/turf_decal/stripes/end{
-	dir = 4
+/obj/machinery/telecomms/processor/discovery,
+/obj/effect/turf_decal/stripes/closeup{
+	dir = 8
 	},
 /turf/open/floor/circuit/green/telecomms/mainframe,
 /area/tcommsat/server)
@@ -57468,10 +57464,7 @@
 /turf/open/floor/iron/techmaint,
 /area/science/shuttle)
 "oJz" = (
-/obj/machinery/ntnet_relay,
-/obj/effect/turf_decal/stripes/box,
-/obj/effect/turf_decal/stripes/red/box,
-/turf/open/floor/iron/dark/telecomms,
+/turf/open/space/basic,
 /area/tcommsat/server)
 "oJD" = (
 /obj/structure/rack,
@@ -58700,12 +58693,8 @@
 /turf/open/floor/iron/dark,
 /area/engine/engine_smes)
 "pbv" = (
-/obj/machinery/telecomms/processor/preset_four,
-/obj/effect/turf_decal/stripes/end{
-	dir = 8
-	},
-/turf/open/floor/circuit/green/telecomms/mainframe,
-/area/tcommsat/server)
+/turf/open/space/basic,
+/area/maintenance/starboard/fore)
 "pbw" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 8
@@ -58883,10 +58872,11 @@
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
 "pdJ" = (
-/obj/machinery/telecomms/bus/preset_four,
 /obj/effect/turf_decal/stripes/end{
 	dir = 4
 	},
+/obj/machinery/telecomms/broadcaster/mission,
+/obj/machinery/light/small,
 /turf/open/floor/circuit/green/telecomms/mainframe,
 /area/tcommsat/server)
 "pdM" = (
@@ -59708,10 +59698,10 @@
 /turf/open/floor/iron/dark/side,
 /area/hallway/primary/aft)
 "ppo" = (
-/obj/machinery/telecomms/broadcaster/preset_left,
 /obj/effect/turf_decal/stripes/closeup{
 	dir = 6
 	},
+/obj/machinery/telecomms/processor/leadership,
 /turf/open/floor/circuit/green/telecomms/mainframe,
 /area/tcommsat/server)
 "ppz" = (
@@ -59733,18 +59723,21 @@
 /turf/closed/wall/r_wall,
 /area/engine/atmos)
 "pqh" = (
-/obj/machinery/telecomms/receiver/preset_right,
 /obj/effect/turf_decal/stripes/closeup{
 	dir = 10
 	},
+/obj/machinery/telecomms/bus/leadership,
 /turf/open/floor/circuit/green/telecomms/mainframe,
 /area/tcommsat/server)
 "pqi" = (
-/obj/machinery/telecomms/processor/preset_three,
 /obj/effect/turf_decal/stripes/end{
 	dir = 8
 	},
-/turf/open/floor/circuit/green/telecomms/mainframe,
+/obj/machinery/telecomms/server/common,
+/obj/effect/turf_decal/stripes/red/end{
+	dir = 8
+	},
+/turf/open/floor/iron/dark/telecomms,
 /area/tcommsat/server)
 "pqp" = (
 /obj/machinery/door/firedoor,
@@ -59784,9 +59777,14 @@
 /turf/open/floor/circuit/green,
 /area/science/xenobiology)
 "pra" = (
-/obj/machinery/telecomms/server/presets/command,
-/obj/effect/turf_decal/stripes/closeup,
-/turf/open/floor/circuit/green/telecomms/mainframe,
+/obj/effect/turf_decal/stripes/end{
+	dir = 4
+	},
+/obj/machinery/telecomms/hub/preset,
+/obj/effect/turf_decal/stripes/red/end{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/telecomms,
 /area/tcommsat/server)
 "prh" = (
 /obj/machinery/light{
@@ -59804,8 +59802,10 @@
 	},
 /area/medical/cryo)
 "pru" = (
-/obj/machinery/telecomms/server/presets/security,
-/obj/effect/turf_decal/stripes/closeup,
+/obj/machinery/telecomms/bus/logistics,
+/obj/effect/turf_decal/stripes/closeup{
+	dir = 6
+	},
 /turf/open/floor/circuit/green/telecomms/mainframe,
 /area/tcommsat/server)
 "prG" = (
@@ -59998,9 +59998,9 @@
 /turf/open/floor/iron,
 /area/hallway/secondary/service)
 "puu" = (
-/obj/machinery/telecomms/bus/preset_three,
-/obj/effect/turf_decal/stripes/end{
-	dir = 4
+/obj/machinery/telecomms/processor/logistics,
+/obj/effect/turf_decal/stripes/closeup{
+	dir = 10
 	},
 /turf/open/floor/circuit/green/telecomms/mainframe,
 /area/tcommsat/server)
@@ -60056,13 +60056,6 @@
 	initial_gas_mix = "o2=14;n2=23;TEMP=300"
 	},
 /area/docking/arrival)
-"pvc" = (
-/obj/effect/turf_decal/stripes/box,
-/obj/effect/turf_decal/stripes/red/box,
-/obj/machinery/telecomms/hub/preset,
-/obj/machinery/light/small,
-/turf/open/floor/iron/dark/telecomms,
-/area/tcommsat/server)
 "pvg" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -63851,11 +63844,11 @@
 	},
 /area/maintenance/starboard/fore)
 "qtg" = (
-/obj/machinery/telecomms/broadcaster/preset_exploration,
 /obj/effect/turf_decal/stripes/end{
 	dir = 8
 	},
 /obj/machinery/light/small,
+/obj/machinery/telecomms/receiver/mission,
 /turf/open/floor/circuit/green/telecomms/mainframe,
 /area/tcommsat/server)
 "qtl" = (
@@ -63897,8 +63890,8 @@
 /turf/open/floor/iron/dark,
 /area/quartermaster/storage)
 "qtA" = (
-/obj/machinery/telecomms/message_server/preset,
 /obj/effect/turf_decal/stripes/closeup,
+/obj/machinery/telecomms/server/command,
 /turf/open/floor/circuit/green/telecomms/mainframe,
 /area/tcommsat/server)
 "qtE" = (
@@ -63998,8 +63991,10 @@
 /turf/open/floor/iron/dark/side,
 /area/engine/atmos)
 "qtY" = (
-/obj/machinery/telecomms/server/presets/service,
-/obj/effect/turf_decal/stripes/closeup,
+/obj/effect/turf_decal/stripes/end{
+	dir = 8
+	},
+/obj/machinery/telecomms/server/exploration,
 /turf/open/floor/circuit/green/telecomms/mainframe,
 /area/tcommsat/server)
 "que" = (
@@ -66192,10 +66187,10 @@
 /turf/open/floor/iron/dark,
 /area/science/robotics/mechbay)
 "qYa" = (
-/obj/machinery/telecomms/bus/preset_exploration,
 /obj/effect/turf_decal/stripes/end{
 	dir = 4
 	},
+/obj/machinery/telecomms/server/security,
 /turf/open/floor/circuit/green/telecomms/mainframe,
 /area/tcommsat/server)
 "qYd" = (
@@ -128177,7 +128172,7 @@ cLU
 lIP
 lIP
 lIP
-lIP
+nWt
 lIP
 mTA
 hIE
@@ -128435,7 +128430,7 @@ oQx
 njL
 lIP
 itx
-lIP
+nWt
 cuc
 nUs
 hes
@@ -146080,7 +146075,7 @@ xTa
 aPP
 fGN
 aTX
-nWt
+nXG
 jRm
 oIc
 pqi
@@ -146342,7 +146337,7 @@ jRm
 oIu
 pra
 kWL
-pbv
+nXG
 aTX
 qlJ
 kGA
@@ -147366,9 +147361,9 @@ mUP
 usp
 nGX
 aTX
-jUs
-oJz
-pvc
+aTX
+aTX
+aTX
 aTX
 aTX
 aTX
@@ -147622,13 +147617,13 @@ joS
 mVm
 uhU
 nHC
-aTX
-aTX
-aTX
-aTX
-aTX
+oJz
+oJz
+oJz
+oJz
+oJz
+pbv
 qul
-kGA
 qlJ
 rAq
 bGI

--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -3191,13 +3191,14 @@
 /turf/open/floor/iron/dark,
 /area/maintenance/port)
 "aFY" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
+/obj/structure/cable,
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/tcommsat/server)
 "aGc" = (
@@ -8993,14 +8994,12 @@
 /turf/open/floor/plating,
 /area/crew_quarters/heads/hop)
 "bPS" = (
-/obj/machinery/telecomms/receiver/preset_right,
 /obj/machinery/camera/directional/north{
 	c_tag = "Telecomms Server SMES";
 	name = "telecomms camera"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/telecomms/server/supply,
 /turf/open/floor/circuit/green/telecomms/mainframe,
 /area/tcommsat/server)
 "bPT" = (
@@ -14568,11 +14567,11 @@
 /turf/open/floor/iron/dark,
 /area/security/brig/aft)
 "cVs" = (
-/obj/machinery/telecomms/broadcaster/preset_right,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
 /obj/effect/turf_decal/stripes/line,
+/obj/machinery/telecomms/server/security,
 /turf/open/floor/circuit/green/telecomms/mainframe,
 /area/tcommsat/server)
 "cVy" = (
@@ -18145,10 +18144,10 @@
 /turf/open/floor/iron/dark,
 /area/storage/primary)
 "dZf" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/engine{
 	initial_gas_mix = "n2=100;TEMP=80";
 	name = "mainframe floor"
@@ -19317,11 +19316,11 @@
 /turf/open/floor/iron/dark,
 /area/hydroponics)
 "epj" = (
-/obj/machinery/telecomms/broadcaster/preset_left,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
 /obj/effect/turf_decal/stripes/line,
+/obj/machinery/telecomms/server/medical,
 /turf/open/floor/circuit/green/telecomms/mainframe,
 /area/tcommsat/server)
 "epl" = (
@@ -19909,10 +19908,10 @@
 /turf/open/floor/iron/showroomfloor,
 /area/medical/medbay/lobby)
 "ezP" = (
-/obj/machinery/telecomms/server/presets/science,
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
+/obj/machinery/telecomms/processor/discovery,
 /turf/open/floor/circuit/green/telecomms/mainframe,
 /area/tcommsat/server)
 "ezS" = (
@@ -20789,6 +20788,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/general/hidden{
 	dir = 9
 	},
+/obj/machinery/telecomms/server/common,
 /turf/open/floor/engine,
 /area/tcommsat/computer)
 "eQQ" = (
@@ -25967,11 +25967,11 @@
 /turf/open/floor/iron/showroomfloor,
 /area/science/research)
 "gzl" = (
-/obj/machinery/telecomms/processor/preset_three,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
 /obj/effect/turf_decal/stripes/line,
+/obj/machinery/telecomms/broadcaster/mission,
 /turf/open/floor/circuit/green/telecomms/mainframe,
 /area/tcommsat/server)
 "gzn" = (
@@ -27834,10 +27834,10 @@
 /turf/open/floor/iron/dark,
 /area/maintenance/disposal/incinerator)
 "hdC" = (
-/obj/machinery/telecomms/server/presets/command,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/obj/machinery/telecomms/bus/support,
 /turf/open/floor/circuit/green/telecomms/mainframe,
 /area/tcommsat/server)
 "hdF" = (
@@ -32157,10 +32157,10 @@
 /turf/open/floor/iron/dark,
 /area/maintenance/fore)
 "izd" = (
-/obj/machinery/telecomms/bus/preset_four,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/obj/machinery/telecomms/receiver/mission,
 /turf/open/floor/circuit/green/telecomms/mainframe,
 /area/tcommsat/server)
 "izf" = (
@@ -32969,7 +32969,6 @@
 /turf/open/floor/iron/dark,
 /area/quartermaster/warehouse)
 "iKB" = (
-/obj/machinery/telecomms/server/presets/exploration,
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/circuit/telecomms/server,
 /area/quartermaster/exploration_prep)
@@ -35811,12 +35810,8 @@
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat/atmos)
 "jGb" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer4{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
 /turf/open/floor/engine{
 	initial_gas_mix = "n2=100;TEMP=80";
 	name = "mainframe floor"
@@ -37504,12 +37499,6 @@
 /turf/open/floor/iron,
 /area/bridge)
 "kkz" = (
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 9
 	},
@@ -38087,10 +38076,13 @@
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "krP" = (
-/obj/machinery/telecomms/bus/preset_two,
 /obj/effect/turf_decal/stripes/end{
 	dir = 4
 	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/telecomms/server/engineering,
 /turf/open/floor/circuit/green/telecomms/mainframe,
 /area/tcommsat/server)
 "krT" = (
@@ -39287,7 +39279,6 @@
 /turf/open/floor/iron/dark,
 /area/crew_quarters/locker)
 "kOd" = (
-/obj/machinery/telecomms/processor/preset_exploration,
 /obj/effect/decal/cleanable/cobweb,
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/circuit/telecomms/server,
@@ -41511,13 +41502,10 @@
 /turf/open/floor/iron/techmaint,
 /area/security/prison)
 "lBU" = (
-/obj/machinery/telecomms/bus/preset_three,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
 /obj/effect/turf_decal/stripes/end{
 	dir = 8
 	},
+/obj/machinery/telecomms/server/command,
 /turf/open/floor/circuit/green/telecomms/mainframe,
 /area/tcommsat/server)
 "lBY" = (
@@ -42053,22 +42041,15 @@
 /turf/open/floor/iron/dark,
 /area/hallway/primary/fore)
 "lLe" = (
-/obj/machinery/power/smes{
-	charge = 5e+006
-	},
 /obj/machinery/light/small{
 	dir = 1
 	},
 /obj/structure/sign/warning/electricshock{
 	pixel_y = 32
 	},
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/turf/open/floor/plating{
-	burnt = 1;
-	initial_gas_mix = "n2=100;TEMP=80"
-	},
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/telecomms/server/common,
+/turf/open/floor/circuit/green/telecomms/mainframe,
 /area/tcommsat/server)
 "lLq" = (
 /obj/effect/landmark/start/scientist,
@@ -44362,10 +44343,10 @@
 	},
 /area/maintenance/port/fore)
 "mwO" = (
-/obj/machinery/telecomms/server/presets/security,
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},
+/obj/machinery/telecomms/processor/support,
 /turf/open/floor/circuit/green/telecomms/mainframe,
 /area/tcommsat/server)
 "mxd" = (
@@ -44719,9 +44700,6 @@
 /turf/open/floor/iron/dark,
 /area/quartermaster/warehouse)
 "mCN" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer2{
 	dir = 4
 	},
@@ -45119,6 +45097,18 @@
 /obj/effect/turf_decal/tile/yellow,
 /turf/open/floor/iron,
 /area/quartermaster/office)
+"mIa" = (
+/obj/machinery/power/terminal{
+	dir = 8
+	},
+/obj/structure/cable/yellow{
+	icon_state = "0-4"
+	},
+/turf/open/floor/engine{
+	initial_gas_mix = "n2=100;TEMP=80";
+	name = "mainframe floor"
+	},
+/area/tcommsat/server)
 "mIl" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/sign/warning/vacuum{
@@ -46554,13 +46544,8 @@
 /turf/open/floor/iron,
 /area/engine/atmos)
 "niW" = (
-/obj/machinery/telecomms/receiver/preset_left,
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
+/obj/machinery/telecomms/server/science,
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/circuit/green/telecomms/mainframe,
 /area/tcommsat/server)
 "njb" = (
@@ -47153,10 +47138,13 @@
 /turf/open/floor/iron/dark,
 /area/chapel/main)
 "nuv" = (
-/obj/machinery/telecomms/server/presets/service,
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/telecomms/processor/leadership,
 /turf/open/floor/circuit/green/telecomms/mainframe,
 /area/tcommsat/server)
 "nuy" = (
@@ -47618,12 +47606,15 @@
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
 "nCh" = (
-/obj/machinery/telecomms/bus/preset_exploration,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
+/obj/machinery/power/smes{
+	charge = 5e+006
 	},
-/turf/open/floor/circuit/green/telecomms/mainframe,
-/area/quartermaster/exploration_prep)
+/obj/structure/cable,
+/turf/open/floor/plating{
+	burnt = 1;
+	initial_gas_mix = "n2=100;TEMP=80"
+	},
+/area/tcommsat/server)
 "nCy" = (
 /obj/machinery/portable_atmospherics/canister/nitrous_oxide,
 /obj/machinery/camera/directional/south{
@@ -47709,6 +47700,20 @@
 	},
 /turf/open/floor/iron/showroomfloor,
 /area/quartermaster/exploration_prep)
+"nEa" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/turf/open/floor/engine{
+	initial_gas_mix = "n2=100;TEMP=80";
+	name = "mainframe floor"
+	},
+/area/tcommsat/server)
 "nEo" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -48812,12 +48817,6 @@
 /turf/open/floor/iron/dark,
 /area/security/warden)
 "nUp" = (
-/obj/machinery/power/terminal{
-	dir = 1
-	},
-/obj/structure/cable/yellow{
-	icon_state = "0-8"
-	},
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer2{
 	dir = 4
 	},
@@ -51121,11 +51120,11 @@
 /turf/open/floor/iron/dark,
 /area/bridge)
 "oER" = (
-/obj/machinery/telecomms/processor/preset_one,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
 /obj/effect/turf_decal/stripes/line,
+/obj/machinery/telecomms/broadcaster/operations,
 /turf/open/floor/circuit/green/telecomms/mainframe,
 /area/tcommsat/server)
 "oFf" = (
@@ -51576,10 +51575,13 @@
 /turf/open/floor/iron/dark,
 /area/science/mixing)
 "oLD" = (
-/obj/machinery/telecomms/server/presets/engineering,
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/telecomms/processor/logistics,
 /turf/open/floor/circuit/green/telecomms/mainframe,
 /area/tcommsat/server)
 "oLV" = (
@@ -55621,9 +55623,6 @@
 	},
 /area/maintenance/starboard)
 "qcN" = (
-/obj/structure/cable/yellow{
-	icon_state = "2-4"
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer2{
 	dir = 1
 	},
@@ -60131,9 +60130,7 @@
 /turf/open/floor/iron,
 /area/engine/atmos)
 "rDi" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
 /turf/open/floor/engine{
 	initial_gas_mix = "n2=100;TEMP=80";
 	name = "mainframe floor"
@@ -61185,7 +61182,6 @@
 /turf/open/floor/iron,
 /area/security/brig)
 "rUi" = (
-/obj/machinery/telecomms/broadcaster/preset_exploration,
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple,
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
@@ -64202,8 +64198,8 @@
 /turf/open/floor/engine,
 /area/ai_monitored/turret_protected/aisat/atmos)
 "sRp" = (
-/obj/machinery/telecomms/processor/preset_two,
 /obj/effect/turf_decal/stripes/line,
+/obj/machinery/telecomms/server/service,
 /turf/open/floor/circuit/green/telecomms/mainframe,
 /area/tcommsat/server)
 "sRr" = (
@@ -66550,10 +66546,10 @@
 /turf/open/floor/grass,
 /area/security/prison)
 "tDD" = (
-/obj/machinery/telecomms/bus/preset_one,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/obj/machinery/telecomms/receiver/operations,
 /turf/open/floor/circuit/green/telecomms/mainframe,
 /area/tcommsat/server)
 "tEv" = (
@@ -68139,9 +68135,7 @@
 	name = "Telecomms Server Room APC";
 	pixel_x = 24
 	},
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
+/obj/structure/cable,
 /turf/open/floor/engine{
 	initial_gas_mix = "n2=100;TEMP=80";
 	name = "mainframe floor"
@@ -69589,6 +69583,9 @@
 "uFV" = (
 /obj/machinery/ntnet_relay,
 /obj/effect/turf_decal/stripes/end,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/circuit/green/telecomms/mainframe,
 /area/tcommsat/server)
 "uFY" = (
@@ -70412,10 +70409,10 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "uRT" = (
-/obj/machinery/telecomms/server/presets/medical,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/obj/machinery/telecomms/bus/discovery,
 /turf/open/floor/circuit/green/telecomms/mainframe,
 /area/tcommsat/server)
 "uSd" = (
@@ -71087,14 +71084,17 @@
 /turf/open/floor/iron/dark,
 /area/maintenance/starboard)
 "vdU" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-4"
-	},
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer2{
 	dir = 5
 	},
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 5
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
 	},
 /turf/open/floor/engine{
 	initial_gas_mix = "n2=100;TEMP=80";
@@ -71905,6 +71905,18 @@
 /obj/machinery/holopad,
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
+"vrK" = (
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/engine{
+	initial_gas_mix = "n2=100;TEMP=80";
+	name = "mainframe floor"
+	},
+/area/tcommsat/server)
 "vsg" = (
 /obj/item/radio/intercom{
 	pixel_x = 28;
@@ -74808,7 +74820,6 @@
 /turf/open/floor/iron/dark,
 /area/hallway/primary/starboard)
 "wld" = (
-/obj/machinery/telecomms/hub/preset/exploration,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -76144,7 +76155,6 @@
 	},
 /area/maintenance/port)
 "wGK" = (
-/obj/machinery/telecomms/receiver/preset_exploration,
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple,
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
@@ -78236,8 +78246,8 @@
 /turf/open/floor/catwalk_floor,
 /area/maintenance/central)
 "xim" = (
-/obj/machinery/telecomms/processor/preset_four,
 /obj/effect/turf_decal/stripes/line,
+/obj/machinery/telecomms/server/exploration,
 /turf/open/floor/circuit/green/telecomms/mainframe,
 /area/tcommsat/server)
 "xiC" = (
@@ -79103,11 +79113,14 @@
 	},
 /area/maintenance/port/fore)
 "xvq" = (
-/obj/machinery/telecomms/server/presets/supply,
 /obj/machinery/light{
 	dir = 4
 	},
 /obj/effect/turf_decal/stripes/line,
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/machinery/telecomms/bus/leadership,
 /turf/open/floor/circuit/green/telecomms/mainframe,
 /area/tcommsat/server)
 "xvK" = (
@@ -80881,11 +80894,14 @@
 /turf/open/floor/iron,
 /area/engine/atmos)
 "xYi" = (
-/obj/machinery/telecomms/server/presets/common,
 /obj/machinery/light{
 	dir = 8
 	},
 /obj/effect/turf_decal/stripes/line,
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/machinery/telecomms/bus/logistics,
 /turf/open/floor/circuit/green/telecomms/mainframe,
 /area/tcommsat/server)
 "xYj" = (
@@ -111132,7 +111148,7 @@ ajC
 qqf
 hdC
 xYi
-sPb
+nCh
 oER
 rdL
 tDD
@@ -111389,7 +111405,7 @@ sRp
 rLn
 mwO
 oLD
-sPb
+mIa
 epj
 xhP
 qIT
@@ -111644,11 +111660,11 @@ qSl
 ajC
 bPS
 qcN
-crJ
-crJ
+jGb
+nEa
 vdU
 krP
-svx
+vrK
 aFY
 cNQ
 aoD
@@ -112158,11 +112174,11 @@ sxG
 ahh
 niW
 mCN
-dZf
+rDi
 dZf
 kkz
 lBU
-jGb
+svx
 ceQ
 cNR
 cge
@@ -112417,7 +112433,7 @@ xim
 pWg
 ezP
 nuv
-rDi
+sPb
 cVs
 qFD
 hWR
@@ -122683,7 +122699,7 @@ rBh
 rUi
 wGK
 ayR
-nCh
+wld
 uSg
 jeo
 ait

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -10124,11 +10124,11 @@
 /turf/open/floor/iron/dark/telecomms,
 /area/tcommsat/server)
 "bEh" = (
-/obj/machinery/telecomms/receiver/preset_left,
+/obj/machinery/telecomms/receiver/mission,
 /turf/open/floor/circuit/green/telecomms/mainframe,
 /area/tcommsat/server)
 "bEj" = (
-/obj/machinery/telecomms/receiver/preset_right,
+/obj/machinery/telecomms/receiver/operations,
 /turf/open/floor/circuit/green/telecomms/mainframe,
 /area/tcommsat/server)
 "bEl" = (
@@ -10257,15 +10257,10 @@
 /turf/open/floor/iron,
 /area/engine/atmos)
 "bGc" = (
-/obj/machinery/telecomms/bus/preset_one,
 /turf/open/floor/circuit/green/telecomms/mainframe,
 /area/tcommsat/server)
 "bGd" = (
 /turf/open/floor/iron/dark/telecomms,
-/area/tcommsat/server)
-"bGf" = (
-/obj/machinery/telecomms/bus/preset_three,
-/turf/open/floor/circuit/green/telecomms/mainframe,
 /area/tcommsat/server)
 "bGj" = (
 /obj/structure/cable/yellow{
@@ -10664,7 +10659,7 @@
 /turf/open/space,
 /area/space/nearstation)
 "bJm" = (
-/obj/machinery/telecomms/bus/preset_two,
+/obj/machinery/telecomms/server/medical,
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/tcommsat/server)
 "bJn" = (
@@ -10888,15 +10883,15 @@
 /turf/closed/wall/r_wall,
 /area/space/nearstation)
 "bKL" = (
-/obj/machinery/telecomms/processor/preset_two,
+/obj/machinery/telecomms/server/engineering,
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/tcommsat/server)
 "bKN" = (
-/obj/machinery/telecomms/bus/preset_four,
+/obj/machinery/telecomms/server/security,
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/tcommsat/server)
 "bKP" = (
-/obj/machinery/telecomms/processor/preset_four,
+/obj/machinery/telecomms/server/command,
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/tcommsat/server)
 "bKS" = (
@@ -11046,7 +11041,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 8
 	},
 /turf/open/floor/iron/dark/telecomms,
@@ -11232,23 +11227,24 @@
 /turf/open/floor/iron/dark,
 /area/science/shuttledock)
 "bNX" = (
-/obj/machinery/telecomms/server/presets/common,
+/obj/machinery/telecomms/server/supply,
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/tcommsat/server)
 "bNY" = (
-/obj/machinery/telecomms/server/presets/engineering,
+/obj/machinery/telecomms/server/service,
+/obj/machinery/telecomms/server/supply,
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/tcommsat/server)
 "bOa" = (
-/obj/machinery/telecomms/server/presets/medical,
+/obj/machinery/telecomms/server/exploration,
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/tcommsat/server)
 "bOb" = (
-/obj/machinery/telecomms/server/presets/science,
+/obj/machinery/telecomms/server/science,
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/tcommsat/server)
 "bOc" = (
-/obj/machinery/telecomms/broadcaster/preset_left,
+/obj/machinery/telecomms/bus/support,
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/tcommsat/server)
 "bOd" = (
@@ -12158,10 +12154,6 @@
 "bUJ" = (
 /turf/open/floor/engine/co2,
 /area/engine/atmos)
-"bUL" = (
-/obj/machinery/telecomms/server/presets/security,
-/turf/open/floor/circuit/telecomms/mainframe,
-/area/tcommsat/server)
 "bUQ" = (
 /obj/structure/cable/yellow{
 	icon_state = "2-8"
@@ -12830,7 +12822,7 @@
 /turf/open/floor/iron/cafeteria,
 /area/crew_quarters/kitchen)
 "ceC" = (
-/obj/machinery/telecomms/server/presets/command,
+/obj/machinery/telecomms/processor/support,
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/tcommsat/server)
 "ceF" = (
@@ -12954,8 +12946,13 @@
 /turf/closed/wall/r_wall,
 /area/science/explab)
 "cgy" = (
-/obj/machinery/telecomms/server/presets/service,
-/turf/open/floor/circuit/telecomms/mainframe,
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
+/turf/open/floor/catwalk_floor/iron_dark{
+	initial_gas_mix = "n2=100;TEMP=80"
+	},
 /area/tcommsat/server)
 "cgz" = (
 /obj/effect/turf_decal/stripes/line{
@@ -13033,11 +13030,11 @@
 /turf/open/floor/iron/white,
 /area/science/lab)
 "chn" = (
-/obj/machinery/telecomms/broadcaster/preset_right,
+/obj/machinery/telecomms/bus/discovery,
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/tcommsat/server)
 "cho" = (
-/obj/machinery/telecomms/server/presets/supply,
+/obj/machinery/telecomms/processor/discovery,
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/tcommsat/server)
 "chp" = (
@@ -19182,6 +19179,9 @@
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "dsr" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 4
+	},
 /obj/machinery/telecomms/hub/preset,
 /turf/open/floor/circuit/green/telecomms/mainframe,
 /area/tcommsat/server)
@@ -19300,10 +19300,10 @@
 /turf/open/floor/iron,
 /area/storage/primary)
 "duh" = (
-/obj/machinery/telecomms/processor/preset_three,
 /obj/machinery/camera/directional/north{
 	c_tag = "Telecomms - Server Room - Fore-Starboard"
 	},
+/obj/machinery/telecomms/broadcaster/operations,
 /turf/open/floor/circuit/green/telecomms/mainframe,
 /area/tcommsat/server)
 "dum" = (
@@ -20280,6 +20280,8 @@
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 6
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /turf/open/floor/catwalk_floor/iron_dark{
 	initial_gas_mix = "n2=100;TEMP=80"
 	},
@@ -22207,7 +22209,7 @@
 /turf/open/floor/prison,
 /area/security/prison)
 "esP" = (
-/obj/machinery/telecomms/hub/preset/exploration,
+/obj/machinery/telecomms/processor/logistics,
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/tcommsat/server)
 "esR" = (
@@ -23069,13 +23071,6 @@
 	},
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/ai_monitored/turret_protected/ai_upload)
-"eId" = (
-/obj/machinery/telecomms/broadcaster/preset_exploration,
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/turf/open/floor/circuit/telecomms/mainframe,
-/area/tcommsat/server)
 "eIA" = (
 /obj/effect/landmark/blobstart,
 /turf/open/floor/plating,
@@ -25713,7 +25708,7 @@
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
 "fEL" = (
-/obj/machinery/telecomms/relay/preset/exploration,
+/obj/machinery/telecomms/processor/leadership,
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/tcommsat/server)
 "fEQ" = (
@@ -26132,6 +26127,7 @@
 	},
 /obj/machinery/atmospherics/pipe/heat_exchanging/manifold,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/catwalk_floor/iron_dark{
 	initial_gas_mix = "n2=100;TEMP=80"
 	},
@@ -29828,6 +29824,8 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /turf/open/floor/catwalk_floor/iron_dark{
 	initial_gas_mix = "n2=100;TEMP=80"
 	},
@@ -31663,6 +31661,10 @@
 	},
 /turf/open/floor/iron/dark/smooth_half,
 /area/security/checkpoint/customs)
+"hHX" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
+/turf/open/floor/iron/dark/telecomms,
+/area/tcommsat/server)
 "hIc" = (
 /obj/machinery/light,
 /obj/structure/closet/secure_closet/brig{
@@ -33421,6 +33423,7 @@
 /turf/open/floor/iron/dark,
 /area/engine/atmos)
 "iig" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /turf/open/floor/catwalk_floor/iron_dark{
 	initial_gas_mix = "n2=100;TEMP=80"
 	},
@@ -36475,6 +36478,7 @@
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /obj/effect/mapping_helpers/airlock/access/all/engineering/tcoms,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/tcommsat/server)
 "jlP" = (
@@ -37005,6 +37009,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/structure/window/reinforced/spawner/directional/west,
 /obj/structure/window/reinforced/spawner/directional/east,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/aisat)
 "jvC" = (
@@ -38512,6 +38517,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /turf/open/floor/iron,
 /area/engine/engineering)
+"jSL" = (
+/obj/structure/window/reinforced/spawner/directional/north,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/aisat)
 "jSP" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -38803,10 +38815,8 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 9
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
 /turf/open/floor/catwalk_floor/iron_dark{
 	initial_gas_mix = "n2=100;TEMP=80"
 	},
@@ -49191,9 +49201,6 @@
 /turf/open/floor/iron/dark,
 /area/maintenance/department/science/xenobiology)
 "nGr" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 1
-	},
 /turf/open/floor/iron/dark,
 /area/aisat)
 "nGw" = (
@@ -51443,10 +51450,10 @@
 /turf/open/floor/iron,
 /area/crew_quarters/fitness/recreation)
 "opy" = (
-/obj/machinery/telecomms/processor/preset_one,
 /obj/machinery/camera/directional/north{
 	c_tag = "Telecomms - Server Room - Fore-Port"
 	},
+/obj/machinery/telecomms/broadcaster/mission,
 /turf/open/floor/circuit/green/telecomms/mainframe,
 /area/tcommsat/server)
 "opF" = (
@@ -53157,6 +53164,13 @@
 	},
 /turf/open/floor/carpet/blue,
 /area/crew_quarters/heads/hop)
+"oNW" = (
+/obj/structure/window/reinforced/spawner/directional/north,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/aisat)
 "oOa" = (
 /obj/effect/turf_decal/tile/blue/half/contrasted,
 /obj/structure/cable/yellow{
@@ -62042,6 +62056,7 @@
 /area/maintenance/aft)
 "rSp" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/catwalk_floor/iron_dark{
 	initial_gas_mix = "n2=100;TEMP=80"
 	},
@@ -62379,6 +62394,7 @@
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 5
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/catwalk_floor/iron_dark{
 	initial_gas_mix = "n2=100;TEMP=80"
 	},
@@ -62452,6 +62468,7 @@
 "rZk" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/light/small/directional/east,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/tcommsat/server)
 "rZo" = (
@@ -63160,10 +63177,6 @@
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible/layer5,
 /turf/open/floor/iron/dark/textured,
 /area/engine/atmos)
-"slE" = (
-/obj/machinery/telecomms/receiver/preset_exploration,
-/turf/open/floor/circuit/telecomms/mainframe,
-/area/tcommsat/server)
 "smg" = (
 /obj/effect/landmark/event_spawn,
 /obj/effect/turf_decal/tile/neutral{
@@ -69568,7 +69581,7 @@
 /turf/open/floor/prison,
 /area/security/prison)
 "utH" = (
-/obj/machinery/telecomms/processor/preset_exploration,
+/obj/machinery/telecomms/bus/leadership,
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/tcommsat/server)
 "utP" = (
@@ -71055,15 +71068,6 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/port)
-"uSg" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
-/turf/open/floor/catwalk_floor/iron_dark{
-	initial_gas_mix = "n2=100;TEMP=80"
-	},
-/area/tcommsat/server)
 "uSl" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -72396,7 +72400,14 @@
 /area/maintenance/starboard)
 "vqh" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
-/turf/open/floor/iron/dark/telecomms,
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 4;
+	hide = 0
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
+/turf/open/floor/catwalk_floor/iron_dark{
+	initial_gas_mix = "n2=100;TEMP=80"
+	},
 /area/tcommsat/server)
 "vqm" = (
 /obj/structure/sign/poster/contraband/lusty_xenomorph{
@@ -75000,6 +75011,7 @@
 	dir = 10
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/catwalk_floor/iron_dark{
 	initial_gas_mix = "n2=100;TEMP=80"
 	},
@@ -75475,6 +75487,7 @@
 /area/science/server)
 "wqj" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/aisat)
 "wqn" = (
@@ -77436,6 +77449,12 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
+"wVX" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
+/turf/open/floor/catwalk_floor/iron_dark{
+	initial_gas_mix = "n2=100;TEMP=80"
+	},
+/area/tcommsat/server)
 "wXa" = (
 /obj/machinery/door/airlock/medical/glass{
 	name = "Medbay Desk";
@@ -77967,10 +77986,8 @@
 /turf/open/floor/iron/dark,
 /area/storage/tech)
 "xfJ" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
-/turf/open/floor/catwalk_floor/iron_dark{
-	initial_gas_mix = "n2=100;TEMP=80"
-	},
+/obj/machinery/telecomms/server/common,
+/turf/open/floor/circuit/green/telecomms/mainframe,
 /area/tcommsat/server)
 "xfP" = (
 /obj/structure/chair{
@@ -81415,7 +81432,7 @@
 /turf/open/floor/wood,
 /area/crew_quarters/dorms)
 "yih" = (
-/obj/machinery/telecomms/bus/preset_exploration,
+/obj/machinery/telecomms/bus/logistics,
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/tcommsat/server)
 "yiF" = (
@@ -136413,15 +136430,15 @@ bCE
 dLl
 rSp
 rSp
+rSp
+rSp
+rSp
 rXi
-slE
-iig
-bUL
 bCD
 aRy
 aRy
 aSD
-xcX
+oNW
 cmK
 bpr
 apQ
@@ -136668,11 +136685,11 @@ upe
 ewI
 thd
 fMa
-tOJ
+bGd
 dsr
-uSg
+tOJ
 xfJ
-xfJ
+bGd
 vqh
 jlu
 rZk
@@ -136928,14 +136945,14 @@ whC
 iop
 iop
 jYb
-eId
+iop
 hah
 cgy
 bCD
 aRy
 aRy
 bcQ
-xcX
+jSL
 cmK
 bpr
 bgn
@@ -137181,7 +137198,7 @@ pvh
 bCD
 bEj
 bGd
-iig
+wVX
 bKP
 bOb
 bGd
@@ -137437,8 +137454,8 @@ pbb
 wlg
 bCD
 bEg
-vOd
-iig
+hHX
+wVX
 bKN
 bOa
 bGd
@@ -137694,7 +137711,7 @@ btL
 btL
 bCD
 duh
-bGf
+bGc
 aVW
 bJn
 aRy

--- a/_maps/map_files/RadStation/RadStation.dmm
+++ b/_maps/map_files/RadStation/RadStation.dmm
@@ -407,7 +407,6 @@
 /turf/open/floor/plating,
 /area/security/brig/medbay)
 "agb" = (
-/obj/machinery/telecomms/broadcaster/preset_exploration,
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 9
 	},
@@ -1920,12 +1919,10 @@
 /area/lawoffice)
 "aCk" = (
 /obj/effect/turf_decal/stripes/line,
-/obj/machinery/telecomms/receiver/preset_left{
-	density = 0
-	},
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 10
 	},
+/obj/machinery/telecomms/receiver/mission,
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/tcommsat/server)
 "aCn" = (
@@ -2760,11 +2757,11 @@
 /turf/open/floor/catwalk_floor,
 /area/maintenance/department/security)
 "aRf" = (
-/obj/machinery/telecomms/server/presets/service,
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple,
+/obj/machinery/telecomms/bus/discovery,
 /turf/open/floor/circuit/green/telecomms/mainframe,
 /area/tcommsat/server)
 "aRk" = (
@@ -7188,7 +7185,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
-/obj/machinery/telecomms/processor/preset_two,
+/obj/machinery/telecomms/broadcaster/operations,
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/tcommsat/server)
 "ckw" = (
@@ -8799,10 +8796,10 @@
 /turf/open/floor/catwalk_floor,
 /area/engine/atmos)
 "cJD" = (
-/obj/machinery/telecomms/bus/preset_three,
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},
+/obj/machinery/telecomms/processor/leadership,
 /turf/open/floor/circuit/green/telecomms/mainframe,
 /area/tcommsat/server)
 "cJM" = (
@@ -10661,13 +10658,11 @@
 /turf/open/floor/iron,
 /area/hallway/primary/port)
 "dpk" = (
-/obj/machinery/telecomms/broadcaster/preset_right{
-	density = 0
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple,
+/obj/machinery/telecomms/server/command,
 /turf/open/floor/circuit/green/telecomms/mainframe,
 /area/tcommsat/server)
 "dpn" = (
@@ -11532,7 +11527,6 @@
 /turf/open/floor/carpet/royalblack,
 /area/lawoffice)
 "dED" = (
-/obj/machinery/telecomms/bus/preset_exploration,
 /obj/machinery/atmospherics/pipe/heat_exchanging/junction{
 	dir = 4
 	},
@@ -14302,7 +14296,7 @@
 /obj/item/radio/intercom{
 	pixel_x = -28
 	},
-/obj/machinery/telecomms/bus/preset_one,
+/obj/machinery/telecomms/server/medical,
 /turf/open/floor/circuit/green/telecomms/mainframe,
 /area/tcommsat/server)
 "eva" = (
@@ -18010,7 +18004,6 @@
 	dir = 1
 	},
 /obj/machinery/camera/directional/east,
-/obj/machinery/telecomms/processor/preset_exploration,
 /turf/open/floor/circuit/green,
 /area/quartermaster/exploration_prep)
 "fGA" = (
@@ -24690,7 +24683,6 @@
 	dir = 10
 	},
 /obj/structure/window/reinforced/spawner/directional/north,
-/obj/machinery/telecomms/hub/preset/exploration,
 /turf/open/floor/circuit/green,
 /area/quartermaster/exploration_prep)
 "hVF" = (
@@ -25259,11 +25251,11 @@
 /turf/open/floor/iron,
 /area/security/main)
 "ifH" = (
-/obj/machinery/telecomms/server/presets/common,
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple,
+/obj/machinery/telecomms/bus/support,
 /turf/open/floor/circuit/green/telecomms/mainframe,
 /area/tcommsat/server)
 "igs" = (
@@ -27249,10 +27241,10 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -32
 	},
-/obj/machinery/telecomms/processor/preset_one,
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
+/obj/machinery/telecomms/processor/logistics,
 /turf/open/floor/circuit/green/telecomms/mainframe,
 /area/tcommsat/server)
 "iQe" = (
@@ -28228,7 +28220,6 @@
 /turf/open/floor/iron/dark,
 /area/chapel/main)
 "jdt" = (
-/obj/machinery/telecomms/server/presets/exploration,
 /obj/structure/window/reinforced/spawner/directional/west,
 /turf/open/floor/circuit/green,
 /area/quartermaster/exploration_prep)
@@ -29474,10 +29465,10 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},
-/obj/machinery/telecomms/processor/preset_four,
 /obj/machinery/status_display/ai{
 	pixel_y = 32
 	},
+/obj/machinery/telecomms/broadcaster/mission,
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/tcommsat/server)
 "jyI" = (
@@ -30322,11 +30313,11 @@
 /turf/closed/wall,
 /area/maintenance/department/security)
 "jKK" = (
-/obj/machinery/telecomms/server/presets/engineering,
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple,
+/obj/machinery/telecomms/bus/logistics,
 /turf/open/floor/circuit/green/telecomms/mainframe,
 /area/tcommsat/server)
 "jKN" = (
@@ -33253,7 +33244,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/machinery/telecomms/bus/preset_four,
+/obj/machinery/telecomms/server/security,
 /turf/open/floor/circuit/green/telecomms/mainframe,
 /area/tcommsat/server)
 "kPN" = (
@@ -33308,7 +33299,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},
-/obj/machinery/telecomms/server/presets/medical,
+/obj/machinery/telecomms/server/exploration,
 /turf/open/floor/circuit/green/telecomms/mainframe,
 /area/tcommsat/server)
 "kQM" = (
@@ -37825,13 +37816,11 @@
 /turf/open/floor/iron,
 /area/crew_quarters/dorms)
 "mpz" = (
-/obj/machinery/telecomms/broadcaster/preset_left{
-	density = 0
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple,
+/obj/machinery/telecomms/server/engineering,
 /turf/open/floor/circuit/green/telecomms/mainframe,
 /area/tcommsat/server)
 "mpA" = (
@@ -38505,8 +38494,8 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},
-/obj/machinery/telecomms/server/presets/security,
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple,
+/obj/machinery/telecomms/server/supply,
 /turf/open/floor/circuit/green/telecomms/mainframe,
 /area/tcommsat/server)
 "mBn" = (
@@ -38610,8 +38599,8 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
-/obj/machinery/telecomms/server/presets/science,
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple,
+/obj/machinery/telecomms/server/science,
 /turf/open/floor/circuit/green/telecomms/mainframe,
 /area/tcommsat/server)
 "mCU" = (
@@ -54216,15 +54205,13 @@
 /area/security/brig/dock)
 "rKn" = (
 /obj/effect/turf_decal/stripes/line,
-/obj/machinery/telecomms/receiver/preset_right{
-	density = 0
-	},
 /obj/structure/sign/warning/electricshock{
 	pixel_y = 32
 	},
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 6
 	},
+/obj/machinery/telecomms/receiver/operations,
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/tcommsat/server)
 "rKp" = (
@@ -61768,11 +61755,11 @@
 /turf/open/floor/iron/dark/textured_large,
 /area/ai_monitored/turret_protected/ai)
 "udb" = (
-/obj/machinery/telecomms/server/presets/supply,
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple,
+/obj/machinery/telecomms/bus/leadership,
 /turf/open/floor/circuit/green/telecomms/mainframe,
 /area/tcommsat/server)
 "udj" = (
@@ -64344,10 +64331,10 @@
 /turf/open/floor/plating/airless,
 /area/science/test_area)
 "uSx" = (
-/obj/machinery/telecomms/processor/preset_three,
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},
+/obj/machinery/telecomms/processor/discovery,
 /turf/open/floor/circuit/green/telecomms/mainframe,
 /area/tcommsat/server)
 "uSz" = (
@@ -69406,7 +69393,6 @@
 /obj/machinery/atmospherics/pipe/heat_exchanging/junction{
 	dir = 4
 	},
-/obj/machinery/telecomms/receiver/preset_exploration,
 /obj/structure/window/reinforced/spawner/directional/west,
 /turf/open/floor/circuit/green,
 /area/quartermaster/exploration_prep)
@@ -70119,10 +70105,11 @@
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "wNh" = (
-/turf/open/floor/engine{
-	initial_gas_mix = "n2=100;TEMP=80";
-	name = "mainframe floor"
+/obj/machinery/telecomms/server/common,
+/obj/effect/turf_decal/stripes/end{
+	dir = 1
 	},
+/turf/open/floor/circuit/green/telecomms/mainframe,
 /area/tcommsat/server)
 "wNm" = (
 /obj/structure/table/wood,
@@ -72939,10 +72926,10 @@
 /turf/closed/wall/r_wall/rust,
 /area/engine/atmos)
 "xHg" = (
-/obj/machinery/telecomms/bus/preset_two,
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
+/obj/machinery/telecomms/processor/support,
 /turf/open/floor/circuit/green/telecomms/mainframe,
 /area/tcommsat/server)
 "xHi" = (
@@ -74405,10 +74392,13 @@
 /turf/open/floor/plating,
 /area/medical/break_room)
 "yjH" = (
+/obj/machinery/telecomms/server/service,
 /obj/effect/turf_decal/stripes/line{
-	dir = 9
+	dir = 8
 	},
-/obj/machinery/telecomms/server/presets/command,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
 /turf/open/floor/circuit/green/telecomms/mainframe,
 /area/tcommsat/server)
 "yjO" = (

--- a/_maps/map_files/generic/CentCom.dmm
+++ b/_maps/map_files/generic/CentCom.dmm
@@ -18683,10 +18683,6 @@
 	},
 /turf/open/floor/iron/tech,
 /area/centcom/ferry)
-"aVV" = (
-/obj/machinery/telecomms/bus/preset_exploration,
-/turf/open/floor/iron,
-/area/ctf)
 "aVW" = (
 /obj/structure/bookcase/manuals,
 /obj/item/clothing/shoes/jackboots{
@@ -78083,7 +78079,7 @@ aGg
 afZ
 aOe
 ahP
-aVV
+ahP
 afZ
 aUy
 aUy
@@ -84494,7 +84490,7 @@ aZZ
 aZZ
 aZZ
 afZ
-aVV
+ahP
 ahP
 aOe
 afZ

--- a/code/game/machinery/telecomms/machines/broadcaster.dm
+++ b/code/game/machinery/telecomms/machines/broadcaster.dm
@@ -64,28 +64,12 @@ GLOBAL_VAR_INIT(message_delay, 0) // To make sure restarting the recentmessages 
 		GLOB.message_delay = 0
 	return ..()
 
-
-
-//Preset Broadcasters
-
-//--PRESET LEFT--//
-
-/obj/machinery/telecomms/broadcaster/preset_left
-	id = "Broadcaster A"
+/obj/machinery/telecomms/broadcaster/mission
+	id = "Broadcaster Mission"
 	network = "tcommsat"
-	autolinkers = list("broadcasterA")
+	autolinkers = list("broadcaster_mission, broadcaster_exploration")
 
-//--PRESET RIGHT--//
-
-/obj/machinery/telecomms/broadcaster/preset_right
-	id = "Broadcaster B"
+/obj/machinery/telecomms/broadcaster/operations
+	id = "Broadcaster Operations"
 	network = "tcommsat"
-	autolinkers = list("broadcasterB")
-
-/obj/machinery/telecomms/broadcaster/preset_left/birdstation
-	name = "Broadcaster"
-
-/obj/machinery/telecomms/broadcaster/preset_exploration
-	id = "Exploration Broadcaster"
-	network = "exploration"
-	autolinkers = list("broadcasterExp")
+	autolinkers = list("broadcaster_operations")

--- a/code/game/machinery/telecomms/machines/bus.dm
+++ b/code/game/machinery/telecomms/machines/bus.dm
@@ -49,42 +49,31 @@
 
 //Preset Buses
 
-/obj/machinery/telecomms/bus/preset_one
-	id = "Bus 1"
-	network = "tcommsat"
-	freq_listening = list(FREQ_SCIENCE, FREQ_MEDICAL)
-	autolinkers = list("processor1", "science", "medical")
-
-/obj/machinery/telecomms/bus/preset_two
-	id = "Bus 2"
-	network = "tcommsat"
-	freq_listening = list(FREQ_SUPPLY, FREQ_SERVICE)
-	autolinkers = list("processor2", "supply", "service")
-
-/obj/machinery/telecomms/bus/preset_three
-	id = "Bus 3"
+/obj/machinery/telecomms/bus/leadership
+	id = "Leadership Bus"
 	network = "tcommsat"
 	freq_listening = list(FREQ_SECURITY, FREQ_COMMAND)
-	autolinkers = list("processor3", "security", "command")
+	autolinkers = list("processor_leadership", "security", "command")
 
-/obj/machinery/telecomms/bus/preset_four
-	id = "Bus 4"
+/obj/machinery/telecomms/bus/discovery
+	id = "Disccovery Bus"
 	network = "tcommsat"
-	freq_listening = list(FREQ_ENGINEERING)
-	autolinkers = list("processor4", "engineering", "common", "messaging")
+	freq_listening = list(FREQ_SCIENCE, FREQ_EXPLORATION)
+	autolinkers = list("processor_discovery", "exploration", "science", "exploration")
 
-/obj/machinery/telecomms/bus/preset_four/Initialize(mapload)
+/obj/machinery/telecomms/bus/logistics
+	id = "Logistics Bus"
+	network = "tcommsat"
+	freq_listening = list(FREQ_SUPPLY, FREQ_ENGINEERING)
+	autolinkers = list("processor_logstics", "engineering", "supply")
+
+/obj/machinery/telecomms/bus/support
+	id = "Support Bus"
+	network = "tcommsat"
+	freq_listening = list(FREQ_SERVICE, FREQ_MEDICAL)
+	autolinkers = list("processor_support", "service", "medical", "common", "messaging")
+
+/obj/machinery/telecomms/bus/support/Initialize(mapload)
 	. = ..()
 	for(var/i = MIN_FREQ, i <= MAX_FREQ, i += 2)
 		freq_listening |= i
-
-/obj/machinery/telecomms/bus/preset_one/birdstation
-	name = "Bus"
-	autolinkers = list("processor1", "common", "messaging")
-	freq_listening = list()
-
-/obj/machinery/telecomms/bus/preset_exploration
-	id = "Exploration Bus"
-	network = "exploration"
-	freq_listening = list(FREQ_EXPLORATION)
-	autolinkers = list("processorExp", "exploration")

--- a/code/game/machinery/telecomms/machines/hub.dm
+++ b/code/game/machinery/telecomms/machines/hub.dm
@@ -34,16 +34,9 @@
 		// Then broadcast that signal to
 		relay_information(signal, /obj/machinery/telecomms/broadcaster)
 
-//Preset HUB
-
 /obj/machinery/telecomms/hub/preset
 	id = "Hub"
 	network = "tcommsat"
 	autolinkers = list("hub", "relay", "s_relay", "m_relay", "r_relay", "h_relay", "science", "medical",
 	"supply", "service", "common", "command", "engineering", "security",
-	"receiverA", "receiverB", "broadcasterA", "broadcasterB", "autorelay", "messaging")
-
-/obj/machinery/telecomms/hub/preset/exploration
-	id = "Exploration Hub"
-	network = "exploration"
-	autolinkers = list("exp_relay", "exploration", "receiverExp", "broadcasterExp")
+	"receiver_mission", "receiver_operations", "broadcaster_mission", "broadcaster_operations", "autorelay", "messaging")

--- a/code/game/machinery/telecomms/machines/processor.dm
+++ b/code/game/machinery/telecomms/machines/processor.dm
@@ -35,30 +35,22 @@
 
 //Preset Processors
 
-/obj/machinery/telecomms/processor/preset_one
-	id = "Processor 1"
+/obj/machinery/telecomms/processor/leadership
+	id = "Leadership Processor"
 	network = "tcommsat"
-	autolinkers = list("processor1") // processors are sort of isolated; they don't need backward links
+	autolinkers = list("processor_leadership")
 
-/obj/machinery/telecomms/processor/preset_two
-	id = "Processor 2"
+/obj/machinery/telecomms/processor/discovery
+	id = "Discovery Processor"
 	network = "tcommsat"
-	autolinkers = list("processor2")
+	autolinkers = list("processor_discovery")
 
-/obj/machinery/telecomms/processor/preset_three
-	id = "Processor 3"
+/obj/machinery/telecomms/processor/support
+	id = "Support Processor"
 	network = "tcommsat"
-	autolinkers = list("processor3")
+	autolinkers = list("processor_support")
 
-/obj/machinery/telecomms/processor/preset_four
-	id = "Processor 4"
+/obj/machinery/telecomms/processor/logistics
+	id = "Logistics Processor"
 	network = "tcommsat"
-	autolinkers = list("processor4")
-
-/obj/machinery/telecomms/processor/preset_one/birdstation
-	name = "Processor"
-
-/obj/machinery/telecomms/processor/preset_exploration
-	id = "Exploration Processor"
-	network = "exploration"
-	autolinkers = list("processorExp")
+	autolinkers = list("processor_logstics")

--- a/code/game/machinery/telecomms/machines/receiver.dm
+++ b/code/game/machinery/telecomms/machines/receiver.dm
@@ -42,35 +42,20 @@
 
 //Preset Receivers
 
-//--PRESET LEFT--//
-
-/obj/machinery/telecomms/receiver/preset_left
-	id = "Receiver A"
+/obj/machinery/telecomms/receiver/mission
+	id = "Receiver Mission"
 	network = "tcommsat"
-	autolinkers = list("receiverA") // link to relay
-	freq_listening = list(FREQ_SCIENCE, FREQ_MEDICAL, FREQ_SUPPLY, FREQ_SERVICE)
+	autolinkers = list("receiver_mission")
+	freq_listening = list(FREQ_COMMAND, FREQ_SECURITY, FREQ_SCIENCE, FREQ_EXPLORATION)
 
-
-//--PRESET RIGHT--//
-
-/obj/machinery/telecomms/receiver/preset_right
-	id = "Receiver B"
+/obj/machinery/telecomms/receiver/operations
+	id = "Receiver Operations"
 	network = "tcommsat"
-	autolinkers = list("receiverB") // link to relay
-	freq_listening = list(FREQ_COMMAND, FREQ_ENGINEERING, FREQ_SECURITY)
+	autolinkers = list("receiver_operations")
+	freq_listening = list(FREQ_MEDICAL, FREQ_ENGINEERING, FREQ_SUPPLY, FREQ_SERVICE)
 
 	//Common and other radio frequencies for people to freely use
-/obj/machinery/telecomms/receiver/preset_right/Initialize(mapload)
+/obj/machinery/telecomms/receiver/operations/Initialize(mapload)
 	. = ..()
 	for(var/i = MIN_FREQ, i <= MAX_FREQ, i += 2)
 		freq_listening |= i
-
-/obj/machinery/telecomms/receiver/preset_left/birdstation
-	name = "Receiver"
-	freq_listening = list()
-
-/obj/machinery/telecomms/receiver/preset_exploration
-	id = "Exploration Receiver"
-	network = "exploration"
-	autolinkers = list("receiverExp") // link to relay
-	freq_listening = list(FREQ_EXPLORATION)

--- a/code/game/machinery/telecomms/machines/server.dm
+++ b/code/game/machinery/telecomms/machines/server.dm
@@ -65,68 +65,58 @@
 	var/name = "data packet (#)"
 	var/parameters = list()  // copied from signal.data above
 
-
-// Preset Servers
-/obj/machinery/telecomms/server/presets
-	network = "tcommsat"
-
-/obj/machinery/telecomms/server/presets/Initialize(mapload)
+/obj/machinery/telecomms/server/Initialize(mapload)
 	. = ..()
 	name = id
 
 
-/obj/machinery/telecomms/server/presets/science
-	id = "Science Server"
+/obj/machinery/telecomms/server/science
+	name = "Science Server"
 	freq_listening = list(FREQ_SCIENCE)
 	autolinkers = list("science")
 
-/obj/machinery/telecomms/server/presets/medical
-	id = "Medical Server"
+/obj/machinery/telecomms/server/medical
+	name = "Medical Server"
 	freq_listening = list(FREQ_MEDICAL)
 	autolinkers = list("medical")
 
-/obj/machinery/telecomms/server/presets/supply
-	id = "Supply Server"
+/obj/machinery/telecomms/server/supply
+	name = "Supply Server"
 	freq_listening = list(FREQ_SUPPLY)
 	autolinkers = list("supply")
 
-/obj/machinery/telecomms/server/presets/exploration
-	id = "Exploration Server"
-	network = "exploration"
+/obj/machinery/telecomms/server/exploration
+	name = "Exploration Server"
 	freq_listening = list(FREQ_EXPLORATION)
 	autolinkers = list("exploration")
 
-/obj/machinery/telecomms/server/presets/service
-	id = "Service Server"
+/obj/machinery/telecomms/server/service
+	name = "Service Server"
 	freq_listening = list(FREQ_SERVICE)
 	autolinkers = list("service")
 
-/obj/machinery/telecomms/server/presets/common
-	id = "Common Server"
+/obj/machinery/telecomms/server/common
+	name = "Common Server"
 	freq_listening = list()
 	autolinkers = list("common")
 
 //Common and other radio frequencies for people to freely use
-/obj/machinery/telecomms/server/presets/common/Initialize(mapload)
+/obj/machinery/telecomms/server/common/Initialize(mapload)
 	. = ..()
 	for(var/i = MIN_FREQ, i <= MAX_FREQ, i += 2)
 		freq_listening |= i
 
-/obj/machinery/telecomms/server/presets/command
-	id = "Command Server"
+/obj/machinery/telecomms/server/command
+	name = "Command Server"
 	freq_listening = list(FREQ_COMMAND)
 	autolinkers = list("command")
 
-/obj/machinery/telecomms/server/presets/engineering
-	id = "Engineering Server"
+/obj/machinery/telecomms/server/engineering
+	name = "Engineering Server"
 	freq_listening = list(FREQ_ENGINEERING)
 	autolinkers = list("engineering")
 
-/obj/machinery/telecomms/server/presets/security
-	id = "Security Server"
+/obj/machinery/telecomms/server/security
+	name = "Security Server"
 	freq_listening = list(FREQ_SECURITY)
 	autolinkers = list("security")
-
-/obj/machinery/telecomms/server/presets/common/birdstation/Initialize(mapload)
-	. = ..()
-	freq_listening = list()


### PR DESCRIPTION
## About The Pull Request
Adds names to each telecom object to make it easier to understand, learn and repair it all without having a doctors degree in theoretical telecommunication. Changed up some of the wiring and location of SMES if it was in the way.

The Telecom presets are grouped into the following categories.

### Mission
**Leadership**
Command
Security

**Discovery**
Science
Exploration
### Operations
**Support**
Engineering
Medical

**Logistics**
Supply
Service

## Why It's Good For The Game
Naming things other than 1, 2, and maybe 4 if it is a Wednesday is good.

## Testing Photographs and Procedure
<details>
<summary>Screenshots&Videos</summary>

<img width="480" height="480" alt="image" src="https://github.com/user-attachments/assets/433f06c8-c478-4666-a011-ad065397771d" />

</details>

## Changelog
:cl:
del: Removed Exploration dedicated telecom presets.
del: Removed Birdstation remnants.
tweak: Tweaked Telecoms to fit everything.
tweak: Merged Exploration coms with the rest of Telecoms.
refactor: Refactored the Telecoms presets.
fix: (Meta) Disconnected Distro pipes in Telecoms.
/:cl: