### PR TITLE
Smartwires mapping pre-requisites 2

### DIFF
--- a/_maps/map_files/CardinalStation/CardinalStation.dmm
+++ b/_maps/map_files/CardinalStation/CardinalStation.dmm
@@ -3805,13 +3805,6 @@
 /obj/structure/window/spawner/directional/south,
 /turf/open/floor/grass/no_border,
 /area/hallway/primary/central)
-"aQS" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/cable/green{
-	icon_state = "1-2"
-	},
-/turf/open/space/basic,
-/area/space/nearstation)
 "aQT" = (
 /obj/effect/turf_decal/stripes/end,
 /obj/effect/turf_decal/caution/stand_clear{
@@ -4395,7 +4388,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden{
 	dir = 5
 	},
-/obj/structure/cable/green{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /turf/open/floor/iron/tech,
@@ -7537,12 +7530,6 @@
 	},
 /turf/open/floor/iron,
 /area/crew_quarters/dorms)
-"bEM" = (
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/medical/central)
 "bEQ" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -8774,14 +8761,14 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/arrows,
-/obj/structure/cable/green{
-	icon_state = "4-8"
-	},
 /obj/structure/cable/cyan{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/components/binary/valve/digital/on/layer2{
 	name = "Station Air supply shut off valve"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
 	},
 /turf/open/floor/plating/rust,
 /area/ai_monitored/turret_protected/aisat/service)
@@ -10377,9 +10364,6 @@
 /turf/open/floor/plating,
 /area/maintenance/central)
 "chQ" = (
-/obj/structure/cable/pink{
-	icon_state = "1-2"
-	},
 /obj/effect/turf_decal/siding/wideplating_new/dark,
 /obj/effect/turf_decal/siding/wideplating_new/dark{
 	dir = 1
@@ -11026,7 +11010,6 @@
 /turf/open/floor/iron/corner,
 /area/hallway/primary/port)
 "coS" = (
-/obj/structure/cable/pink,
 /obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
@@ -12603,11 +12586,14 @@
 /obj/effect/turf_decal/siding/dark,
 /obj/machinery/airalarm/directional/north,
 /obj/machinery/camera/motion/directional/north,
-/obj/effect/turf_decal/stripes/corner{
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/power/terminal{
 	dir = 4
 	},
 /obj/structure/cable/cyan{
-	icon_state = "2-4"
+	icon_state = "0-2"
 	},
 /turf/open/floor/engine,
 /area/ai_monitored/turret_protected/ai)
@@ -13270,7 +13256,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
-/obj/structure/cable/green{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/iron/dark/textured_half{
@@ -14141,7 +14127,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/supply/visible{
 	dir = 4
 	},
-/obj/structure/cable/green{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /turf/open/space/basic,
@@ -16289,13 +16275,6 @@
 /obj/structure/window/reinforced/spawner/directional/south,
 /turf/open/floor/engine,
 /area/science/xenobiology)
-"duz" = (
-/obj/structure/cable/blue{
-	icon_state = "1-2"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/maintenance/department/medical/central)
 "duD" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/yellow{
@@ -16780,9 +16759,6 @@
 /turf/open/floor/engine,
 /area/maintenance/disposal/incinerator)
 "dzr" = (
-/obj/structure/cable/pink{
-	icon_state = "1-2"
-	},
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/plating,
 /area/maintenance/department/medical/central)
@@ -18190,6 +18166,9 @@
 	dir = 1
 	},
 /obj/machinery/light/directional/east,
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
 /turf/open/floor/iron/dark/textured,
 /area/engine/engine_room)
 "dRZ" = (
@@ -19936,13 +19915,6 @@
 /obj/machinery/flasher/directional/west,
 /turf/open/space/basic,
 /area/space)
-"eog" = (
-/obj/structure/cable/pink{
-	icon_state = "1-8"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/maintenance/department/medical/central)
 "eos" = (
 /obj/structure/closet/emcloset,
 /turf/open/floor/plating,
@@ -21384,10 +21356,10 @@
 /turf/open/floor/wood,
 /area/crew_quarters/heads/captain)
 "eGm" = (
-/obj/structure/cable/blue{
-	icon_state = "1-8"
-	},
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plating,
 /area/maintenance/department/medical/central)
 "eGx" = (
@@ -22557,13 +22529,6 @@
 /obj/structure/closet/l3closet/virology,
 /turf/open/floor/iron/white,
 /area/medical/virology)
-"eUR" = (
-/obj/structure/cable/blue{
-	icon_state = "2-4"
-	},
-/obj/effect/decal/cleanable/blood,
-/turf/open/floor/plating,
-/area/maintenance/department/medical/central)
 "eVh" = (
 /obj/effect/turf_decal/tile/monorust,
 /obj/structure/sign/poster/official/random/directional/west,
@@ -24397,12 +24362,9 @@
 /turf/open/floor/engine,
 /area/ai_monitored/turret_protected/aisat_interior)
 "fqP" = (
-/obj/structure/cable/pink,
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
 /obj/effect/spawner/structure/window/reinforced/tinted/nightclub,
-/obj/structure/cable{
+/obj/structure/cable/yellow,
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /turf/open/floor/plating,
@@ -25799,8 +25761,11 @@
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /obj/structure/cable/pink{
-	icon_state = "2-4"
+	icon_state = "1-2"
 	},
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai)
@@ -29902,12 +29867,12 @@
 	dir = 1
 	},
 /obj/machinery/power/terminal,
-/obj/structure/cable/green{
-	icon_state = "0-4"
-	},
 /obj/machinery/camera/motion/directional/west,
 /obj/item/radio/intercom/directional/west,
 /obj/machinery/atmospherics/pipe/smart/simple/general/hidden,
+/obj/structure/cable/yellow{
+	icon_state = "0-4"
+	},
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/aisat/service)
 "gya" = (
@@ -32634,9 +32599,6 @@
 /turf/open/floor/iron/smooth,
 /area/engine/engine_room)
 "hdG" = (
-/obj/structure/cable/pink{
-	icon_state = "2-8"
-	},
 /obj/effect/turf_decal/siding/purple{
 	dir = 1
 	},
@@ -32644,6 +32606,9 @@
 /obj/effect/turf_decal/guideline/guideline_in/purple,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
+	},
 /turf/open/floor/iron/dark,
 /area/maintenance/club)
 "hdU" = (
@@ -35529,14 +35494,12 @@
 /turf/open/floor/iron/dark,
 /area/crew_quarters/kitchen)
 "hKo" = (
-/obj/machinery/power/smes{
-	charge = 5e+006
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
 	},
-/obj/structure/cable/pink{
-	icon_state = "0-2"
-	},
-/turf/open/floor/plating/elevatorshaft,
-/area/ai_monitored/turret_protected/ai)
+/obj/structure/lattice,
+/turf/open/space/basic,
+/area/space/nearstation)
 "hKq" = (
 /obj/effect/turf_decal/siding/dirt/corner{
 	dir = 4
@@ -40428,7 +40391,7 @@
 /area/engine/engine_room)
 "iND" = (
 /obj/effect/spawner/structure/window/reinforced/tinted/nightclub,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
 /turf/open/floor/plating,
@@ -43047,9 +43010,6 @@
 /turf/open/floor/wood/big,
 /area/library/lounge)
 "jsW" = (
-/obj/structure/cable/pink{
-	icon_state = "2-8"
-	},
 /obj/effect/turf_decal/edges/borderfloor/black,
 /obj/effect/turf_decal/guideline/guideline_in/purple,
 /obj/machinery/light{
@@ -43622,16 +43582,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/hallway/secondary/exit/departure_lounge)
-"jzm" = (
-/obj/structure/cable/yellow{
-	icon_state = "0-4"
-	},
-/obj/structure/cable/blue{
-	icon_state = "0-8"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/maintenance/department/medical/central)
 "jzq" = (
 /obj/machinery/door/airlock/public/glass,
 /obj/machinery/door/firedoor,
@@ -43718,7 +43668,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden{
 	dir = 1
 	},
-/obj/structure/cable/green{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/iron/tech,
@@ -44837,9 +44787,6 @@
 /obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
 /obj/effect/spawner/structure/window/reinforced/tinted/nightclub,
 /turf/open/floor/plating,
 /area/maintenance/club)
@@ -45813,11 +45760,11 @@
 	},
 /area/chapel/main)
 "jWX" = (
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold/cyan/visible{
 	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
 /turf/open/floor/iron/techmaint,
 /area/engine/engine_room)
@@ -45989,7 +45936,7 @@
 /obj/effect/turf_decal/stripes/closeup{
 	dir = 1
 	},
-/obj/structure/cable/green{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/iron/techmaint,
@@ -49898,9 +49845,6 @@
 /turf/open/floor/vault/rock,
 /area/science/mixing)
 "kSY" = (
-/obj/structure/cable/pink{
-	icon_state = "4-8"
-	},
 /obj/effect/turf_decal/siding/purple{
 	dir = 1
 	},
@@ -49908,6 +49852,9 @@
 /obj/effect/turf_decal/guideline/guideline_in/purple,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
 /turf/open/floor/iron/dark,
 /area/maintenance/club)
 "kTa" = (
@@ -50023,7 +49970,7 @@
 /area/maintenance/disposal)
 "kVl" = (
 /obj/structure/lattice,
-/obj/structure/cable/green{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/space/basic,
@@ -51291,13 +51238,6 @@
 /obj/effect/turf_decal/tile/blue/opposingcorners,
 /turf/open/floor/iron/white,
 /area/medical/surgery)
-"lgw" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/maintenance/department/medical/central)
 "lgx" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/railing,
@@ -51428,13 +51368,6 @@
 /obj/effect/spawner/random/trash/grille_or_waste,
 /turf/open/floor/plating,
 /area/maintenance/department/medical)
-"lif" = (
-/obj/structure/cable/blue{
-	icon_state = "1-4"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/maintenance/department/medical/central)
 "lik" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -53378,9 +53311,6 @@
 /area/hallway/secondary/command)
 "lEP" = (
 /obj/structure/cable/yellow,
-/obj/structure/cable/pink{
-	icon_state = "0-4"
-	},
 /obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
@@ -55996,9 +55926,6 @@
 /turf/open/floor/iron,
 /area/hallway/primary/port)
 "mkg" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
 /obj/machinery/power/apc/auto_name/directional/south{
 	areastring = "/area/engine/supermatter"
 	},
@@ -57346,6 +57273,9 @@
 	},
 /obj/structure/cable/cyan{
 	icon_state = "1-8"
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
 	},
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai)
@@ -58995,13 +58925,6 @@
 	},
 /area/hallway/secondary/exit/departure_lounge)
 "mRH" = (
-/obj/structure/cable/pink{
-	icon_state = "0-4"
-	},
-/obj/structure/cable,
-/obj/structure/cable/pink{
-	icon_state = "0-8"
-	},
 /obj/effect/turf_decal/siding/purple{
 	dir = 1
 	},
@@ -59011,6 +58934,9 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
 /turf/open/floor/iron/dark,
 /area/maintenance/club)
 "mRJ" = (
@@ -60003,7 +59929,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /turf/open/floor/light/colour_cycle/dancefloor_a,
@@ -60716,8 +60642,8 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 8
 	},
-/obj/structure/cable/pink{
-	icon_state = "1-8"
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
 	},
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai)
@@ -61069,7 +60995,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden{
 	dir = 1
 	},
-/obj/structure/cable/green{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/iron/tech,
@@ -61349,7 +61275,7 @@
 /area/hydroponics/garden)
 "ntd" = (
 /obj/structure/lattice,
-/obj/structure/cable/green{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/space/basic,
@@ -63090,6 +63016,9 @@
 /obj/effect/turf_decal/trimline/yellow/warning{
 	dir = 8
 	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
 /turf/open/floor/iron/dark/textured,
 /area/engine/engine_room)
 "nNe" = (
@@ -64803,7 +64732,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden{
 	dir = 4
 	},
-/obj/structure/cable/green{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/iron/dark/textured_half{
@@ -69054,7 +68983,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
-/obj/structure/cable/green{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/iron/tech,
@@ -71098,7 +71027,7 @@
 	dir = 6
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
-/obj/structure/cable/green{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/iron/dark,
@@ -71894,10 +71823,7 @@
 /area/maintenance/central)
 "pHK" = (
 /obj/structure/cable/yellow{
-	icon_state = "0-8"
-	},
-/obj/structure/cable/blue{
-	icon_state = "0-4"
+	icon_state = "4-8"
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/medical/central)
@@ -72814,12 +72740,12 @@
 /obj/effect/turf_decal/siding/dark/corner{
 	dir = 4
 	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/iron/dark/textured,
 /area/engine/engine_room)
 "pSf" = (
-/obj/structure/cable/pink{
-	icon_state = "2-4"
-	},
 /obj/effect/turf_decal/siding/purple/corner{
 	dir = 8
 	},
@@ -73570,7 +73496,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden{
 	dir = 10
 	},
-/obj/structure/cable/green{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /turf/open/floor/iron/tech,
@@ -75642,13 +75568,13 @@
 /turf/open/floor/grass,
 /area/hydroponics/garden)
 "qze" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
 /obj/machinery/light/floor{
 	name = "moody floor light";
 	bulb_colour = "#9b1d70";
 	bulb_power = 0.4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
 	},
 /turf/open/floor/light/colour_cycle/dancefloor_a,
 /area/maintenance/club)
@@ -76920,7 +76846,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden{
 	dir = 4
 	},
-/obj/structure/cable/green{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/iron/tech,
@@ -77609,6 +77535,9 @@
 /obj/effect/turf_decal/caution{
 	dir = 4
 	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/iron/techmaint,
 /area/engine/engine_room)
 "qUR" = (
@@ -77967,7 +77896,7 @@
 "qYF" = (
 /obj/structure/lattice/catwalk,
 /obj/machinery/camera/motion/directional/west,
-/obj/structure/cable/green{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /turf/open/space/basic,
@@ -81293,6 +81222,9 @@
 /obj/effect/turf_decal/siding/thinplating_new/dark{
 	dir = 1
 	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/iron/techmaint,
 /area/engine/engine_room)
 "rLw" = (
@@ -84137,10 +84069,10 @@
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden{
 	dir = 1
 	},
-/obj/structure/cable/green{
+/obj/effect/decal/fakestairs/newstairs/right,
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/effect/decal/fakestairs/newstairs/right,
 /turf/open/floor/iron/tech,
 /area/ai_monitored/turret_protected/aisat/hallway)
 "sqa" = (
@@ -84521,7 +84453,7 @@
 /obj/effect/turf_decal/siding/dark{
 	dir = 1
 	},
-/obj/structure/cable/green{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /turf/open/floor/plating/rust,
@@ -86130,13 +86062,6 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
 /turf/open/floor/iron/edge,
 /area/hallway/secondary/entry)
-"sPN" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/cable/green{
-	icon_state = "1-4"
-	},
-/turf/open/space/basic,
-/area/space/nearstation)
 "sPP" = (
 /obj/structure/disposalpipe/segment{
 	dir = 1
@@ -93400,11 +93325,8 @@
 /obj/machinery/light/small/directional/south,
 /obj/structure/wall_closet/emergency/directional/north,
 /obj/item/reagent_containers/hypospray/medipen/dexalin,
-/obj/structure/cable/green{
-	icon_state = "0-8"
-	},
 /obj/structure/cable/yellow{
-	icon_state = "0-4"
+	icon_state = "4-8"
 	},
 /turf/open/floor/catwalk_floor,
 /area/science/mixing)
@@ -93413,12 +93335,9 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/siding/dark,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
 /obj/machinery/status_display/evac/directional/north,
-/obj/structure/cable/pink{
-	icon_state = "2-8"
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
 	},
 /turf/open/floor/engine,
 /area/ai_monitored/turret_protected/ai)
@@ -97729,12 +97648,6 @@
 	},
 /turf/open/floor/catwalk_floor/iron,
 /area/maintenance/central/secondary)
-"vot" = (
-/obj/structure/cable/blue{
-	icon_state = "2-8"
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/medical/central)
 "vow" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable{
@@ -99590,7 +99503,7 @@
 /area/crew_quarters/toilet/restrooms)
 "vGV" = (
 /obj/structure/lattice,
-/obj/structure/cable/green{
+/obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /turf/open/space/basic,
@@ -108964,7 +108877,7 @@
 /obj/machinery/ai_slipper,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
-/obj/structure/cable/green{
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /turf/open/floor/iron/dark,
@@ -109835,20 +109748,11 @@
 /area/quartermaster/storage)
 "xVL" = (
 /obj/effect/turf_decal/siding/dark,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/machinery/ai_slipper{
-	uses = 10
-	},
-/obj/machinery/power/terminal{
-	dir = 1
+/obj/machinery/power/smes{
+	charge = 5e+006
 	},
 /obj/structure/cable/pink{
-	icon_state = "1-4"
-	},
-/obj/structure/cable/cyan{
-	icon_state = "0-8"
+	icon_state = "0-2"
 	},
 /turf/open/floor/engine,
 /area/ai_monitored/turret_protected/ai)
@@ -110031,7 +109935,7 @@
 /obj/machinery/atmospherics/pipe/layer_manifold/general/hidden{
 	dir = 4
 	},
-/obj/structure/cable/green{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/iron/dark/textured_half{
@@ -110119,14 +110023,14 @@
 /area/hydroponics)
 "xZI" = (
 /obj/machinery/meter,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
 /obj/effect/turf_decal/trimline/yellow/warning{
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold/cyan/visible{
 	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
 	},
 /turf/open/floor/iron/techmaint,
 /area/engine/engine_room)
@@ -122066,7 +121970,7 @@ pAq
 wjd
 mwp
 mwp
-hKo
+mwp
 xVL
 fGU
 hpB
@@ -125440,7 +125344,7 @@ nzj
 nzj
 hyT
 cVA
-aQS
+pLl
 qYF
 hyT
 nzj
@@ -126469,7 +126373,7 @@ nzj
 nzj
 kuA
 nzj
-ntd
+hKo
 nzj
 nzj
 nzj
@@ -128786,8 +128690,8 @@ vGV
 kVl
 kVl
 kVl
-aQS
-sPN
+pLl
+ipy
 cbI
 hyT
 hyT
@@ -156213,7 +156117,7 @@ agQ
 tGg
 kSY
 vFC
-lgw
+qcx
 lha
 lha
 pHK
@@ -156470,9 +156374,9 @@ lFA
 gxB
 hdG
 fqP
-bEM
-eUR
-duz
+lha
+dzr
+qcx
 eGm
 lha
 slK
@@ -156728,9 +156632,9 @@ pOC
 qPr
 iND
 lha
-vot
-duz
-lif
+lha
+qcx
+eGm
 lha
 bkV
 trv
@@ -156987,7 +156891,7 @@ cuD
 lha
 lha
 lha
-jzm
+eGm
 lha
 bkV
 hMH
@@ -157499,7 +157403,7 @@ jMl
 jsW
 chQ
 dzr
-eog
+qcx
 uhQ
 qcx
 lha

--- a/_maps/map_files/CardinalStation/CardinalStation.dmm
+++ b/_maps/map_files/CardinalStation/CardinalStation.dmm
@@ -1374,9 +1374,6 @@
 	},
 /obj/effect/turf_decal/tile/dark/fourcorners,
 /obj/effect/turf_decal/tile/monorust,
-/obj/structure/cable/cyan{
-	icon_state = "4-8"
-	},
 /obj/effect/turf_decal/guideline/guideline_in/darkblue{
 	dir = 1
 	},
@@ -1384,6 +1381,9 @@
 /obj/machinery/holopad,
 /obj/machinery/atmospherics/pipe/smart/manifold/general/hidden{
 	dir = 8
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
 	},
 /turf/open/floor/iron/large{
 	initial_gas_mix = "n2=100;TEMP=80"
@@ -2216,10 +2216,10 @@
 /obj/effect/turf_decal/siding/wideplating_new/dark{
 	dir = 4
 	},
-/obj/structure/cable/yellow{
+/obj/machinery/light/directional/south,
+/obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/light/directional/south,
 /turf/open/floor/iron/large{
 	initial_gas_mix = "n2=100;TEMP=80"
 	},
@@ -5454,14 +5454,14 @@
 /turf/open/floor/iron/half,
 /area/hallway/primary/central)
 "bho" = (
-/obj/structure/cable/cyan{
-	icon_state = "4-8"
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /obj/structure/railing/perspective/black,
 /obj/effect/decal/fakestairs{
 	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
 	},
 /turf/open/floor/iron/dark/textured_large,
 /area/tcommsat/computer)
@@ -8109,14 +8109,14 @@
 /turf/open/floor/grass/no_border,
 /area/hallway/primary/aft)
 "bKV" = (
-/obj/structure/cable/orange{
-	icon_state = "2-4"
-	},
-/obj/structure/cable/orange{
-	icon_state = "1-2"
-	},
 /obj/effect/turf_decal/siding/dark{
 	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "2-4"
 	},
 /turf/open/floor/iron/dark/smooth_half{
 	dir = 1
@@ -11789,7 +11789,7 @@
 /obj/effect/turf_decal/tile/monorust,
 /obj/machinery/airalarm/directional/west,
 /obj/effect/mapping_helpers/airalarm/tlv_no_checks,
-/obj/structure/cable/yellow{
+/obj/structure/cable{
 	icon_state = "1-2"
 	},
 /turf/open/floor/iron/large{
@@ -12602,14 +12602,14 @@
 	dir = 9
 	},
 /obj/effect/turf_decal/box/corners,
-/obj/structure/cable/orange{
-	icon_state = "0-8"
-	},
 /obj/effect/turf_decal/arrows{
 	dir = 8
 	},
 /obj/effect/turf_decal/box/corners{
 	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "0-8"
 	},
 /turf/open/floor/iron/tech/grid,
 /area/engine/engine_room)
@@ -12648,11 +12648,11 @@
 	},
 /obj/effect/turf_decal/tile/dark/fourcorners,
 /obj/effect/turf_decal/tile/monorust,
-/obj/structure/cable/yellow,
 /obj/machinery/power/apc/auto_name/directional/west,
-/obj/structure/cable/yellow{
+/obj/structure/cable{
 	icon_state = "0-2"
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/large{
 	initial_gas_mix = "n2=100;TEMP=80"
 	},
@@ -15697,13 +15697,13 @@
 	},
 /obj/effect/turf_decal/tile/dark/fourcorners,
 /obj/effect/turf_decal/tile/monorust,
-/obj/structure/cable/cyan{
-	icon_state = "1-2"
-	},
 /obj/effect/turf_decal/guideline/guideline_in/darkblue{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/simple/general/hidden,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
 /turf/open/floor/iron/large{
 	initial_gas_mix = "n2=100;TEMP=80"
 	},
@@ -16875,11 +16875,11 @@
 /turf/open/floor/iron/dark,
 /area/hallway/secondary/service)
 "dAq" = (
-/obj/structure/cable/orange{
-	icon_state = "2-8"
-	},
 /obj/effect/turf_decal/siding/dark{
 	dir = 8
+	},
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
 	},
 /turf/open/floor/iron/dark/smooth_half{
 	dir = 1
@@ -18369,7 +18369,7 @@
 "dUn" = (
 /obj/machinery/telecomms/server/presets/security,
 /obj/effect/turf_decal/bot_white,
-/obj/structure/cable/yellow{
+/obj/structure/cable{
 	icon_state = "4-8"
 	},
 /turf/open/floor/circuit/telecomms/mainframe,
@@ -18935,7 +18935,7 @@
 /area/science/mixing)
 "ecs" = (
 /obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable/yellow{
+/obj/structure/cable{
 	icon_state = "0-8"
 	},
 /turf/open/floor/plating,
@@ -19764,7 +19764,7 @@
 "elW" = (
 /obj/machinery/telecomms/server/presets/service,
 /obj/effect/turf_decal/bot_white,
-/obj/structure/cable/yellow{
+/obj/structure/cable{
 	icon_state = "4-8"
 	},
 /turf/open/floor/circuit/telecomms/mainframe,
@@ -25352,10 +25352,10 @@
 /obj/effect/turf_decal/guideline/guideline_in/darkblue{
 	dir = 4
 	},
-/obj/structure/cable/yellow{
+/obj/machinery/camera/directional/north,
+/obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/camera/directional/north,
 /turf/open/floor/iron/large{
 	initial_gas_mix = "n2=100;TEMP=80"
 	},
@@ -27444,17 +27444,16 @@
 /obj/effect/turf_decal/tile/steelgrid/diagonal{
 	dir = 4
 	},
-/obj/structure/cable/orange{
-	icon_state = "0-4"
-	},
-/obj/structure/cable/cyan{
-	icon_state = "0-8"
-	},
-/obj/structure/cable/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /obj/effect/turf_decal/box,
 /obj/effect/turf_decal/alphabet/symbol_plus,
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-8"
+	},
 /turf/open/floor/iron/smooth,
 /area/engine/engine_room)
 "gaP" = (
@@ -27628,7 +27627,7 @@
 /obj/effect/turf_decal/tile/dark/fourcorners,
 /obj/effect/turf_decal/tile/monorust,
 /obj/structure/extinguisher_cabinet/directional/west,
-/obj/structure/cable/yellow{
+/obj/structure/cable{
 	icon_state = "1-2"
 	},
 /turf/open/floor/iron/large{
@@ -28679,12 +28678,12 @@
 /turf/open/floor/iron/smooth,
 /area/security/checkpoint/medical)
 "gns" = (
-/obj/structure/cable/yellow{
-	icon_state = "0-4"
-	},
 /obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable/yellow{
+/obj/structure/cable{
 	icon_state = "0-2"
+	},
+/obj/structure/cable{
+	icon_state = "0-4"
 	},
 /turf/open/floor/plating,
 /area/tcommsat/server)
@@ -34272,9 +34271,9 @@
 /obj/effect/turf_decal/siding/wideplating_new/dark{
 	dir = 10
 	},
-/obj/structure/cable/cyan,
 /obj/machinery/power/apc/auto_name/directional/south,
 /obj/item/radio/intercom/directional/west,
+/obj/structure/cable/yellow,
 /turf/open/floor/iron/dark/smooth_large,
 /area/tcommsat/computer)
 "hyc" = (
@@ -35583,10 +35582,10 @@
 	},
 /obj/effect/turf_decal/tile/dark/fourcorners,
 /obj/effect/turf_decal/tile/monorust,
-/obj/structure/cable/yellow{
+/obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/structure/cable/yellow{
+/obj/structure/cable{
 	icon_state = "1-8"
 	},
 /turf/open/floor/iron/large{
@@ -36014,10 +36013,10 @@
 	},
 /obj/effect/turf_decal/tile/dark/fourcorners,
 /obj/effect/turf_decal/tile/monorust,
-/obj/structure/cable/yellow{
+/obj/machinery/light/directional/north,
+/obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/light/directional/north,
 /turf/open/floor/iron/large{
 	initial_gas_mix = "n2=100;TEMP=80"
 	},
@@ -37959,10 +37958,10 @@
 /area/medical/sleeper)
 "ine" = (
 /obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable/yellow{
+/obj/structure/cable,
+/obj/structure/cable{
 	icon_state = "0-2"
 	},
-/obj/structure/cable/yellow,
 /turf/open/floor/plating,
 /area/tcommsat/server)
 "inF" = (
@@ -43739,14 +43738,14 @@
 	},
 /obj/effect/turf_decal/tile/dark/fourcorners,
 /obj/effect/turf_decal/tile/monorust,
-/obj/structure/cable/cyan{
-	icon_state = "4-8"
-	},
 /obj/effect/turf_decal/guideline/guideline_in/darkblue{
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/smart/simple/general/hidden{
 	dir = 8
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
 	},
 /turf/open/floor/iron/large{
 	initial_gas_mix = "n2=100;TEMP=80"
@@ -44406,14 +44405,14 @@
 /turf/open/floor/prison/dark,
 /area/storage/tech)
 "jJT" = (
-/obj/structure/cable/cyan{
-	icon_state = "4-8"
-	},
 /obj/machinery/atmospherics/pipe/smart/simple/general/hidden{
 	dir = 8
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
 	},
 /turf/open/floor/iron/dark/textured_large,
 /area/tcommsat/computer)
@@ -47277,10 +47276,10 @@
 "kmY" = (
 /obj/machinery/telecomms/server/presets/engineering,
 /obj/effect/turf_decal/bot_white,
-/obj/structure/cable/yellow{
+/obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/structure/cable/yellow{
+/obj/structure/cable{
 	icon_state = "1-8"
 	},
 /turf/open/floor/circuit/telecomms/mainframe,
@@ -48272,13 +48271,13 @@
 /turf/open/floor/plating,
 /area/maintenance/port/central)
 "kzD" = (
-/obj/structure/cable/yellow{
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable{
 	icon_state = "0-2"
 	},
-/obj/structure/cable/yellow{
+/obj/structure/cable{
 	icon_state = "0-8"
 	},
-/obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/tcommsat/server)
 "kzP" = (
@@ -50990,14 +50989,14 @@
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
 "ldQ" = (
-/obj/structure/cable/orange{
-	icon_state = "4-8"
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
 /obj/effect/turf_decal/siding/thinplating_new/dark{
 	dir = 1
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
 	},
 /turf/open/floor/iron/techmaint,
 /area/engine/engine_room)
@@ -51798,9 +51797,6 @@
 /obj/effect/turf_decal/edges/techfloor{
 	dir = 6
 	},
-/obj/structure/cable/orange{
-	icon_state = "0-4"
-	},
 /obj/effect/turf_decal/arrows{
 	dir = 4
 	},
@@ -51809,6 +51805,9 @@
 	},
 /obj/effect/turf_decal/box/corners{
 	dir = 8
+	},
+/obj/structure/cable/yellow{
+	icon_state = "0-4"
 	},
 /turf/open/floor/iron/tech/grid,
 /area/engine/engine_room)
@@ -53847,9 +53846,6 @@
 	},
 /obj/effect/turf_decal/tile/dark/fourcorners,
 /obj/effect/turf_decal/tile/monorust,
-/obj/structure/cable/cyan{
-	icon_state = "2-8"
-	},
 /obj/effect/turf_decal/guideline/guideline_in_alt/darkblue{
 	dir = 8
 	},
@@ -53857,6 +53853,9 @@
 	dir = 10
 	},
 /obj/machinery/light_switch/directional/east,
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
+	},
 /turf/open/floor/iron/large{
 	initial_gas_mix = "n2=100;TEMP=80"
 	},
@@ -53871,10 +53870,10 @@
 /obj/effect/turf_decal/tile/dark/fourcorners,
 /obj/effect/turf_decal/tile/monorust,
 /obj/effect/mapping_helpers/make_non_slip,
-/obj/structure/cable/yellow{
+/obj/machinery/camera/directional/south,
+/obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/camera/directional/south,
 /turf/open/floor/iron/large{
 	initial_gas_mix = "n2=100;TEMP=80"
 	},
@@ -55929,10 +55928,10 @@
 /obj/machinery/power/apc/auto_name/directional/south{
 	areastring = "/area/engine/supermatter"
 	},
-/obj/structure/cable/orange,
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
 	dir = 4
 	},
+/obj/structure/cable/yellow,
 /turf/open/floor/iron/techmaint,
 /area/engine/engine_room)
 "mkp" = (
@@ -57188,13 +57187,13 @@
 /obj/machinery/power/emitter/welded{
 	dir = 8
 	},
-/obj/structure/cable/orange{
-	icon_state = "0-8"
-	},
 /obj/effect/turf_decal/arrows{
 	dir = 8
 	},
 /obj/effect/turf_decal/box/corners,
+/obj/structure/cable/yellow{
+	icon_state = "0-8"
+	},
 /turf/open/floor/iron/tech/grid,
 /area/engine/engine_room)
 "mzo" = (
@@ -60744,10 +60743,10 @@
 /turf/open/floor/iron/showroomfloor,
 /area/security/prison)
 "nne" = (
-/obj/structure/cable/yellow{
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable{
 	icon_state = "0-4"
 	},
-/obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/tcommsat/server)
 "nnh" = (
@@ -61229,10 +61228,10 @@
 /area/crew_quarters/locker)
 "nss" = (
 /obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable/yellow{
+/obj/structure/cable,
+/obj/structure/cable{
 	icon_state = "0-8"
 	},
-/obj/structure/cable/yellow,
 /turf/open/floor/plating,
 /area/tcommsat/server)
 "nsu" = (
@@ -61557,14 +61556,14 @@
 /turf/open/floor/carpet,
 /area/crew_quarters/dorms)
 "nwB" = (
-/obj/structure/cable/orange{
-	icon_state = "1-8"
-	},
-/obj/structure/cable/orange{
-	icon_state = "4-8"
-	},
 /obj/effect/turf_decal/siding/thinplating_new/dark{
 	dir = 1
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-8"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
 	},
 /turf/open/floor/iron/techmaint,
 /area/engine/engine_room)
@@ -64058,11 +64057,11 @@
 /turf/open/floor/iron/grid/steel,
 /area/quartermaster/storage)
 "nYS" = (
-/obj/structure/cable/orange{
-	icon_state = "1-2"
-	},
 /obj/effect/turf_decal/siding/dark/corner{
 	dir = 1
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
 	},
 /turf/open/floor/iron/dark/textured,
 /area/engine/engine_room)
@@ -65127,14 +65126,14 @@
 /turf/open/floor/iron/smooth,
 /area/hallway/primary/fore)
 "okY" = (
-/obj/structure/cable/orange{
-	icon_state = "4-8"
-	},
 /obj/effect/turf_decal/siding/thinplating_new/dark{
 	dir = 1
 	},
 /obj/effect/turf_decal/caution{
 	dir = 8
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
 	},
 /turf/open/floor/iron/techmaint,
 /area/engine/engine_room)
@@ -66819,9 +66818,6 @@
 /area/maintenance/starboard/fore)
 "oGg" = (
 /obj/effect/turf_decal/siding/wideplating_new/dark/corner,
-/obj/structure/cable/cyan{
-	icon_state = "4-8"
-	},
 /obj/machinery/atmospherics/pipe/smart/simple/general/hidden{
 	dir = 10
 	},
@@ -66831,6 +66827,9 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/effect/landmark/navigate_destination,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
 /turf/open/floor/iron/dark/textured_large,
 /area/tcommsat/computer)
 "oGh" = (
@@ -67268,10 +67267,10 @@
 /obj/effect/turf_decal/tile/dark/fourcorners,
 /obj/effect/turf_decal/tile/monorust,
 /obj/machinery/newscaster/directional/west,
-/obj/structure/cable/yellow{
+/obj/machinery/light/directional/north,
+/obj/structure/cable{
 	icon_state = "2-4"
 	},
-/obj/machinery/light/directional/north,
 /turf/open/floor/iron/large{
 	initial_gas_mix = "n2=100;TEMP=80"
 	},
@@ -68565,7 +68564,7 @@
 "oYN" = (
 /obj/machinery/telecomms/bus/preset_one,
 /obj/effect/turf_decal/bot_white,
-/obj/structure/cable/yellow{
+/obj/structure/cable{
 	icon_state = "4-8"
 	},
 /turf/open/floor/circuit/telecomms/mainframe,
@@ -70153,14 +70152,14 @@
 /turf/open/floor/iron/smooth_half,
 /area/engine/engineering)
 "ppj" = (
-/obj/structure/cable/orange{
-	icon_state = "2-8"
-	},
-/obj/structure/cable/orange{
-	icon_state = "1-2"
-	},
 /obj/effect/turf_decal/siding/dark{
 	dir = 8
+	},
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
 	},
 /turf/open/floor/iron/dark/smooth_half{
 	dir = 1
@@ -71264,11 +71263,11 @@
 /turf/open/floor/engine,
 /area/engine/supermatter)
 "pBl" = (
-/obj/structure/cable/orange{
-	icon_state = "4-8"
-	},
 /obj/effect/turf_decal/siding/thinplating_new/dark{
 	dir = 1
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
 	},
 /turf/open/floor/iron/techmaint,
 /area/engine/engine_room)
@@ -72734,14 +72733,14 @@
 /turf/open/floor/carpet/black,
 /area/vacant_room/office)
 "pSd" = (
-/obj/structure/cable/orange{
-	icon_state = "1-2"
-	},
 /obj/effect/turf_decal/siding/dark/corner{
 	dir = 4
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
 	},
 /turf/open/floor/iron/dark/textured,
 /area/engine/engine_room)
@@ -74906,10 +74905,10 @@
 /obj/machinery/power/smes{
 	charge = 5e+006
 	},
-/obj/structure/cable/yellow{
+/obj/structure/cable{
 	icon_state = "0-2"
 	},
-/obj/structure/cable/yellow,
+/obj/structure/cable,
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/tcommsat/server)
 "qrm" = (
@@ -76451,14 +76450,14 @@
 /turf/open/floor/iron,
 /area/maintenance/department/engine)
 "qIj" = (
-/obj/structure/cable/orange{
-	icon_state = "1-8"
-	},
-/obj/structure/cable/orange{
-	icon_state = "2-8"
-	},
 /obj/effect/turf_decal/siding/thinplating_new/dark{
 	dir = 1
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-8"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
 	},
 /turf/open/floor/iron/techmaint,
 /area/engine/engine_room)
@@ -76677,14 +76676,14 @@
 /obj/effect/turf_decal/tile/steelgrid/diagonal{
 	dir = 4
 	},
-/obj/structure/cable/orange{
-	icon_state = "4-8"
-	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
 /turf/open/floor/iron/smooth,
 /area/engine/engine_room)
 "qLa" = (
@@ -76996,9 +76995,6 @@
 /obj/effect/turf_decal/edges/techfloor{
 	dir = 4
 	},
-/obj/structure/cable/orange{
-	icon_state = "0-4"
-	},
 /obj/effect/turf_decal/arrows{
 	dir = 4
 	},
@@ -77007,6 +77003,9 @@
 	},
 /obj/effect/turf_decal/box/corners{
 	dir = 1
+	},
+/obj/structure/cable/yellow{
+	icon_state = "0-4"
 	},
 /turf/open/floor/iron/tech/grid,
 /area/engine/engine_room)
@@ -77025,10 +77024,10 @@
 "qOE" = (
 /obj/machinery/telecomms/processor/preset_three,
 /obj/effect/turf_decal/bot_white,
-/obj/structure/cable/yellow{
+/obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/structure/cable/yellow{
+/obj/structure/cable{
 	icon_state = "1-8"
 	},
 /turf/open/floor/circuit/telecomms/mainframe,
@@ -77526,9 +77525,6 @@
 /turf/open/floor/iron/techmaint,
 /area/medical/morgue)
 "qUL" = (
-/obj/structure/cable/orange{
-	icon_state = "4-8"
-	},
 /obj/effect/turf_decal/siding/thinplating_new/dark{
 	dir = 1
 	},
@@ -77537,6 +77533,9 @@
 	},
 /obj/structure/cable{
 	icon_state = "1-2"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
 	},
 /turf/open/floor/iron/techmaint,
 /area/engine/engine_room)
@@ -78505,7 +78504,7 @@
 "reU" = (
 /obj/machinery/telecomms/bus/preset_four,
 /obj/effect/turf_decal/bot_white,
-/obj/structure/cable/yellow{
+/obj/structure/cable{
 	icon_state = "4-8"
 	},
 /turf/open/floor/circuit/telecomms/mainframe,
@@ -78808,9 +78807,6 @@
 	},
 /obj/effect/turf_decal/tile/dark/fourcorners,
 /obj/effect/turf_decal/tile/monorust,
-/obj/structure/cable/cyan{
-	icon_state = "1-4"
-	},
 /obj/effect/turf_decal/guideline/guideline_in/darkblue{
 	dir = 5
 	},
@@ -78818,6 +78814,9 @@
 	dir = 5
 	},
 /obj/effect/turf_decal/siding/wideplating_new/dark/corner,
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
 /turf/open/floor/iron/large{
 	initial_gas_mix = "n2=100;TEMP=80"
 	},
@@ -79245,11 +79244,11 @@
 "roe" = (
 /obj/machinery/telecomms/processor/preset_two,
 /obj/effect/turf_decal/bot_white,
-/obj/structure/cable/yellow{
-	icon_state = "2-4"
-	},
-/obj/structure/cable/yellow{
+/obj/structure/cable{
 	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
 	},
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/tcommsat/server)
@@ -80601,11 +80600,11 @@
 /obj/effect/turf_decal/tile/monorust{
 	alpha = 255
 	},
-/obj/structure/cable/cyan{
-	icon_state = "1-4"
-	},
 /obj/effect/turf_decal/guideline/guideline_in/darkblue{
 	dir = 5
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
 	},
 /turf/open/floor/iron/large{
 	initial_gas_mix = "n2=100;TEMP=80"
@@ -81978,9 +81977,6 @@
 /obj/effect/turf_decal/arrows{
 	dir = 4
 	},
-/obj/structure/cable/orange{
-	icon_state = "0-4"
-	},
 /obj/machinery/power/emitter/welded{
 	dir = 4
 	},
@@ -81989,6 +81985,9 @@
 	},
 /obj/effect/turf_decal/box/corners{
 	dir = 1
+	},
+/obj/structure/cable/yellow{
+	icon_state = "0-4"
 	},
 /turf/open/floor/iron/tech/grid,
 /area/engine/engine_room)
@@ -82351,9 +82350,6 @@
 /obj/effect/turf_decal/siding/wideplating_new/dark/corner{
 	dir = 4
 	},
-/obj/structure/cable/cyan{
-	icon_state = "4-8"
-	},
 /obj/machinery/atmospherics/pipe/smart/simple/general/hidden{
 	dir = 8
 	},
@@ -82368,8 +82364,11 @@
 /obj/effect/turf_decal/caution/stand_clear{
 	dir = 4
 	},
-/obj/structure/cable/yellow{
+/obj/structure/cable{
 	icon_state = "1-2"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
 	},
 /turf/open/floor/iron/dark/textured_half{
 	dir = 1
@@ -82544,13 +82543,13 @@
 /obj/effect/turf_decal/siding/wideplating_new/dark/corner{
 	dir = 8
 	},
-/obj/structure/cable/cyan{
-	icon_state = "4-8"
-	},
 /obj/machinery/atmospherics/pipe/smart/simple/general/hidden{
 	dir = 8
 	},
-/obj/structure/cable/cyan{
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /turf/open/floor/iron/dark/textured_large,
@@ -82819,11 +82818,11 @@
 /obj/effect/turf_decal/siding/wideplating_new/dark{
 	dir = 8
 	},
-/obj/structure/cable/cyan{
-	icon_state = "1-2"
-	},
 /obj/effect/turf_decal/alphabet/letter_t/quarter{
 	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
 	},
 /turf/open/floor/iron/dark/smooth_corner{
 	dir = 4
@@ -83349,9 +83348,6 @@
 /obj/machinery/power/emitter/welded{
 	dir = 8
 	},
-/obj/structure/cable/orange{
-	icon_state = "0-8"
-	},
 /obj/effect/turf_decal/arrows{
 	dir = 8
 	},
@@ -83359,6 +83355,9 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/box/corners,
+/obj/structure/cable/yellow{
+	icon_state = "0-8"
+	},
 /turf/open/floor/iron/tech/grid,
 /area/engine/engine_room)
 "shZ" = (
@@ -84710,10 +84709,10 @@
 	dir = 8
 	},
 /obj/machinery/newscaster/directional/west,
-/obj/structure/cable/yellow{
+/obj/machinery/light/directional/south,
+/obj/structure/cable{
 	icon_state = "1-4"
 	},
-/obj/machinery/light/directional/south,
 /turf/open/floor/iron/large{
 	initial_gas_mix = "n2=100;TEMP=80"
 	},
@@ -86334,7 +86333,7 @@
 /obj/effect/turf_decal/tile/dark/fourcorners,
 /obj/effect/turf_decal/tile/monorust,
 /obj/item/radio/intercom/directional/west,
-/obj/structure/cable/yellow{
+/obj/structure/cable{
 	icon_state = "1-2"
 	},
 /turf/open/floor/iron/large{
@@ -87215,7 +87214,7 @@
 /area/science/robotics/lab)
 "tdo" = (
 /obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable/yellow{
+/obj/structure/cable{
 	icon_state = "0-2"
 	},
 /turf/open/floor/plating,
@@ -88603,7 +88602,7 @@
 /obj/effect/turf_decal/stripes/closeup{
 	dir = 1
 	},
-/obj/structure/cable/orange{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/iron/textured_half{
@@ -90578,9 +90577,6 @@
 /obj/effect/turf_decal/siding/thinplating_new/dark/corner{
 	dir = 8
 	},
-/obj/structure/cable/cyan{
-	icon_state = "4-8"
-	},
 /obj/effect/turf_decal/trimline/dark_blue/warning_offset{
 	dir = 8
 	},
@@ -90591,6 +90587,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /obj/effect/turf_decal/siding/thinplating_new/dark/corner{
 	dir = 1
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
 	},
 /turf/open/floor/iron/smooth,
 /area/engine/engine_room)
@@ -90750,11 +90749,11 @@
 	},
 /obj/effect/turf_decal/tile/dark/fourcorners,
 /obj/effect/turf_decal/tile/monorust,
-/obj/structure/cable/cyan{
-	icon_state = "4-8"
-	},
 /obj/effect/turf_decal/guideline/guideline_in/darkblue{
 	dir = 1
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
 	},
 /turf/open/floor/iron/large{
 	initial_gas_mix = "n2=100;TEMP=80"
@@ -94456,12 +94455,12 @@
 /obj/machinery/power/terminal{
 	dir = 8
 	},
-/obj/structure/cable/cyan{
-	icon_state = "0-2"
-	},
 /obj/effect/mapping_helpers/make_non_slip,
 /obj/effect/turf_decal/guideline/guideline_in/darkblue{
 	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "0-2"
 	},
 /turf/open/floor/iron/large{
 	initial_gas_mix = "n2=100;TEMP=80"
@@ -100151,11 +100150,11 @@
 "vNL" = (
 /obj/machinery/telecomms/server/presets/science,
 /obj/effect/turf_decal/bot_white,
-/obj/structure/cable/yellow{
-	icon_state = "2-4"
-	},
-/obj/structure/cable/yellow{
+/obj/structure/cable{
 	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
 	},
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/tcommsat/server)
@@ -105969,8 +105968,8 @@
 /turf/open/floor/engine/n2o,
 /area/engine/atmos)
 "xdT" = (
-/obj/structure/cable/yellow,
 /obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/tcommsat/server)
 "xdV" = (
@@ -107311,13 +107310,6 @@
 	dir = 4
 	},
 /area/engine/storage_shared)
-"xvV" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable/yellow{
-	icon_state = "0-4"
-	},
-/turf/open/floor/plating,
-/area/tcommsat/server)
 "xwm" = (
 /obj/effect/turf_decal/siding/dark{
 	dir = 8
@@ -108413,14 +108405,14 @@
 	},
 /obj/effect/turf_decal/tile/dark/fourcorners,
 /obj/effect/turf_decal/tile/monorust,
-/obj/structure/cable/cyan{
-	icon_state = "4-8"
-	},
 /obj/effect/turf_decal/guideline/guideline_in/darkblue{
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/smart/simple/general/hidden{
 	dir = 8
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
 	},
 /turf/open/floor/iron/large{
 	initial_gas_mix = "n2=100;TEMP=80"
@@ -108571,11 +108563,11 @@
 /turf/open/floor/concrete/slab,
 /area/ai_monitored/turret_protected/aisat_interior)
 "xIT" = (
-/obj/structure/cable/orange{
-	icon_state = "2-4"
-	},
 /obj/effect/turf_decal/siding/dark{
 	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "2-4"
 	},
 /turf/open/floor/iron/dark/smooth_half{
 	dir = 1
@@ -110457,15 +110449,15 @@
 /obj/effect/turf_decal/stripes/closeup{
 	dir = 1
 	},
-/obj/structure/cable/cyan{
-	icon_state = "4-8"
-	},
 /obj/machinery/door/airlock/highsecurity{
 	name = "Telecomms Foyer";
 	req_one_access_txt = "19; 61"
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
 /turf/open/floor/iron/dark/textured_half{
 	dir = 1
 	},
@@ -110489,11 +110481,11 @@
 /turf/open/floor/iron/tech/grid,
 /area/science/xenobiology)
 "yfB" = (
-/obj/structure/cable/orange{
-	icon_state = "4-8"
-	},
 /obj/effect/turf_decal/siding/thinplating_new/dark/corner{
 	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
 	},
 /turf/open/floor/iron/smooth,
 /area/engine/engine_room)
@@ -137968,13 +137960,13 @@ jDr
 qVx
 hhb
 hhb
-xvV
+nne
 hhb
 hhb
 hhb
 hhb
 hhb
-xvV
+nne
 hhb
 hhb
 pzO
@@ -139261,7 +139253,7 @@ xHG
 epz
 fAr
 oYN
-xvV
+nne
 nzj
 nzj
 wJq

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -30043,10 +30043,10 @@
 	name = "Prison Blast Door"
 	},
 /obj/structure/cable/yellow,
-/obj/structure/cable/yellow{
-	icon_state = "1-6"
-	},
 /obj/effect/spawner/structure/window/reinforced/prison,
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
 /turf/open/floor/plating,
 /area/security/prison)
 "hIL" = (
@@ -35631,9 +35631,6 @@
 /obj/structure/railing{
 	dir = 1
 	},
-/obj/structure/cable/yellow{
-	icon_state = "4-9"
-	},
 /obj/item/stack/package_wrap,
 /obj/item/stack/package_wrap,
 /obj/item/stack/package_wrap,
@@ -35647,6 +35644,9 @@
 /obj/item/prison_scanner,
 /obj/item/prison_scanner,
 /obj/item/prison_scanner,
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
 /turf/open/floor/prison,
 /area/security/prison)
 "jCO" = (
@@ -40963,6 +40963,12 @@
 	dir = 1
 	},
 /area/security/brig)
+"lEs" = (
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
+	},
+/turf/open/floor/holofloor/plating,
+/area/holodeck/prison)
 "lEI" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 4
@@ -98621,7 +98627,7 @@ ttO
 ttO
 ttO
 ttO
-ttO
+lEs
 jCJ
 noC
 oJD

--- a/_maps/map_files/RadStation/RadStation.dmm
+++ b/_maps/map_files/RadStation/RadStation.dmm
@@ -12587,13 +12587,10 @@
 /area/maintenance/port/aft)
 "egl" = (
 /obj/structure/cable{
-	icon_state = "4-8"
+	icon_state = "1-8"
 	},
 /obj/structure/cable{
-	icon_state = "0-8"
-	},
-/obj/machinery/power/terminal{
-	dir = 1
+	icon_state = "4-8"
 	},
 /turf/open/floor/plating,
 /area/maintenance/solars/port/aft)
@@ -24137,9 +24134,9 @@
 	},
 /area/hallway/secondary/exit/departure_lounge)
 "inY" = (
-/obj/machinery/power/smes,
-/obj/structure/cable/yellow{
-	icon_state = "0-4"
+/obj/machinery/power/solar_control,
+/obj/structure/cable{
+	icon_state = "0-2"
 	},
 /turf/open/floor/plating,
 /area/maintenance/solars/port/aft)
@@ -25816,12 +25813,15 @@
 /turf/open/floor/iron/dark,
 /area/security/warden)
 "iSh" = (
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
 /obj/machinery/light_switch{
 	pixel_x = 1;
 	pixel_y = -21
+	},
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/machinery/power/terminal{
+	dir = 1
 	},
 /turf/open/floor/plating,
 /area/maintenance/solars/port/aft)
@@ -34931,14 +34931,11 @@
 /turf/open/floor/plating,
 /area/medical/morgue)
 "maO" = (
-/obj/machinery/power/solar_control,
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
 /obj/machinery/airalarm/directional/north,
 /obj/structure/cable/yellow{
-	icon_state = "4-8"
+	icon_state = "0-4"
 	},
+/obj/machinery/power/smes,
 /turf/open/floor/plating,
 /area/maintenance/solars/port/aft)
 "mbm" = (
@@ -47473,15 +47470,15 @@
 /turf/open/floor/engine/co2,
 /area/engine/atmos)
 "qsz" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
 /obj/machinery/door/airlock/external{
 	name = "Solar Maintenance";
 	req_one_access_txt = "10;13"
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
 /turf/open/floor/plating,
 /area/maintenance/solars/port/aft)
@@ -51472,9 +51469,6 @@
 /area/ai_monitored/turret_protected/ai)
 "rQz" = (
 /obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
 /turf/open/floor/plating,
 /area/maintenance/solars/port/aft)
 "rQG" = (

--- a/_maps/shuttles/hunter/hunter_russian.dmm
+++ b/_maps/shuttles/hunter/hunter_russian.dmm
@@ -422,9 +422,6 @@
 /turf/open/floor/wood,
 /area/shuttle/hunter)
 "wv" = (
-/obj/structure/cable/yellow{
-	icon_state = "9-10"
-	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/item/weldingtool{
@@ -432,6 +429,9 @@
 	pixel_y = 11
 	},
 /obj/effect/mapping_helpers/tile_breaker,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
 /turf/open/floor/mineral/plastitanium,
 /area/shuttle/hunter)
 "xq" = (
@@ -547,6 +547,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold/purple/visible,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
+	},
 /turf/open/floor/mineral/plastitanium,
 /area/shuttle/hunter)
 "AY" = (
@@ -726,11 +729,11 @@
 /obj/machinery/atmospherics/pipe/smart/manifold/purple/visible{
 	dir = 1
 	},
-/obj/structure/cable/yellow{
-	icon_state = "1-6"
-	},
 /obj/effect/decal/cleanable/oil,
 /obj/effect/mapping_helpers/tile_breaker,
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
 /turf/open/floor/mineral/plastitanium,
 /area/shuttle/hunter)
 "KB" = (
@@ -969,7 +972,7 @@
 /area/shuttle/hunter)
 "TM" = (
 /obj/structure/cable/yellow{
-	icon_state = "4-9"
+	icon_state = "1-4"
 	},
 /turf/open/floor/mineral/plastitanium,
 /area/shuttle/hunter)

--- a/_maps/shuttles/pirate/pirate_default.dmm
+++ b/_maps/shuttles/pirate/pirate_default.dmm
@@ -199,6 +199,9 @@
 /obj/structure/fluff/fans{
 	pixel_x = 24
 	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
 /turf/open/floor/pod/light,
 /area/shuttle/pirate)
 "fl" = (
@@ -223,7 +226,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
-	icon_state = "6-8"
+	icon_state = "4-8"
 	},
 /turf/open/floor/pod/light,
 /area/shuttle/pirate)
@@ -1085,9 +1088,7 @@
 /obj/machinery/power/port_gen/pacman{
 	anchored = 1
 	},
-/obj/structure/cable{
-	icon_state = "0-9"
-	},
+/obj/structure/cable,
 /turf/open/floor/pod/light,
 /area/shuttle/pirate)
 "AW" = (

--- a/code/modules/unit_tests/mapping/check_wire_crossing.dm
+++ b/code/modules/unit_tests/mapping/check_wire_crossing.dm
@@ -1,28 +1,43 @@
 /datum/unit_test/map_test/check_wire_crossing/check_turf(turf/check_turf, is_map_border)
+	// Smartwires reduces the number of wire colours, so we need
+	// to make sure we won't get accidental connections
+	var/static/list/powernet_lookup = list(
+		"red" = "red",
+		"yellow" = "yellow",
+		"green" = "green",
+		"blue" = "pink",
+		"pink" = "pink",
+		"orange" = "orange",
+		"cyan" = "orange",
+		"white" = "pink",
+	)
 	var/list/powernets = null
 	for (var/obj/structure/cable/cable in check_turf)
 		if (!powernets)
 			powernets = list()
-		if (!powernets[cable.color])
-			powernets[cable.color] = cable.powernet
-		else if (powernets[cable.color] != cable.powernet)
+		var/actual_colour = powernet_lookup[cable.color]
+		if (!powernets[actual_colour])
+			powernets[actual_colour] = cable.powernet
+		else if (powernets[actual_colour] != cable.powernet)
 			return "Two wires with the [cable.color] colour were on the same tile with different powernets. This will cause issues when we update to smartcables, please connect these cables or use a different colour."
 	// Check adjacent turfs
 	for (var/obj/structure/cable/cable in get_step(check_turf, NORTH))
 		if (!powernets)
 			powernets = list()
+		var/actual_colour = powernet_lookup[cable.color]
 		// If we don't have that colour, its fine
-		if (!powernets[cable.color])
+		if (!powernets[actual_colour])
 			continue
-		else if (powernets[cable.color] != cable.powernet)
+		else if (powernets[actual_colour] != cable.powernet)
 			return "Two wires with the [cable.color] colour were on the adjacent tile with different powernets. This will cause issues when we update to smartcables, please connect these cables or use a different colour."
 	// Check adjacent turfs
 	for (var/obj/structure/cable/cable in get_step(check_turf, EAST))
 		if (!powernets)
 			powernets = list()
+		var/actual_colour = powernet_lookup[cable.color]
 		// If we don't have that colour, its fine
-		if (!powernets[cable.color])
+		if (!powernets[actual_colour])
 			continue
-		else if (powernets[cable.color] != cable.powernet)
+		else if (powernets[actual_colour] != cable.powernet)
 			return "Two wires with the [cable.color] colour were on the adjacent tile with different powernets. This will cause issues when we update to smartcables, please connect these cables or use a different colour."
 

--- a/code/modules/unit_tests/mapping/check_wire_crossing.dm
+++ b/code/modules/unit_tests/mapping/check_wire_crossing.dm
@@ -15,29 +15,29 @@
 	for (var/obj/structure/cable/cable in check_turf)
 		if (!powernets)
 			powernets = list()
-		var/actual_colour = powernet_lookup[cable.color]
+		var/actual_colour = powernet_lookup[cable.cable_color]
 		if (!powernets[actual_colour])
 			powernets[actual_colour] = cable.powernet
 		else if (powernets[actual_colour] != cable.powernet)
-			return "Two wires with the [cable.color] colour were on the same tile with different powernets. This will cause issues when we update to smartcables, please connect these cables or use a different colour."
+			return "Two wires with the [cable.cable_color] colour were on the same tile with different powernets. This will cause issues when we update to smartcables, please connect these cables or use a different colour."
 	// Check adjacent turfs
 	for (var/obj/structure/cable/cable in get_step(check_turf, NORTH))
 		if (!powernets)
 			powernets = list()
-		var/actual_colour = powernet_lookup[cable.color]
+		var/actual_colour = powernet_lookup[cable.cable_color]
 		// If we don't have that colour, its fine
 		if (!powernets[actual_colour])
 			continue
 		else if (powernets[actual_colour] != cable.powernet)
-			return "Two wires with the [cable.color] colour were on the adjacent tile with different powernets. This will cause issues when we update to smartcables, please connect these cables or use a different colour."
+			return "Two wires with the [cable.cable_color] colour were on the adjacent tile with different powernets. This will cause issues when we update to smartcables, please connect these cables or use a different colour."
 	// Check adjacent turfs
 	for (var/obj/structure/cable/cable in get_step(check_turf, EAST))
 		if (!powernets)
 			powernets = list()
-		var/actual_colour = powernet_lookup[cable.color]
+		var/actual_colour = powernet_lookup[cable.cable_color]
 		// If we don't have that colour, its fine
 		if (!powernets[actual_colour])
 			continue
 		else if (powernets[actual_colour] != cable.powernet)
-			return "Two wires with the [cable.color] colour were on the adjacent tile with different powernets. This will cause issues when we update to smartcables, please connect these cables or use a different colour."
+			return "Two wires with the [cable.cable_color] colour were on the adjacent tile with different powernets. This will cause issues when we update to smartcables, please connect these cables or use a different colour."
 

--- a/code/modules/unit_tests/mapping/check_wire_crossing.dm
+++ b/code/modules/unit_tests/mapping/check_wire_crossing.dm
@@ -15,29 +15,29 @@
 	for (var/obj/structure/cable/cable in check_turf)
 		if (!powernets)
 			powernets = list()
-		var/actual_colour = powernet_lookup[cable.cable_color]
+		var/actual_colour = powernet_lookup[cable::cable_color]
 		if (!powernets[actual_colour])
 			powernets[actual_colour] = cable.powernet
 		else if (powernets[actual_colour] != cable.powernet)
-			return "Two wires with the [cable.cable_color] colour were on the same tile with different powernets. This will cause issues when we update to smartcables, please connect these cables or use a different colour."
+			return "Two wires with the [cable::cable_color] colour were on the same tile with different powernets. This will cause issues when we update to smartcables, please connect these cables or use a different colour."
 	// Check adjacent turfs
 	for (var/obj/structure/cable/cable in get_step(check_turf, NORTH))
 		if (!powernets)
 			powernets = list()
-		var/actual_colour = powernet_lookup[cable.cable_color]
+		var/actual_colour = powernet_lookup[cable::cable_color]
 		// If we don't have that colour, its fine
 		if (!powernets[actual_colour])
 			continue
 		else if (powernets[actual_colour] != cable.powernet)
-			return "Two wires with the [cable.cable_color] colour were on the adjacent tile with different powernets. This will cause issues when we update to smartcables, please connect these cables or use a different colour."
+			return "Two wires with the [cable::cable_color] colour were on the adjacent tile with different powernets. This will cause issues when we update to smartcables, please connect these cables or use a different colour."
 	// Check adjacent turfs
 	for (var/obj/structure/cable/cable in get_step(check_turf, EAST))
 		if (!powernets)
 			powernets = list()
-		var/actual_colour = powernet_lookup[cable.cable_color]
+		var/actual_colour = powernet_lookup[cable::cable_color]
 		// If we don't have that colour, its fine
 		if (!powernets[actual_colour])
 			continue
 		else if (powernets[actual_colour] != cable.powernet)
-			return "Two wires with the [cable.cable_color] colour were on the adjacent tile with different powernets. This will cause issues when we update to smartcables, please connect these cables or use a different colour."
+			return "Two wires with the [cable::cable_color] colour were on the adjacent tile with different powernets. This will cause issues when we update to smartcables, please connect these cables or use a different colour."
 

--- a/tools/maplint/lints/bad_smartwire_cable_varedits.yml
+++ b/tools/maplint/lints/bad_smartwire_cable_varedits.yml
@@ -1,0 +1,5 @@
+help: "You are using a cable with a diagonal direction which will not be supported in the future. Please replace these with cardinal direction running cables."
+/obj/structure/cable:
+  banned_variables:
+    icon_state:
+      deny: ["0-5", "0-6", "0-9", "0-10", "1-5", "1-6", "1-9", "1-10", "2-5", "2-6", "2-9", "2-10", "4-5", "4-6", "4-9", "4-10", "5-6", "5-8", "5-9", "5-10", "6-8", "6-9", "6-10", "8-9", "8-10", "9-10", "5-32", "6-32", "9-32", "10-32", "5-16", "6-16", "9-16", "10-16"]


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This test is removed in #13968

- Smartwires reduces the number of wire colours available, we need to apply colour conversions when checking for adjacent wires so that we can guarantee we won't get faults when the smartwires update path runs.
- Smartwires does not support diagonal wires, so just outright ban these.

## Why It's Good For The Game

If smartwires is only auto-updates it is much easier to deconflict.

## Testing Photographs and Procedure

See CI

## Changelog
:cl:
tweak: Updates some maps for future support of smartwires
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
