### PR TITLE
Morph no longer drop implants out of people they eat

### DIFF
--- a/code/modules/antagonists/morph/morph.dm
+++ b/code/modules/antagonists/morph/morph.dm
@@ -132,6 +132,9 @@
 			for(var/obj/item/item in living_target.contents)
 				if(isclothing(item))
 					continue //no reason to strip them of sensors
+				// Something inside of the mob rather than worn by it
+				if (!living_target.get_slot_by_item(item))
+					continue
 				living_target.dropItemToGround(item, TRUE)
 				if(QDELING(item))
 					continue //skip it

--- a/code/modules/antagonists/morph/morph.dm
+++ b/code/modules/antagonists/morph/morph.dm
@@ -129,12 +129,10 @@
 	if(do_after(src, 3 SECONDS, living_target))
 		if(ishuman(living_target) || ismonkey(living_target) || isalienadult(living_target) || istype(living_target, /mob/living/basic/pet/dog) || istype(living_target, /mob/living/simple_animal/parrot))
 			var/list/turfs_to_throw = view(2, src)
-			for(var/obj/item/item in living_target.contents)
+			var/list/target_contents = living_target.get_equipped_items(include_pockets = TRUE) + living_target.held_items
+			for(var/obj/item/item in target_contents)
 				if(isclothing(item))
 					continue //no reason to strip them of sensors
-				// Something inside of the mob rather than worn by it
-				if (!living_target.get_slot_by_item(item))
-					continue
 				living_target.dropItemToGround(item, TRUE)
 				if(QDELING(item))
 					continue //skip it


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Discovered during testing of #13546

- Morphs now skip stripping anything that isn't worn by a mob, on top of anything that is clothing
- This means that when a morph eats someone, the only things dropped are their storage items and pocket items, not their implants.

## Why It's Good For The Game

Morphs stripping implants causes traitors to get their uplink implants stripped which is rather unfair.

## Testing Photographs and Procedure

Pre-eat:

<img width="448" height="302" alt="image" src="https://github.com/user-attachments/assets/1554d550-6b0c-4854-8d08-fafc0bef2c26" />

Post-eat:

<img width="470" height="201" alt="image" src="https://github.com/user-attachments/assets/2f227300-015d-4edd-84f9-dbaeb2a05003" />


## Changelog
:cl:
fix: Morphs no longer cause mobs that they eat to drop implants and other items inside of the mob that aren't being worn by the mob.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
