### PR TITLE
TGUI lag fix

### DIFF
--- a/code/_onclick/hud/hud.dm
+++ b/code/_onclick/hud/hud.dm
@@ -163,7 +163,8 @@ GLOBAL_LIST_INIT(available_ui_styles, list(
 		return FALSE
 	// This code is the absolute fucking worst, I want it to go die in a fire
 	// Seriously, why
-	if(screenmob.client.prefs?.character_preview_view) // Changing HUDs clears the screen, we need to reregister then.
+	var/wants_preview = screenmob.client.prefs?.character_preview_view && (screenmob.client in screenmob.client.prefs?.character_preview_view.viewing_clients)
+	if(wants_preview) // Changing HUDs clears the screen, we need to reregister then.
 		screenmob.client.prefs.character_preview_view.unregister_from_client(screenmob.client)
 
 	screenmob.client.screen = list()
@@ -243,7 +244,8 @@ GLOBAL_LIST_INIT(available_ui_styles, list(
 	else if (viewmob.hud_used)
 		viewmob.hud_used.plane_masters_update()
 
-	if(screenmob.client.prefs?.character_preview_view) // Changing HUDs clears the screen, we need to reregister then.
+	// Changing HUDs clears the screen, we need to reregister then (but only if we are viewing it already)
+	if (wants_preview)
 		screenmob.client.prefs.character_preview_view.register_to_client(screenmob.client)
 
 	return TRUE

--- a/code/modules/client/preferences/submodules/preference_character_preview.dm
+++ b/code/modules/client/preferences/submodules/preference_character_preview.dm
@@ -2,8 +2,6 @@
 	if(istype(character_preview_view))
 		return
 	character_preview_view = new(null, src)
-	if(parent)
-		character_preview_view.register_to_client(parent)
 
 /datum/preferences/proc/render_new_preview_appearance(mob/living/carbon/human/dummy/mannequin)
 	var/datum/job/preview_job = get_highest_priority_job()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

fixes #13948

ByondUI is total shitcode, it feels like this issue exists because of how bad it is but this fix still works for now.

- Registering a ByondUI screen and then not rendering it causes lag issues.
- Prevents preferences from registering the character preview with your client every time you change mob.

## Why It's Good For The Game

This makes it so that you don't need to open and close the preferences menu every time you change mob to prevent violent lag. 

Not sure why this became an issue now, since this code has been like this since day 0. Perhaps only 516 causes the lag, but it has been present since day 1?

## Testing Photographs and Procedure

https://github.com/user-attachments/assets/5b1f595b-109d-4128-b37d-c300305f4b15

## Changelog
:cl:
fix: Fixes TGUI windows lagging the game when opened until you open the preferences screen.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
