### PR TITLE
Drastically reduces artifact maintenance spawns

### DIFF
--- a/code/_globalvars/lists/maintenance_loot.dm
+++ b/code/_globalvars/lists/maintenance_loot.dm
@@ -107,10 +107,6 @@ GLOBAL_LIST_INIT(common_loot, list( //common: basic items
 		/obj/item/storage/wallet/random = 1,
 		) = 1,
 
-	list(//xenoartifacts
-		/obj/item/xenoartifact/maint = 1,
-		) = 2,
-
 	list(//construction and crafting
 		/obj/item/sign_backing = 1,
 		/obj/item/stack/cable_coil = 1,
@@ -155,6 +151,9 @@ GLOBAL_LIST_INIT(common_loot, list( //common: basic items
 		/obj/item/stack/sticky_tape = 1,
 		/obj/item/tank/internals/emergency_oxygen = 1,
 		/obj/item/paper_reader = 1,
+
+		// xenoartifacts
+		/obj/item/xenoartifact/maint = 3,
 
 		//light sources
 		/obj/effect/spawner/random/decoration/glowstick = 1,

--- a/code/_globalvars/lists/maintenance_loot.dm
+++ b/code/_globalvars/lists/maintenance_loot.dm
@@ -152,9 +152,6 @@ GLOBAL_LIST_INIT(common_loot, list( //common: basic items
 		/obj/item/tank/internals/emergency_oxygen = 1,
 		/obj/item/paper_reader = 1,
 
-		// xenoartifacts
-		/obj/item/xenoartifact/maint = 3,
-
 		//light sources
 		/obj/effect/spawner/random/decoration/glowstick = 1,
 		/obj/item/clothing/head/utility/hardhat/red = 1,
@@ -239,6 +236,10 @@ GLOBAL_LIST_INIT(uncommon_loot, list(//uncommon: useful items
 			) = 1,
 		/obj/item/food/monkeycube = 1,
 		) = 8,
+
+	list(//xenoartifacts
+		/obj/item/xenoartifact/maint = 1
+		) = 6,
 
 	list(//modsuits
 		/obj/effect/spawner/random/mod/maint = 3,

--- a/tools/maint_loot_analyzer.py
+++ b/tools/maint_loot_analyzer.py
@@ -10,20 +10,20 @@ import sys
 def extract_weights_from_dm(filepath="code/_globalvars/lists/maintenance_loot.dm"):
     """Extract weight definitions from maintenance_loot.dm"""
     weights = {}
-    
+
     # Pattern to match #define statements like: #define maint_trash_weight 4500
     weight_pattern = re.compile(r'#define\s+(maint_\w+_weight)\s+(\d+)')
-    
+
     # Handle relative path from tools directory
     script_dir = os.path.dirname(os.path.abspath(__file__))
     repo_root = os.path.dirname(script_dir)
     full_path = os.path.join(repo_root, filepath)
-    
+
     if not os.path.exists(full_path):
         print(f"Error: Could not find {filepath}")
         print(f"Looked in: {full_path}")
         sys.exit(1)
-    
+
     with open(full_path, 'r', encoding='utf-8') as f:
         for line in f:
             match = weight_pattern.match(line.strip())
@@ -31,7 +31,7 @@ def extract_weights_from_dm(filepath="code/_globalvars/lists/maintenance_loot.dm
                 weight_name = match.group(1).upper()  # Convert to uppercase
                 weight_value = int(match.group(2))
                 weights[weight_name] = weight_value
-    
+
     return weights
 
 # Automatically extract weights from the DM file
@@ -60,7 +60,6 @@ categories = {
         "subcategories": {
             "Tools": 1,
             "Equipment": 1,
-            "Xenoartifacts": 2,
             "Construction/Crafting": 1,
             "Medical/Chemicals": 1,
             "Food": 1,

--- a/tools/maint_loot_analyzer.py
+++ b/tools/maint_loot_analyzer.py
@@ -74,6 +74,7 @@ categories = {
             "Construction/Crafting": 8,
             "Medical/Chemicals": 8,
             "Food": 8,
+            "Xenoartifacts": 6,
             "Modsuits": 4,
             "Music": 2,
             "Fakeout items": 1


### PR DESCRIPTION
## About The Pull Request

Moves artifacts from their own weighted section to the misc section. Also why tf were they given a weight of 2?

## Why It's Good For The Game

There is an absurd amount of artifacts spawning.

closes #14020

## Testing Photographs and Procedure

With the new weights, 2-3 artifacts now spawn per round on average (MetaStation). I first thought this may be too few, but artifacts should by no means be common maintenance and the primary ways to obtain them should be xenoarcheology, lavaland, and cargo.

<img width="483" height="333" alt="image" src="https://github.com/user-attachments/assets/6b8540c7-dc00-42d5-be9b-6a8abc0581a5" />

<img width="533" height="517" alt="image" src="https://github.com/user-attachments/assets/9a5c3165-217d-46d3-9358-f82cf5ca3c9b" />

<img width="311" height="394" alt="image" src="https://github.com/user-attachments/assets/db583208-2136-40d2-bdbc-ffbb12d5b8f3" />

<img width="347" height="476" alt="image" src="https://github.com/user-attachments/assets/05e5de0c-1aa6-41c1-977c-244508b97998" />

## Changelog
:cl:
tweak: Much less artifacts spawn in maintenance now
/:cl: