### PR TITLE
Fixes organ smartfridge runtime

### DIFF
--- a/code/modules/food_and_drinks/kitchen_machinery/smartfridge.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/smartfridge.dm
@@ -731,7 +731,7 @@
 
 /obj/machinery/smartfridge/organ/Exited(atom/movable/gone, direction)
 	. = ..()
-	if(istype(gone))
+	if(isorgan(gone))
 		var/obj/item/organ/organ = gone
 		organ.organ_flags &= ~ORGAN_FROZEN
 


### PR DESCRIPTION
## About The Pull Request

We were doing an `istype()` check when we should've been doing an `isorgan()` check

## Why It's Good For The Game

uh

## Testing Photographs and Procedure

previously the runtime was most commonly triggered by the smartfridge being destroyed

https://github.com/user-attachments/assets/940cbc8a-49d3-4c4c-a957-6fd3d4a94d70

## Changelog
:cl:
fix: Fixed organ smart fridges runtiming when a non-organ is removed from their contents
/:cl:
