### PR TITLE
Fixes kitty ear spawners spawning fake kitty ears

### DIFF
--- a/code/game/objects/effects/spawners/random/clothing.dm
+++ b/code/game/objects/effects/spawners/random/clothing.dm
@@ -26,7 +26,7 @@
 /obj/effect/spawner/random/clothing/kittyears_or_rabbitears
 	name = "kitty ears or rabbit ears spawner"
 	loot = list(
-		/obj/item/clothing/head/kitty,
+		/obj/item/clothing/head/costume/kitty,
 		/obj/item/clothing/head/costume/rabbitears,
 	)
 

--- a/code/modules/clothing/head/misc_special.dm
+++ b/code/modules/clothing/head/misc_special.dm
@@ -133,18 +133,6 @@
 		update_icon()
 	. = ..()
 
-/obj/item/clothing/head/kitty/visual_equipped(mob/living/carbon/human/user, slot)
-	. = ..()
-	if(ishuman(user) && (slot == ITEM_SLOT_HEAD || slot == ITEM_SLOT_NECK))
-		update_icon(ALL, user)
-		user.update_worn_head() //Color might have been changed by update_appearance.
-	..()
-
-/obj/item/clothing/head/kitty/update_icon(updates=ALL, mob/living/carbon/human/user)
-	. = ..()
-	if(ishuman(user))
-		add_atom_colour(user.hair_color, FIXED_COLOUR_PRIORITY)
-
 /obj/item/clothing/head/costume/speedwagon
 	name = "hat of ultimate masculinity"
 	desc = "Even the mere act of wearing this makes you want to pose menacingly."


### PR DESCRIPTION
## About The Pull Request

See title

## Why It's Good For The Game

I don't like seeing people wearing a pink and black checkerboard pattern on their head

## Testing Photographs and Procedure

After spawning `/obj/effect/spawner/random/clothing/kittyears_or_rabbitears`

<img width="161" height="146" alt="image" src="https://github.com/user-attachments/assets/ef3e2a53-35e2-4256-8389-931ea8ae9138" />

## Changelog
:cl:
fix: fixed kitty ear spawners spawning fake kitty ears
/:cl:
