### PR TITLE
Fixes attack logging

### DIFF
--- a/code/game/atom/atom_defense.dm
+++ b/code/game/atom/atom_defense.dm
@@ -131,6 +131,7 @@
 		CRASH("unimplemented /atom/proc/attack_generic()!")
 	user.do_attack_animation(src)
 	user.changeNext_move(CLICK_CD_MELEE)
+	log_combat(user, src, "attacked")
 	return take_damage(damage_amount, damage_type, damage_flag, sound_effect, get_dir(src, user), armor_penetration)
 
 /// Called after the atom takes damage and integrity is below integrity_failure level

--- a/code/game/atom/atom_defense.dm
+++ b/code/game/atom/atom_defense.dm
@@ -131,7 +131,7 @@
 		CRASH("unimplemented /atom/proc/attack_generic()!")
 	user.do_attack_animation(src)
 	user.changeNext_move(CLICK_CD_MELEE)
-	log_combat(user, src, "attacked")
+	log_combat(user, src, "attacked", addition="([damage_amount] [damage_type])")
 	return take_damage(damage_amount, damage_type, damage_flag, sound_effect, get_dir(src, user), armor_penetration)
 
 /// Called after the atom takes damage and integrity is below integrity_failure level

--- a/code/game/atom/atom_defense.dm
+++ b/code/game/atom/atom_defense.dm
@@ -131,8 +131,9 @@
 		CRASH("unimplemented /atom/proc/attack_generic()!")
 	user.do_attack_animation(src)
 	user.changeNext_move(CLICK_CD_MELEE)
-	log_combat(user, src, "attacked", addition="([damage_amount] [damage_type]), ([atom_integrity] / [max_integrity] integrity)")
-	return take_damage(damage_amount, damage_type, damage_flag, sound_effect, get_dir(src, user), armor_penetration)
+	var/old_integrity = atom_integrity
+	. = take_damage(damage_amount, damage_type, damage_flag, sound_effect, get_dir(src, user), armor_penetration)
+	log_combat(user, src, "attacked", addition="integrity: ([max(atom_integrity, 0)] / [max_integrity]), took [old_integrity - atom_integrity] damage")
 
 /// Called after the atom takes damage and integrity is below integrity_failure level
 /atom/proc/atom_break(damage_flag)

--- a/code/game/atom/atom_defense.dm
+++ b/code/game/atom/atom_defense.dm
@@ -131,7 +131,7 @@
 		CRASH("unimplemented /atom/proc/attack_generic()!")
 	user.do_attack_animation(src)
 	user.changeNext_move(CLICK_CD_MELEE)
-	log_combat(user, src, "attacked", addition="([damage_amount] [damage_type])")
+	log_combat(user, src, "attacked", addition="([damage_amount] [damage_type]), ([atom_integrity] / [max_integrity] integrity)")
 	return take_damage(damage_amount, damage_type, damage_flag, sound_effect, get_dir(src, user), armor_penetration)
 
 /// Called after the atom takes damage and integrity is below integrity_failure level


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

When atoms take damage from a mob, it is now logged. 

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

For some reason this is not currently logged unless it is specifically done by an item (such as when being held/wielded by a carbon mob). There is no logging for attacks from other sources such as simplemobs. 

I'm not sure precisely when this broke, but non-carbons are free to grief the server as long as they don't attack another player or mob directly and there won't be a shred of evidence left in the logs when admins go to investigate. 

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

<img width="367" height="591" alt="image" src="https://github.com/user-attachments/assets/b6cf73a6-f7b6-4341-815a-f4d6f6e49525" />

</details>

## Changelog
:cl:
admin: The destruction of station objects is now properly logged again
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
