### PR TITLE
Shield belt decharges when dropped

### DIFF
--- a/code/__DEFINES/combat.dm
+++ b/code/__DEFINES/combat.dm
@@ -315,3 +315,5 @@ GLOBAL_LIST_INIT(shove_disarming_types, typecacheof(list(
 #define ENERGY_SHIELD_INVISIBLE (1 << 2)
 /// Energy shield will take max damage when EMP'd
 #define ENERGY_SHIELD_EMP_VULNERABLE (1 << 3)
+/// Energy shield starts at 0 health
+#define ENERGY_SHIELD_DEPLETE_EQUIP (1 << 4)

--- a/code/game/objects/items/combat/shield_belt.dm
+++ b/code/game/objects/items/combat/shield_belt.dm
@@ -15,7 +15,7 @@
 
 /obj/item/shield_belt/Initialize(mapload)
 	. = ..()
-	AddComponent(/datum/component/shielded, max_integrity = max_shield_integrity, charge_recovery = 10, shield_flags = ENERGY_SHIELD_BLOCK_PROJECTILES | ENERGY_SHIELD_INVISIBLE | ENERGY_SHIELD_EMP_VULNERABLE, on_active_effects = CALLBACK(src, PROC_REF(add_shield_effects)), on_deactive_effects = CALLBACK(src, PROC_REF(remove_shield_effects)), on_integrity_changed = CALLBACK(src, PROC_REF(update_shield_health)))
+	AddComponent(/datum/component/shielded, max_integrity = max_shield_integrity, charge_recovery = 10, shield_flags = ENERGY_SHIELD_BLOCK_PROJECTILES | ENERGY_SHIELD_INVISIBLE | ENERGY_SHIELD_EMP_VULNERABLE | ENERGY_SHIELD_DEPLETE_EQUIP, on_active_effects = CALLBACK(src, PROC_REF(add_shield_effects)), on_deactive_effects = CALLBACK(src, PROC_REF(remove_shield_effects)), on_integrity_changed = CALLBACK(src, PROC_REF(update_shield_health)))
 
 /obj/item/shield_belt/proc/add_shield_effects(mob/living/wearer, current_integrity)
 	RegisterSignal(wearer, COMSIG_MOB_BEFORE_FIRE_GUN, PROC_REF(intercept_gun_fire))
@@ -26,6 +26,9 @@
 	wearer.remove_filter("shield_filter")
 
 /obj/item/shield_belt/proc/update_shield_health(mob/living/wearer, current_integrity)
+	if (current_integrity <= 0)
+		wearer.remove_filter("shield_filter")
+		return
 	var/list/good = rgb2num(COLOUR_GOOD)
 	var/list/bad = rgb2num(COLOUR_BAD)
 	var/proportion = current_integrity / max_shield_integrity


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

- Shield belt starts from 0 charge when equipped.
- Fixes event firing and shield belt charging in some cases.

## Why It's Good For The Game

Makes it so you can't carry around a shieldbelt and instantly equip it, take it off to fire, then re-equip; forcing you into the true melee grindset that a true shield belt user should take. It also means you can't stack 5 of them to swap them around for more charge.

## Testing Photographs and Procedure

https://github.com/user-attachments/assets/4b6700f2-7954-4867-8b9d-729b95343c0f

## Changelog
:cl:
balance: Shields belts now starts from 0 charge when equipped.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
