### PR TITLE
Fixes silicons not being able to sign into records

### DIFF
--- a/code/game/machinery/computer/records/medical.dm
+++ b/code/game/machinery/computer/records/medical.dm
@@ -59,7 +59,7 @@
 	if(.)
 		return
 
-	if (!authenticated)
+	if (!authenticated || issilicon(usr)) // Silicons are forbidden from editing records.
 		return FALSE
 
 	var/datum/record/crew/target_record

--- a/code/game/machinery/computer/records/records.dm
+++ b/code/game/machinery/computer/records/records.dm
@@ -37,7 +37,7 @@
 
 	var/mob/user = ui.user
 
-	if (!authenticated || issilicon(user)) // Silicons are forbidden from editing records.
+	if (issilicon(user)) // Silicons are forbidden from editing records.
 		return FALSE
 
 	var/datum/record/crew/target_record

--- a/code/game/machinery/computer/records/records.dm
+++ b/code/game/machinery/computer/records/records.dm
@@ -141,7 +141,7 @@
 
 /// Detects whether a user can use buttons on the machine
 /obj/machinery/computer/records/proc/has_auth(mob/user)
-	if(IsAdminGhost(user)) // Admins don't need to authenticate
+	if(IsAdminGhost(user) || user.has_unlimited_silicon_privilege) // Admins (and silicons) don't need to authenticate
 		return TRUE
 
 	if(!isliving(user))

--- a/code/game/machinery/computer/records/records.dm
+++ b/code/game/machinery/computer/records/records.dm
@@ -37,6 +37,9 @@
 
 	var/mob/user = ui.user
 
+	if (!authenticated || issilicon(user)) // Silicons are forbidden from editing records.
+		return FALSE
+
 	var/datum/record/crew/target_record
 	if(params["record_ref"])
 		target_record = locate(params["record_ref"]) in GLOB.manifest.general
@@ -141,7 +144,7 @@
 
 /// Detects whether a user can use buttons on the machine
 /obj/machinery/computer/records/proc/has_auth(mob/user)
-	if(IsAdminGhost(user) || user.has_unlimited_silicon_privilege) // Admins (and silicons) don't need to authenticate
+	if(IsAdminGhost(user)) // Admins don't need to authenticate
 		return TRUE
 
 	if(!isliving(user))

--- a/code/game/machinery/computer/records/security.dm
+++ b/code/game/machinery/computer/records/security.dm
@@ -128,7 +128,7 @@ CREATION_TEST_IGNORE_SUBTYPES(/obj/machinery/computer/records/security)
 	var/mob/user = ui.user
 	var/datum/record/crew/target_record
 
-	if (!authenticated)
+	if (!authenticated || issilicon(user)) // Silicons are forbidden from editing records.
 		return FALSE
 
 	if (action == "set_amount")

--- a/tgui/packages/tgui/interfaces/MedicalRecords/RecordView.tsx
+++ b/tgui/packages/tgui/interfaces/MedicalRecords/RecordView.tsx
@@ -101,7 +101,7 @@ export const MedicalRecordView = (props) => {
                   onChange={(_, value) =>
                     act('edit_field', {
                       field: 'age',
-                      ref: record_ref,
+                      record_ref: record_ref,
                       value: value,
                     })
                   }

--- a/tgui/packages/tgui/interfaces/MedicalRecords/index.tsx
+++ b/tgui/packages/tgui/interfaces/MedicalRecords/index.tsx
@@ -8,13 +8,13 @@ import { MedicalRecordData } from './types';
 
 export const MedicalRecords = (props) => {
   const { data } = useBackend<MedicalRecordData>();
-  const { authenticated } = data;
+  const { authenticated, is_silicon } = data;
 
   return (
     <Window title="Medical Records" width={750} height={550}>
       <Window.Content>
         <Stack fill>
-          {!authenticated ? <UnauthorizedView /> : <AuthView />}
+          {authenticated || is_silicon ? <AuthView /> : <UnauthorizedView />}
         </Stack>
       </Window.Content>
     </Window>


### PR DESCRIPTION
## About The Pull Request

I have no idea why this broke now and worked fine a few months ago when I made my changes.

## Why It's Good For The Game

closes #14005

## Testing Photographs and Procedure

<img width="1532" height="596" alt="image" src="https://github.com/user-attachments/assets/95e558a4-d6ee-4a65-90a9-26a9d3bba771" />

https://github.com/user-attachments/assets/989a4c7e-a9fc-49e3-aa8a-a0fd74c18e15

## Changelog
:cl:
fix: Fixed silicons not being able to sign into security/medical records
/:cl: