### PR TITLE
[s] Sanity checks the banning panel - kills all moderators (they EXPLODE)

### DIFF
--- a/tgui/packages/tgui/interfaces/BanningPanel.jsx
+++ b/tgui/packages/tgui/interfaces/BanningPanel.jsx
@@ -42,6 +42,12 @@ export const BanningPanel = (props) => {
     selected_groups,
   } = data;
 
+  // The anti-moderator death grinder
+  const hasValidKey = key_enabled && key && key.trim() !== '';
+  const hasValidIp = ip_enabled && ip && ip.trim() !== '';
+  const hasValidCid = cid_enabled && cid && cid.trim() !== '';
+  const canSubmit = hasValidKey || hasValidIp || hasValidCid;
+
   return (
     <Window
       theme="admin"
@@ -239,6 +245,9 @@ export const BanningPanel = (props) => {
         <Button.Confirm
           content="Submit"
           onClick={() => act('submit_ban')}
+          // Disabled if no key OR no IP OR no CID. Look at the checkbox too so some wiseguy doesn't fuck it up by inputting then unchecking either
+          disabled={!canSubmit}
+          tooltip={!canSubmit ? 'CKEY/IP/CID is required' : null}
           m={0.5}
           width={7}
           height={2}


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This sanity checks the banning panel so it no longer assumes that relevant identification fields have been filled out before submission.

The code is the following:
``
canSubmit = (key_enabled && key && key.trim() !== '' ) || (ip_enabled && ip && ip.trim() !== '') || (cid_enabled && cid && cid.trim() !== '');
``

AKA

``
We have the ckey checked AND there is words in the box AND the words are not just whitespace OR We have the ip checked AND there is words in the box AND the words are not just whitepace OR We have the CID checked AND there is words in the box AND the words are not just whitepace
``

In my hubris I declare this code unbeatable.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Administration issue

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

Tooltip upon failing the checks

<img width="970" height="1035" alt="Screenshot from 2026-01-14 22-31-36" src="https://github.com/user-attachments/assets/eb4a12e1-641b-4ebb-8ab1-da9cac77fcc1" />

Non-disabled after atleast one parameter fulfilled

<img width="879" height="572" alt="image" src="https://github.com/user-attachments/assets/e504f358-5def-4027-9c78-981f6f66e1f4" />


</details>

## Changelog
:cl:
admin: Adds sanity checks to administration banning tool to prevent orphan entries (submission with no player identifiers)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
