### PR TITLE
Fixes shield belt not activating correctly

### DIFF
--- a/code/datums/components/shielded.dm
+++ b/code/datums/components/shielded.dm
@@ -203,6 +203,10 @@
 	RegisterSignal(wearer, COMSIG_QDELETING, PROC_REF(lost_wearer))
 	if(current_integrity)
 		wearer.update_appearance(UPDATE_ICON)
+	// re-add effects when the shield recovers
+	if (!_effects_activated)
+		on_active_effects?.Invoke(wearer, current_integrity)
+		_effects_activated = TRUE
 
 /// Used to draw the shield overlay on the wearer
 /datum/component/shielded/proc/on_update_overlays(atom/parent_atom, list/overlays)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

- Activate effect now applies when the shielded component is equipped, meaning shield belt works again.

## Why It's Good For The Game

Shield belt works correctly, nothing else uses this activate effect and it doesn't work properly anyway.

## Testing Photographs and Procedure


https://github.com/user-attachments/assets/d2a3a8d7-525f-48bc-b90c-c9b44dcc05aa



## Changelog
:cl:
fix: Fixes shield belt not applying its effects when equipped
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
