### PR TITLE
Basically John Mapper 2: Some More Mapping Fixes

### DIFF
--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -14311,6 +14311,9 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/simple/green/visible/layer1,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
+	dir = 6
+	},
 /turf/open/floor/iron/dark/side{
 	dir = 8
 	},
@@ -17178,7 +17181,7 @@
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
 "esF" = (
-/obj/machinery/atmospherics/components/binary/valve/layer2,
+/obj/machinery/atmospherics/components/binary/valve/digital/layer2,
 /turf/open/floor/iron/dark/side{
 	dir = 10
 	},
@@ -21443,12 +21446,12 @@
 	name = "Atmos RC";
 	pixel_x = 30
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
 /obj/machinery/light{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
 /turf/open/floor/catwalk_floor/iron,
 /area/engine/atmos)
 "gbp" = (
@@ -28657,6 +28660,15 @@
 	},
 /turf/open/floor/wood,
 /area/library)
+"iXN" = (
+/obj/machinery/atmospherics/pipe/smart/simple/green/visible/layer1,
+/obj/machinery/atmospherics/components/binary/pump/on{
+	name = "Waste to Filter"
+	},
+/turf/open/floor/iron/dark/side{
+	dir = 8
+	},
+/area/engine/atmos)
 "iXQ" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
 	dir = 5
@@ -31170,6 +31182,7 @@
 /obj/item/stack/cable_coil/white,
 /obj/structure/table,
 /obj/machinery/atmospherics/pipe/smart/simple/green/visible/layer1,
+/obj/machinery/atmospherics/pipe/smart/simple/green/visible,
 /turf/open/floor/iron/dark/side{
 	dir = 8
 	},
@@ -31525,6 +31538,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/simple/green/visible/layer1,
+/obj/machinery/atmospherics/pipe/smart/simple/green/visible,
 /turf/open/floor/iron/dark/side{
 	dir = 8
 	},
@@ -58235,6 +58249,7 @@
 /obj/item/t_scanner,
 /obj/item/clothing/gloves/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/simple/green/visible/layer1,
+/obj/machinery/atmospherics/pipe/smart/simple/green/visible,
 /turf/open/floor/iron/dark/side{
 	dir = 8
 	},
@@ -97047,7 +97062,7 @@ gty
 hwD
 hdg
 djc
-hwD
+iXN
 klg
 kaW
 vpB

--- a/_maps/map_files/CardinalStation/CardinalStation.dmm
+++ b/_maps/map_files/CardinalStation/CardinalStation.dmm
@@ -8658,6 +8658,12 @@
 /obj/effect/turf_decal/siding/thinplating_new/dark/corner{
 	dir = 4
 	},
+/obj/machinery/atmospherics/components/binary/pump/on{
+	name = "Waste to Filter";
+	dir = 1;
+	piping_layer = 4;
+	icon_state = "pump_on_map-4"
+	},
 /turf/open/floor/iron/smooth,
 /area/engine/atmos)
 "bSf" = (
@@ -16598,6 +16604,16 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /turf/open/floor/iron/smooth_edge,
 /area/hallway/secondary/command)
+"dyZ" = (
+/obj/structure/platform/gray{
+	dir = 2
+	},
+/obj/effect/turf_decal/tile/dark/fourcorners/contrasted,
+/obj/machinery/light/floor{
+	pixel_y = 16
+	},
+/turf/open/floor/iron/tech,
+/area/hallway/primary/port)
 "dzc" = (
 /obj/effect/turf_decal/siding/dark/corner{
 	dir = 1
@@ -27760,6 +27776,9 @@
 /obj/machinery/atmospherics/pipe/smart/simple/brown/visible/layer2{
 	dir = 6
 	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible/layer4{
+	dir = 9
+	},
 /turf/open/floor/iron/smooth,
 /area/engine/atmos)
 "geA" = (
@@ -30605,8 +30624,8 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
 	dir = 9
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible/layer4{
-	dir = 1
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/visible/layer4{
+	dir = 8
 	},
 /turf/open/floor/iron/smooth_edge{
 	dir = 4
@@ -40812,7 +40831,7 @@
 /area/medical/storage)
 "iRU" = (
 /obj/structure/platform/warning/stair_cutoff{
-	dir = 4
+	dir = 1
 	},
 /obj/effect/decal/fakestairs/newstairs/left{
 	dir = 4
@@ -89618,9 +89637,6 @@
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "tCF" = (
-/obj/machinery/atmospherics/components/binary/pump/on{
-	name = "Waste In"
-	},
 /obj/machinery/camera/directional/east,
 /obj/effect/turf_decal/siding/wideplating_new/dark{
 	dir = 4
@@ -89633,6 +89649,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible/layer4{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
 /turf/open/floor/iron/ridged/steel,
 /area/engine/atmos)
 "tCS" = (
@@ -93207,7 +93224,7 @@
 	icon_state = "4-8"
 	},
 /obj/structure/platform/warning/stair_cutoff{
-	dir = 4
+	dir = 1
 	},
 /obj/effect/decal/fakestairs/newstairs/left{
 	dir = 4
@@ -132231,7 +132248,7 @@ nvg
 waW
 gyk
 oHy
-aZZ
+dyZ
 gDQ
 wWI
 nvg

--- a/_maps/map_files/CardinalStation/CardinalStation.dmm
+++ b/_maps/map_files/CardinalStation/CardinalStation.dmm
@@ -8658,11 +8658,9 @@
 /obj/effect/turf_decal/siding/thinplating_new/dark/corner{
 	dir = 4
 	},
-/obj/machinery/atmospherics/components/binary/pump/on{
+/obj/machinery/atmospherics/components/binary/pump/on/layer4{
 	name = "Waste to Filter";
-	dir = 1;
-	piping_layer = 4;
-	icon_state = "pump_on_map-4"
+	dir = 1
 	},
 /turf/open/floor/iron/smooth,
 /area/engine/atmos)

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -6557,6 +6557,13 @@
 /obj/effect/loot_jobscale/armoury/laser_gun,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/security/armory)
+"aSN" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
+/turf/open/floor/iron,
+/area/engine/atmos)
 "aSP" = (
 /obj/structure/lattice,
 /obj/structure/disposalpipe/segment{
@@ -8736,6 +8743,7 @@
 	dir = 4
 	},
 /obj/effect/landmark/event_spawn,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
 /turf/open/floor/iron,
 /area/engine/atmos)
 "bkT" = (
@@ -8746,9 +8754,8 @@
 /turf/open/floor/iron,
 /area/engine/atmos)
 "bkU" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
-/obj/machinery/atmospherics/pipe/smart/simple/orange/visible{
+/obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
 	dir = 4
 	},
 /turf/open/floor/iron,
@@ -9352,7 +9359,6 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
 /turf/open/floor/iron,
 /area/engine/atmos)
 "boy" = (
@@ -9544,7 +9550,7 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
-	dir = 4
+	dir = 9
 	},
 /turf/open/floor/iron,
 /area/engine/atmos)
@@ -9554,9 +9560,6 @@
 	},
 /obj/structure/sign/poster/official/work_for_a_future{
 	pixel_x = 32
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
-	dir = 9
 	},
 /turf/open/floor/iron,
 /area/engine/atmos)
@@ -20083,6 +20086,17 @@
 	},
 /turf/open/floor/iron,
 /area/crew_quarters/fitness/recreation)
+"cIn" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/corner{
+	dir = 1
+	},
+/area/engine/atmos)
 "cIp" = (
 /obj/structure/closet/emcloset/anchored,
 /obj/effect/decal/cleanable/dirt,
@@ -31324,6 +31338,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/green/visible/layer1{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/visible{
 	dir = 8
 	},
 /turf/open/floor/catwalk_floor/iron,
@@ -43042,11 +43059,11 @@
 /obj/item/stack/sheet/glass/fifty,
 /obj/item/stack/rods/fifty,
 /obj/effect/turf_decal/bot,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
-	dir = 9
-	},
 /obj/machinery/atmospherics/pipe/smart/simple/green/visible/layer1{
 	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
+	dir = 4
 	},
 /turf/open/floor/iron,
 /area/engine/atmos)
@@ -43489,7 +43506,8 @@
 /area/crew_quarters/locker)
 "iPt" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
-/obj/machinery/atmospherics/components/binary/valve/on{
+/obj/machinery/atmospherics/components/binary/valve/digital{
+	name = "Waste Release";
 	dir = 4
 	},
 /turf/open/floor/iron/dark,
@@ -68198,14 +68216,11 @@
 /area/security/prison)
 "rGS" = (
 /obj/structure/cable/yellow{
-	icon_state = "1-2"
+	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
-/turf/open/floor/catwalk_floor/iron,
+/obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
+/turf/open/floor/iron,
 /area/engine/atmos)
 "rGV" = (
 /obj/structure/chair/office{
@@ -68911,6 +68926,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/green/visible/layer1{
 	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
+	dir = 4
 	},
 /turf/open/floor/catwalk_floor/iron,
 /area/engine/atmos)
@@ -70801,11 +70819,12 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
-	dir = 6
-	},
 /obj/machinery/atmospherics/pipe/smart/simple/green/visible/layer1{
 	dir = 8
+	},
+/obj/machinery/atmospherics/components/binary/pump/on{
+	dir = 4;
+	name = "Waste to Filter"
 	},
 /turf/open/floor/iron,
 /area/engine/atmos)
@@ -71358,8 +71377,6 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
-/obj/machinery/meter,
 /obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
 /turf/open/floor/iron,
 /area/engine/atmos)
@@ -74924,6 +74941,9 @@
 /obj/machinery/atmospherics/pipe/smart/simple/green/visible/layer1{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/engine/atmos)
 "tUZ" = (
@@ -76272,6 +76292,16 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
 /turf/open/floor/iron/dark,
 /area/science/xenobiology)
+"uuh" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
+	dir = 9
+	},
+/turf/open/floor/iron,
+/area/engine/atmos)
 "uus" = (
 /obj/effect/turf_decal/delivery,
 /obj/item/kirbyplants{
@@ -82891,6 +82921,9 @@
 	dir = 4
 	},
 /obj/machinery/vending/wardrobe/atmos_wardrobe,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
+	dir = 6
+	},
 /turf/open/floor/iron/dark/corner{
 	dir = 1
 	},
@@ -113281,10 +113314,10 @@ fLC
 ksJ
 aWH
 wGY
-oPr
+rGS
 bkR
 eMw
-bad
+aSN
 bqc
 bws
 bad
@@ -113537,12 +113570,12 @@ bad
 bad
 beF
 aWG
-bho
+cIn
 dCY
 wbS
 rRz
 ujA
-rGS
+ujA
 ujA
 avR
 flT
@@ -113794,7 +113827,7 @@ hvQ
 hvQ
 hvQ
 sxj
-hvQ
+bkU
 oPr
 bkT
 sys
@@ -114051,9 +114084,9 @@ pxN
 mou
 mou
 mou
-mou
+uuh
 sIf
-bkU
+bkP
 iHN
 aRF
 aRF

--- a/_maps/map_files/FlandStation/FlandStation.dmm
+++ b/_maps/map_files/FlandStation/FlandStation.dmm
@@ -37453,11 +37453,11 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 8;
-	name = "Waste to Space"
-	},
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/components/binary/valve/digital{
+	name = "Waste Release";
+	dir = 4
+	},
 /turf/open/floor/iron/dark/side{
 	dir = 8
 	},
@@ -52197,7 +52197,9 @@
 /turf/open/floor/iron,
 /area/engine/atmos)
 "oiB" = (
-/obj/machinery/atmospherics/pipe/bridge_pipe/scrubbers/visible,
+/obj/machinery/atmospherics/pipe/smart/manifold/green/visible{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/engine/atmos)
 "oiJ" = (
@@ -72427,6 +72429,13 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
+"tLC" = (
+/obj/machinery/atmospherics/components/binary/valve/digital{
+	name = "Waste Release";
+	dir = 4
+	},
+/turf/open/floor/engine,
+/area/engine/atmos)
 "tLH" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
@@ -136853,7 +136862,7 @@ vNt
 uzm
 sZm
 qaD
-aWm
+tLC
 xoK
 sZm
 cQb

--- a/_maps/map_files/FlandStation/FlandStation.dmm
+++ b/_maps/map_files/FlandStation/FlandStation.dmm
@@ -72429,13 +72429,6 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
-"tLC" = (
-/obj/machinery/atmospherics/components/binary/valve/digital{
-	name = "Waste Release";
-	dir = 4
-	},
-/turf/open/floor/engine,
-/area/engine/atmos)
 "tLH" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
@@ -136862,7 +136855,7 @@ vNt
 uzm
 sZm
 qaD
-tLC
+aWm
 xoK
 sZm
 cQb

--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -44679,9 +44679,6 @@
 	dir = 8;
 	target_pressure = 4500
 	},
-/obj/machinery/atmospherics/components/binary/pump/on/layer4{
-	dir = 4
-	},
 /turf/open/floor/plating,
 /area/maintenance/port)
 "ntG" = (
@@ -65410,11 +65407,9 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
 	dir = 5
 	},
-/obj/machinery/atmospherics/components/binary/pump/on{
-	dir = 8;
+/obj/machinery/atmospherics/components/binary/pump/on/layer4{
 	name = "Waste to Filter";
-	icon_state = "pump_on_map-4";
-	piping_layer = 4
+	dir = 8
 	},
 /turf/open/floor/iron,
 /area/engine/atmos)

--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -11188,9 +11188,6 @@
 /turf/open/floor/engine/vacuum,
 /area/engine/atmos)
 "cts" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
-	dir = 10
-	},
 /obj/machinery/light_switch{
 	pixel_y = 24
 	},
@@ -11212,6 +11209,9 @@
 	},
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
 	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
+	dir = 10
 	},
 /turf/open/floor/iron,
 /area/engine/atmos)
@@ -31101,7 +31101,6 @@
 /turf/open/floor/iron/showroomfloor,
 /area/crew_quarters/cryopods)
 "iFI" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/tile/yellow/half/contrasted{
 	dir = 1
@@ -31109,6 +31108,7 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
 /turf/open/floor/iron,
 /area/engine/atmos)
 "iFL" = (
@@ -40306,6 +40306,9 @@
 /obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/iron,
 /area/security/brig)
+"lSk" = (
+/turf/open/space/basic,
+/area/maintenance/aft)
 "lSB" = (
 /obj/effect/landmark/start/bartender,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
@@ -41678,12 +41681,12 @@
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
 "moK" = (
-/obj/machinery/atmospherics/components/binary/valve/digital{
-	dir = 8;
-	name = "Waste Release"
-	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/neutral,
+/obj/machinery/atmospherics/components/binary/valve/digital{
+	name = "Waste Release";
+	dir = 4
+	},
 /turf/open/floor/iron/dark,
 /area/engine/atmos)
 "moM" = (
@@ -64501,11 +64504,11 @@
 /turf/open/floor/iron,
 /area/hallway/secondary/exit/departure_lounge)
 "ufY" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
-	dir = 4
-	},
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/layer_manifold/scrubbers/visible{
+	dir = 8
 	},
 /turf/open/floor/iron,
 /area/engine/atmos)
@@ -65397,15 +65400,21 @@
 /turf/open/floor/iron/dark,
 /area/science/robotics/lab)
 "uty" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
-	dir = 5
-	},
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/tile/yellow/half/contrasted{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
+	dir = 5
+	},
+/obj/machinery/atmospherics/components/binary/pump/on{
+	dir = 8;
+	name = "Waste to Filter";
+	icon_state = "pump_on_map-4";
+	piping_layer = 4
 	},
 /turf/open/floor/iron,
 /area/engine/atmos)
@@ -67346,6 +67355,7 @@
 /obj/effect/turf_decal/tile/red/fourcorners/contrasted,
 /obj/effect/turf_decal/tile/neutral/opposingcorners,
 /obj/machinery/atmospherics/pipe/smart/simple/green/visible/layer1,
