### PR TITLE
Fixes exploration breaching charge functioning as grenades

### DIFF
--- a/code/modules/exploration_crew/exploration_explosives.dm
+++ b/code/modules/exploration_crew/exploration_explosives.dm
@@ -25,6 +25,9 @@
 	attached_detonators = null
 	. = ..()
 
+/obj/item/grenade/exploration/attack_self(mob/user)
+	return
+
 /obj/item/grenade/exploration/attackby(obj/item/W, mob/user, params)
 	if(istype(W, /obj/item/exploration_detonator))
 		var/obj/item/exploration_detonator/detonator = W


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

- Prevents exploration breaching charges from being primed like grenades using the same method C4 uses.

## Why It's Good For The Game

Exploration should not be able to prime breaching charges as grenades.

## Testing Photographs and Procedure

https://github.com/user-attachments/assets/a8c37c60-b06a-45f7-b39a-c43ad582071f

## Changelog
:cl:
fix: Breaching charges can no longer have their pin pulled as if they were a grenade.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
