### PR TITLE
Changes the cryopod message to be more clear

### DIFF
--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -275,7 +275,7 @@ GLOBAL_LIST_EMPTY(cryopod_computers)
 				INVOKE_ASYNC(src, PROC_REF(persistent_offer_to_ghosts), mob_occupant)
 
 /obj/machinery/cryopod/proc/persistent_offer_to_ghosts(mob/living/target)
-	if(target.client && tgui_alert(target, "Would you like to leave the game? Your role will be automatically transfered to another player.", "Leave Game", list("Yes", "No")) != "Yes")
+	if(target.client && tgui_alert(target, "Would you like to leave the game? Your character will be automatically offered to other players.", "Leave Game", list("Yes", "No")) != "Yes")
 		if (target.client)
 			open_machine()
 			return
@@ -283,7 +283,7 @@ GLOBAL_LIST_EMPTY(cryopod_computers)
 	offer_control_persistently(target)
 
 /obj/machinery/cryopod/proc/offering_to_ghosts(mob/living/target)
-	if(target.client && tgui_alert(target, "Would you like to leave the game? Your role will be automatically transfered to another player.", "Leave Game", list("Yes", "No")) != "Yes")
+	if(target.client && tgui_alert(target, "Would you like to leave the game? Your character will be automatically offered to other players.", "Leave Game", list("Yes", "No")) != "Yes")
 		if (target.client)
 			open_machine()
 			return


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Changes the cryopod message as an antagonist when you cryo to be more clear from

**`"Would you like to leave the game? Your role will be automatically transfered to another player."`**

to

**`"Would you like to leave the game? Your character will be automatically offered to other players."`**
## Why It's Good For The Game

I do not think the original is clear enough. I got confused as a player and I thought it refered to my role (job) and not my character. Also it does not automatically transfer it, it offers it to other players.

## Testing Photographs and Procedure

<img width="484" height="325" alt="image" src="https://github.com/user-attachments/assets/ed624033-e2eb-43fc-bf34-48a742cce252" />

## Changelog
:cl:
add: Changes the cryopod message as an antagonist when you cryo to be more clear
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