+/obj/machinery/atmospherics/pipe/smart/simple/green/visible/layer4,
 /turf/open/floor/iron/showroomfloor,
 /area/engine/atmos)
 "vcj" = (
@@ -69326,6 +69336,9 @@
 /obj/effect/turf_decal/tile/red/fourcorners/contrasted,
 /obj/effect/turf_decal/tile/neutral/opposingcorners,
 /obj/machinery/atmospherics/pipe/smart/simple/green/visible/layer1,
+/obj/machinery/atmospherics/pipe/smart/simple/green/visible/layer4{
+	dir = 5
+	},
 /turf/open/floor/iron/showroomfloor,
 /area/engine/atmos)
 "vHK" = (
@@ -107650,7 +107663,7 @@ fIl
 off
 bFa
 bGG
-bGG
+lSk
 lXr
 tbC
 cXN

--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -40306,9 +40306,6 @@
 /obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/iron,
 /area/security/brig)
-"lSk" = (
-/turf/open/space/basic,
-/area/maintenance/aft)
 "lSB" = (
 /obj/effect/landmark/start/bartender,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
@@ -107658,7 +107655,7 @@ fIl
 off
 bFa
 bGG
-lSk
+wVB
 lXr
 tbC
 cXN

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -22570,12 +22570,12 @@
 /turf/open/floor/iron,
 /area/crew_quarters/toilet/auxiliary)
 "eKY" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/visible,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/simple/green/visible/layer1,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
 /turf/open/floor/iron,
 /area/engine/atmos)
 "eLi" = (
@@ -26824,7 +26824,7 @@
 /area/hallway/primary/central)
 "goC" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 4
+	dir = 1
 	},
 /turf/open/floor/iron/dark,
 /area/engine/transit_tube)
@@ -28543,6 +28543,9 @@
 /obj/machinery/atmospherics/pipe/smart/simple/green/visible/layer1,
 /obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
 	dir = 4
+	},
+/obj/machinery/atmospherics/components/binary/pump/on{
+	name = "Waste to Filter"
 	},
 /turf/open/floor/iron,
 /area/engine/atmos)
@@ -36795,6 +36798,9 @@
 /obj/effect/mapping_helpers/airlock/access/any/command/minisat,
 /obj/effect/mapping_helpers/airlock/access/any/command/general,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
+	},
 /turf/open/floor/iron/dark,
 /area/engine/transit_tube)
 "jRx" = (
@@ -56215,7 +56221,7 @@
 	name = "Inner Pipe Access";
 	req_access_txt = "24"
 	},
-/obj/machinery/atmospherics/components/binary/valve/digital/on,
+/obj/machinery/atmospherics/components/binary/valve/digital,
 /turf/open/floor/iron/dark,
 /area/engine/atmos)
 "qVZ" = (
@@ -60293,6 +60299,9 @@
 /obj/effect/mapping_helpers/airlock/access/any/engineering/tcoms,
 /obj/effect/mapping_helpers/airlock/access/any/command/minisat,
 /obj/effect/mapping_helpers/airlock/access/any/command/general,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
 /turf/open/floor/iron/dark,
 /area/engine/transit_tube)
 "sxv" = (

--- a/_maps/map_files/RadStation/RadStation.dmm
+++ b/_maps/map_files/RadStation/RadStation.dmm
@@ -4075,6 +4075,9 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/smart/simple/green/visible/layer1,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible/layer4{
+	dir = 6
+	},
 /turf/open/floor/iron/tech,
 /area/engine/atmos)
 "bqO" = (
@@ -20476,6 +20479,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/simple/green/visible/layer1,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible/layer4,
 /turf/open/floor/iron/dark,
 /area/engine/atmos)
 "gTA" = (
@@ -31091,6 +31095,12 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
 	dir = 5
 	},
+/obj/machinery/atmospherics/components/binary/pump/on{
+	name = "Waste to Filter";
+	dir = 2;
+	piping_layer = 4;
+	icon_state = "pump_on_map-4"
+	},
 /turf/open/floor/iron/dark,
 /area/engine/atmos)
 "kJv" = (
@@ -34012,6 +34022,9 @@
 	name = "Waste to Filter"
 	},
 /obj/effect/turf_decal/delivery,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible/layer4{
+	dir = 8
+	},
 /turf/open/floor/iron/tech,
 /area/engine/atmos)
 "lKP" = (
@@ -41645,11 +41658,8 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/components/binary/valve/digital{
-	dir = 1;
-	name = "Waste Release"
-	},
 /obj/effect/turf_decal/delivery,
+/obj/machinery/atmospherics/components/binary/valve/digital,
 /turf/open/floor/iron/dark,
 /area/engine/atmos)
 "otE" = (
@@ -47138,6 +47148,7 @@
 	},
 /obj/machinery/atmospherics/pipe/bridge_pipe/scrubbers/visible,
 /obj/machinery/atmospherics/pipe/smart/simple/green/visible/layer1,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible/layer4,
 /turf/open/floor/iron/tech,
 /area/engine/atmos)
 "qkg" = (
@@ -50216,6 +50227,7 @@
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/simple/green/visible/layer1,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible/layer4,
 /turf/open/floor/iron/tech,
 /area/engine/atmos)
 "rqq" = (
@@ -51019,6 +51031,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
 	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible/layer4{
+	dir = 8
 	},
 /turf/open/floor/catwalk_floor,
 /area/engine/atmos)

