### PR TITLE
Fixes Energy Shield Modules not working

### DIFF
--- a/code/datums/components/shielded.dm
+++ b/code/datums/components/shielded.dm
@@ -56,7 +56,7 @@
 		shield_inhand = FALSE,
 		shield_flags = ENERGY_SHIELD_BLOCK_PROJECTILES | ENERGY_SHIELD_BLOCK_MELEE,
 		shield_alpha = 160,
-		rechage_path = null,
+		recharge_path = null,
 		run_hit_callback,
 		on_active_effects,
 		on_deactive_effects,

--- a/code/datums/components/shielded.dm
+++ b/code/datums/components/shielded.dm
@@ -165,6 +165,12 @@
 			on_active_effects?.Invoke(wearer, current_integrity)
 			_effects_activated = TRUE
 
+/datum/component/shielded/proc/set_charge(new_value)
+	current_integrity = clamp(new_value, 0, max_integrity)
+	on_integrity_changed?.Invoke(wearer, current_integrity)
+	// activate cooldown after updating the charge
+	COOLDOWN_START(src, recently_hit_cd, recharge_start_delay)
+
 /// Check if we've been equipped to a valid slot to shield
 /datum/component/shielded/proc/on_equipped(datum/source, mob/user, slot)
 	SIGNAL_HANDLER

--- a/code/datums/components/shielded.dm
+++ b/code/datums/components/shielded.dm
@@ -272,5 +272,5 @@
 
 	max_integrity += recharge_rune.added_shield
 	adjust_charge(recharge_rune.added_shield)
-	to_chat(user, span_notice("You charge \the [parent]. It can now absorb [current_integrity] hits."))
+	to_chat(user, span_notice("You charge \the [parent]. It can now absorb [current_integrity] damage."))
 	qdel(recharge_rune)

--- a/code/modules/antagonists/wizard/equipment/spellbook_entries/defensive.dm
+++ b/code/modules/antagonists/wizard/equipment/spellbook_entries/defensive.dm
@@ -134,7 +134,7 @@
 
 /datum/spellbook_entry/item/battlemage_charge
 	name = "Battlemage Armour Charges"
-	desc = "A powerful defensive rune, it will grant 150 additional charges to a battlemage shield."
+	desc = "A powerful defensive rune, it will grant 300 additional charges to a battlemage shield."
 	item_path = /obj/item/wizard_armour_charge
 	category = "Defensive"
 	cost = 1

--- a/code/modules/antagonists/wizard/equipment/spellbook_entries/defensive.dm
+++ b/code/modules/antagonists/wizard/equipment/spellbook_entries/defensive.dm
@@ -134,7 +134,7 @@
 
 /datum/spellbook_entry/item/battlemage_charge
 	name = "Battlemage Armour Charges"
-	desc = "A powerful defensive rune, it will grant eight additional charges to a battlemage shield."
+	desc = "A powerful defensive rune, it will grant 150 additional charges to a battlemage shield."
 	item_path = /obj/item/wizard_armour_charge
 	category = "Defensive"
 	cost = 1

--- a/code/modules/antagonists/wizard/equipment/spellbook_entries/defensive.dm
+++ b/code/modules/antagonists/wizard/equipment/spellbook_entries/defensive.dm
@@ -134,7 +134,7 @@
 
 /datum/spellbook_entry/item/battlemage_charge
 	name = "Battlemage Armour Charges"
-	desc = "A powerful defensive rune, it will grant 300 additional charges to a battlemage shield."
+	desc = "A powerful defensive rune, it will grant 300 additional integrity to a battlemage shield."
 	item_path = /obj/item/wizard_armour_charge
 	category = "Defensive"
 	cost = 1

--- a/code/modules/clothing/suits/wiz_robe.dm
+++ b/code/modules/clothing/suits/wiz_robe.dm
@@ -250,4 +250,4 @@
 	desc = "A powerful rune that will increase the number of hits a suit of battlemage armour can take before failing.."
 	icon = 'icons/effects/effects.dmi'
 	icon_state = "electricity2"
-	added_shield = 400
+	added_shield = 150

--- a/code/modules/clothing/suits/wiz_robe.dm
+++ b/code/modules/clothing/suits/wiz_robe.dm
@@ -247,7 +247,7 @@
 // The actual code for this is handled in the shielded component, see [/datum/component/shielded/proc/check_recharge_rune]
 /obj/item/wizard_armour_charge
 	name = "battlemage shield charges"
-	desc = "A powerful rune that will increase the number of hits a suit of battlemage armour can take before failing.."
+	desc = "A powerful rune that will increase the amount of damage the battlemage shield can take before failing.."
 	icon = 'icons/effects/effects.dmi'
 	icon_state = "electricity2"
 	added_shield = 300

--- a/code/modules/clothing/suits/wiz_robe.dm
+++ b/code/modules/clothing/suits/wiz_robe.dm
@@ -250,4 +250,4 @@
 	desc = "A powerful rune that will increase the number of hits a suit of battlemage armour can take before failing.."
 	icon = 'icons/effects/effects.dmi'
 	icon_state = "electricity2"
-	added_shield = 150
+	added_shield = 300

--- a/code/modules/mod/modules/modules_antag.dm
+++ b/code/modules/mod/modules/modules_antag.dm
@@ -147,9 +147,7 @@
 	var/shield_icon_file = 'icons/effects/effects.dmi'
 	/// The icon_state of the shield.
 	var/shield_icon = "shield-red"
-	/// Charges the shield should start with.
-	var/charges
-	/// Self explaining, the charges it currently has
+	/// Self explaining, the charges it currently has, it's being saved upon deactivation and activation
 	var/current_charges
 
 /obj/item/mod/module/energy_shield/Initialize(mapload)
@@ -160,9 +158,11 @@
 	mod.AddComponent(/datum/component/shielded, max_integrity = max_charges, recharge_start_delay = recharge_start_delay, charge_increment_delay = charge_increment_delay, \
 	charge_recovery = charge_recovery, recharge_path = recharge_path, shield_icon_file = shield_icon_file, shield_icon = shield_icon)
 	var/datum/component/shielded/shield = mod.GetComponent(/datum/component/shielded)
-	if(shield && current_charges < max_charges)
-		shield.current_integrity = current_charges
-	if(mod?.wearer)
+	if (shield && current_charges < max_charges)
+		shield.set_charge(current_charges)
+		if (current_charges <= 0 && mod?.wearer)
+			mod.wearer.update_appearance(UPDATE_ICON)
+	if (mod?.wearer)
 		RegisterSignal(mod.wearer, COMSIG_HUMAN_CHECK_SHIELDS, PROC_REF(shield_reaction))
 
 /obj/item/mod/module/energy_shield/on_part_deactivation(deleting = FALSE)
@@ -200,7 +200,6 @@
 	max_charges = 600
 	charge_increment_delay = 1 SECONDS
 	charge_recovery = 0
-	charges = 300
 	recharge_path = /obj/item/wizard_armour_charge
 	required_slots = list()
 

--- a/code/modules/mod/modules/modules_antag.dm
+++ b/code/modules/mod/modules/modules_antag.dm
@@ -149,24 +149,29 @@
 	var/shield_icon = "shield-red"
 	/// Charges the shield should start with.
 	var/charges
+	/// Self explaining, the charges it currently has
+	var/current_charges
 
 /obj/item/mod/module/energy_shield/Initialize(mapload)
-	. = ..()
-	charges = max_charges
+    . = ..()
+    current_charges = max_charges
 
 /obj/item/mod/module/energy_shield/on_part_activation()
