### PR TITLE
Fixes simplified eye stabbing

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -935,6 +935,24 @@ GLOBAL_VAR_INIT(rpg_loot_items, FALSE)
 
 	user.do_attack_animation(M)
 
+	if(is_human_victim)
+		var/mob/living/carbon/human/U = M
+		var/blocked = U.run_armor_check(BODY_ZONE_HEAD, MELEE, armour_penetration = weapon.armour_penetration)
+		U.apply_damage(weapon.force, BRUTE, affecting, blocked = blocked)
+		if (prob(blocked))
+			if(M != user)
+				M.visible_message(span_danger("[user] stabbed [M] in the head with [src]!"), \
+									span_userdanger("[user] stabs you in the head with [src], but your armor protects your eyes!"))
+			else
+				user.visible_message( \
+					span_danger("[user] has stabbed [user.p_them()]self in the head with [src]!"), \
+					span_userdanger("You stab yourself in the head with [src], your armor protecting your eyes!") \
+				)
+			return TRUE
+
+	else
+		M.take_bodypart_damage(weapon.force)
+
 	if(M != user)
 		M.visible_message(span_danger("[user] has stabbed [M] in the eye with [src]!"), \
 							span_userdanger("[user] stabs you in the eye with [src]!"))
@@ -943,12 +961,6 @@ GLOBAL_VAR_INIT(rpg_loot_items, FALSE)
 			span_danger("[user] has stabbed [user.p_them()]self in the eyes with [src]!"), \
 			span_userdanger("You stab yourself in the eyes with [src]!") \
 		)
-	if(is_human_victim)
-		var/mob/living/carbon/human/U = M
-		U.apply_damage(weapon.force, BRUTE, affecting)
-
-	else
-		M.take_bodypart_damage(weapon.force)
 
 	SEND_SIGNAL(M, COMSIG_ADD_MOOD_EVENT, "eye_stab", /datum/mood_event/eye_stab)
 

--- a/code/game/objects/items/kitchen.dm
+++ b/code/game/objects/items/kitchen.dm
@@ -62,9 +62,7 @@
 			M = user
 		if (eyestab(M, user, src, silent = user.is_zone_selected(BODY_GROUP_CHEST_HEAD)))
 			return TRUE
-		return ..()
-	else
-		return ..()
+	return ..()
 
 /obj/item/knife/kitchen
 	name = "kitchen knife"

--- a/code/game/objects/items/kitchen.dm
+++ b/code/game/objects/items/kitchen.dm
@@ -57,10 +57,12 @@
 		icon_state = "fork"
 		forkload = null
 
-	else if(user.is_zone_selected(BODY_ZONE_PRECISE_EYES, simplified_probability = 30))
+	else if(user.is_zone_selected(BODY_ZONE_PRECISE_EYES, precise_only = TRUE) && user.is_zone_selected(BODY_GROUP_CHEST_HEAD))
 		if(HAS_TRAIT(user, TRAIT_CLUMSY) && prob(50))
 			M = user
-		return eyestab(M,user)
+		if (eyestab(M, user, src, silent = user.is_zone_selected(BODY_GROUP_CHEST_HEAD)))
+			return TRUE
+		return ..()
 	else
 		return ..()
 

--- a/code/game/objects/items/knives.dm
+++ b/code/game/objects/items/knives.dm
@@ -46,9 +46,7 @@
 			M = user
 		if (eyestab(M, user, src, silent = user.is_zone_selected(BODY_GROUP_CHEST_HEAD)))
 			return TRUE
-		return ..()
-	else
-		return ..()
+	return ..()
 
 ///Adds the butchering component, used to override stats for special cases
 /obj/item/knife/proc/set_butchering()

--- a/code/game/objects/items/knives.dm
+++ b/code/game/objects/items/knives.dm
@@ -41,10 +41,12 @@
 	set_butchering()
 
 /obj/item/knife/attack(mob/living/carbon/M, mob/living/carbon/user)
-	if(user.is_zone_selected(BODY_ZONE_PRECISE_EYES))
+	if(user.is_zone_selected(BODY_ZONE_PRECISE_EYES, precise_only = TRUE) || user.is_zone_selected(BODY_GROUP_CHEST_HEAD))
 		if(HAS_TRAIT(user, TRAIT_CLUMSY) && prob(50))
 			M = user
-		return eyestab(M,user)
+		if (eyestab(M, user, src, silent = user.is_zone_selected(BODY_GROUP_CHEST_HEAD)))
+			return TRUE
+		return ..()
 	else
 		return ..()
 

--- a/code/game/objects/items/tools/screwdriver.dm
+++ b/code/game/objects/items/tools/screwdriver.dm
@@ -64,14 +64,16 @@
 /obj/item/screwdriver/attack(mob/living/carbon/M, mob/living/carbon/user)
 	if(!istype(M))
 		return ..()
-	if(!user.is_zone_selected(BODY_ZONE_PRECISE_EYES, precise_only = TRUE) && !user.is_zone_selected(BODY_ZONE_HEAD, simplified_probability = 40))
+	if(!user.is_zone_selected(BODY_ZONE_PRECISE_EYES, precise_only = TRUE) && !user.is_zone_selected(BODY_GROUP_CHEST_HEAD))
 		return ..()
 	if(HAS_TRAIT(user, TRAIT_PACIFISM))
 		to_chat(user, span_warning("You don't want to harm [M]!"))
-		return
+		return TRUE
 	if(HAS_TRAIT(user, TRAIT_CLUMSY) && prob(50))
 		M = user
-	return eyestab(M,user)
+	if (eyestab(M, user, src, silent = user.is_zone_selected(BODY_GROUP_CHEST_HEAD)))
+		return TRUE
+	return ..()
 
 /obj/item/screwdriver/brass
 	name = "brass screwdriver"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

fixes #13920

- Simplified targeting will now eye stab when targeting the upper body.
- Eye-stabs now do the same amount of damage as a regular attack (rather than a fixed 7 damage) but also apply the blinding effect on top, meaning they are always optimal.

## Why It's Good For The Game

- Fixes some bad behaviour with the simplified targeting mode.

## Testing Photographs and Procedure

https://github.com/user-attachments/assets/f03c0109-568c-4cb7-8a0d-18c6a78f8f94

Screwdriver no armour:

<img width="189" height="40" alt="image" src="https://github.com/user-attachments/assets/9f066c90-ff9a-41ea-b5b8-28519a786963" />

Death commando armour:

<img width="213" height="34" alt="image" src="https://github.com/user-attachments/assets/7db61661-9ce2-4e61-88c3-01f51052f877" />

## Changelog
:cl:
fix: Eye-stabbing will now always deal the same damage as a regular attack, and will perform a regular attack if it fails making it behave better while on simplified mode.
fix: Fixes eye-stabbing having 100% armour penetration.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
