### PR TITLE
Virtual z documentation, fixes immovable rod

### DIFF
--- a/code/__HELPERS/virtual_z_level.dm
+++ b/code/__HELPERS/virtual_z_level.dm
@@ -17,7 +17,7 @@
   *
   * For example, two shuttles both of the reserved z-levels have different virtual
   * z-levels and all content that compares z-levels (suit sensors, radios, etc.)
-  * should compare virtual-zs so that the are treated entirel independantly. If
+  * should compare virtual-zs so that the are treated entirely independently. If
   * you need to use physical Zs to get an area (such as with block), then you should
   * compare the virtual z values for each tile in that if the behaviour should be
   * locked down to a single z.

--- a/code/__HELPERS/virtual_z_level.dm
+++ b/code/__HELPERS/virtual_z_level.dm
@@ -8,9 +8,21 @@
 	return virtual_value ++
 
 /**
-  * Used to get the virtual z-level.
+  * Returns a logical z-value which must be used for comparing of two different
+  * locations are on the same z-level, or on different ones.
+  *
+  * This returns numbers outside of the range of world.maxz, and should not be
+  * used when you need to get a physical location such as with locate(), but
+  * should be used if you want to check if two turfs are on the same z.
+  *
+  * For example, two shuttles both of the reserved z-levels have different virtual
+  * z-levels and all content that compares z-levels (suit sensors, radios, etc.)
+  * should compare virtual-zs so that the are treated entirel independantly. If
+  * you need to use physical Zs to get an area (such as with block), then you should
+  * compare the virtual z values for each tile in that if the behaviour should be
+  * locked down to a single z.
+  *
   * Will give unique values to each shuttle while it is in a transit level.
-  * Note: If the user teleports to another virtual z on the same z-level they will need to have reset_virtual_z called. (Teleportations etc.)
   */
 /atom/proc/get_virtual_z_level()
 	var/turf/T = get_turf(src)

--- a/code/game/objects/items/teleportation.dm
+++ b/code/game/objects/items/teleportation.dm
@@ -51,7 +51,7 @@
 			var/turf/tr = get_turf(W)
 
 			// Make sure it's on a turf and that its Z-level matches the tracker's Z-level
-			if (tr && tr.z == sr.z)
+			if (tr && tr.get_virtual_z_level() == sr.get_virtual_z_level())
 				// Get the distance between the beacon's turf and our turf
 				var/distance = max(abs(tr.x - sr.x), abs(tr.y - sr.y))
 

--- a/code/modules/events/immovable_rod.dm
+++ b/code/modules/events/immovable_rod.dm
@@ -58,7 +58,7 @@ In my current plan for it, 'solid' will be defined as anything with density == 1
 	var/notify = TRUE
 	var/atom/special_target
 
-/obj/effect/immovablerod/New(atom/start, atom/end, aimed_at)
+/obj/effect/immovablerod/Initialize(mapload, atom/end, aimed_at)
 	..()
 	SSaugury.register_doom(src, 2000)
 	z_original = get_virtual_z_level()
@@ -73,6 +73,7 @@ In my current plan for it, 'solid' will be defined as anything with density == 1
 		if(T.get_virtual_z_level() == z_original)
 			special_target_valid = TRUE
 	if(special_target_valid)
+		destination = special_target
 		SSmove_manager.home_onto(src, special_target)
 		previous_distance = get_dist(src, special_target)
 	else if(end && end.get_virtual_z_level() == z_original)

--- a/code/modules/events/immovable_rod.dm
+++ b/code/modules/events/immovable_rod.dm
@@ -61,7 +61,7 @@ In my current plan for it, 'solid' will be defined as anything with density == 1
 /obj/effect/immovablerod/New(atom/start, atom/end, aimed_at)
 	..()
 	SSaugury.register_doom(src, 2000)
-	z_original = z
+	z_original = get_virtual_z_level()
 	destination = end
 	special_target = aimed_at
 	AddElement(/datum/element/point_of_interest)
@@ -70,12 +70,12 @@ In my current plan for it, 'solid' will be defined as anything with density == 1
 	var/special_target_valid = FALSE
 	if(special_target)
 		var/turf/T = get_turf(special_target)
-		if(T.z == z_original)
+		if(T.get_virtual_z_level() == z_original)
 			special_target_valid = TRUE
 	if(special_target_valid)
 		SSmove_manager.home_onto(src, special_target)
 		previous_distance = get_dist(src, special_target)
-	else if(end && end.z==z_original)
+	else if(end && end.get_virtual_z_level() == z_original)
 		SSmove_manager.home_onto(src, destination)
 		previous_distance = get_dist(src, destination)
 
@@ -94,7 +94,7 @@ In my current plan for it, 'solid' will be defined as anything with density == 1
 		return ..()
 	//Moved more than 10 tiles in 1 move.
 	var/cur_dist = get_dist(src, destination)
-	if((z != z_original) || (loc == destination) || (FLOOR(cur_dist - previous_distance, 1) > 10))
+	if((get_virtual_z_level() != z_original) || (loc == destination) || (FLOOR(cur_dist - previous_distance, 1) > 10))
 		qdel(src)
 	previous_distance = cur_dist
 	if(special_target && loc == get_turf(special_target))

--- a/code/modules/modular_computers/file_system/programs/rbmk_monitor.dm
+++ b/code/modules/modular_computers/file_system/programs/rbmk_monitor.dm
@@ -52,7 +52,7 @@
 		return
 	for(var/obj/machinery/atmospherics/components/unary/rbmk/core/reactor in GLOB.machines)
 		// Exclude Syndicate owned, Delaminating, not within coverage, not on a tile.
-		if(!isturf(reactor.loc) || !(is_station_level(reactor.z) || is_mining_level(reactor.z) || reactor.z == user_turf.z))
+		if(!isturf(reactor.loc) || !(is_station_level(reactor.z) || is_mining_level(reactor.z) || reactor.get_virtual_z_level() == user_turf.get_virtual_z_level()))
 			continue
 		reactors += reactor
 		RegisterSignal(reactor, COMSIG_QDELETING, PROC_REF(clear_reactor))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes some bad logical z checks and adds virtual z documentation.

## Why It's Good For The Game

Makes it easier to use since you can ctrl-click to see exactly what it is for.

## Testing Photographs and Procedure

Immovable rod is really hard to show but here is it only breaking one shuttle:

<img width="702" height="659" alt="image" src="https://github.com/user-attachments/assets/52b311be-ef86-4f23-bf75-3c39f00e692a" />

Here is it breaking the station

<img width="815" height="294" alt="image" src="https://github.com/user-attachments/assets/d2ce44c5-1826-4f5b-b528-eda990d3e197" />


## Changelog
:cl:
tweak: Adds some documentation to get_virtual_z and fixes the logical z comparisons of nuclear reactors and immovable rods.
fix: Fixes immovable rod appearing to not work correctly.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
