### PR TITLE
Fixes glowy blood flaky test

### DIFF
--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -933,7 +933,7 @@
 	var/glowyblood = FALSE
 	if(ishuman(src))
 		var/mob/living/carbon/human/humanoid = src
-		glowyblood = humanoid.dna.blood_type.glowy
+		glowyblood = humanoid.dna.blood_type?.glowy
 
 	if(isturf(start))
 		var/trail_type = getTrail()


### PR DESCRIPTION
## About The Pull Request

This code is pretty stupid, I'm not going to refactor it and get it up to date with /tg/ when I can just add an inline null check to "fix" the issue most affecting us.

The real problem is that consistent human dummies don't have their `blood_type` set. I have no idea why- I don't even know where `blood_type` gets set normally, maybe I'm stupid but I haven't been able to find it for the life of me.

## Why It's Good For The Game

closes #13759

## Testing Photographs and Procedure

it passes the integration tests

## Changelog
:cl:
fix: fixed consistent human dummies runtiming when spewing blood trails
/:cl:
