### PR TITLE
Cleans up some examination code, improving support for examine line/title overrides

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -1655,7 +1655,7 @@ GLOBAL_VAR_INIT(rpg_loot_items, FALSE)
 /// in the title of that item.
 /// This proc also appends inspection links, which can be clicked in the chatbox to examine this
 /// item in greater detail.
-/obj/item/proc/examine_worn_title(mob/user, skip_examine_link = FALSE)
+/obj/item/proc/examine_worn_title(mob/living/wearer, mob/user, skip_examine_link = FALSE)
 	if (!user)
 		CRASH("Cannot generate worn examination title without a user, worn titles require the target which you are showing them to.")
 	if (!user.client)

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -1656,10 +1656,8 @@ GLOBAL_VAR_INIT(rpg_loot_items, FALSE)
 /// This proc also appends inspection links, which can be clicked in the chatbox to examine this
 /// item in greater detail.
 /obj/item/proc/examine_worn_title(mob/living/wearer, mob/user, skip_examine_link = FALSE)
-	if (!user)
-		CRASH("Cannot generate worn examination title without a user, worn titles require the target which you are showing them to.")
-	if (!user.client)
-		CRASH("Attempting to generate worn title for a mob without a client, which is not allowed.")
+	ASSERT(user, "Cannot generate worn examination title without a user, worn titles require the target which you are showing them to.")
+	ASSERT(user.client, "Attempting to generate worn title for a mob without a client, which is not allowed.")
 	var/examine_name = get_examine_name(user)
 
 	// Don't add examine link if this is the item being directly examined

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -1649,32 +1649,34 @@ GLOBAL_VAR_INIT(rpg_loot_items, FALSE)
 		usr.examinate(src)
 		return TRUE
 
-/obj/item/examine_title(mob/user, thats = FALSE)
-	// Items use get_examine_line() which includes blood stains, ID links, examine links, etc.
-	// When thats=TRUE, this is the main item being examined, so skip the self-referential examine link
-	// When thats=FALSE, this is an inventory item, so include the examine link
-	var/examine_line = get_examine_line(skip_examine_link = thats)
-	if(thats)
-		examine_line = "[examine_thats] [examine_line]"
-	return examine_line
-
-/obj/item/proc/get_examine_line(skip_examine_link = FALSE)
-	var/whole_word = usr?.client?.prefs?.read_player_preference(/datum/preference/toggle/whole_word_examine_links)
-	var/examine_name = get_examine_name(usr)
+/// Gets the examination title of an item that is equipped by another mob, this is what
+/// shows on every line when you examine someone. Certain things, such as uniforms, may include
+/// more details such as information on the accessories equipped which would not be appropriate
+/// in the title of that item.
+/// This proc also appends inspection links, which can be clicked in the chatbox to examine this
+/// item in greater detail.
+/obj/item/proc/examine_worn_title(mob/user, skip_examine_link = FALSE)
+	if (!user)
+		CRASH("Cannot generate worn examination title without a user, worn titles require the target which you are showing them to.")
+	if (!user.client)
+		CRASH("Attempting to generate worn title for a mob without a client, which is not allowed.")
+	var/examine_name = get_examine_name(user)
 
 	// Don't add examine link if this is the item being directly examined
 	if(skip_examine_link)
-		return "[icon2html(src, viewers(get_turf(src)))] [examine_name]"
+		return "[icon2html(src, user.client)] [examine_name]"
+	return examine_inspection_link(user, "[icon2html(src, user.client)] [examine_name]")
 
+/// Appends the inspection links to the name of this item.
+/// This may be overriden to provice custom inspection commands, or may be called with a custom item name
+/// that differs from the returned examine name of the item.
+/obj/item/proc/examine_inspection_link(mob/user, examine_name)
+	var/whole_word = user.client.prefs?.read_player_preference(/datum/preference/toggle/whole_word_examine_links)
 	var/obj/item/card/id/ID = GetID()
 	if(ID)
-		if(whole_word)
-			return "<a href='byond://?src=\ref[src];examine=1'>[icon2html(src, viewers(get_turf(src)))] [examine_name]</a> <a href='byond://?src=\ref[ID];look_at_id=1'>\[Look at ID\]</a>"
-		else
-			return "[icon2html(src, viewers(get_turf(src)))] [examine_name] <a href='byond://?src=\ref[ID];look_at_id=1'>\[Look at ID\]</a>"
+		return "[examine_name] <a href='byond://?src=\ref[ID];look_at_id=1'>\[Examine ID\]</a>"
 	else
 		if(whole_word)
-			return "<a href='byond://?src=\ref[src];examine=1'>[icon2html(src, viewers(get_turf(src)))] [examine_name]</a>"
+			return "<a href='byond://?src=\ref[src];examine=1'>[examine_name]</a>"
 		else
-			return "[icon2html(src, viewers(get_turf(src)))] [examine_name] <a href='byond://?src=\ref[src];examine=1'>\[?\]</a>"
-
+			return "[examine_name] <a href='byond://?src=\ref[src];examine=1'>\[?\]</a>"

--- a/code/game/objects/items/storage/belt.dm
+++ b/code/game/objects/items/storage/belt.dm
@@ -866,14 +866,14 @@
 	atom_storage.max_specific_storage = WEIGHT_CLASS_SMALL
 
 /obj/item/storage/belt/fannypack/worn
-	name = "Worn belt"
+	name = "worn belt"
 	desc = "A weathered belt"
 	icon_state = "utilitybelt" //Placeholder for now.
 	inhand_icon_state = "utility"
 	worn_icon_state = "utility"
 
 /obj/item/storage/belt/fannypack/worn/detective //Starting contents defined in detective.dm where the rest of their loadout is handled.
-	name = "Worn belt"
+	name = "worn belt"
 	desc = "A weathered belt that is used for storing various gadgets"
 
 /obj/item/storage/belt/fannypack/black

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -655,23 +655,6 @@ BLIND	 // can't see anything
 	if (!is_mining_level(T.z))
 		return . * high_pressure_multiplier
 
-/obj/item/clothing/get_examine_line(skip_examine_link = FALSE)
-	. = ..()
-	// Check if we have an attached accessory that should be visible
-	if(!istype(src, /obj/item/clothing/under))
-		return
-	var/obj/item/clothing/under/U = src
-	if(!U.attached_accessory)
-		return
-	var/covered = FALSE
-	// Check if the accessory is hidden by a suit
-	if(ishuman(loc))
-		var/mob/living/carbon/human/H = loc
-		if(src == H.w_uniform && H.wear_suit && !U.attached_accessory.above_suit)
-			covered = H.wear_suit.body_parts_covered & U.attached_accessory.attachment_slot
-	if(!covered)
-		. += " with \icon[U.attached_accessory] \a [U.attached_accessory] attached"
-
 #undef SENSORS_OFF
 #undef SENSORS_BINARY
 #undef SENSORS_VITALS

--- a/code/modules/clothing/under/_under.dm
+++ b/code/modules/clothing/under/_under.dm
@@ -405,15 +405,15 @@
 
 	return FALSE
 
-/obj/item/clothing/under/examine_worn_title(mob/user, skip_examine_link)
+/obj/item/clothing/under/examine_worn_title(mob/living/wearer, mob/user, skip_examine_link = FALSE)
 	. = ..()
 	if(!attached_accessory)
 		return
 	var/covered = FALSE
 	// Check if the accessory is hidden by a suit
-	if(ishuman(loc))
-		var/mob/living/carbon/human/H = loc
+	if(ishuman(wearer))
+		var/mob/living/carbon/human/H = wearer
 		if(src == H.w_uniform && H.wear_suit && !attached_accessory.above_suit)
 			covered = H.wear_suit.body_parts_covered & attached_accessory.attachment_slot
-	if(!covered)
-		. += " with [attached_accessory.examine_worn_title(user)] attached"
+	if(!covered || wearer == user)
+		. += " with [attached_accessory.examine_worn_title(wearer, user)] attached"

--- a/code/modules/clothing/under/_under.dm
+++ b/code/modules/clothing/under/_under.dm
@@ -404,3 +404,16 @@
 		return TRUE
 
 	return FALSE
+
+/obj/item/clothing/under/examine_worn_title(mob/user, skip_examine_link)
+	. = ..()
+	if(!attached_accessory)
+		return
+	var/covered = FALSE
+	// Check if the accessory is hidden by a suit
+	if(ishuman(loc))
+		var/mob/living/carbon/human/H = loc
+		if(src == H.w_uniform && H.wear_suit && !attached_accessory.above_suit)
+			covered = H.wear_suit.body_parts_covered & attached_accessory.attachment_slot
+	if(!covered)
+		. += " with [attached_accessory.examine_worn_title(user)] attached"

--- a/code/modules/clothing/under/accessories.dm
+++ b/code/modules/clothing/under/accessories.dm
@@ -432,17 +432,12 @@
 //Security Badges
 /obj/item/clothing/accessory/badge
 	name = "badge"
+	desc = "A badge that symbolises a person's authority as a member of security."
 	icon_state = "officerbadge"
 	worn_icon_state = "officerbadge"
 	w_class = WEIGHT_CLASS_TINY
 	var/badge_title = "Security Officer"
 	var/officer_name
-
-/obj/item/clothing/accessory/badge/get_examine_line(skip_examine_link = FALSE)
-	. = ..()
-	// Only add the View link if we're not skipping examine links
-	if(!skip_examine_link)
-		. += " <a href='byond://?src=\ref[src];look_at_me=1'>\[View\]</a>"
 
 /obj/item/clothing/accessory/badge/examine(mob/user)
 	. = ..()
@@ -468,16 +463,6 @@
 		user.visible_message(span_danger("[user] invades [target]'s personal space, thrusting \the [src] into their face insistently."), span_danger("You invade [target]'s personal space, thrusting \the [src] into their face insistently."))
 		if (officer_name)
 			to_chat(target, span_warning("The [src]'s text reads: [officer_name], [badge_title]."))
-
-/obj/item/clothing/accessory/badge/Topic(href, href_list)
-	. = ..()
-	if(!usr.canUseTopic(src, BE_CLOSE))
-		return
-	add_fingerprint(usr)
-
-	if (href_list["look_at_me"])
-		usr.examinate(src)
-		return TRUE
 
 /obj/item/clothing/accessory/badge/det
 	icon_state = "detbadge"

--- a/code/modules/mob/living/carbon/examine.dm
+++ b/code/modules/mob/living/carbon/examine.dm
@@ -326,53 +326,53 @@
 
 	//uniform
 	if(w_uniform && !(obscured & ITEM_SLOT_ICLOTHING) && !HAS_TRAIT(w_uniform, TRAIT_EXAMINE_SKIP))
-		. += "[t_He] [t_is] wearing [w_uniform.examine_worn_title(user)]."
+		. += "[t_He] [t_is] wearing [w_uniform.examine_worn_title(src, user)]."
 	//head
 	if(head && !(obscured & ITEM_SLOT_HEAD) && !HAS_TRAIT(head, TRAIT_EXAMINE_SKIP))
-		. += "[t_He] [t_is] wearing [head.examine_worn_title(user)] on [t_his] head."
+		. += "[t_He] [t_is] wearing [head.examine_worn_title(src, user)] on [t_his] head."
 	//mask
 	if(wear_mask && !(obscured & ITEM_SLOT_MASK)  && !HAS_TRAIT(wear_mask, TRAIT_EXAMINE_SKIP))
-		. += "[t_He] [t_has] [wear_mask.examine_worn_title(user)] on [t_his] face."
+		. += "[t_He] [t_has] [wear_mask.examine_worn_title(src, user)] on [t_his] face."
 	//neck
 	if(wear_neck && !(obscured & ITEM_SLOT_NECK)  && !HAS_TRAIT(wear_neck, TRAIT_EXAMINE_SKIP))
-		. += "[t_He] [t_is] wearing [wear_neck.examine_worn_title(user)] around [t_his] neck."
+		. += "[t_He] [t_is] wearing [wear_neck.examine_worn_title(src, user)] around [t_his] neck."
 	//eyes
 	if(!(obscured & ITEM_SLOT_EYES) )
 		if(glasses  && !HAS_TRAIT(glasses, TRAIT_EXAMINE_SKIP))
-			. += "[t_He] [t_has] [glasses.examine_worn_title(user)] covering [t_his] eyes."
+			. += "[t_He] [t_has] [glasses.examine_worn_title(src, user)] covering [t_his] eyes."
 		else if(HAS_TRAIT(src, CULT_EYES))
 			. += span_boldwarning("[t_His] eyes are glowing with an unnatural red aura!")
 	//ears
 	if(ears && !(obscured & ITEM_SLOT_EARS) && !HAS_TRAIT(ears, TRAIT_EXAMINE_SKIP))
-		. += "[t_He] [t_has] [ears.examine_worn_title(user)] on [t_his] ears."
+		. += "[t_He] [t_has] [ears.examine_worn_title(src, user)] on [t_his] ears."
 	//suit/armor
 	if(wear_suit && !HAS_TRAIT(wear_suit, TRAIT_EXAMINE_SKIP))
-		. += "[t_He] [t_is] wearing [wear_suit.examine_worn_title(user)]."
+		. += "[t_He] [t_is] wearing [wear_suit.examine_worn_title(src, user)]."
 		//suit/armor storage
 		if(s_store && !(obscured & ITEM_SLOT_SUITSTORE) && !HAS_TRAIT(s_store, TRAIT_EXAMINE_SKIP))
-			. += "[t_He] [t_is] carrying [s_store.examine_worn_title(user)] on [t_his] [wear_suit.name]."
+			. += "[t_He] [t_is] carrying [s_store.examine_worn_title(src, user)] on [t_his] [wear_suit.name]."
 	//back
 	if(back && !HAS_TRAIT(back, TRAIT_EXAMINE_SKIP))
-		. += "[t_He] [t_has] [back.examine_worn_title(user)] on [t_his] back."
+		. += "[t_He] [t_has] [back.examine_worn_title(src, user)] on [t_his] back."
 	//ID
 	if(wear_id && !HAS_TRAIT(wear_id, TRAIT_EXAMINE_SKIP))
 		var/obj/item/card/id/id = wear_id.GetID()
 		if(id && get_dist(user, src) <= ID_EXAMINE_DISTANCE)
 			// Get the item description without any examine link, then add our own clickable [Look at ID] link
-			var/id_line = wear_id.examine_worn_title(user, skip_examine_link = TRUE)
+			var/id_line = wear_id.examine_worn_title(src, user, skip_examine_link = TRUE)
 			var/id_link = "<a href='byond://?src=[REF(src)];see_id=1;id_ref=[REF(id)];id_name=[id.registered_name];examine_time=[world.time]'>\[Look at ID\]</a>"
 			. += "[t_He] [t_is] wearing [id_line] [id_link]."
 
 		else
-			. += "[t_He] [t_is] wearing [wear_id.examine_worn_title(user)]."
+			. += "[t_He] [t_is] wearing [wear_id.examine_worn_title(src, user)]."
 	//Hands
 	for(var/obj/item/held_thing in held_items)
 		if((held_thing.item_flags & (ABSTRACT|HAND_ITEM)) || HAS_TRAIT(held_thing, TRAIT_EXAMINE_SKIP))
 			continue
-		. += "[t_He] [t_is] holding [held_thing.examine_worn_title(user)] in [t_his] [get_held_index_name(get_held_index_of_item(held_thing))]."
+		. += "[t_He] [t_is] holding [held_thing.examine_worn_title(src, user)] in [t_his] [get_held_index_name(get_held_index_of_item(held_thing))]."
 	//gloves
 	if(gloves && !(obscured & ITEM_SLOT_GLOVES) && !HAS_TRAIT(gloves, TRAIT_EXAMINE_SKIP))
-		. += "[t_He] [t_has] [gloves.examine_worn_title(user)] on [t_his] hands."
+		. += "[t_He] [t_has] [gloves.examine_worn_title(src, user)] on [t_his] hands."
 	else if(GET_ATOM_BLOOD_DNA_LENGTH(src) || blood_in_hands)
 		if(num_hands)
 			. += span_warning("[t_He] [t_has] [num_hands > 1 ? "" : "a "]blood-stained hand[num_hands > 1 ? "s" : ""]!")
@@ -382,10 +382,10 @@
 		. += span_warning("[t_He] [t_is] [icon2html(handcuffed, user)] [cables_or_cuffs]!")
 	//belt
 	if(belt && !(obscured & ITEM_SLOT_BELT) && !HAS_TRAIT(belt, TRAIT_EXAMINE_SKIP))
-		. += "[t_He] [t_has] [belt.examine_worn_title(user)] about [t_his] waist."
+		. += "[t_He] [t_has] [belt.examine_worn_title(src, user)] about [t_his] waist."
 	//shoes
 	if(shoes && !(obscured & ITEM_SLOT_FEET)  && !HAS_TRAIT(shoes, TRAIT_EXAMINE_SKIP))
-		. += "[t_He] [t_is] wearing [shoes.examine_worn_title(user)] on [t_his] feet."
+		. += "[t_He] [t_is] wearing [shoes.examine_worn_title(src, user)] on [t_his] feet."
 
 /// Collects info displayed about any HUDs the user has when examining src
 /mob/living/carbon/proc/get_hud_examine_info(mob/living/user)

--- a/code/modules/mob/living/carbon/examine.dm
+++ b/code/modules/mob/living/carbon/examine.dm
@@ -326,60 +326,53 @@
 
 	//uniform
 	if(w_uniform && !(obscured & ITEM_SLOT_ICLOTHING) && !HAS_TRAIT(w_uniform, TRAIT_EXAMINE_SKIP))
-		//accessory
-		var/accessory_message = ""
-		if(istype(w_uniform, /obj/item/clothing/under))
-			var/obj/item/clothing/under/undershirt = w_uniform
-			if(undershirt.attached_accessory)
-				accessory_message += " with [icon2html(undershirt.attached_accessory, user)] \a [undershirt.attached_accessory]"
-
-		. += "[t_He] [t_is] wearing [w_uniform.examine_title(user)][accessory_message]."
+		. += "[t_He] [t_is] wearing [w_uniform.examine_worn_title(user)]."
 	//head
 	if(head && !(obscured & ITEM_SLOT_HEAD) && !HAS_TRAIT(head, TRAIT_EXAMINE_SKIP))
-		. += "[t_He] [t_is] wearing [head.examine_title(user)] on [t_his] head."
+		. += "[t_He] [t_is] wearing [head.examine_worn_title(user)] on [t_his] head."
 	//mask
 	if(wear_mask && !(obscured & ITEM_SLOT_MASK)  && !HAS_TRAIT(wear_mask, TRAIT_EXAMINE_SKIP))
-		. += "[t_He] [t_has] [wear_mask.examine_title(user)] on [t_his] face."
+		. += "[t_He] [t_has] [wear_mask.examine_worn_title(user)] on [t_his] face."
 	//neck
 	if(wear_neck && !(obscured & ITEM_SLOT_NECK)  && !HAS_TRAIT(wear_neck, TRAIT_EXAMINE_SKIP))
