### PR TITLE
Thermomachine turning off Fix

### DIFF
--- a/_maps/_basemap.dm
+++ b/_maps/_basemap.dm
@@ -2,7 +2,7 @@
 // #define QUICKSTART // uncomment this to start the round immidiately when ready and automatically spawn players with debug outfit
 
 // uncomment this for a map you need to use
-// #define FORCE_MAP "boxstation"
+#define FORCE_MAP "boxstation"
 // #define FORCE_MAP "cardinalstation"
 // #define FORCE_MAP "metastation"
 // #define FORCE_MAP "deltastation"

--- a/_maps/_basemap.dm
+++ b/_maps/_basemap.dm
@@ -2,7 +2,7 @@
 // #define QUICKSTART // uncomment this to start the round immidiately when ready and automatically spawn players with debug outfit
 
 // uncomment this for a map you need to use
-#define FORCE_MAP "boxstation"
+// #define FORCE_MAP "boxstation"
 // #define FORCE_MAP "cardinalstation"
 // #define FORCE_MAP "metastation"
 // #define FORCE_MAP "deltastation"

--- a/code/modules/atmospherics/machinery/components/unary_devices/thermomachine.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/thermomachine.dm
@@ -32,6 +32,7 @@
 	var/base_heating = 140
 	var/base_cooling = 170
 	var/color_index = 1
+	var/wanted_on = FALSE // Does it want/need to be on if power goes out?
 
 
 /datum/armor/unary_thermomachine
@@ -177,6 +178,8 @@
 
 	var/port_capacity = port.heat_capacity()
 
+
+
 	// The difference between target and what we need to heat/cool. Positive if heating, negative if cooling.
 	var/temperature_target_delta = target_temperature - port.temperature
 
@@ -192,6 +195,14 @@
 
 	use_power = power_usage
 	update_parents()
+
+/obj/machinery/atmospherics/components/unary/thermomachine/power_change()
+	. = ..()
+	if(!powered())
+		on = FALSE
+	else
+		on = wanted_on
+	update_appearance()
 
 /obj/machinery/atmospherics/components/unary/thermomachine/screwdriver_act(mob/living/user, obj/item/tool)
 	if(on)
@@ -281,7 +292,8 @@
 
 	switch(action)
 		if("power")
-			on = !on
+			wanted_on = !wanted_on
+			on = wanted_on && powered()
 			update_use_power(on ? ACTIVE_POWER_USE : IDLE_POWER_USE)
 			investigate_log("was turned [on ? "on" : "off"] by [key_name(usr)]", INVESTIGATE_ATMOS)
 			. = TRUE
@@ -314,7 +326,9 @@
 	if(!is_operational)
 		return TRUE
 
-	on = !on
+
+	wanted_on = !wanted_on
+	on = wanted_on && powered()
 	balloon_alert(user, "turned [on ? "on" : "off"]")
 	investigate_log("was turned [on ? "on" : "off"] by [key_name(user)]", INVESTIGATE_ATMOS)
 	update_appearance()

--- a/code/modules/atmospherics/machinery/components/unary_devices/thermomachine.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/thermomachine.dm
@@ -196,12 +196,11 @@
 	update_parents()
 
 /obj/machinery/atmospherics/components/unary/thermomachine/power_change()
-	. = ..()
 	if(!powered())
 		on = FALSE
 	else
 		on = wanted_on
-	update_appearance()
+	return ..()
 
 /obj/machinery/atmospherics/components/unary/thermomachine/screwdriver_act(mob/living/user, obj/item/tool)
 	if(on)

--- a/code/modules/atmospherics/machinery/components/unary_devices/thermomachine.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/thermomachine.dm
@@ -42,6 +42,7 @@
 
 /obj/machinery/atmospherics/components/unary/thermomachine/Initialize(mapload)
 	. = ..()
+	wanted_on = on
 	RefreshParts()
 	update_appearance()
 

--- a/code/modules/atmospherics/machinery/components/unary_devices/thermomachine.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/thermomachine.dm
@@ -179,8 +179,6 @@
 
 	var/port_capacity = port.heat_capacity()
 
-
-
 	// The difference between target and what we need to heat/cool. Positive if heating, negative if cooling.
 	var/temperature_target_delta = target_temperature - port.temperature
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This was a feature that used to be pre-linda, thermomachines would automatically turn on if they were already on, which prevented some issues with thermomachines that needed to be on constantly > R&D Servers / Telecommunications

## Why It's Good For The Game

Re-Adds a feature that already existed

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

<img width="551" height="341" alt="image" src="https://github.com/user-attachments/assets/156008a8-7f8f-4ef3-8eef-f19189d18cfc" />

<img width="549" height="340" alt="image" src="https://github.com/user-attachments/assets/615fed43-1c72-492a-a652-e64bfb90cfa1" />

</details>

## Changelog
:cl: Isaac
fix: Thermomachines will not turn themselves off if power goes out
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
