### PR TITLE
Allows assemblies to be attached to grenades when completed, adds screentips

### DIFF
--- a/code/__DEFINES/devices.dm
+++ b/code/__DEFINES/devices.dm
@@ -90,5 +90,3 @@ GLOBAL_LIST_INIT(ntos_device_themes_emagged, list(
 #define GRENADE_WIRED 2
 /// Grenade is ready to be activated
 #define GRENADE_READY 3
-/// Grenade is detonated and useless
-#define GRENADE_DETONATED 4

--- a/code/datums/wires/explosive.dm
+++ b/code/datums/wires/explosive.dm
@@ -24,8 +24,7 @@
 	if(!..())
 		return FALSE
 	var/obj/item/grenade/chem_grenade/G = holder
-	if(G.stage == GRENADE_WIRED)
-		return TRUE
+	return !G.active
 
 /datum/wires/explosive/chem_grenade/attach_assembly(color, obj/item/assembly/S)
 	if(istype(S,/obj/item/assembly/timer))

--- a/code/game/objects/items/grenades/_grenade.dm
+++ b/code/game/objects/items/grenades/_grenade.dm
@@ -128,6 +128,7 @@
 	if(shrapnel_type && shrapnel_radius && !shrapnel_initialized) // add a second check for adding the component in case whatever triggered the grenade went straight to prime (badminnery for example)
 		shrapnel_initialized = TRUE
 		AddComponent(/datum/component/pellet_cloud, projectile_type=shrapnel_type, magnitude=shrapnel_radius)
+	update_appearance()
 
 	SEND_SIGNAL(src, COMSIG_GRENADE_PRIME, lanced_by)
 	if(ex_heavy || ex_light || ex_flame)

--- a/code/game/objects/items/grenades/_grenade.dm
+++ b/code/game/objects/items/grenades/_grenade.dm
@@ -119,8 +119,8 @@
 	addtimer(CALLBACK(src, PROC_REF(prime)), isnull(delayoverride)? det_time : delayoverride)
 
 /obj/item/grenade/proc/prime(mob/living/lanced_by)
+	active = FALSE
 	if (dud_flags)
-		active = FALSE
 		update_icon()
 		return FALSE
 

--- a/code/game/objects/items/grenades/_grenade.dm
+++ b/code/game/objects/items/grenades/_grenade.dm
@@ -92,7 +92,7 @@
 
 		return
 
-	if (active)
+	if (active || (dud_flags & GRENADE_USED))
 		return
 	if(!botch_check(user)) // if they botch the prime, it'll be handled in botch_check
 		preprime(user)
@@ -121,15 +121,15 @@
 /obj/item/grenade/proc/prime(mob/living/lanced_by)
 	active = FALSE
 	if (dud_flags)
-		update_icon()
+		update_appearance()
 		return FALSE
 
 	dud_flags |= GRENADE_USED // Don't detonate if we have already detonated.
 	if(shrapnel_type && shrapnel_radius && !shrapnel_initialized) // add a second check for adding the component in case whatever triggered the grenade went straight to prime (badminnery for example)
 		shrapnel_initialized = TRUE
 		AddComponent(/datum/component/pellet_cloud, projectile_type=shrapnel_type, magnitude=shrapnel_radius)
-	update_icon()
 
+	update_appearance()
 	SEND_SIGNAL(src, COMSIG_GRENADE_PRIME, lanced_by)
 	if(ex_heavy || ex_light || ex_flame)
 		explosion(loc, 0, ex_heavy, ex_light, flame_range = ex_flame)

--- a/code/game/objects/items/grenades/_grenade.dm
+++ b/code/game/objects/items/grenades/_grenade.dm
@@ -128,7 +128,7 @@
 	if(shrapnel_type && shrapnel_radius && !shrapnel_initialized) // add a second check for adding the component in case whatever triggered the grenade went straight to prime (badminnery for example)
 		shrapnel_initialized = TRUE
 		AddComponent(/datum/component/pellet_cloud, projectile_type=shrapnel_type, magnitude=shrapnel_radius)
-	update_appearance()
+	update_icon()
 
 	SEND_SIGNAL(src, COMSIG_GRENADE_PRIME, lanced_by)
 	if(ex_heavy || ex_light || ex_flame)

--- a/code/game/objects/items/grenades/chem_grenade.dm
+++ b/code/game/objects/items/grenades/chem_grenade.dm
@@ -74,6 +74,7 @@
 			if (do_after(user, 2 SECONDS, src))
 				to_chat(user, span_notice("You reset the trigger."))
 				dud_flags &= ~GRENADE_USED
+				update_appearance()
 		return
 	if(istype(I, /obj/item/slime_extract) && stage == GRENADE_WIRED)
 		if(!user.transferItemToLoc(I, src))
@@ -135,6 +136,8 @@
 
 	else if(I.tool_behaviour == TOOL_WRENCH)
 		if(beakers.len)
+			// Clear reagents out to prevent exploiting by filling up with reagents and then re-detonating
+			reagents.clear_reagents()
 			for(var/obj/O in beakers)
 				O.forceMove(drop_location())
 				if(!O.reagents)

--- a/code/game/objects/items/grenades/chem_grenade.dm
+++ b/code/game/objects/items/grenades/chem_grenade.dm
@@ -152,7 +152,6 @@
 		return ..()
 
 /obj/item/grenade/chem_grenade/add_context_interaction(datum/screentip_context/context, mob/user, atom/target)
-
 	if (active)
 		context.add_attack_self_action("Accept your fate")
 		return
@@ -164,6 +163,8 @@
 		context.add_attack_self_action("Inspect Wires")
 
 /obj/item/grenade/chem_grenade/add_context_self(datum/screentip_context/context, mob/user)
+	if (active)
+		return
 	if(dud_flags & GRENADE_USED)
 		context.add_left_click_tool_action("Reset trigger", TOOL_SCREWDRIVER)
 		return
@@ -185,23 +186,41 @@
 /obj/item/grenade/chem_grenade/proc/stage_change(N)
 	if(N)
 		stage = N
+	update_appearance()
+	refresh_screentips()
+
+/obj/item/grenade/chem_grenade/update_name(updates)
+	. = ..()
 	if (dud_flags & GRENADE_USED)
 		name = "expended [initial(name)]"
-		desc = "A detonated [initial(desc)]"
-		icon_state = "[initial(icon_state)]_ass"
 	else if(stage == GRENADE_EMPTY)
 		name = "[initial(name)] casing"
-		desc = "A do it yourself [initial(name)]! [initial(casedesc)]"
-		icon_state = initial(icon_state)
 	else if(stage == GRENADE_WIRED)
 		name = "unsecured [initial(name)]"
-		desc = "An unsecured [initial(name)] assembly."
-		icon_state = "[initial(icon_state)]_ass"
 	else if(stage == GRENADE_READY)
 		name = initial(name)
+
+/obj/item/grenade/chem_grenade/update_desc(updates)
+	. = ..()
+	if (dud_flags & GRENADE_USED)
+		desc = "A detonated [initial(desc)]"
+	else if(stage == GRENADE_EMPTY)
+		desc = "A do it yourself [initial(name)]! [initial(casedesc)]"
+	else if(stage == GRENADE_WIRED)
+		desc = "An unsecured [initial(name)] assembly."
+	else if(stage == GRENADE_READY)
 		desc = initial(desc)
+
+/obj/item/grenade/chem_grenade/update_icon_state()
+	. = ..()
+	if (dud_flags & GRENADE_USED)
+		icon_state = "[initial(icon_state)]_ass"
+	else if(stage == GRENADE_EMPTY)
+		icon_state = initial(icon_state)
+	else if(stage == GRENADE_WIRED)
+		icon_state = "[initial(icon_state)]_ass"
+	else if(stage == GRENADE_READY)
 		icon_state = "[initial(icon_state)]_locked"
-	refresh_screentips()
 
 /obj/item/grenade/chem_grenade/on_found(mob/finder)
 	var/obj/item/assembly/A = wires.get_attached(wires.get_wire(1))
@@ -329,7 +348,7 @@
 /obj/item/grenade/chem_grenade/adv_release/prime(mob/living/lanced_by)
 	if(stage != GRENADE_READY || dud_flags)
 		active = FALSE
-		update_icon()
+		update_appearance()
 		return
 
 	max_integrity = 1

--- a/code/game/objects/items/grenades/chem_grenade.dm
+++ b/code/game/objects/items/grenades/chem_grenade.dm
@@ -173,7 +173,7 @@
 		context.add_left_click_tool_action("Complete", TOOL_SCREWDRIVER)
 	else if (stage == GRENADE_READY)
 		context.add_left_click_tool_action("Adjust Timer", TOOL_SCREWDRIVER)
-	if (is_type_in_list(context.held_item, allowed_containers) && beakers.len < 2)
+	if (stage == GRENADE_WIRED && is_type_in_list(context.held_item, allowed_containers) && beakers.len < 2)
 		context.add_left_click_action("Insert")
 	if (stage == GRENADE_EMPTY)
 		context.add_left_click_item_action("Wire", /obj/item/stack/cable_coil)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

- Assemblies no longer require chemical grenades to be in their wired state to be attached
- Adds screentip controls to chemical grenades
- Removes the code for detonated grenades, because it already exists. You can now use screwdrivers to reset detonated chemical grenades that did not get destroyed in an explosion.

## Why It's Good For The Game

These things have been real buggers to use because you complete it and then are unable to attach any wires. This also adds screentips to help the process out.

## Testing Photographs and Procedure



https://github.com/user-attachments/assets/9a9e556b-3f12-4141-bf0a-a33f1d27f6e8


## Changelog
:cl:
tweak: Chemical grenades can now have assemblies attached when completed.
add: Adds screentips to chemical grenades.
tweak: If a chemical grenade does not explode, you can screwdriver it to reset it. You cannot re-use the reagents though as they will be cleared when you remove the beakers from it.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
