### PR TITLE
Fixes bleeding being 5x faster than it was previously

### DIFF
--- a/code/modules/mob/living/blood.dm
+++ b/code/modules/mob/living/blood.dm
@@ -57,7 +57,7 @@ bleedsuppress has been replaced for is_bandaged(). Note that is_bleeding() retur
 		// For heavy bleeding, leave drops if we are standing.
 		// If we are lying down, allow the trail to form
 		// This doesn't actually cause you to lose blood any faster
-		if (bleed_rate > BLEED_RATE_MINOR && owner.body_position == STANDING_UP)
+		if (bleed_rate > BLEED_RATE_MINOR && owner.body_position == STANDING_UP && !HAS_TRAIT(owner, TRAIT_BLEED_HELD))
 			owner.add_splatter_floor(owner.loc, TRUE)
 		return
 	time_applied = 0

--- a/code/modules/mob/living/blood.dm
+++ b/code/modules/mob/living/blood.dm
@@ -50,8 +50,6 @@ bleedsuppress has been replaced for is_bandaged(). Note that is_bleeding() retur
 
 	time_applied += seconds_between_ticks SECONDS
 
-	// For light bleeding, only process healing/bleeding every 1 second
-	// For heavy bleeding, process every tick (0.2 seconds)
 	var/should_process = time_applied >= 1 SECONDS
 	if (!should_process)
 		// For heavy bleeding, leave drops if we are standing.

--- a/code/modules/mob/living/blood.dm
+++ b/code/modules/mob/living/blood.dm
@@ -355,7 +355,7 @@ bleedsuppress has been replaced for is_bandaged(). Note that is_bleeding() retur
 			decrease_multiplier = BLEED_RATE_MULTIPLIER_NO_HEART
 		var/blood_loss_amount = blood_volume - blood_volume * NUM_E ** (-(amt * decrease_multiplier)/BLOOD_VOLUME_NORMAL)
 		blood_volume = max(blood_volume - blood_loss_amount, 0)
-		if(isturf(src.loc) && !isgroundlessturf(src.loc) && prob(sqrt(blood_loss_amount)*BLOOD_DRIP_RATE_MOD)) //Blood loss still happens in locker, floor stays clean
+		if(prob(sqrt(blood_loss_amount)*BLOOD_DRIP_RATE_MOD)) //Blood loss still happens in locker, floor stays clean
 			if(blood_loss_amount >= 2)
 				add_splatter_floor(src.loc)
 			else
@@ -499,8 +499,10 @@ bleedsuppress has been replaced for is_bandaged(). Note that is_bleeding() retur
 		return
 	if(get_blood_id() != /datum/reagent/blood)
 		return
-	if(!T)
+	if(!isturf(T))
 		T = get_turf(src)
+	if (!T || isgroundlessturf(T))
+		return
 
 	var/list/temp_blood_DNA
 	if(small_drip)

--- a/code/modules/mob/living/blood.dm
+++ b/code/modules/mob/living/blood.dm
@@ -499,8 +499,10 @@ bleedsuppress has been replaced for is_bandaged(). Note that is_bleeding() retur
 		return
 	if(get_blood_id() != /datum/reagent/blood)
 		return
-	if(!isturf(T))
+	if (!T)
 		T = get_turf(src)
+	if(!isturf(T))
+		T = get_turf(T)
 	if (!T || isgroundlessturf(T))
 		return
 

--- a/code/modules/mob/living/blood.dm
+++ b/code/modules/mob/living/blood.dm
@@ -501,7 +501,7 @@ bleedsuppress has been replaced for is_bandaged(). Note that is_bleeding() retur
 		return
 	if (!T)
 		T = get_turf(src)
-	if(!isturf(T))
+	if(T && !isturf(T))
 		T = get_turf(T)
 	if (!T || isgroundlessturf(T))
 		return

--- a/code/modules/mob/living/blood.dm
+++ b/code/modules/mob/living/blood.dm
@@ -28,11 +28,10 @@ bleedsuppress has been replaced for is_bandaged(). Note that is_bleeding() retur
 	id = "bleeding"
 	status_type = STATUS_EFFECT_MERGE
 	alert_type = /atom/movable/screen/alert/status_effect/bleeding
-	tick_interval = 0.2 SECONDS
+	tick_interval = 1 SECONDS
 
 	var/bandaged_bleeding = 0
 	var/bleed_rate = 0
-	var/time_applied = 0
 	var/bleed_heal_multiplier = 1
 
 /datum/status_effect/bleeding/merge(bleed_level)
@@ -47,15 +46,6 @@ bleedsuppress has been replaced for is_bandaged(). Note that is_bleeding() retur
 	if (HAS_TRAIT(owner, TRAIT_NO_BLOOD))
 		qdel(src)
 		return
-
-	time_applied += seconds_between_ticks SECONDS
-
-	// For light bleeding, only process healing/bleeding every 1 second
-	// For heavy bleeding, process every tick (0.2 seconds)
-	var/should_process = (bleed_rate > BLEED_RATE_MINOR) || (time_applied >= 1 SECONDS)
-	if (!should_process)
-		return
-	time_applied = 0
 	// Non-humans stop bleeding a lot quicker, even if it is not a minor cut
 	if (!ishuman(owner))
 		bleed_rate -= BLEED_HEAL_RATE_MINOR * 4 * bleed_heal_multiplier


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

The original bleeding (#10372) contained a bug, where bleeding would always occur once per second even when bleeding heavily. It was intended in the code that if you had serious bleeding, you would drop more blood. This bug was fixed in #13542 which in turn made bleeding 5x faster than had previously become used to. While this would have been noticed in a PR testing bleeding as a design issue, here it was only a bug fix so went unnoticed which had resulted in multiple attempts to fix this issue.

- Actual blood loss only happens every second, even during deep bleeding.
- If you are deep bleeding, then you drop small splatters of blood every 0.2 seconds (but these don't consume any blood)

## Why It's Good For The Game

Currently we bleed out way too quickly which results in a far quicker death than was originally intended. Even if bleeding fast was intended in the code, bleeding was designed based off of practical testing so this was not intended when the PR was completed.

## Testing Photographs and Procedure

https://github.com/user-attachments/assets/d68be7a5-a05e-4336-b418-af9473090086

## Changelog
:cl:
fix: Fixes players bleeding out 5 times faster than intended when having more than 2.4 bleed.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