--- a/_maps/map_files/RadStation/RadStation.dmm
+++ b/_maps/map_files/RadStation/RadStation.dmm
@@ -31095,11 +31095,9 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
 	dir = 5
 	},
-/obj/machinery/atmospherics/components/binary/pump/on{
+/obj/machinery/atmospherics/components/binary/pump/on/layer4{
 	name = "Waste to Filter";
-	dir = 2;
-	piping_layer = 4;
-	icon_state = "pump_on_map-4"
+	dir = 2
 	},
 /turf/open/floor/iron/dark,
 /area/engine/atmos)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Changes so that the scrubnet dumps into filters roundstart instead of into space. The valves to dump into space are still present, but this helps not waste a shit load of gas if no one is in atmos. It makes no sense to have gas dumped overboard roundstart if the AGR isnt even on roundstart to take up the filter lines. 

Also fixes Meta's AI sat access room. A vent there was unconnected to distro and the airlocks wouldnt cycle. Now they do!

Further fixes a couple stairs on Card where they platforms had bad hitboxes. 

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Issue bad, no issue good.

Closes: https://github.com/BeeStation/BeeStation-Hornet/issues/13777

Maybe some others? Idk, I just fixed things that pissed me off.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

Rad
<img width="427" height="851" alt="image" src="https://github.com/user-attachments/assets/c077435e-0dc2-4e6d-8805-1f54102f2eb8" />

Card
<img width="198" height="328" alt="image" src="https://github.com/user-attachments/assets/d3252814-308a-4310-9e74-bca8720a8932" />
<img width="199" height="199" alt="image" src="https://github.com/user-attachments/assets/76af3e38-240d-48e0-a8b5-dea377b0a42c" />
<img width="263" height="198" alt="image" src="https://github.com/user-attachments/assets/357187e1-5c3f-4abf-950f-0c8caaf81d9a" />

Box
<img width="131" height="521" alt="image" src="https://github.com/user-attachments/assets/bad958f4-3b6f-4876-892b-4e8829fe556c" />

Delta
<img width="388" height="325" alt="image" src="https://github.com/user-attachments/assets/200400d6-ecd2-46a0-8421-1ae78cec7ed1" />
<img width="394" height="361" alt="image" src="https://github.com/user-attachments/assets/6955eb44-1519-4c40-bcd7-dd375ece2d80" />

Fland. Humorously enough, this thermo was already there and connected only to one red pipe with that pressure pump already existing. It had no purpose.
<img width="267" height="398" alt="image" src="https://github.com/user-attachments/assets/bc698d8e-302f-45a1-9b57-e9aaebc90c74" />

Kilo
<img width="397" height="264" alt="image" src="https://github.com/user-attachments/assets/f01ba33c-3e31-4af9-a38b-3755f558a88c" />

Meta
<img width="393" height="462" alt="image" src="https://github.com/user-attachments/assets/2cae5525-88c9-4a15-a2b8-90d4a7852562" />
<img width="203" height="329" alt="image" src="https://github.com/user-attachments/assets/c81e17c2-c2f6-4584-bfad-451d299387f5" />


</details>

## Changelog
:cl:
fix: Meta stationside AI sat access airlocks now cycle. 
fix: Meta stationside AI sat access air vent now connected to distro
fix: A couple stairs in Card now allow you to pass them. 
map: Changed all maps to dump scrubnet into filters by default instead of venting it into space.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
