### PR TITLE
Buffs MOD Energy Shield, adds it to traitor uplink

### DIFF
--- a/code/modules/mod/modules/modules_antag.dm
+++ b/code/modules/mod/modules/modules_antag.dm
@@ -119,9 +119,9 @@
 	use_power_cost = DEFAULT_CHARGE_DRAIN * 2
 	incompatible_modules = list(/obj/item/mod/module/energy_shield)
 	required_slots = list(ITEM_SLOT_BACK)
-	max_integrity = 60 	/// Max integrity of the shield.
+	max_integrity = 80 	/// Max integrity of the shield.
 	/// How long we have to avoid being hit to start replenishing integrity.
-	var/recharge_start_delay = 20 SECONDS
+	var/recharge_start_delay = 10 SECONDS
 	/// Once we go unhit long enough to recharge, we replenish integrity this often.
 	var/charge_increment_delay = 1 SECONDS
 	/// How much integrity we recover on each increment.

--- a/code/modules/mod/modules/modules_antag.dm
+++ b/code/modules/mod/modules/modules_antag.dm
@@ -119,13 +119,13 @@
 	use_power_cost = DEFAULT_CHARGE_DRAIN * 2
 	incompatible_modules = list(/obj/item/mod/module/energy_shield)
 	required_slots = list(ITEM_SLOT_BACK)
-	max_integrity = 80 	/// Max integrity of the shield.
+	max_integrity = 60 	/// Max integrity of the shield.
 	/// How long we have to avoid being hit to start replenishing integrity.
-	var/recharge_start_delay = 10 SECONDS
+	var/recharge_start_delay = 5 SECONDS
 	/// Once we go unhit long enough to recharge, we replenish integrity this often.
 	var/charge_increment_delay = 1 SECONDS
 	/// How much integrity we recover on each increment.
-	var/charge_recovery = 20
+	var/charge_recovery = 5
 	/// The item path to recharge this shield.
 	var/recharge_path
 	/// The icon file of the shield.

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -1623,7 +1623,7 @@ GLOBAL_LIST_INIT(illegal_tech_blacklist, typecacheof(list(
 	desc = "An energy shield module for a MODsuit. The shield can handle small caliber gunfire, \
 			will rapidly recharge while not under fire."
 	item = /obj/item/mod/module/energy_shield
-	cost = 6
+	cost = 8
 
 /datum/uplink_item/suits/emp_shield
 	name = "MODsuit Advanced EMP Shield Module"

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -1623,7 +1623,7 @@ GLOBAL_LIST_INIT(illegal_tech_blacklist, typecacheof(list(
 	desc = "An energy shield module for a MODsuit. The shield can handle small caliber gunfire, \
 			will rapidly recharge while not under fire."
 	item = /obj/item/mod/module/energy_shield
-	cost = 8
+	cost = 6
 
 /datum/uplink_item/suits/emp_shield
 	name = "MODsuit Advanced EMP Shield Module"

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -1624,7 +1624,6 @@ GLOBAL_LIST_INIT(illegal_tech_blacklist, typecacheof(list(
 			will rapidly recharge while not under fire."
 	item = /obj/item/mod/module/energy_shield
 	cost = 8
-	purchasable_from = UPLINK_NUKE_OPS | UPLINK_CLOWN_OPS
 
 /datum/uplink_item/suits/emp_shield
 	name = "MODsuit Advanced EMP Shield Module"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This PR buffs the energy shield module, reducing the time it takes to recharge from not being hit to 5  seconds from 20
this means, it'll recharge a lot faster, but a lot less, you can be in fights a lot longer just keep in mind it's recharging 5 per increment

## Why It's Good For The Game

It was recently fixed, has barely been used and from the few people that have tried it, it's too weak 
With recent changes to https://github.com/BeeStation/BeeStation-Hornet/pull/13546 i find this might be a good addition to the traitor uplink, to hopefully help them in their path


## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

<img width="376" height="314" alt="image" src="https://github.com/user-attachments/assets/ceb58310-bf85-4244-abdb-872053c85f3f" />

<img width="845" height="554" alt="image" src="https://github.com/user-attachments/assets/47d5f0fb-c544-40f7-9fde-4c5e923f778e" />

<img width="1127" height="776" alt="image" src="https://github.com/user-attachments/assets/54632cda-5a92-485b-8742-1e01e28aa4a5" />


</details>

## Changelog
:cl:

balance: MOD energy shield can withstand 60 damage and recharges 5 seconds after not being hit, recharging 5 per second, roughly reaching max charge in 16 total seconds of not being hit
add: Mod Energy shield to the traitor uplink
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
