### PR TITLE
Fixes changeling ID sec hud

### DIFF
--- a/code/modules/antagonists/changeling/changeling.dm
+++ b/code/modules/antagonists/changeling/changeling.dm
@@ -479,6 +479,11 @@
 	new_profile.undershirt = target.undershirt
 	new_profile.socks = target.socks
 
+	var/obj/item/card/id/id_card = target.wear_id?.GetID()
+	if (istype(id_card))
+		new_profile.id_job_name = id_card.assignment
+		new_profile.id_hud_state = id_card.hud_state
+
 	// Hair and facial hair gradients, alongside their colours.
 	//new_profile.grad_style = LAZYLISTDUPLICATE(target.grad_style)
 	//new_profile.grad_color = LAZYLISTDUPLICATE(target.grad_color)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

fixes #13428

- Changeling ID will now appear correctly on the sechud

## Why It's Good For The Game

This just totally gives changelings away and makes transform suck

## Testing Photographs and Procedure

<img width="498" height="327" alt="image" src="https://github.com/user-attachments/assets/b4064dd1-7816-4344-9ab4-6fbc2f3e8e10" />


## Changelog
:cl:
fix: Changeling transformed IDs will now correctly display their job on the sechud.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