-		. += "[t_He] [t_is] wearing [wear_neck.examine_title(user)] around [t_his] neck."
+		. += "[t_He] [t_is] wearing [wear_neck.examine_worn_title(user)] around [t_his] neck."
 	//eyes
 	if(!(obscured & ITEM_SLOT_EYES) )
 		if(glasses  && !HAS_TRAIT(glasses, TRAIT_EXAMINE_SKIP))
-			. += "[t_He] [t_has] [glasses.examine_title(user)] covering [t_his] eyes."
+			. += "[t_He] [t_has] [glasses.examine_worn_title(user)] covering [t_his] eyes."
 		else if(HAS_TRAIT(src, CULT_EYES))
 			. += span_boldwarning("[t_His] eyes are glowing with an unnatural red aura!")
 	//ears
 	if(ears && !(obscured & ITEM_SLOT_EARS) && !HAS_TRAIT(ears, TRAIT_EXAMINE_SKIP))
-		. += "[t_He] [t_has] [ears.examine_title(user)] on [t_his] ears."
+		. += "[t_He] [t_has] [ears.examine_worn_title(user)] on [t_his] ears."
 	//suit/armor
 	if(wear_suit && !HAS_TRAIT(wear_suit, TRAIT_EXAMINE_SKIP))
-		. += "[t_He] [t_is] wearing [wear_suit.examine_title(user)]."
+		. += "[t_He] [t_is] wearing [wear_suit.examine_worn_title(user)]."
 		//suit/armor storage
 		if(s_store && !(obscured & ITEM_SLOT_SUITSTORE) && !HAS_TRAIT(s_store, TRAIT_EXAMINE_SKIP))
-			. += "[t_He] [t_is] carrying [s_store.examine_title(user)] on [t_his] [wear_suit.name]."
+			. += "[t_He] [t_is] carrying [s_store.examine_worn_title(user)] on [t_his] [wear_suit.name]."
 	//back
 	if(back && !HAS_TRAIT(back, TRAIT_EXAMINE_SKIP))
-		. += "[t_He] [t_has] [back.examine_title(user)] on [t_his] back."
+		. += "[t_He] [t_has] [back.examine_worn_title(user)] on [t_his] back."
 	//ID
 	if(wear_id && !HAS_TRAIT(wear_id, TRAIT_EXAMINE_SKIP))
 		var/obj/item/card/id/id = wear_id.GetID()
 		if(id && get_dist(user, src) <= ID_EXAMINE_DISTANCE)
 			// Get the item description without any examine link, then add our own clickable [Look at ID] link
-			var/id_line = wear_id.get_examine_line(skip_examine_link = TRUE)
+			var/id_line = wear_id.examine_worn_title(user, skip_examine_link = TRUE)
 			var/id_link = "<a href='byond://?src=[REF(src)];see_id=1;id_ref=[REF(id)];id_name=[id.registered_name];examine_time=[world.time]'>\[Look at ID\]</a>"
 			. += "[t_He] [t_is] wearing [id_line] [id_link]."
 
 		else
-			. += "[t_He] [t_is] wearing [wear_id.examine_title(user)]."
+			. += "[t_He] [t_is] wearing [wear_id.examine_worn_title(user)]."
 	//Hands
 	for(var/obj/item/held_thing in held_items)
 		if((held_thing.item_flags & (ABSTRACT|HAND_ITEM)) || HAS_TRAIT(held_thing, TRAIT_EXAMINE_SKIP))
 			continue
-		. += "[t_He] [t_is] holding [held_thing.examine_title(user)] in [t_his] [get_held_index_name(get_held_index_of_item(held_thing))]."
+		. += "[t_He] [t_is] holding [held_thing.examine_worn_title(user)] in [t_his] [get_held_index_name(get_held_index_of_item(held_thing))]."
 	//gloves
 	if(gloves && !(obscured & ITEM_SLOT_GLOVES) && !HAS_TRAIT(gloves, TRAIT_EXAMINE_SKIP))
-		. += "[t_He] [t_has] [gloves.examine_title(user)] on [t_his] hands."
+		. += "[t_He] [t_has] [gloves.examine_worn_title(user)] on [t_his] hands."
 	else if(GET_ATOM_BLOOD_DNA_LENGTH(src) || blood_in_hands)
 		if(num_hands)
 			. += span_warning("[t_He] [t_has] [num_hands > 1 ? "" : "a "]blood-stained hand[num_hands > 1 ? "s" : ""]!")
@@ -389,10 +382,10 @@
 		. += span_warning("[t_He] [t_is] [icon2html(handcuffed, user)] [cables_or_cuffs]!")
 	//belt
 	if(belt && !(obscured & ITEM_SLOT_BELT) && !HAS_TRAIT(belt, TRAIT_EXAMINE_SKIP))
-		. += "[t_He] [t_has] [belt.examine_title(user)] about [t_his] waist."
+		. += "[t_He] [t_has] [belt.examine_worn_title(user)] about [t_his] waist."
 	//shoes
 	if(shoes && !(obscured & ITEM_SLOT_FEET)  && !HAS_TRAIT(shoes, TRAIT_EXAMINE_SKIP))
-		. += "[t_He] [t_is] wearing [shoes.examine_title(user)] on [t_his] feet."
+		. += "[t_He] [t_is] wearing [shoes.examine_worn_title(user)] on [t_his] feet."
 
 /// Collects info displayed about any HUDs the user has when examining src
 /mob/living/carbon/proc/get_hud_examine_info(mob/living/user)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Does a slight refactor on the examination code, which should make it easier to override examination code appropriately.

- Removes the examine_title override for /obj/item, since it isn't necessary. The title should be the starting point for generating the examine line, rather than have the title use the examine line but with all the links stripped away.
- Seperates the link adding part from examine_worn_title, meaning that it can be overriden or called seperately.
- Renames get_examine_line to examine_worn_title, since it is the rendered title of the item when examined, rather than the whole line itself.
- Fixes the detective's belt's name being proper, since I noticed that while testing.
- Moves uniform accessory code to uniform instead of trying to use istype() on the parent clothing type.
- Accessories now use standardised code instead of trying to do \icon themselves.
- Adds a description to badges, since they were missing one and it would just show "Something went wrong"
- Modularises accessory examination into uniform, instead of keeping it inside examine.
- Removes the [Look at] action for badges, since it was just the exact same examination that everything else has.

## Why It's Good For The Game

Right now we need to do a bit of jank using skip_examine_link and usr to override the examine line for certain objects, which makes for some unclean code. This gives us better support for that and removes some unnecessary code.

## Testing Photographs and Procedure

<img width="790" height="194" alt="image" src="https://github.com/user-attachments/assets/1731f5c7-b0d3-41fe-8c05-187d4c1a853e" />

<img width="785" height="418" alt="image" src="https://github.com/user-attachments/assets/b590a2d5-6ddf-4902-8eef-9af0ebb9867d" />

<img width="788" height="360" alt="image" src="https://github.com/user-attachments/assets/b58e2d92-1fb2-40be-b28e-1bd5dc31c4ac" />

<img width="789" height="138" alt="image" src="https://github.com/user-attachments/assets/00bf5b07-2857-4f74-a8d5-ae2e0b54ab08" />

<img width="787" height="179" alt="image" src="https://github.com/user-attachments/assets/57ef13d3-8d48-4640-85ca-52f646b4b694" />

## Changelog
:cl: PowerfulBacon, RKz
refactor: Slightly cleans up some examination code to make it easier to override, improving support for things like custom examinations and accessories being shown on uniforms.
fix: Fixes security badges having no description.
fix: Fixes detective's belt being a proper noun.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
