### PR TITLE
Fixes traitor & chaplain carp suit helmet not having environment protections

### DIFF
--- a/code/modules/clothing/head/costume.dm
+++ b/code/modules/clothing/head/costume.dm
@@ -174,6 +174,12 @@
 	icon_state = "carp_helm"
 	inhand_icon_state = "syndicate"
 	armor_type = /datum/armor/carp_hood_spaceproof
+	cold_protection = HEAD
+	min_cold_protection_temperature = SPACE_SUIT_MIN_TEMP_PROTECT
+	heat_protection = HEAD
+	max_heat_protection_temperature = SPACE_SUIT_MAX_TEMP_PROTECT
+	clothing_flags = STOPSPRESSUREDAMAGE|THICKMATERIAL
+	body_parts_covered = HEAD
 	light_system = NO_LIGHT_SUPPORT
 	light_range = 0 //luminosity when on
 	actions_types = list()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Gives /obj/item/clothing/head/hooded/carp_hood/spaceproof and as a result /obj/item/clothing/head/hooded/carp_hood/spaceproof/old temperature and presssure protections to go along with the suits since they're clearly mismatched.

## Why It's Good For The Game
Fix

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

<img width="448" height="273" alt="dreamseeker_GUlH23Yn7B" src="https://github.com/user-attachments/assets/daa44827-1262-49e2-bd3f-8163f01c822c" />

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>

## Changelog
:cl:
fix: Fixed traitor and chaplain carp suit not protecting against space.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
