### PR TITLE
Fixes screen shake crash

### DIFF
--- a/code/datums/status_effects/debuffs/dizziness.dm
+++ b/code/datums/status_effects/debuffs/dizziness.dm
@@ -68,8 +68,8 @@
 	animate(owner.client, pixel_x = x_diff, pixel_y = y_diff, 3, easing = JUMP_EASING | EASE_OUT, flags = ANIMATION_RELATIVE)
 	delay += 0.3 SECONDS // This counts as a 0.3 second wait, so we need to shift the sine wave by that much
 
-	x_diff = amplitude * sin(next_amount * (time + delay))
-	y_diff = amplitude * cos(next_amount * (time + delay))
+	x_diff = clamp(amplitude * sin(next_amount * (time + delay)), -view_range, view_range)
+	y_diff = clamp(amplitude * cos(next_amount * (time + delay)), -view_range, view_range)
 	pixel_x_diff += x_diff
 	pixel_y_diff += y_diff
 	animate(pixel_x = x_diff, pixel_y = y_diff, 3, easing = JUMP_EASING | EASE_OUT, flags = ANIMATION_RELATIVE)

--- a/code/datums/status_effects/debuffs/dizziness.dm
+++ b/code/datums/status_effects/debuffs/dizziness.dm
@@ -53,12 +53,9 @@
 	var/pixel_x_diff = 0
 	var/pixel_y_diff = 0
 
-	// This shit is annoying at high strengthvar/pixel_x_diff = 0
-	var/list/view_range_list = getviewsize(owner.client.view)
-	var/view_range = view_range_list[1]
 	var/amplitude = amount * (sin(amount * (time)) + 1)
-	var/x_diff = clamp(amplitude * sin(amount * time), -view_range, view_range)
-	var/y_diff = clamp(amplitude * cos(amount * time), -view_range, view_range)
+	var/x_diff = clamp(amplitude * sin(amount * time), -32, 32)
+	var/y_diff = clamp(amplitude * cos(amount * time), -32, 32)
 	pixel_x_diff += x_diff
 	pixel_y_diff += y_diff
 	// Brief explanation. We're basically snapping between different pixel_x/ys instantly, with delays between
@@ -68,8 +65,8 @@
 	animate(owner.client, pixel_x = x_diff, pixel_y = y_diff, 3, easing = JUMP_EASING | EASE_OUT, flags = ANIMATION_RELATIVE)
 	delay += 0.3 SECONDS // This counts as a 0.3 second wait, so we need to shift the sine wave by that much
 
-	x_diff = clamp(amplitude * sin(next_amount * (time + delay)), -view_range, view_range)
-	y_diff = clamp(amplitude * cos(next_amount * (time + delay)), -view_range, view_range)
+	x_diff = clamp(amplitude * sin(next_amount * (time + delay)), -32, 32)
+	y_diff = clamp(amplitude * cos(next_amount * (time + delay)), -32, 32)
 	pixel_x_diff += x_diff
 	pixel_y_diff += y_diff
 	animate(pixel_x = x_diff, pixel_y = y_diff, 3, easing = JUMP_EASING | EASE_OUT, flags = ANIMATION_RELATIVE)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

fixes #13973

- Screen shake now shakes to a maximum on both effects, preventing crashing
- Replaces the screen size shake with just the number 32 (1 tile) because limiting the shake to 17 is totally arbitrary and 17*32 would probably just crash.

## Why It's Good For The Game

I dont like crashing from buggy code.

## Testing Photographs and Procedure

https://github.com/user-attachments/assets/250f1dd2-7ebf-4747-a27d-763a5ca463fe

## Changelog
:cl:
fix: Crashing caused by dizziness status effect.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
