### PR TITLE
Small lavaland Swarmer Nerf

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/megafauna/swarmer.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/swarmer.dm
@@ -247,7 +247,7 @@ GLOBAL_LIST_INIT(AISwarmerCapsByType, list(/mob/living/simple_animal/hostile/swa
 /mob/living/simple_animal/hostile/swarmer/ai/ranged_combat
 	icon_state = "swarmer_ranged"
 	icon_living = "swarmer_ranged"
-	projectiletype = /obj/projectile/beam/laser
+	projectiletype = /obj/projectile/beam/laser/lesslethal
 	projectilesound = 'sound/weapons/laser.ogg'
 	check_friendly_fire = TRUE //you're supposed to protect the resource swarmers, you poop
 	retreat_distance = 3
@@ -262,8 +262,8 @@ GLOBAL_LIST_INIT(AISwarmerCapsByType, list(/mob/living/simple_animal/hostile/swa
 /mob/living/simple_animal/hostile/swarmer/ai/melee_combat
 	icon_state = "swarmer_melee"
 	icon_living = "swarmer_melee"
-	health = 60
-	maxHealth = 60
+	health = 40
+	maxHealth = 40
 	ranged = FALSE
 
 /mob/living/simple_animal/hostile/swarmer/ai/melee_combat/Aggro()
@@ -277,9 +277,9 @@ GLOBAL_LIST_INIT(AISwarmerCapsByType, list(/mob/living/simple_animal/hostile/swa
 			StartAction(30)
 			DisperseTarget(target)
 		else
-			var/mob/living/L = target
-			L.attack_animal(src)
-			L.electrocute_act(10, src, flags = SHOCK_NOGLOVES)
+			var/mob/living/mob = target
+			mob.attack_animal(src)
+			mob.apply_damage(25, STAMINA) // Why did it use the shocking, that's ass
 		return TRUE
 	else
 		return ..()

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/swarmer.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/swarmer.dm
@@ -279,7 +279,7 @@ GLOBAL_LIST_INIT(AISwarmerCapsByType, list(/mob/living/simple_animal/hostile/swa
 		else
 			var/mob/living/mob = target
 			mob.attack_animal(src)
-			mob.adjustStaminaLoss(25) // Why did it use shocking, that's ass
+			mob.adjustStaminaLoss(40) // Why did it use shocking, that's ass
 		return TRUE
 	else
 		return ..()

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/swarmer.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/swarmer.dm
@@ -262,8 +262,8 @@ GLOBAL_LIST_INIT(AISwarmerCapsByType, list(/mob/living/simple_animal/hostile/swa
 /mob/living/simple_animal/hostile/swarmer/ai/melee_combat
 	icon_state = "swarmer_melee"
 	icon_living = "swarmer_melee"
-	health = 40
-	maxHealth = 40
+	health = 60
+	maxHealth = 60
 	ranged = FALSE
 
 /mob/living/simple_animal/hostile/swarmer/ai/melee_combat/Aggro()
@@ -279,7 +279,7 @@ GLOBAL_LIST_INIT(AISwarmerCapsByType, list(/mob/living/simple_animal/hostile/swa
 		else
 			var/mob/living/mob = target
 			mob.attack_animal(src)
-			mob.apply_damage(25, STAMINA) // Why did it use the shocking, that's ass
+			mob.adjustStaminaLoss(25) // Why did it use shocking, that's ass
 		return TRUE
 	else
 		return ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

People have been complaining for ages on lavaland swarmers, we either remove them completely or nerf them 

## Why It's Good For The Game


Hopefully they're a lot more bearable to deal with 

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

It's just a few minor code changes

</details>

## Changelog
:cl: Isaac
balance: Melee swarmers now deal stamina damage instead of straight up shocking you
balance: Ranged swarmers (red ones) now shoot less lethal ammo instead of just lasers
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
