### PR TITLE
Fixes syndicate borgs not having syndimov + technically 3 other things

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot_defines.dm
+++ b/code/modules/mob/living/silicon/robot/robot_defines.dm
@@ -209,19 +209,33 @@
 // --------------------- Syndicate Assault
 /mob/living/silicon/robot/model/syndicate
 	icon_state = "synd_sec"
-	faction = list(FACTION_SYNDICATE)
 	bubble_icon = "syndibot"
+	faction = list(FACTION_SYNDICATE)
 	req_access = list(ACCESS_SYNDICATE)
 	lawupdate = FALSE
 	scrambledcodes = TRUE // These are rogue borgs.
 	ionpulse = TRUE
-	var/playstyle_string = span_bigbold("You are a Syndicate assault cyborg!") + "\
-							<br><b>You are armed with powerful offensive tools to aid you in your mission: help the operatives secure the nuclear authentication disk. \
-							Your cyborg LMG will slowly produce ammunition from your power supply, and your operative pinpointer will find and locate fellow nuclear operatives. \
-							<i>Help the operatives secure the disk at all costs!</i></b>"
 	set_model = /obj/item/robot_model/syndicate
 	cell = /obj/item/stock_parts/cell/hyper
 	radio = /obj/item/radio/borg/syndicate
+
+	var/playstyle_string = "<span class='big bold'>You are a Syndicate assault cyborg!</span><br>\
+		<b>You are armed with powerful offensive tools to aid you in your mission: help the operatives secure the nuclear authentication disk. \
+		Your cyborg LMG will slowly produce ammunition from your power supply, and your operative pinpointer will find and locate fellow nuclear operatives. \
+		<i>Help the operatives secure the disk at all costs!</i></b>"
+
+/mob/living/silicon/robot/model/syndicate/Initialize(mapload)
+	laws = new /datum/ai_laws/syndicate_override()
+	laws.associate(src)
+	. = ..()
+	addtimer(CALLBACK(src, PROC_REF(show_playstyle)), 0.5 SECONDS)
+
+/mob/living/silicon/robot/model/syndicate/create_modularInterface()
+	if(!modularInterface)
+		modularInterface = new /obj/item/modular_computer/tablet/integrated/syndicate(src)
+		modularInterface.saved_identification = real_name
+		modularInterface.saved_job = JOB_NAME_CYBORG
+	return ..()
 
 /mob/living/silicon/robot/model/syndicate/proc/show_playstyle()
 	if(playstyle_string)
@@ -230,22 +244,22 @@
 // --------------------- Syndicate Medical
 /mob/living/silicon/robot/model/syndicate/medical
 	icon_state = "synd_medical"
-	playstyle_string = span_bigbold("You are a Syndicate medical cyborg!") + "\
-						<br><b>You are armed with powerful medical tools to aid you in your mission: help the operatives secure the nuclear authentication disk. \
-						Your hypospray will produce Restorative Nanites, a wonder-drug that will heal most types of bodily damages, including clone and brain damage. It also produces morphine for offense. \
-						Your defibrillator paddles can revive operatives through their hardsuits, or can be used on harm intent to shock enemies! \
-						Your energy saw functions as a circular saw, but can be activated to deal more damage, and your operative pinpointer will find and locate fellow nuclear operatives. \
-						<i>Help the operatives secure the disk at all costs!</i></b>"
+	playstyle_string = "<span class='big bold'>You are a Syndicate medical cyborg!</span><br>\
+		<b>You are armed with powerful medical tools to aid you in your mission: help the operatives secure the nuclear authentication disk. \
+		Your hypospray will produce Restorative Nanites, a wonder-drug that will heal most types of bodily damages, including brain damage. It also produces morphine for offense. \
+		Your defibrillator paddles can revive operatives through their suits, or can be used on harm intent to shock enemies! \
+		Your energy saw functions as a circular saw, but can be activated to deal more damage, and your operative pinpointer will find and locate fellow nuclear operatives. \
+		<i>Help the operatives secure the disk at all costs!</i></b>"
 	set_model = /obj/item/robot_model/syndicate_medical
 
 // --------------------- Syndicate Saboteur
 /mob/living/silicon/robot/model/syndicate/saboteur
 	icon_state = "synd_engi"
-	playstyle_string = span_bigbold("You are a Syndicate saboteur cyborg!") + "\
-						<b>You are armed with robust engineering tools to aid you in your mission: help the operatives secure the nuclear authentication disk. \
-						Your destination tagger will allow you to stealthily traverse the disposal network across the station \
-						Your welder will allow you to repair the operatives' exosuits, but also yourself and your fellow cyborgs \
-						Your cyborg chameleon projector allows you to assume the appearance and registered name of a Nanotrasen engineering borg, and undertake covert actions on the station \
-						Be aware that almost any physical contact or incidental damage will break your camouflage \
-						<i>Help the operatives secure the disk at all costs!</i></b>"
+	playstyle_string = "<span class='big bold'>You are a Syndicate saboteur cyborg!</span><br>\
+		<b>You are armed with robust engineering tools to aid you in your mission: help the operatives secure the nuclear authentication disk. \
+		Your destination tagger will allow you to stealthily traverse the disposal network across the station \
+		Your welder will allow you to repair the operatives' exosuits, but also yourself and your fellow cyborgs \
+		Your cyborg chameleon projector allows you to assume the appearance and registered name of a Nanotrasen engineering borg, and undertake covert actions on the station \
+		Be aware that almost any physical contact or incidental damage will break your camouflage \
+		<i>Help the operatives secure the disk at all costs!</i></b>"
 	set_model = /obj/item/robot_model/saboteur

--- a/code/modules/mob/living/silicon/robot/robot_defines.dm
+++ b/code/modules/mob/living/silicon/robot/robot_defines.dm
@@ -246,7 +246,7 @@
 	icon_state = "synd_medical"
 	playstyle_string = "<span class='big bold'>You are a Syndicate medical cyborg!</span><br>\
 		<b>You are armed with powerful medical tools to aid you in your mission: help the operatives secure the nuclear authentication disk. \
-		Your hypospray will produce Restorative Nanites, a wonder-drug that will heal most types of bodily damages, including brain damage. It also produces morphine for offense. \
+		Your hypospray will produce Restorative Nanites, a wonder-drug that will heal most types of bodily damages, including clone and brain damage. It also produces morphine for offense. \
 		Your defibrillator paddles can revive operatives through their suits, or can be used on harm intent to shock enemies! \
 		Your energy saw functions as a circular saw, but can be activated to deal more damage, and your operative pinpointer will find and locate fellow nuclear operatives. \
 		<i>Help the operatives secure the disk at all costs!</i></b>"

--- a/code/modules/mob/living/silicon/silicon.dm
+++ b/code/modules/mob/living/silicon/silicon.dm
@@ -105,14 +105,6 @@
 		modularInterface.saved_job = JOB_NAME_PAI
 		modularInterface.install_component(new /obj/item/computer_hardware/hard_drive/small/pda/ai)
 
-/mob/living/silicon/robot/model/syndicate/create_modularInterface()
-	if(!modularInterface)
-		modularInterface = new /obj/item/modular_computer/tablet/integrated/syndicate(src)
-		modularInterface.saved_identification = real_name
-		modularInterface.saved_job = JOB_NAME_CYBORG
-	return ..()
-
-
 /mob/living/silicon/med_hud_set_health()
 	return //we use a different hud
 


### PR DESCRIPTION
## About The Pull Request

This PR does 4 things:
- Fixes syndicate borgs not having syndimov
- Fixes the playstyle_string not being sent to the borg
- Converts playstyle_strings to **not** use span macros
- Moves `/mob/.../model/syndicate/create_modularInterface()` from `silicon.dm` to directly under `/mob/.../model/syndicate`

## Why It's Good For The Game

Only two of the changes made I feel actually need any sort of justification.
1. I moved `/mob/.../model/syndicate/create_modularInterface()` under its parent for better organization- 90% of the time it makes more sense to keep a datum's overridden proc with said datum.
2. I made the playstyle_strings not use span macros because formatting with macros in compile-time vars is a pain, requiring using the `+` operator a bunch which looks ugly. See `golems.dm` if you want an example

## Testing Photographs and Procedure

<img width="787" height="221" alt="image" src="https://github.com/user-attachments/assets/3e2d4632-7f6c-48ec-92b2-2275a476aac1" />

<img width="938" height="134" alt="image" src="https://github.com/user-attachments/assets/bff7fbfe-d101-4b5a-a4d5-d526de87f966" />

## Changelog
:cl:
fix: fixed syndicate borgs not starting with syndimov laws
fix: playstyle strings are once more properly sent to syndicate borgs
/:cl:
