### PR TITLE
remove power cell overrides

### DIFF
--- a/_maps/RandomRooms/5x4/sk_rdm047_metarobotics.dmm
+++ b/_maps/RandomRooms/5x4/sk_rdm047_metarobotics.dmm
@@ -74,10 +74,7 @@
 "n" = (
 /obj/structure/table,
 /obj/machinery/cell_charger,
-/obj/item/stock_parts/cell/high{
-	charge = 100;
-	maxcharge = 15000
-	},
+/obj/item/stock_parts/cell/high,
 /turf/open/floor/plating,
 /area/template_noop)
 "x" = (

--- a/_maps/RandomRuins/SpaceRuins/TheDerelict.dmm
+++ b/_maps/RandomRuins/SpaceRuins/TheDerelict.dmm
@@ -1551,10 +1551,7 @@
 /area/ruin/space/derelict/bridge/access)
 "fB" = (
 /obj/structure/table,
-/obj/item/stock_parts/cell{
-	charge = 100;
-	maxcharge = 15000
-	},
+/obj/item/stock_parts/cell,
 /turf/open/floor/iron/airless,
 /area/ruin/space/derelict/bridge/access)
 "fC" = (

--- a/_maps/RandomRuins/SpaceRuins/oldstation.dmm
+++ b/_maps/RandomRuins/SpaceRuins/oldstation.dmm
@@ -4273,10 +4273,7 @@
 /area/ruin/space/has_grav/ancientstation/rnd)
 "Fy" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/item/stock_parts/cell{
-	charge = 100;
-	maxcharge = 15000
-	},
+/obj/item/stock_parts/cell,
 /obj/effect/turf_decal/tile/yellow/half/contrasted{
 	dir = 4
 	},

--- a/_maps/RandomRuins/SpaceRuins/oldteleporter.dmm
+++ b/_maps/RandomRuins/SpaceRuins/oldteleporter.dmm
@@ -45,10 +45,7 @@
 /area/ruin/space/oldteleporter)
 "l" = (
 /obj/structure/table,
-/obj/item/stock_parts/cell{
-	charge = 100;
-	maxcharge = 15000
-	},
+/obj/item/stock_parts/cell,
 /turf/open/floor/iron/airless,
 /area/ruin/space/oldteleporter)
 "m" = (

--- a/_maps/RandomRuins/SpaceRuins/whiteshipruin_box.dmm
+++ b/_maps/RandomRuins/SpaceRuins/whiteshipruin_box.dmm
@@ -227,10 +227,7 @@
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/whiteship/box)
 "Ph" = (
-/obj/item/stock_parts/cell{
-	charge = 100;
-	maxcharge = 15000
-	},
+/obj/item/stock_parts/cell,
 /turf/open/floor/mineral/titanium/white,
 /area/ruin/space/has_grav/whiteship/box)
 "QS" = (

--- a/_maps/RuinGeneration/13x9_researchlab.dmm
+++ b/_maps/RuinGeneration/13x9_researchlab.dmm
@@ -228,10 +228,7 @@
 	},
 /obj/structure/table,
 /obj/machinery/cell_charger,
-/obj/item/stock_parts/cell/high{
-	charge = 100;
-	maxcharge = 15000
-	},
+/obj/item/stock_parts/cell/high,
 /obj/effect/turf_decal/tile/purple/opposingcorners,
 /turf/open/floor/iron,
 /area/ruin/unpowered)

--- a/_maps/RuinGeneration/9x13_teleporter.dmm
+++ b/_maps/RuinGeneration/9x13_teleporter.dmm
@@ -6,10 +6,7 @@
 /area/ruin/unpowered)
 "c" = (
 /obj/structure/table,
-/obj/item/stock_parts/cell{
-	charge = 100;
-	maxcharge = 15000
-	},
+/obj/item/stock_parts/cell,
 /turf/open/floor/iron/airless,
 /area/ruin/unpowered)
 "e" = (

--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -3500,9 +3500,7 @@
 "aZp" = (
 /obj/structure/rack,
 /obj/item/electronics/apc,
-/obj/item/stock_parts/cell{
-	maxcharge = 2000
-	},
+/obj/item/stock_parts/cell,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/quartermaster/warehouse)
@@ -54376,10 +54374,7 @@
 /obj/item/stack/cable_coil{
 	pixel_y = 4
 	},
-/obj/item/stock_parts/cell/high{
-	charge = 100;
-	maxcharge = 15000
-	},
+/obj/item/stock_parts/cell/high,
 /turf/open/floor/iron/techmaint,
 /area/storage/tech)
 "tEW" = (

--- a/_maps/map_files/CardinalStation/CardinalStation.dmm
+++ b/_maps/map_files/CardinalStation/CardinalStation.dmm
@@ -1776,10 +1776,7 @@
 	},
 /obj/structure/table/reinforced,
 /obj/machinery/cell_charger,
-/obj/item/stock_parts/cell/high{
-	charge = 100;
-	maxcharge = 15000
-	},
+/obj/item/stock_parts/cell/high,
 /turf/open/floor/iron/dark,
 /area/science/xenobiology)
 "auA" = (
@@ -23193,10 +23190,7 @@
 	dir = 8
 	},
 /obj/structure/table/reinforced,
-/obj/item/stock_parts/cell/high{
-	charge = 100;
-	maxcharge = 15000
-	},
+/obj/item/stock_parts/cell/high,
 /obj/machinery/cell_charger,
 /obj/item/radio/intercom/directional/west,
 /turf/open/floor/iron/ameridiner,
@@ -25512,10 +25506,7 @@
 	color = "#c2bfa3"
 	},
 /obj/machinery/cell_charger,
-/obj/item/stock_parts/cell/high{
-	charge = 100;
-	maxcharge = 15000
-	},
+/obj/item/stock_parts/cell/high,
 /obj/machinery/light/small/directional/north,
 /obj/structure/cable/yellow{
 	icon_state = "0-2"
@@ -47554,10 +47545,7 @@
 	dir = 8
 	},
 /obj/machinery/cell_charger,
-/obj/item/stock_parts/cell/high{
-	charge = 100;
-	maxcharge = 15000
-	},
+/obj/item/stock_parts/cell/high,
 /obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
@@ -65565,14 +65553,8 @@
 "ooN" = (
 /obj/structure/table/reinforced,
 /obj/machinery/cell_charger,
-/obj/item/stock_parts/cell/high{
-	charge = 100;
-	maxcharge = 15000
-	},
-/obj/item/stock_parts/cell/high{
-	charge = 100;
-	maxcharge = 15000
-	},
+/obj/item/stock_parts/cell/high,
+/obj/item/stock_parts/cell/high,
 /obj/effect/turf_decal/siding/thinplating_new,
 /obj/machinery/light/directional/north,
 /obj/effect/turf_decal/tile/dark/fourcorners/contrasted,
@@ -73046,10 +73028,7 @@
 /obj/structure/closet/toolcloset,
 /obj/item/flashlight,
 /obj/item/storage/belt/utility,
-/obj/item/stock_parts/cell/high{
-	charge = 100;
-	maxcharge = 15000
-	},
+/obj/item/stock_parts/cell/high,
 /obj/item/mmi,
 /obj/effect/decal/cleanable/cobweb,
 /obj/item/assembly/flash/handheld/weak,
@@ -91129,15 +91108,9 @@
 	},
 /obj/machinery/light/directional/north,
 /obj/structure/table,
-/obj/item/stock_parts/cell/high{
-	charge = 100;
-	maxcharge = 15000
-	},
+/obj/item/stock_parts/cell/high,
 /obj/machinery/cell_charger,
-/obj/item/stock_parts/cell/high{
-	charge = 100;
-	maxcharge = 15000
-	},
+/obj/item/stock_parts/cell/high,
 /obj/effect/turf_decal/trimline/black/filled/line{
 	dir = 1
 	},
@@ -107191,10 +107164,7 @@
 /obj/item/stack/sheet/glass/fifty,
 /obj/item/electronics/airlock,
 /obj/item/electronics/airlock,
-/obj/item/stock_parts/cell/high{
-	charge = 100;
-	maxcharge = 15000
-	},
+/obj/item/stock_parts/cell/high,
 /obj/item/stack/sheet/mineral/plasma{
 	amount = 30
 	},

--- a/_maps/map_files/EchoStation/EchoStation.dmm
+++ b/_maps/map_files/EchoStation/EchoStation.dmm
@@ -4595,8 +4595,6 @@
 	pixel_y = 9
 	},
 /obj/item/stock_parts/cell/high{
-	charge = 100;
-	maxcharge = 15000;
 	pixel_x = 1;
 	pixel_y = 12
 	},

--- a/_maps/map_files/FlandStation/FlandStation.dmm
+++ b/_maps/map_files/FlandStation/FlandStation.dmm
@@ -1968,10 +1968,7 @@
 /turf/open/floor/plating,
 /area/medical/surgery)
 "aBt" = (
-/obj/item/stock_parts/cell/high{
-	charge = 100;
-	maxcharge = 15000
-	},
+/obj/item/stock_parts/cell/high,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "aBw" = (
@@ -3606,10 +3603,7 @@
 "aTQ" = (
 /obj/structure/table,
 /obj/machinery/cell_charger,
-/obj/item/stock_parts/cell/high{
-	charge = 100;
-	maxcharge = 15000
-	},
+/obj/item/stock_parts/cell/high,
 /obj/effect/turf_decal/bot{
 	dir = 1
 	},
@@ -8823,10 +8817,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/rack,
 /obj/effect/spawner/random/maintenance/two,
-/obj/item/stock_parts/cell/high{
-	charge = 100;
-	maxcharge = 15000
-	},
+/obj/item/stock_parts/cell/high,
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
 	dir = 8
 	},
@@ -13873,10 +13864,7 @@
 /turf/open/floor/plating,
 /area/bridge)
 "dSO" = (
-/obj/item/stock_parts/cell/high{
-	charge = 100;
-	maxcharge = 15000
-	},
+/obj/item/stock_parts/cell/high,
 /turf/open/floor/plating,
 /area/maintenance/port/central)
 "dSV" = (
@@ -17521,10 +17509,7 @@
 "eRp" = (
 /obj/structure/table,
 /obj/machinery/cell_charger,
-/obj/item/stock_parts/cell/high{
-	charge = 100;
-	maxcharge = 15000
-	},
+/obj/item/stock_parts/cell/high,
 /obj/effect/turf_decal/bot{
 	dir = 1
 	},
@@ -21343,18 +21328,9 @@
 "fOp" = (
 /obj/structure/table,
 /obj/machinery/cell_charger,
-/obj/item/stock_parts/cell/high{
-	charge = 100;
-	maxcharge = 15000
-	},
-/obj/item/stock_parts/cell/high{
-	charge = 100;
-	maxcharge = 15000
-	},
-/obj/item/stock_parts/cell/high{
-	charge = 100;
-	maxcharge = 15000
-	},
+/obj/item/stock_parts/cell/high,
+/obj/item/stock_parts/cell/high,
+/obj/item/stock_parts/cell/high,
 /obj/item/crowbar,
 /obj/item/assembly/prox_sensor{
 	pixel_x = -8;
@@ -31645,9 +31621,7 @@
 "iEy" = (
 /obj/structure/rack,
 /obj/item/electronics/apc,
-/obj/item/stock_parts/cell{
-	maxcharge = 2000
-	},
+/obj/item/stock_parts/cell,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/random/maintenance/three,
 /turf/open/floor/iron/dark/side{
@@ -37023,10 +36997,7 @@
 	pixel_x = 1;
 	pixel_y = 5
 	},
-/obj/item/stock_parts/cell/high{
-	charge = 100;
-	maxcharge = 15000
-	},
+/obj/item/stock_parts/cell/high,
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 8
 	},
@@ -46411,10 +46382,7 @@
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "mCi" = (
-/obj/item/stock_parts/cell/high{
-	charge = 100;
-	maxcharge = 15000
-	},
+/obj/item/stock_parts/cell/high,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 1
 	},
@@ -46477,10 +46445,7 @@
 /obj/item/stack/sheet/glass/fifty,
 /obj/item/electronics/airlock,
 /obj/item/electronics/airlock,
-/obj/item/stock_parts/cell/high{
-	charge = 100;
-	maxcharge = 15000
-	},
+/obj/item/stock_parts/cell/high,
 /obj/item/stack/sheet/mineral/plasma{
 	amount = 30
 	},
@@ -56845,10 +56810,7 @@
 	},
 /obj/structure/table,
 /obj/machinery/cell_charger,
-/obj/item/stock_parts/cell/high{
-	charge = 100;
-	maxcharge = 15000
-	},
+/obj/item/stock_parts/cell/high,
 /turf/open/floor/iron/white,
 /area/science/lobby)
 "pxU" = (
@@ -64219,10 +64181,7 @@
 /turf/open/floor/iron/dark,
 /area/quartermaster/sorting)
 "rAq" = (
-/obj/item/stock_parts/cell/high{
-	charge = 100;
-	maxcharge = 15000
-	},
+/obj/item/stock_parts/cell/high,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "rAx" = (
@@ -73144,10 +73103,7 @@
 "tTr" = (
 /obj/structure/table,
 /obj/machinery/cell_charger,
-/obj/item/stock_parts/cell/high{
-	charge = 100;
-	maxcharge = 15000
-	},
+/obj/item/stock_parts/cell/high,
 /obj/effect/turf_decal/bot{
 	dir = 1
 	},

--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -27685,10 +27685,7 @@
 /obj/item/stack/sheet/glass/fifty,
 /obj/item/electronics/airlock,
 /obj/item/electronics/airlock,
-/obj/item/stock_parts/cell/high{
-	charge = 100;
-	maxcharge = 15000
-	},
+/obj/item/stock_parts/cell/high,
 /obj/item/stack/sheet/mineral/plasma{
 	amount = 30
 	},

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -4048,10 +4048,7 @@
 /obj/item/stack/sheet/glass/fifty,
 /obj/item/electronics/airlock,
 /obj/item/electronics/airlock,
-/obj/item/stock_parts/cell/high{
-	charge = 100;
-	maxcharge = 15000
-	},
+/obj/item/stock_parts/cell/high,
 /obj/item/stack/sheet/mineral/plasma{
 	amount = 30
 	},
@@ -4061,10 +4058,7 @@
 "aNq" = (
 /obj/structure/table,
 /obj/machinery/cell_charger,
-/obj/item/stock_parts/cell/high{
-	charge = 100;
-	maxcharge = 15000
-	},
+/obj/item/stock_parts/cell/high,
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/iron,
 /area/engine/engineering)
@@ -5736,10 +5730,7 @@
 	pixel_y = 3
 	},
 /obj/item/stack/cable_coil,
-/obj/item/stock_parts/cell/high{
-	charge = 100;
-	maxcharge = 15000
-	},
+/obj/item/stock_parts/cell/high,
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 27
 	},
@@ -5757,10 +5748,7 @@
 "aZG" = (
 /obj/structure/table/reinforced,
 /obj/machinery/cell_charger,
-/obj/item/stock_parts/cell/high{
-	charge = 100;
-	maxcharge = 15000
-	},
+/obj/item/stock_parts/cell/high,
 /obj/item/rcl/pre_loaded,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
@@ -8241,10 +8229,7 @@
 	pixel_y = 4
 	},
 /obj/structure/table/glass,
-/obj/item/stock_parts/cell/high{
-	charge = 100;
-	maxcharge = 15000
-	},
+/obj/item/stock_parts/cell/high,
 /turf/open/floor/iron/dark,
 /area/bridge)
 "bqM" = (
@@ -8797,14 +8782,8 @@
 	},
 /obj/structure/table,
 /obj/machinery/cell_charger,
-/obj/item/stock_parts/cell/high{
-	charge = 100;
-	maxcharge = 15000
-	},
-/obj/item/stock_parts/cell/high{
-	charge = 100;
-	maxcharge = 15000
-	},
+/obj/item/stock_parts/cell/high,
+/obj/item/stock_parts/cell/high,
 /turf/open/floor/iron,
 /area/storage/primary)
 "bvI" = (
@@ -10982,14 +10961,8 @@
 "bPZ" = (
 /obj/structure/table,
 /obj/machinery/cell_charger,
-/obj/item/stock_parts/cell/high{
-	charge = 100;
-	maxcharge = 15000
-	},
-/obj/item/stock_parts/cell/high{
-	charge = 100;
-	maxcharge = 15000
-	},
+/obj/item/stock_parts/cell/high,
+/obj/item/stock_parts/cell/high,
 /turf/open/floor/iron,
 /area/ai_monitored/storage/eva)
 "bQa" = (
@@ -11316,10 +11289,7 @@
 "bRJ" = (
 /obj/structure/table,
 /obj/machinery/cell_charger,
-/obj/item/stock_parts/cell/high{
-	charge = 100;
-	maxcharge = 15000
-	},
+/obj/item/stock_parts/cell/high,
 /obj/effect/turf_decal/bot{
 	dir = 1
 	},
@@ -13466,10 +13436,7 @@
 /area/science/lab)
 "cqx" = (
 /obj/machinery/cell_charger,
-/obj/item/stock_parts/cell/high{
-	charge = 100;
-	maxcharge = 15000
-	},
+/obj/item/stock_parts/cell/high,
 /obj/machinery/power/apc{
 	areastring = "/area/science/lab";
 	name = "Research Lab APC";
@@ -15328,18 +15295,9 @@
 "cJN" = (
 /obj/structure/table,
 /obj/machinery/cell_charger,
-/obj/item/stock_parts/cell/high{
-	charge = 100;
-	maxcharge = 15000
-	},
-/obj/item/stock_parts/cell/high{
-	charge = 100;
-	maxcharge = 15000
-	},
-/obj/item/stock_parts/cell/high{
-	charge = 100;
-	maxcharge = 15000
-	},
+/obj/item/stock_parts/cell/high,
+/obj/item/stock_parts/cell/high,
+/obj/item/stock_parts/cell/high,
 /obj/item/crowbar,
 /obj/item/assembly/prox_sensor{
 	pixel_x = -8;
@@ -24728,10 +24686,7 @@
 /obj/machinery/cell_charger,
 /obj/item/multitool,
 /obj/item/stack/cable_coil,
-/obj/item/stock_parts/cell/high{
-	charge = 100;
-	maxcharge = 15000
-	},
+/obj/item/stock_parts/cell/high,
 /turf/open/floor/engine,
 /area/maintenance/department/science/xenobiology)
 "fGk" = (
@@ -25488,10 +25443,7 @@
 /obj/item/stack/sheet/glass,
 /obj/item/stack/sheet/glass,
 /obj/item/stack/sheet/glass,
-/obj/item/stock_parts/cell/high{
-	charge = 100;
-	maxcharge = 15000
-	},
+/obj/item/stock_parts/cell/high,
 /obj/effect/turf_decal/stripes/line,
 /obj/item/clothing/glasses/science,
 /turf/open/floor/iron,
@@ -38556,10 +38508,7 @@
 	pixel_x = 1;
 	pixel_y = 5
 	},
-/obj/item/stock_parts/cell/high{
-	charge = 100;
-	maxcharge = 15000
-	},
+/obj/item/stock_parts/cell/high,
 /obj/item/stack/cable_coil{
 	pixel_x = 3;
 	pixel_y = -7
@@ -43323,10 +43272,7 @@
 /area/hallway/secondary/entry)
 "mtr" = (
 /obj/machinery/light/small,
-/obj/item/stock_parts/cell/high{
-	charge = 100;
-	maxcharge = 15000
-	},
+/obj/item/stock_parts/cell/high,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/maintenance/starboard/secondary)
@@ -47068,10 +47014,7 @@
 /obj/structure/table,
 /obj/machinery/cell_charger,
 /obj/machinery/airalarm/directional/east,
-/obj/item/stock_parts/cell/high{
-	charge = 100;
-	maxcharge = 15000
-	},
+/obj/item/stock_parts/cell/high,
 /turf/open/floor/iron/dark,
 /area/storage/tech)
 "nNe" = (
@@ -49378,10 +49321,7 @@
 "oyG" = (
 /obj/structure/table,
 /obj/machinery/cell_charger,
-/obj/item/stock_parts/cell/high{
-	charge = 100;
-	maxcharge = 15000
-	},
+/obj/item/stock_parts/cell/high,
 /obj/machinery/light{
 	dir = 1
 	},
@@ -54479,10 +54419,7 @@
 "qpE" = (
 /obj/structure/table,
 /obj/machinery/cell_charger,
-/obj/item/stock_parts/cell/high{
-	charge = 100;
-	maxcharge = 15000
-	},
+/obj/item/stock_parts/cell/high,
 /obj/effect/turf_decal/tile/purple/half/contrasted{
 	dir = 8
 	},
@@ -68623,9 +68560,7 @@
 "vxk" = (
 /obj/structure/rack,
 /obj/item/electronics/apc,
-/obj/item/stock_parts/cell{
-	maxcharge = 2000
-	},
+/obj/item/stock_parts/cell,
 /obj/machinery/firealarm{
 	dir = 8;
 	pixel_x = 24

--- a/_maps/shuttles/whiteship/whiteship_delta.dmm
+++ b/_maps/shuttles/whiteship/whiteship_delta.dmm
@@ -828,8 +828,6 @@
 	pixel_y = 8
 	},
 /obj/item/stock_parts/cell/high{
-	charge = 100;
-	maxcharge = 15000;
 	pixel_x = 3;
 	pixel_y = -1
 	},

--- a/tools/maplint/lints/powercell_charge_overrides.yml
+++ b/tools/maplint/lints/powercell_charge_overrides.yml
@@ -1,0 +1,4 @@
+/obj/item/stock_parts/cell:
+  banned_variables:
+  - charge
+  - maxcharge


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Closes #13881 
Also addresses the same issue in many other places

Removes all charge and maxcharge overrides from loose power cells on the station. These were overlooked when making the original power overhauls - it didn't make any sense for loose power cells to have overrides outside of the normal values expected for that type of cell so we didn't even check. 

Adds a lint to check for power cells having their charge or maxcharge values overridden. 

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Power cells should have capacity that players expect from every other power cell of the same type. 

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

There is no meaningful way to show testing evidence for this because the cells look identical and I may have still missed some. 

<img width="1918" height="1016" alt="image" src="https://github.com/user-attachments/assets/b3a394cf-a99d-41a7-ab84-05b0de9a44eb" />


</details>

## Changelog
:cl:
fix: Loose power cells mapped into stations no longer have unusual capacities
add: Maps will now lint against changes to charge and maxcharge variables for power cells
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
