### PR TITLE
Destroyed catwalks now drop 2 iron rods instead of just 1

### DIFF
--- a/code/game/objects/structures/catwalk.dm
+++ b/code/game/objects/structures/catwalk.dm
@@ -8,6 +8,7 @@
 	smoothing_groups = list(SMOOTH_GROUP_OPEN_FLOOR, SMOOTH_GROUP_CATWALK, SMOOTH_GROUP_LATTICE)
 	canSmoothWith = list(SMOOTH_GROUP_CATWALK)
 	z_flags = Z_BLOCK_OUT_DOWN | Z_BLOCK_IN_UP
+	number_of_rods = 2
 	//Negates the effect of space and openspace.
 	//Shouldn't be placed above anything else.
 	FASTDMM_PROP(\

--- a/code/game/objects/structures/lattice.dm
+++ b/code/game/objects/structures/lattice.dm
@@ -4,19 +4,17 @@
 	icon = 'icons/obj/smooth_structures/catwalks/lattice.dmi'
 	icon_state = "lattice-255"
 	base_icon_state = "lattice"
-	smoothing_flags = SMOOTH_BITMASK
-	smoothing_groups = list(SMOOTH_GROUP_LATTICE)
-	canSmoothWith = list(SMOOTH_GROUP_OPEN_FLOOR, SMOOTH_GROUP_WALLS, SMOOTH_GROUP_WINDOW_FULLTILE, SMOOTH_GROUP_LATTICE)
 	density = FALSE
 	anchored = TRUE
 	armor_type = /datum/armor/structure_lattice
 	max_integrity = 50
 	layer = LATTICE_LAYER //under pipes
 	plane = FLOOR_PLANE
-	var/number_of_rods = 1
-	//	flags = CONDUCT_1
+	smoothing_flags = SMOOTH_BITMASK
+	smoothing_groups = list(SMOOTH_GROUP_LATTICE)
+	canSmoothWith = list(SMOOTH_GROUP_OPEN_FLOOR, SMOOTH_GROUP_WALLS, SMOOTH_GROUP_WINDOW_FULLTILE, SMOOTH_GROUP_LATTICE)
 	z_flags = Z_BLOCK_OUT_DOWN
-
+	var/number_of_rods = 1
 
 /datum/armor/structure_lattice
 	melee = 50


### PR DESCRIPTION
## About The Pull Request

Catwalks take two rods to make but only drop one when destroyed. This is incredibly annoying if you accidentally make a catwalk (very common when laying lattice in space) and you only get the one rod back after destroying it.

## Why It's Good For The Game

What goes in must come out

## Testing Photographs and Procedure

https://github.com/user-attachments/assets/e6e8b328-901d-4c23-a3b2-ffd929d14a42

## Changelog
:cl:
tweak: Destroyed catwalks now drop 2 iron rods instead of just 1
/:cl:
