### PR TITLE
Fixes Firing speed on Plasma Cutter / Gravity Gun, nerfs delimb chance and mech plasma cutter

### DIFF
--- a/code/modules/projectiles/guns/energy/special.dm
+++ b/code/modules/projectiles/guns/energy/special.dm
@@ -117,7 +117,7 @@
 	usesound = list('sound/items/welder.ogg', 'sound/items/welder2.ogg')
 	tool_behaviour = TOOL_WELDER
 	weapon_weight = WEAPON_LIGHT
-	fire_rate = 3
+	fire_rate = 0.7
 	automatic = 1
 	toolspeed = 0.7 //plasmacutters can be used as welders, and are faster than standard welders
 	var/progress_flash_divisor = 10  //copypasta is best pasta
@@ -361,4 +361,5 @@
 	inhand_icon_state = "gravity_gun"
 	icon_state = "gravity_gun"
 	automatic_charge_overlays = FALSE
+	fire_rate = 0.5
 	var/power = 4

--- a/code/modules/projectiles/guns/energy/special.dm
+++ b/code/modules/projectiles/guns/energy/special.dm
@@ -117,7 +117,7 @@
 	usesound = list('sound/items/welder.ogg', 'sound/items/welder2.ogg')
 	tool_behaviour = TOOL_WELDER
 	weapon_weight = WEAPON_LIGHT
-	fire_rate = 0.7
+	fire_rate = 0.5 
 	automatic = 1
 	toolspeed = 0.7 //plasmacutters can be used as welders, and are faster than standard welders
 	var/progress_flash_divisor = 10  //copypasta is best pasta
@@ -361,5 +361,5 @@
 	inhand_icon_state = "gravity_gun"
 	icon_state = "gravity_gun"
 	automatic_charge_overlays = FALSE
-	fire_rate = 0.5
+	fire_rate = 0.2
 	var/power = 4

--- a/code/modules/projectiles/guns/energy/special.dm
+++ b/code/modules/projectiles/guns/energy/special.dm
@@ -208,6 +208,7 @@
 	icon_state = "adv_plasmacutter"
 	inhand_icon_state = "adv_plasmacutter"
 	force = 15
+	fire_rate = 0.75
 	ammo_type = list(/obj/item/ammo_casing/energy/plasma/adv)
 
 /obj/item/gun/energy/plasmacutter/cyborg

--- a/code/modules/projectiles/projectile/special/plasma.dm
+++ b/code/modules/projectiles/projectile/special/plasma.dm
@@ -4,7 +4,7 @@
 	damage_type = BRUTE
 	damage = 10
 	range = 4
-	dismemberment = 20
+	dismemberment = 10
 	impact_effect_type = /obj/effect/temp_visual/impact_effect/purple_laser
 	var/mine_range = 3 //mines this many additional tiles of rock
 	tracer_type = /obj/effect/projectile/tracer/plasma_cutter

--- a/code/modules/vehicles/mecha/equipment/weapons/weapons.dm
+++ b/code/modules/vehicles/mecha/equipment/weapons/weapons.dm
@@ -121,7 +121,7 @@
 	harmful = TRUE
 
 /obj/item/mecha_parts/mecha_equipment/weapon/energy/plasma
-	equip_cooldown = 10
+	equip_cooldown = 20
 	name = "217-D Heavy Plasma Cutter"
 	desc = "A device that shoots resonant plasma bursts at extreme velocity. The blasts are capable of crushing rock and demolishing solid obstacles."
 	icon_state = "mecha_plasmacutter"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Balances the Plasma Cutters, so they fire slower since it's way too much currently, added with their delimb chances


## Why It's Good For The Game

No more instadelimb / Getting pulled around 

Closes https://github.com/BeeStation/BeeStation-Hornet/issues/13937

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>


https://github.com/user-attachments/assets/6ddb333a-39a9-49eb-8d7a-b8dac62b2a4e

Sorry about the lag, my pc cant give more lol, gotta belive it ain't that slow 


</details>

## Changelog
:cl: Isaac
balance: Plasma Cutter now fires at a rate of 0.5
balance: Gravity gun now fires at a rate of 0.2
balance: Advanced Plasma Cutter now fires at a rate of 0.75
balance: Mech Plasma Cutter fires as fast as a regular plasma cutter
balance: Lowers the delimb chance to 10%, 1 out of 10 shots might cut your limb
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
