### PR TITLE
Stat panel says area name

### DIFF
--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -6,6 +6,7 @@
 /area
 	name = "Space"
 	var/navigation_area_name /// when multiple areas should have the same name, set this. get_area_navigation_name() proc will use name variable if this is null
+	var/ingame_area_name /// players will read this name instead of "var/name" in their stat panel. This exists to suppress some metaknowledge of area names
 	icon = 'icons/turf/areas.dmi'
 	icon_state = "unknown"
 	layer = AREA_LAYER

--- a/code/modules/mob/mob_stat.dm
+++ b/code/modules/mob/mob_stat.dm
@@ -268,6 +268,12 @@
 		tab_data["Reboot"] = GENERATE_STAT_TEXT("DELAYED")
 
 	tab_data["divider_4"] = GENERATE_STAT_DIVIDER
+	if(!isnewplayer(src))
+		if(!isobserver(src) && HAS_TRAIT(src, TRAIT_INCAPACITATED))
+			tab_data["Current Area"] = GENERATE_STAT_TEXT("(Unable to recognise)")
+		else
+			var/area/my_area = get_area(src)
+			tab_data["Current Area"] = GENERATE_STAT_TEXT(my_area?.ingame_area_name || my_area?.name || "??Unknown??")
 	if(SSshuttle.emergency)
 		var/ETA = SSshuttle.emergency.getModeStr()
 		if(ETA)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Stat panel says area name

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
That we have no way to figure out the area name makes us we have no idea of where we are at. fore? aft?
minour issue: there will be some weird names, but I will gather the info later. ther's a variable "ingame_area_name" that exists to cover such weird area names.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

<img width="1342" height="767" alt="image" src="https://github.com/user-attachments/assets/42b8ada1-ed4d-47ab-9d28-67e38a422c87" />

<img width="1112" height="625" alt="image" src="https://github.com/user-attachments/assets/aba96670-a740-48e4-be2c-69791f8a9be0" />

<img width="1150" height="671" alt="image" src="https://github.com/user-attachments/assets/a5f1f5f6-8331-4ec2-a785-3f897571f1ce" />


<img width="1199" height="496" alt="image" src="https://github.com/user-attachments/assets/ce2d092a-f656-471f-a8f5-9cf083ba6648" />


<img width="1130" height="551" alt="image" src="https://github.com/user-attachments/assets/594cbe77-bddd-4090-bef0-40b80a7836ff" />

<img width="1188" height="385" alt="image" src="https://github.com/user-attachments/assets/1977f1cf-4c53-4b19-af2e-501c206dae83" />


</details>

## Changelog
:cl:
add: You can now recognise area names at the stat panel. Only works when you are conscious or ghost
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
