### PR TITLE
Fix compilation on 516.1670 by using alist for numbered assoc lists

### DIFF
--- a/code/__DEFINES/food.dm
+++ b/code/__DEFINES/food.dm
@@ -82,7 +82,7 @@ DEFINE_BITFIELD(foodtypes, list(
 #define FOOD_COMPLEXITY_5 5
 
 /// Labels for food quality
-GLOBAL_LIST_INIT(food_quality_description, list(
+GLOBAL_LIST_INIT(food_quality_description, alist(
 	FOOD_QUALITY_NORMAL = "okay",
 	FOOD_QUALITY_NICE = "nice",
 	FOOD_QUALITY_GOOD = "good",
@@ -93,7 +93,7 @@ GLOBAL_LIST_INIT(food_quality_description, list(
 ))
 
 /// Mood events for food quality
-GLOBAL_LIST_INIT(food_quality_events, list(
+GLOBAL_LIST_INIT(food_quality_events, alist(
 	FOOD_QUALITY_NORMAL = /datum/mood_event/food,
 	FOOD_QUALITY_NICE = /datum/mood_event/food/nice,
 	FOOD_QUALITY_GOOD = /datum/mood_event/food/good,
@@ -104,7 +104,7 @@ GLOBAL_LIST_INIT(food_quality_events, list(
 ))
 
 /// Weighted lists of crafted food buffs randomly given according to crafting_complexity unless the food has a specific buff
-GLOBAL_LIST_INIT(food_buffs, list(
+GLOBAL_LIST_INIT(food_buffs, alist(
 	FOOD_COMPLEXITY_1 = list(
 		/datum/status_effect/food/haste = 1,
 	),

--- a/code/controllers/subsystem/processing/station.dm
+++ b/code/controllers/subsystem/processing/station.dm
@@ -7,7 +7,7 @@ PROCESSING_SUBSYSTEM_DEF(station)
 	/// A list of currently active station traits
 	var/list/station_traits = list()
 	/// Assoc list of trait type || assoc list of traits with weighted value. Used for picking traits from a specific category.
-	var/list/selectable_traits_by_types = list(
+	var/list/selectable_traits_by_types = alist(
 		STATION_TRAIT_POSITIVE = list(),
 		STATION_TRAIT_NEUTRAL = list(),
 		STATION_TRAIT_NEGATIVE = list(),

--- a/code/datums/hud.dm
+++ b/code/datums/hud.dm
@@ -3,7 +3,7 @@
 GLOBAL_LIST_EMPTY(all_huds)
 
 //GLOBAL HUD LIST
-GLOBAL_LIST_INIT(huds, list(
+GLOBAL_LIST_INIT(huds, alist(
 	DATA_HUD_SECURITY_BASIC = new/datum/atom_hud/data/human/security/basic(),
 	DATA_HUD_SECURITY_ADVANCED = new/datum/atom_hud/data/human/security/advanced(),
 	DATA_HUD_MEDICAL_BASIC = new/datum/atom_hud/data/human/medical/basic(),

--- a/code/modules/antagonists/clock_cult/items/clockwork_slab.dm
+++ b/code/modules/antagonists/clock_cult/items/clockwork_slab.dm
@@ -25,7 +25,7 @@ GLOBAL_LIST_INIT(clockwork_slabs, list())
 	)
 
 	//Initialise an empty list for quickbinding
-	var/list/quick_bound_scriptures = list(
+	var/list/quick_bound_scriptures = alist(
 		1 = null,
 		2 = null,
 		3 = null,

--- a/code/modules/atmospherics/gasmixtures/immutable_mixtures.dm
+++ b/code/modules/atmospherics/gasmixtures/immutable_mixtures.dm
@@ -96,4 +96,4 @@
 //hoped for an initial_gas_string but apparently that's a turf thing
 /datum/gas_mixture/immutable/planetary/cloner
 	initial_temperature = T20C
-	initial_gas = list(/datum/gas/nitrogen = list(MOLES = 104, ARCHIVE = 104))
+	initial_gas = list(/datum/gas/nitrogen = alist(MOLES = 104, ARCHIVE = 104))

--- a/code/modules/atmospherics/gasmixtures/reactions.dm
+++ b/code/modules/atmospherics/gasmixtures/reactions.dm
@@ -6,7 +6,7 @@
 
 	//Builds a list of gas id to reaction group
 	for(var/gas_id in GLOB.meta_gas_info)
-		priority_reactions[gas_id] = list(
+		priority_reactions[gas_id] = alist(
 			PRIORITY_PRE_FORMATION = list(),
 			PRIORITY_FORMATION = list(),
 			PRIORITY_POST_FORMATION = list(),

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/hivelord.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/hivelord.dm
@@ -330,7 +330,7 @@
 			if(prob(70))
 				backpack_contents += pick(list(/obj/item/stamp/clown = 1, /obj/item/reagent_containers/spray/waterflower = 1, /obj/item/food/grown/banana = 1, /obj/item/megaphone/clown = 1, /obj/item/reagent_containers/cup/soda_cans/canned_laughter = 1, /obj/item/pneumatic_cannon/pie = 1))
 			if(prob(30))
-				backpack_contents += list(/obj/item/stack/sheet/mineral/bananium = pick_weight(list( 1 = 3, 2 = 2, 3 = 1)))
+				backpack_contents += list(/obj/item/stack/sheet/mineral/bananium = pick_weight(alist( 1 = 3, 2 = 2, 3 = 1)))
 			if(prob(10))
 				l_pocket = pick_weight(list(/obj/item/bikehorn/golden = 3, /obj/item/bikehorn/airhorn= 1 ))
 			if(prob(10))

--- a/code/modules/vehicles/mecha/_mecha.dm
+++ b/code/modules/vehicles/mecha/_mecha.dm
@@ -52,7 +52,7 @@
 	///chance to deflect the incoming projectiles, hits, or lesser the effect of ex_act.
 	var/deflect_chance = 10
 	///Modifiers for directional armor
-	var/list/facing_modifiers = list(MECHA_FRONT_ARMOUR = 1.5, MECHA_SIDE_ARMOUR = 1, MECHA_BACK_ARMOUR = 0.5)
+	var/list/facing_modifiers = alist(MECHA_FRONT_ARMOUR = 1.5, MECHA_SIDE_ARMOUR = 1, MECHA_BACK_ARMOUR = 0.5)
 	///if we cant use our equipment(such as due to EMP)
 	var/equipment_disabled = FALSE
 	/// Keeps track of the mech's cell


### PR DESCRIPTION
## About The Pull Request

Changelog for 516.1670:

<img width="1439" height="212" alt="image" src="https://github.com/user-attachments/assets/82629ee1-201d-4d63-b427-98d5c27e770d" />


## Why It's Good For The Game

Allows compiling on newer 516 build

## Testing Photographs and Procedure

<details>
<summary>Screenshots&Videos</summary>

<img width="604" height="171" alt="image" src="https://github.com/user-attachments/assets/7c9dd1ca-d79b-4358-980a-2de221ddb8d5" />

<img width="1845" height="980" alt="image" src="https://github.com/user-attachments/assets/57ce7c89-4bc9-4e4c-ac5d-038591f7079a" />

<img width="583" height="299" alt="image" src="https://github.com/user-attachments/assets/6b0add01-5da5-488c-b5e9-58023b584867" />

</details>

## Changelog
:cl:
code: Fixed compilation errors on BYOND 516.1670
/:cl:
