### PR TITLE
Makes ventcrawling time-taken customizable per-mob, increases the delay for morphs.

### DIFF
--- a/code/modules/antagonists/morph/morph.dm
+++ b/code/modules/antagonists/morph/morph.dm
@@ -14,7 +14,7 @@
 	status_flags = CANPUSH
 	pass_flags = PASSTABLE
 	ventcrawler = VENTCRAWLER_ALWAYS
-	ventcrawl_delay = 100 // Morphs take longer to enter vents (10 seconds vs 2.5 seconds)
+	ventcrawl_delay = 5 SECONDS
 	atmos_requirements = list("min_oxy" = 0, "max_oxy" = 0, "min_tox" = 0, "max_tox" = 0, "min_co2" = 0, "max_co2" = 0, "min_n2" = 0, "max_n2" = 0)
 	minbodytemp = 0
 	maxHealth = 150

--- a/code/modules/antagonists/morph/morph.dm
+++ b/code/modules/antagonists/morph/morph.dm
@@ -1,5 +1,3 @@
-
-
 /mob/living/simple_animal/hostile/morph
 	name = "morph"
 	real_name = "morph"
@@ -16,6 +14,7 @@
 	status_flags = CANPUSH
 	pass_flags = PASSTABLE
 	ventcrawler = VENTCRAWLER_ALWAYS
+	ventcrawl_delay = 100 // Morphs take longer to enter vents (10 seconds vs 2.5 seconds)
 	atmos_requirements = list("min_oxy" = 0, "max_oxy" = 0, "min_tox" = 0, "max_tox" = 0, "min_co2" = 0, "max_co2" = 0, "min_n2" = 0, "max_n2" = 0)
 	minbodytemp = 0
 	maxHealth = 150

--- a/code/modules/mob/living/living_defines.dm
+++ b/code/modules/mob/living/living_defines.dm
@@ -63,6 +63,7 @@
 	var/bloodcrawl = 0 //0 No blood crawling, BLOODCRAWL for bloodcrawling, BLOODCRAWL_EAT for crawling+mob devour
 	var/holder = null //The holder for blood crawling
 	var/ventcrawler = 0 //0 No vent crawling, 1 vent crawling in the nude, 2 vent crawling always
+	var/ventcrawl_delay = 25 //How long it takes to enter a vent in deciseconds (default 2.5 seconds)
 	var/limb_destroyer = FALSE //1 Sets AI behavior that allows mobs to target and dismember limbs with their basic attack.
 
 	var/mob_size = MOB_SIZE_HUMAN

--- a/code/modules/mob/living/living_defines.dm
+++ b/code/modules/mob/living/living_defines.dm
@@ -63,7 +63,7 @@
 	var/bloodcrawl = 0 //0 No blood crawling, BLOODCRAWL for bloodcrawling, BLOODCRAWL_EAT for crawling+mob devour
 	var/holder = null //The holder for blood crawling
 	var/ventcrawler = 0 //0 No vent crawling, 1 vent crawling in the nude, 2 vent crawling always
-	var/ventcrawl_delay = 25 //How long it takes to enter a vent in deciseconds (default 2.5 seconds)
+	var/ventcrawl_delay = 2.5 SECONDS //How long it takes to enter a vent in seconds
 	var/limb_destroyer = FALSE //1 Sets AI behavior that allows mobs to target and dismember limbs with their basic attack.
 
 	var/mob_size = MOB_SIZE_HUMAN

--- a/code/modules/mob/living/simple_animal/hostile/headcrab.dm
+++ b/code/modules/mob/living/simple_animal/hostile/headcrab.dm
@@ -20,6 +20,7 @@
 	environment_smash = ENVIRONMENT_SMASH_NONE
 	speak_emote = list("squeaks")
 	ventcrawler = VENTCRAWLER_ALWAYS
+	ventcrawl_delay = 2 SECONDS
 	/// The mind to transfer to our egg when it hatches
 	var/datum/mind/origin
 	/// Set to true once we've implanted our egg

--- a/code/modules/mob/living/ventcrawling.dm
+++ b/code/modules/mob/living/ventcrawling.dm
@@ -55,7 +55,7 @@ GLOBAL_LIST_INIT(ventcrawl_machinery, typecacheof(list(
 			ADD_TRAIT(src, TRAIT_NO_MOVE_PULL, VENTCRAWLING_TRAIT)
 			ADD_TRAIT(src, TRAIT_NOMOBSWAP, VENTCRAWLING_TRAIT)
 			ADD_TRAIT(src, TRAIT_PUSHIMMUNE, VENTCRAWLING_TRAIT)
-			if(!do_after(src, 25, target = vent_found))
+			if(!do_after(src, ventcrawl_delay, target = vent_found))
 				REMOVE_TRAIT(src, TRAIT_NO_MOVE_PULL, VENTCRAWLING_TRAIT)
 				REMOVE_TRAIT(src, TRAIT_NOMOBSWAP, VENTCRAWLING_TRAIT)
 				REMOVE_TRAIT(src, TRAIT_PUSHIMMUNE, VENTCRAWLING_TRAIT)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This change introduces a `ventcrawl_delay` variable to control the time it takes for a creature to enter a vent.

Morphs now have a longer delay than other vent crawlers. We may want to adjust the time taken for others as well, but that is not the focus of this PR.

Additionally we lower headspider delay from standard 2.5 to 2, due to bacon's request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Ventcrawling is a profoundly busted ability that, when utilized correctly, is basically impossible to work against. Welding vents is indeed a form of counterplay but requires too much effort and too much coordination to be a valid strategy in most situations currently faced by the average crew.

Morphs specifically are being changed due to their general tankyness and ability for open warfare. Often you don't even have the time to approach a morph before they are in a vent.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

![dreamseeker_Lmw0n9Swpa](https://github.com/user-attachments/assets/b64c1e55-e49a-4f8b-a0b8-5e348080bc65)

![dreamseeker_TMNsN9JeNV](https://github.com/user-attachments/assets/41287d4f-7c81-4e51-b222-36d816338925)

</details>

## Changelog
:cl:
add: Added a way to customize ventcrawling time on mobs.
balance: morphs ventcrawl takes longer now.
balance: headspider ventcrawl is a bit faster.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
