### PR TITLE
Rubber ducks can be ordered from cargo

### DIFF
--- a/code/game/objects/items/stacks/sheets/miscellaneous/miscellaneous_mats_recipes.dm
+++ b/code/game/objects/items/stacks/sheets/miscellaneous/miscellaneous_mats_recipes.dm
@@ -27,6 +27,7 @@ GLOBAL_LIST_INIT(plastic_recipes, list(
 	new /datum/stack_recipe("water bottle", /obj/item/reagent_containers/cup/glass/waterbottle/empty, category = CAT_CONTAINERS), \
 	new /datum/stack_recipe("large water bottle", /obj/item/reagent_containers/cup/glass/waterbottle/large/empty, 3, category = CAT_CONTAINERS), \
 	new /datum/stack_recipe("wet floor sign", /obj/item/clothing/suit/caution, 2, category = CAT_EQUIPMENT), \
+	new /datum/stack_recipe("rubber ducky", /obj/item/bikehorn/rubberducky, 1, category = CAT_ENTERTAINMENT), \
 ))
 
 STACKSIZE_MACRO(/obj/item/stack/sheet/plastic)

--- a/code/game/objects/items/stacks/sheets/miscellaneous/miscellaneous_mats_recipes.dm
+++ b/code/game/objects/items/stacks/sheets/miscellaneous/miscellaneous_mats_recipes.dm
@@ -27,7 +27,6 @@ GLOBAL_LIST_INIT(plastic_recipes, list(
 	new /datum/stack_recipe("water bottle", /obj/item/reagent_containers/cup/glass/waterbottle/empty, category = CAT_CONTAINERS), \
 	new /datum/stack_recipe("large water bottle", /obj/item/reagent_containers/cup/glass/waterbottle/large/empty, 3, category = CAT_CONTAINERS), \
 	new /datum/stack_recipe("wet floor sign", /obj/item/clothing/suit/caution, 2, category = CAT_EQUIPMENT), \
-	new /datum/stack_recipe("rubber ducky", /obj/item/bikehorn/rubberducky, 1, category = CAT_ENTERTAINMENT), \
 ))
 
 STACKSIZE_MACRO(/obj/item/stack/sheet/plastic)

--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -3384,6 +3384,21 @@
 		plush_nomoth = pick(_temporary_list_plush_nomoth)
 		new plush_nomoth(C)
 
+/datum/supply_pack/costumes_toys/ducks
+	name = "Rubber Duck Crate"
+	desc = "A crate filled with 5 adorable rubber ducks!"
+	cost = 100
+	max_supply = 100000
+	contains = list(
+		/obj/item/bikehorn/rubberducky,
+		/obj/item/bikehorn/rubberducky,
+		/obj/item/bikehorn/rubberducky,
+		/obj/item/bikehorn/rubberducky,
+		/obj/item/bikehorn/rubberducky,
+	)
+	crate_name = "duck crate"
+	crate_type = /obj/structure/closet/crate/wooden
+
 //////////////////////////////////////////////////////////////////////////////
 ///////////////////////// Wardrobe Resupplies ////////////////////////////////
 //////////////////////////////////////////////////////////////////////////////

--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -3387,8 +3387,8 @@
 /datum/supply_pack/costumes_toys/ducks
 	name = "Rubber Duck Crate"
 	desc = "A crate filled with 5 adorable rubber ducks!"
-	cost = 100
-	max_supply = 100000
+	cost = 2000
+	max_supply = 5
 	contains = list(
 		/obj/item/bikehorn/rubberducky,
 		/obj/item/bikehorn/rubberducky,


### PR DESCRIPTION
## About The Pull Request

~~Rubber ducks can be crafted with 1 plastic~~ Rubber ducks can be bought from cargo

## Why It's Good For The Game

Rubber ducks are a fun gimmick item which can be crafted into explosive rubber duckies given the right equipment (explosive flash bulbs). This allows rubber ducks to be readily obtainable if they are not otherwise

## Testing Photographs and Procedure




<summary>Screenshots&Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.
<img width="846" height="1138" alt="Screenshot 2026-01-14 003015" src="https://github.com/user-attachments/assets/d77e7467-e136-4140-b057-df4962e0cc14" />


</details>

## Changelog
:cl:
add: Rubber ducks can be purchased from cargo
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
