### PR TITLE
Fix Hydroponic Tray & Strange Reagent interaction

### DIFF
--- a/code/modules/hydroponics/hydroponics.dm
+++ b/code/modules/hydroponics/hydroponics.dm
@@ -964,7 +964,7 @@
 /obj/machinery/hydroponics/proc/spawnplant() // why would you put strange reagent in a hydro tray you monster I bet you also feed them blood
 	var/list/livingplants = list(/mob/living/simple_animal/hostile/tree, /mob/living/simple_animal/hostile/killertomato)
 	var/chosen = pick(livingplants)
-	var/mob/living/simple_animal/hostile/C = new chosen
+	var/mob/living/simple_animal/hostile/C = new chosen(get_turf(src))
 	C.faction = list(FACTION_PLANTS)
 
 /obj/machinery/hydroponics/proc/become_self_sufficient() // Ambrosia Gaia effect


### PR DESCRIPTION
## About The Pull Request

Fixes a **10** year old bug, with a reagent interaction on hydroponic trays.
When using strange reagent on a tray, it's supposed to spawn a plant monster, but it didn't. This amends that.

I'm sure now that it's fixed, we will enjoy its peak balancing.

## Why It's Good For The Game

This is a bug, unintended behaviour. 

## Testing Photographs and Procedure
<details>
<summary>Screenshots&Videos</summary>

<img width="433" height="444" alt="image" src="https://github.com/user-attachments/assets/a47fc745-ec22-400d-9be7-a89ac744d5a5" />

</details>

## Changelog
:cl:
fix: Fixes plant trays not properly spawning mobs when exposed to Strange Reagent.
/:cl:
