### PR TITLE
Adds 11 more character slots + allows donators to have access to the BYOND members character slots 

### DIFF
--- a/code/__DEFINES/preferences.dm
+++ b/code/__DEFINES/preferences.dm
@@ -91,8 +91,8 @@ GLOBAL_LIST_INIT(helmet_styles, list(
 	HELMET_PROTECTIVE,
 ))
 
-// True value of max save slots (3 is default, 8 is byond member, +1 to either if you have the extra slot loadout entry). Potential max is 9
-#define TRUE_MAX_SAVE_SLOTS 9
+// True value of max save slots (9 is default, 18 is byond member / donors, +2 to either if you have the extra slot loadout entry). Potential max is 20
+#define TRUE_MAX_SAVE_SLOTS 20
 
 // Values for /datum/preference/preference_type
 /// This preference is character specific.

--- a/code/modules/client/loadout/loadout_ooc.dm
+++ b/code/modules/client/loadout/loadout_ooc.dm
@@ -5,14 +5,14 @@
 	is_equippable = FALSE
 
 /datum/gear/ooc/char_slot
-	display_name = "extra character slot"
-	description = "An extra charslot. Pretty self-explanatory."
+	display_name = "two extra character slots"
+	description = "Two extra charslots. Pretty self-explanatory."
 	cost = 10000
 	path = /obj/item/toy/figure/captain
 
 /datum/gear/ooc/char_slot/purchase(client/C)
 	// This is only locally immediately after purchase - this will be incremented on load in preferences.dm
-	C.prefs.max_save_slots += 1
+	C.prefs.max_save_slots += 2
 
 /datum/gear/ooc/real_antagtoken
 	display_name = "antag token"

--- a/code/modules/client/preferences/preferences.dm
+++ b/code/modules/client/preferences/preferences.dm
@@ -10,7 +10,7 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 	/// The current active slot, and the one that will be saved as active
 	var/default_slot = 1
 	/// The maximum number of slots we're allowed to contain
-	var/max_save_slots = 3
+	var/max_save_slots = 9
 	/// Cache for the current active character slot
 	var/datum/preferences_holder/preferences_character/character_data
 	/// Cache for player datumized preferences
@@ -111,9 +111,9 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 
 	if(istype(parent))
 		if(!IS_GUEST_KEY(parent.key))
-			unlock_content = !!parent.IsByondMember()
+			unlock_content = (!IS_PATRON(parent)) || !!parent.IsByondMember()
 			if(unlock_content)
-				max_save_slots = 8
+				max_save_slots = 18
 			log_preferences("[parent.ckey]: Checked BYOND membership: [unlock_content ? "MEMBER" : "NONMEMBER"].")
 	else
 		CRASH("attempted to create a preferences datum without a client!")

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/CharacterPreferenceWindow.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/CharacterPreferenceWindow.tsx
@@ -44,7 +44,7 @@ const CharacterProfiles = (props: {
             }}
             tooltip={
               !props.content_unlocked && slot >= props.maxSlot
-                ? 'Buy a BYOND Membership to unlock more slots!'
+                ? 'Buy a BYOND Membership or donate to Beestation to unlock more slots!'
                 : null
             }
             fluid


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Says what it does on the tin. Now the max amount of slots is 20 
Gives a base of 9 slots to non donors who haven't bought the extra character slots (this was the max before if you had both)
The extra character slot gives now 2 slots instead of 1
Donors / byond members get 9 extra slots.

Based on rkz old pr #11523 

Also, before cross comes in here to demand that I make it so that the beecoin purchasable slots be able to be bought twice and half the price, it would be annoying to code something that can only be bought twice + it would be unfair to the people who already bought the slot that they now have lot 5k beecoins. And the whole thing feels rather arbitrary, I'd rather remove the whole thing and split the slots between the dono slots and normal slots. 
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

The current amount of character slots is pitiful, with only 3 slots + 1 more that you can grind for hours to get. It is not really a system that encourages people to play different characters with different personalities, instead it just cements players into playing statics that can do any job across several rounds. 

There is a ton of players, including me, that want to play more characters with interesting backgrounds, personalities and species, but are limited by the current amount of slots. The common answer to this has just been "write down your characters" which I've felt is annoying to do and I'd rather just not play a new character then if I have to constantly switch out and remake characters. So see this as a QoL. 

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

<img width="1484" height="989" alt="image" src="https://github.com/user-attachments/assets/bbc79fd8-8ab2-4021-a106-6de6ff46e5a2" />

</details>

## Changelog
:cl: Geatish
config: Upped the number of character slots from a maximum of 9 to 20. Now everyone has 9 base slots, 2 slots being purchasable from the beecoins store and 9 more if you donate to BYOND or beestation
config: Beestation donators now also have access to the extra character slots, instead of only BYOND donators
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
