### PR TITLE
Stops mice spawning during unit testing

### DIFF
--- a/code/controllers/subsystem/minor_mapping.dm
+++ b/code/controllers/subsystem/minor_mapping.dm
@@ -7,7 +7,9 @@ SUBSYSTEM_DEF(minor_mapping)
 	flags = SS_NO_FIRE
 
 /datum/controller/subsystem/minor_mapping/Initialize()
+#ifndef UNIT_TESTS
 	trigger_migration(CONFIG_GET(number/mice_roundstart))
+#endif
 	place_satchels()
 	return SS_INIT_SUCCESS
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

- Mice no longer spawn at roundstart when the UNIT_TESTS flag is defined.

fixes #13961

## Why It's Good For The Game

Tests randomly fail

## Testing Photographs and Procedure

See CI

## Changelog
:cl:
fix: Mice no longer spawn during unit testing, which breaks cable tests.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
