### PR TITLE
Fixes play_attack_sound() runtime

### DIFF
--- a/code/game/atom/atom_defense.dm
+++ b/code/game/atom/atom_defense.dm
@@ -120,7 +120,7 @@
 			else
 				playsound(src, 'sound/weapons/tap.ogg', 50, TRUE)
 		if(BURN)
-			playsound(src.loc, 'sound/items/welder.ogg', 100, TRUE)
+			playsound(src, 'sound/items/welder.ogg', 100, TRUE)
 
 ///Called to get the damage that hulks will deal to the atom.
 /atom/proc/hulk_damage()


### PR DESCRIPTION
## About The Pull Request

When attacking a turf, its loc will be an area, we cannot play sounds in areas.

## Why It's Good For The Game



## Testing Photographs and Procedure

https://github.com/user-attachments/assets/bfbce9a7-80c8-41c4-bc53-9a56ca9f05d7

## Changelog
:cl:
fix: Fixed a runtime when hitting a turf with a burn weapon
/:cl:
