### PR TITLE
Radiation exposure now causes more consistent mutations

### DIFF
--- a/code/__DEFINES/radiation.dm
+++ b/code/__DEFINES/radiation.dm
@@ -9,11 +9,6 @@ Ask Mothblocks if they're around
 /// Chance of you hair starting to fall out every second when over threshold
 #define RAD_MOB_HAIRLOSS_PROB 7.5
 
-/// How much stored radiation to check for mutation
-#define RAD_MOB_MUTATE 90
-/// Chance of randomly mutating every second when over threshold
-#define RAD_MOB_MUTATE_PROB 0.5
-
 /// How much stored radiation to check for vomitting
 #define RAD_MOB_VOMIT 60
 /// Chance per second of vomitting

--- a/code/datums/components/irradiated.dm
+++ b/code/datums/components/irradiated.dm
@@ -5,7 +5,7 @@
 
 #define RADIATION_GLOW_THRESHOLD 20
 #define RADIATION_ALERT_THRESHOLD 20
-#define RADIATION_MUTATE_THRESHOLD 40
+#define RADIATION_MUTATE_THRESHOLD 75
 #define RADIATION_BURN_THRESHOLD 75
 
 #define RADIATION_BURN_SPLOTCH_DAMAGE 11
@@ -121,7 +121,7 @@
 	if (intensity >= RADIATION_BURN_THRESHOLD && !trying_to_burn)
 		start_burn_splotch_timer()
 
-	if(intensity >= RADIATION_MUTATE_THRESHOLD && COOLDOWN_FINISHED(src, irradiated_mutation))
+	if(intensity >= RADIATION_MUTATE_THRESHOLD && COOLDOWN_FINISHED(src, irradiated_mutation) && DT_PROB(5, delta_time))
 		mutate_human_parent(human_parent)
 
 	var/damage = min(RADIATION_TOX_DAMAGE_PER_INTENSITY * intensity * delta_time, RADIATION_MAX_TOX_DAMAGE)
@@ -147,9 +147,11 @@
 
 /datum/component/irradiated/proc/mutate_human_parent(mob/living/carbon/human/human_parent)
 	COOLDOWN_START(src, irradiated_mutation, rand(45, 120) SECONDS)
-	human_parent.easy_random_mutate()
-	human_parent.random_mutate_unique_features()
-	human_parent.random_mutate_unique_identity()
+	if(prob(75)) //usually a mutation, sometimes a total appearance change instead
+		human_parent.easy_random_mutate()
+	else
+		human_parent.random_mutate_unique_features()
+		human_parent.random_mutate_unique_identity()
 
 /datum/component/irradiated/proc/start_burn_splotch_timer()
 	trying_to_burn = TRUE

--- a/code/datums/components/irradiated.dm
+++ b/code/datums/components/irradiated.dm
@@ -5,6 +5,7 @@
 
 #define RADIATION_GLOW_THRESHOLD 20
 #define RADIATION_ALERT_THRESHOLD 20
+#define RADIATION_MUTATE_THRESHOLD 40
 #define RADIATION_BURN_THRESHOLD 75
 
 #define RADIATION_BURN_SPLOTCH_DAMAGE 11
@@ -31,6 +32,7 @@
 
 	COOLDOWN_DECLARE(clean_cooldown)
 	COOLDOWN_DECLARE(last_tox_damage)
+	COOLDOWN_DECLARE(irradiated_mutation)
 
 /datum/component/irradiated/Initialize(intensity)
 	if (!CAN_IRRADIATE(parent))
@@ -119,6 +121,9 @@
 	if (intensity >= RADIATION_BURN_THRESHOLD && !trying_to_burn)
 		start_burn_splotch_timer()
 
+	if(intensity >= RADIATION_MUTATE_THRESHOLD && COOLDOWN_FINISHED(src, irradiated_mutation))
+		mutate_human_parent(human_parent)
+
 	var/damage = min(RADIATION_TOX_DAMAGE_PER_INTENSITY * intensity * delta_time, RADIATION_MAX_TOX_DAMAGE)
 	if(!HAS_TRAIT(human_parent, TRAIT_TOXIMMUNE))
 		human_parent.adjustToxLoss(damage)
@@ -139,6 +144,12 @@
 		return TRUE
 
 	return FALSE
+
+/datum/component/irradiated/proc/mutate_human_parent(mob/living/carbon/human/human_parent)
+	COOLDOWN_START(src, irradiated_mutation, rand(45, 120) SECONDS)
+	human_parent.easy_random_mutate()
+	human_parent.random_mutate_unique_features()
+	human_parent.random_mutate_unique_identity()
 
 /datum/component/irradiated/proc/start_burn_splotch_timer()
 	trying_to_burn = TRUE

--- a/code/modules/mob/living/carbon/human/_species.dm
+++ b/code/modules/mob/living/carbon/human/_species.dm
@@ -1629,12 +1629,6 @@ GLOBAL_LIST_EMPTY(features_by_species)
 	if(intensity > RAD_MOB_VOMIT && DT_PROB(RAD_MOB_VOMIT_PROB, delta_time))
 		source.vomit(10, TRUE)
 
-	if(intensity > RAD_MOB_MUTATE && source.can_mutate() && DT_PROB(RAD_MOB_MUTATE_PROB, delta_time))
-		to_chat(source, span_danger("You mutate!"))
-		source.easy_random_mutate(NEGATIVE + MINOR_NEGATIVE)
-		source.emote("gasp")
-		source.domutcheck()
-
 	if(intensity > RAD_MOB_HAIRLOSS && DT_PROB(RAD_MOB_HAIRLOSS_PROB, delta_time))
 		if(!(source.hair_style == "Bald") && (HAIR in species_traits) && !HAS_TRAIT(source, TRAIT_NOHAIRLOSS))
 			to_chat(source, span_danger("Your hair starts to fall out in clumps."))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

* Radiation now has a 5% chance per second to mutate humanoids that can be mutated, starting at 75% intensity. 
* After mutating someone, it goes on cooldown for 45-120 seconds so that unlucky players don't get spammed with mutations
* Mutations are no longer locked to negative mutations and may be positive, but also have a 25% chance of changing appearance instead of being a simple genetic mutation you take mutadone for.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

They're my favorite part of radstorms, and with radstorms getting properly fixed to simply cause radiation damage soon I'd like to see this behavior moved into radiation as a whole, but in a more sensible way. 

Radstorms had the problem of absolutely bombarding you with mutations, stacking them sky high, so this PR aims to be more sensible about them giving a bit more breathing room between each mutation, and also having a much higher chance of yielding good mutations so maybe getting irradiated isn't entirely awful and some crazy folks will do it just to get mutated for fun. 

Radiation as a whole already had a chance to mutate, but it was so low that not only did I not realize this, but the person who ported the system didn't remember it doing so at first glance so I think increasing the consistency of this effect will be good for the player experience. 

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

I tested this by irradiating someone and verifying the cooldown was applying properly, then manually resetting the cooldown to 0 to trigger a new round of mutations. There's not really a lot to show in the case of pictures since most mutations are largely invisible. 

I will post a screenshot of whatever you would like, but github's gif/video limit has rendered my recordings too large to attach. 

<img width="1325" height="295" alt="image" src="https://github.com/user-attachments/assets/8c1c2658-fefb-4596-8020-3637e215e038" />


</details>

## Changelog
:cl:
tweak: Players now have a greater chance of being mutated when irradiated
tweak: Mutations from radiation are no longer locked to being negative mutations, you have an equal chance at any mutation
tweak: Mutations from radiation have a lower chance of affecting your appearance instead of giving an easily reversible genetic mutation
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