-	mod.AddComponent(/datum/component/shielded, max_integrity = max_charges, recharge_start_delay = recharge_start_delay, charge_increment_delay = charge_increment_delay, \
-	charge_recovery = charge_recovery, recharge_path = recharge_path, shield_icon_file = shield_icon_file, shield_icon = shield_icon)
-	if(mod?.wearer)
-		RegisterSignal(mod.wearer, COMSIG_HUMAN_CHECK_SHIELDS, PROC_REF(shield_reaction))
+    mod.AddComponent(/datum/component/shielded, max_integrity = max_charges, recharge_start_delay = recharge_start_delay, charge_increment_delay = charge_increment_delay, \
+    charge_recovery = charge_recovery, recharge_path = recharge_path, shield_icon_file = shield_icon_file, shield_icon = shield_icon)
+    var/datum/component/shielded/shield = mod.GetComponent(/datum/component/shielded)
+    if(shield && current_charges < max_charges)
+        shield.current_integrity = current_charges
+    if(mod?.wearer)
+        RegisterSignal(mod.wearer, COMSIG_HUMAN_CHECK_SHIELDS, PROC_REF(shield_reaction))
 
 /obj/item/mod/module/energy_shield/on_part_deactivation(deleting = FALSE)
-	var/datum/component/shielded/shield = mod?.GetComponent(/datum/component/shielded)
-	if(shield)
-		charges = shield.current_integrity
-		qdel(shield)
-	if(mod?.wearer)
-		UnregisterSignal(mod.wearer, COMSIG_HUMAN_CHECK_SHIELDS)
+    var/datum/component/shielded/shield = mod?.GetComponent(/datum/component/shielded)
+    if(shield)
+        current_charges = shield.current_integrity // Saving the current charge
+        qdel(shield)
+    if(mod?.wearer)
+        UnregisterSignal(mod.wearer, COMSIG_HUMAN_CHECK_SHIELDS)
 
 /obj/item/mod/module/energy_shield/proc/shield_reaction(
 	mob/living/carbon/human/owner,

--- a/code/modules/mod/modules/modules_antag.dm
+++ b/code/modules/mod/modules/modules_antag.dm
@@ -153,25 +153,25 @@
 	var/current_charges
 
 /obj/item/mod/module/energy_shield/Initialize(mapload)
-    . = ..()
-    current_charges = max_charges
+	. = ..()
+	current_charges = max_charges
 
 /obj/item/mod/module/energy_shield/on_part_activation()
-    mod.AddComponent(/datum/component/shielded, max_integrity = max_charges, recharge_start_delay = recharge_start_delay, charge_increment_delay = charge_increment_delay, \
-    charge_recovery = charge_recovery, recharge_path = recharge_path, shield_icon_file = shield_icon_file, shield_icon = shield_icon)
-    var/datum/component/shielded/shield = mod.GetComponent(/datum/component/shielded)
-    if(shield && current_charges < max_charges)
-        shield.current_integrity = current_charges
-    if(mod?.wearer)
-        RegisterSignal(mod.wearer, COMSIG_HUMAN_CHECK_SHIELDS, PROC_REF(shield_reaction))
+	mod.AddComponent(/datum/component/shielded, max_integrity = max_charges, recharge_start_delay = recharge_start_delay, charge_increment_delay = charge_increment_delay, \
+	charge_recovery = charge_recovery, recharge_path = recharge_path, shield_icon_file = shield_icon_file, shield_icon = shield_icon)
+	var/datum/component/shielded/shield = mod.GetComponent(/datum/component/shielded)
+	if(shield && current_charges < max_charges)
+		shield.current_integrity = current_charges
+	if(mod?.wearer)
+		RegisterSignal(mod.wearer, COMSIG_HUMAN_CHECK_SHIELDS, PROC_REF(shield_reaction))
 
 /obj/item/mod/module/energy_shield/on_part_deactivation(deleting = FALSE)
-    var/datum/component/shielded/shield = mod?.GetComponent(/datum/component/shielded)
-    if(shield)
-        current_charges = shield.current_integrity // Saving the current charge
-        qdel(shield)
-    if(mod?.wearer)
-        UnregisterSignal(mod.wearer, COMSIG_HUMAN_CHECK_SHIELDS)
+	var/datum/component/shielded/shield = mod?.GetComponent(/datum/component/shielded)
+	if(shield)
+		current_charges = shield.current_integrity // Saving the current charge
+		qdel(shield)
+	if(mod?.wearer)
+		UnregisterSignal(mod.wearer, COMSIG_HUMAN_CHECK_SHIELDS)
 
 /obj/item/mod/module/energy_shield/proc/shield_reaction(
 	mob/living/carbon/human/owner,

--- a/code/modules/mod/modules/modules_antag.dm
+++ b/code/modules/mod/modules/modules_antag.dm
@@ -158,16 +158,16 @@
 	charge_recovery = charge_recovery, recharge_path = recharge_path, shield_icon_file = shield_icon_file, shield_icon = shield_icon)
 	var/datum/component/shielded/shield = mod.GetComponent(/datum/component/shielded)
 	if (shield && current_integrity < max_integrity)
-		shield.set_charge(current_integrity)
+		shield.set_charge(current_integrity) // No exploiting the integrity by deactivating and reactivating
 		if (current_integrity <= 0 && mod?.wearer)
-			mod.wearer.update_appearance(UPDATE_ICON)
+			mod.wearer.update_appearance(UPDATE_ICON) // It kept the shield visible if it was at 0 integrity, this fixes that
 	if (mod?.wearer)
 		RegisterSignal(mod.wearer, COMSIG_HUMAN_CHECK_SHIELDS, PROC_REF(shield_reaction))
 
 /obj/item/mod/module/energy_shield/on_part_deactivation(deleting = FALSE)
 	var/datum/component/shielded/shield = mod?.GetComponent(/datum/component/shielded)
 	if(shield)
-		current_integrity = shield.current_integrity // Saving the current charge
+		current_integrity = shield.current_integrity // Saving the current integrity for later
 		qdel(shield)
 	if(mod?.wearer)
 		UnregisterSignal(mod.wearer, COMSIG_HUMAN_CHECK_SHIELDS)
@@ -179,7 +179,7 @@
 	attack_text = "the attack",
 	attack_type = MELEE_ATTACK,
 	armour_penetration = 0)
-	(SEND_SIGNAL(mod, COMSIG_ITEM_HIT_REACT, owner, hitby, attack_text, damage, attack_type) & COMPONENT_HIT_REACTION_BLOCK)
+	(SEND_SIGNAL(mod, COMSIG_ITEM_HIT_REACT, owner, hitby, attack_text, damage, attack_type))
 	var/datum/component/shielded/shield = mod?.GetComponent(/datum/component/shielded)
 	if(!shield || shield.current_integrity <= 0)
 		return NONE

--- a/code/modules/mod/modules/modules_antag.dm
+++ b/code/modules/mod/modules/modules_antag.dm
@@ -126,20 +126,19 @@
 	desc = "A personal, protective forcefield typically seen in military applications. \
 		This advanced deflector shield is essentially a scaled down version of those seen on starships, \
 		and the power cost can be an easy indicator of this. However, it is capable of blocking nearly any incoming attack, \
-		though with its low amount of separate charges, the user remains mortal."
+		though with its low durability, the user remains mortal."
 	icon_state = "energy_shield"
 	complexity = 3
 	idle_power_cost = DEFAULT_CHARGE_DRAIN * 0.5
 	use_power_cost = DEFAULT_CHARGE_DRAIN * 2
 	incompatible_modules = list(/obj/item/mod/module/energy_shield)
 	required_slots = list(ITEM_SLOT_BACK)
-	/// Max charges of the shield.
-	var/max_charges = 60
-	/// How long we have to avoid being hit to replenish charges.
+	max_integrity = 60 	/// Max integrity of the shield.
+	/// How long we have to avoid being hit to start replenishing integrity.
 	var/recharge_start_delay = 20 SECONDS
-	/// Once we go unhit long enough to recharge, we replenish charges this often.
+	/// Once we go unhit long enough to recharge, we replenish integrity this often.
 	var/charge_increment_delay = 1 SECONDS
-	/// How many charges we recover on each charge increment.
+	/// How much integrity we recover on each increment.
 	var/charge_recovery = 20
 	/// The item path to recharge this shield.
 	var/recharge_path
@@ -147,20 +146,20 @@
 	var/shield_icon_file = 'icons/effects/effects.dmi'
 	/// The icon_state of the shield.
 	var/shield_icon = "shield-red"
-	/// Self explaining, the charges it currently has, it's being saved upon deactivation and activation
-	var/current_charges
+	/// Self explaining, the integrity it currently has, it's being saved upon deactivation and activation
+	var/current_integrity
 
 /obj/item/mod/module/energy_shield/Initialize(mapload)
 	. = ..()
-	current_charges = max_charges
+	current_integrity = max_integrity
 
 /obj/item/mod/module/energy_shield/on_part_activation()
-	mod.AddComponent(/datum/component/shielded, max_integrity = max_charges, recharge_start_delay = recharge_start_delay, charge_increment_delay = charge_increment_delay, \
+	mod.AddComponent(/datum/component/shielded, max_integrity = max_integrity, recharge_start_delay = recharge_start_delay, charge_increment_delay = charge_increment_delay, \
 	charge_recovery = charge_recovery, recharge_path = recharge_path, shield_icon_file = shield_icon_file, shield_icon = shield_icon)
 	var/datum/component/shielded/shield = mod.GetComponent(/datum/component/shielded)
-	if (shield && current_charges < max_charges)
-		shield.set_charge(current_charges)
-		if (current_charges <= 0 && mod?.wearer)
+	if (shield && current_integrity < max_integrity)
+		shield.set_charge(current_integrity)
+		if (current_integrity <= 0 && mod?.wearer)
 			mod.wearer.update_appearance(UPDATE_ICON)
 	if (mod?.wearer)
 		RegisterSignal(mod.wearer, COMSIG_HUMAN_CHECK_SHIELDS, PROC_REF(shield_reaction))
@@ -168,7 +167,7 @@
 /obj/item/mod/module/energy_shield/on_part_deactivation(deleting = FALSE)
 	var/datum/component/shielded/shield = mod?.GetComponent(/datum/component/shielded)
 	if(shield)
-		current_charges = shield.current_integrity // Saving the current charge
+		current_integrity = shield.current_integrity // Saving the current charge
 		qdel(shield)
 	if(mod?.wearer)
 		UnregisterSignal(mod.wearer, COMSIG_HUMAN_CHECK_SHIELDS)
@@ -197,7 +196,7 @@
 	icon_state = "battlemage_shield"
 	idle_power_cost = DEFAULT_CHARGE_DRAIN * 0 //magic
 	use_power_cost = DEFAULT_CHARGE_DRAIN * 0 //magic too
-	max_charges = 600
+	max_integrity = 600
 	charge_increment_delay = 1 SECONDS
 	charge_recovery = 0
 	recharge_path = /obj/item/wizard_armour_charge

--- a/code/modules/mod/modules/modules_antag.dm
+++ b/code/modules/mod/modules/modules_antag.dm
@@ -179,7 +179,7 @@
 	attack_text = "the attack",
 	attack_type = MELEE_ATTACK,
 	armour_penetration = 0)
-	(SEND_SIGNAL(mod, COMSIG_ITEM_HIT_REACT, owner, hitby, attack_text, damage, attack_type))
+	SEND_SIGNAL(mod, COMSIG_ITEM_HIT_REACT, owner, hitby, attack_text, damage, attack_type)
 	var/datum/component/shielded/shield = mod?.GetComponent(/datum/component/shielded)
 	if(!shield || shield.current_integrity <= 0)
 		return NONE

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -1618,6 +1618,14 @@ GLOBAL_LIST_INIT(illegal_tech_blacklist, typecacheof(list(
 	item = /obj/item/mod/control/pre_equipped/traitor_elite
 	purchasable_from = (UPLINK_NUKE_OPS | UPLINK_CLOWN_OPS)
 
+/datum/uplink_item/suits/energy_shield
+	name = "MODsuit Energy Shield Module"
+	desc = "An energy shield module for a MODsuit. The shield can handle small caliber gunfire, \
+			 will rapidly recharge while not under fire."
+	item = /obj/item/mod/module/energy_shield
+	cost = 15
+	purchasable_from = UPLINK_NUKE_OPS | UPLINK_CLOWN_OPS
+
 /datum/uplink_item/suits/emp_shield
 	name = "MODsuit Advanced EMP Shield Module"
 	desc = "An advanced EMP shield module for a MODsuit. It protects your entire body from electromagnetic pulses."

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -1623,7 +1623,7 @@ GLOBAL_LIST_INIT(illegal_tech_blacklist, typecacheof(list(
 	desc = "An energy shield module for a MODsuit. The shield can handle small caliber gunfire, \
 			will rapidly recharge while not under fire."
 	item = /obj/item/mod/module/energy_shield
-	cost = 10
+	cost = 8
 	purchasable_from = UPLINK_NUKE_OPS | UPLINK_CLOWN_OPS
 
 /datum/uplink_item/suits/emp_shield

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -1621,7 +1621,7 @@ GLOBAL_LIST_INIT(illegal_tech_blacklist, typecacheof(list(
 /datum/uplink_item/suits/energy_shield
 	name = "MODsuit Energy Shield Module"
 	desc = "An energy shield module for a MODsuit. The shield can handle small caliber gunfire, \
-			 will rapidly recharge while not under fire."
+			will rapidly recharge while not under fire."
 	item = /obj/item/mod/module/energy_shield
 	cost = 15
 	purchasable_from = UPLINK_NUKE_OPS | UPLINK_CLOWN_OPS

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -1623,7 +1623,7 @@ GLOBAL_LIST_INIT(illegal_tech_blacklist, typecacheof(list(
 	desc = "An energy shield module for a MODsuit. The shield can handle small caliber gunfire, \
 			will rapidly recharge while not under fire."
 	item = /obj/item/mod/module/energy_shield
-	cost = 15
+	cost = 10
 	purchasable_from = UPLINK_NUKE_OPS | UPLINK_CLOWN_OPS
 
 /datum/uplink_item/suits/emp_shield


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes a bug that was caused by a merge skew

Values for the shields were taken from the original PR

https://github.com/BeeStation/BeeStation-Hornet/pull/10990

## Why It's Good For The Game

Features Working good

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

Unsure if it's the best way, but it works

<img width="439" height="353" alt="image" src="https://github.com/user-attachments/assets/cb61123f-963d-48e5-ad2f-210b5c11247d" /> 

Regular syndie shield, unhit

<img width="431" height="298" alt="image" src="https://github.com/user-attachments/assets/e4188335-d145-466b-b5eb-e433ccf36dd9" />

Shield after being hit once with a toolbox

<img width="753" height="476" alt="image" src="https://github.com/user-attachments/assets/bc000d66-d6bf-4ddf-b290-184ddf44dd45" />

Fully recharges after not being hit for 20 seconds (20 per recharge)

<img width="588" height="37" alt="image" src="https://github.com/user-attachments/assets/c95564e1-fae8-4d2c-a413-f4c673a0d00f" />

Shield Working

<img width="399" height="343" alt="image" src="https://github.com/user-attachments/assets/0966114a-6ed2-4760-ac3e-544a79cb2909" />

Shield Overload

<img width="1824" height="748" alt="image" src="https://github.com/user-attachments/assets/14bb8504-5624-494f-925f-c6db122ce120" />




</details>

Closes https://github.com/BeeStation/BeeStation-Hornet/issues/13816

## Changelog
:cl: Isaac
fix: Energy Shield Modules not working
fix: Wizard Shield not working
fix: Wizard battlemage shield can be recharged again by using the "Battlemage shield charges" on the backpack modsuit
add: Energy Shield Module can be purchased from the nukie uplink for 8 TC's
balance: Wizard shield can withstand 600 damage, has to be recharged manually
balance: Syndicate Energy shield can withstand 60 damage, recharges after not being hit for 20 seconds



/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
