### PR TITLE
Clockwork slab fixes + UX improvements

### DIFF
--- a/beestation.dme
+++ b/beestation.dme
@@ -4518,7 +4518,7 @@
 #include "code\modules\tgui\states\admin.dm"
 #include "code\modules\tgui\states\admin_holder.dm"
 #include "code\modules\tgui\states\always.dm"
-#include "code\modules\tgui\states\clockcult_state.dm"
+#include "code\modules\tgui\states\clockcult_held_state.dm"
 #include "code\modules\tgui\states\conscious.dm"
 #include "code\modules\tgui\states\contained.dm"
 #include "code\modules\tgui\states\debug.dm"

--- a/code/modules/antagonists/clock_cult/items/clockwork_slab.dm
+++ b/code/modules/antagonists/clock_cult/items/clockwork_slab.dm
@@ -149,7 +149,7 @@ GLOBAL_LIST_INIT(clockwork_slabs, list())
 		ui.open()
 
 /obj/item/clockwork/clockwork_slab/ui_state(mob/user)
-	return GLOB.clockcult_state
+	return GLOB.clockcult_held_state
 
 /obj/item/clockwork/clockwork_slab/ui_data(mob/user)
 	//Data

--- a/code/modules/antagonists/clock_cult/items/clockwork_slab.dm
+++ b/code/modules/antagonists/clock_cult/items/clockwork_slab.dm
@@ -15,7 +15,6 @@ GLOBAL_LIST_INIT(clockwork_slabs, list())
 
 	var/holder_class
 	var/list/scriptures = list()
-	var/empowerment
 	var/charge_overlay
 
 	var/calculated_cogs = 0
@@ -93,11 +92,22 @@ GLOBAL_LIST_INIT(clockwork_slabs, list())
 		calculated_cogs += difference
 		cogs += difference
 
+/obj/item/clockwork/clockwork_slab/pre_attack(atom/A, mob/living/user, params)
+	if (active_scripture)
+		if (active_scripture.on_slab_attack(A, user, FALSE))
+			active_scripture.end_invokation()
+		// Block the attack chain, even if we didn't perform our action
+		return TRUE
+	return ..()
+
 /obj/item/clockwork/clockwork_slab/afterattack(atom/target, mob/user, proximity_flag, click_parameters)
-	. = ..()
-	INVOKE_ASYNC(active_scripture, TYPE_PROC_REF(/datum/clockcult/scripture/slab, on_slab_attack), target, user)
-	if(active_scripture)
+	if (proximity_flag)
+		return ..()
+	// Ranged attacks
+	if (active_scripture?.on_slab_attack(target, user, TRUE))
 		active_scripture.end_invokation()
+		return TRUE
+	return ..()
 
 //==================================//
 // !   Quick bind spell handling  ! //

--- a/code/modules/antagonists/clock_cult/ratvarian_language.dm
+++ b/code/modules/antagonists/clock_cult/ratvarian_language.dm
@@ -99,6 +99,7 @@ List of nuances:
 
 //Causes the mob or AM in question to speak a message; it assumes that the message is already translated to ratvar speech using text2ratvar()
 /proc/clockwork_say(atom/movable/AM, message, whisper=FALSE)
+	set waitfor = FALSE
 	var/list/spans = list(SPAN_ROBOT)
 
 	if(isliving(AM))

--- a/code/modules/antagonists/clock_cult/scriptures/_clockwork_scripture.dm
+++ b/code/modules/antagonists/clock_cult/scriptures/_clockwork_scripture.dm
@@ -173,8 +173,6 @@
 	var/uses_left
 	var/time_left = 0
 	var/loop_timer_id
-	var/empowerment
-
 
 /datum/clockcult/scripture/slab/Destroy()
 	if(progress)
@@ -189,7 +187,6 @@
 	invoking_slab.charge_overlay = slab_overlay
 	invoking_slab.update_icon()
 	invoking_slab.active_scripture = src
-	invoking_slab.empowerment = empowerment
 	to_chat(invoker, span_brass("You prepare [name]. <b>Click on a target to use.</b>"))
 	count_down()
 	invoke_success()
@@ -215,22 +212,12 @@
 	invoking_slab.charge_overlay = null
 	invoking_slab.update_icon()
 	invoking_slab.active_scripture = null
-	empowerment = null
 	end_invoke()
 
 
-/datum/clockcult/scripture/slab/proc/on_slab_attack(atom/target, mob/user)
-	switch(empowerment)
-		if(KINDLE)
-			kindle(user, target)
-			end_invokation()
-		if(MANACLES)
-			hateful_manacles(user, target)
-			end_invokation()
-		if(COMPROMISE)
-			sentinels_compromise(user, target)
-			end_invokation()
-	return
+/datum/clockcult/scripture/slab/proc/on_slab_attack(atom/target, mob/user, ranged_attack)
+	SHOULD_NOT_SLEEP(TRUE)
+	return FALSE
 
 //==================================//
 // !       Quick bind spell       ! //

--- a/code/modules/antagonists/clock_cult/scriptures/slab_empowerments/hateful_manacles.dm
+++ b/code/modules/antagonists/clock_cult/scriptures/slab_empowerments/hateful_manacles.dm
@@ -13,45 +13,47 @@
 	use_time = 200
 	cogs_required = 0
 	category = SPELLTYPE_SERVITUDE
-	empowerment = MANACLES
 
 //For the Hateful Manacles scripture; applies replicant handcuffs to the clicked_on.
 
-/datum/clockcult/scripture/slab/proc/hateful_manacles(mob/living/clicker, atom/clicked_on)
-	empowerment = null
-	var/turf/T = clicker.loc
+/datum/clockcult/scripture/slab/hateful_manacles/on_slab_attack(atom/target, mob/user, ranged_attack)
+	var/turf/T = user.loc
 	if(!isturf(T))
 		return FALSE
 
-	if(iscarbon(clicked_on) && clicked_on.Adjacent(clicker))
-		var/mob/living/carbon/L = clicked_on
-		if(IS_SERVANT_OF_RATVAR(L))
-			to_chat(clicker, ("<span class='neovgre'>\"[L.p_Theyre()] a servant.\"</span>"))
-			return FALSE
-		else if(L.stat)
-			to_chat(clicker, ("<span class='neovgre'>\"There is use in shackling the dead, but for examples.\"</span>"))
-			return FALSE
-		else if (istype(L.handcuffed, /obj/item/restraints/handcuffs/clockwork))
-			to_chat(clicker, ("<span class='neovgre'>\"[L.p_Theyre()] already helpless, no?\"</span>"))
-			return FALSE
-
-		playsound(clicker.loc, 'sound/weapons/handcuffs.ogg', 30, TRUE)
-		clicker.visible_message(("<span class='danger'>[clicker] begins forming manacles around [L]'s wrists!</span>"), \
-		("<span class='neovgre_small'>You begin shaping replicant alloy into manacles around [L]'s wrists...</span>"))
-		to_chat(L, ("<span class='userdanger'>[clicker] begins forming manacles around your wrists!</span>"))
-		if(do_after(clicker, 3 SECONDS, L))
-			if(!(istype(L.handcuffed,/obj/item/restraints/handcuffs/clockwork)))
-				var/obj/item/restraints/handcuffs/clockwork/restraints = new(L)
-				if (!restraints.apply_cuffs(L, clicker))
-					qdel(restraints)
-					return TRUE
-				restraints.item_flags |= DROPDEL
-
-				to_chat(clicker, ("<span class='neovgre_small'>You shackle [L].</span>"))
-				log_combat(clicker, L, "handcuffed")
-		else
-			to_chat(clicker, ("<span class='warning'>You fail to shackle [L].</span>"))
+	if(!iscarbon(target) || ranged_attack)
+		return FALSE
+	var/mob/living/carbon/carbon_target = target
+	if(IS_SERVANT_OF_RATVAR(carbon_target))
+		to_chat(user, span_neovgre("\"[carbon_target.p_Theyre()] a servant.\""))
+		return FALSE
+	else if(carbon_target.stat)
+		to_chat(user, span_neovgre("\"There is use in shackling the dead, but for examples.\""))
+		return FALSE
+	else if (istype(carbon_target.handcuffed, /obj/item/restraints/handcuffs/clockwork))
+		to_chat(user, span_neovgre("\"[carbon_target.p_Theyre()] already helpless, no?\""))
+		return FALSE
+	do_cuff(carbon_target, user)
 	return TRUE
+
+/datum/clockcult/scripture/slab/hateful_manacles/proc/do_cuff(mob/living/carbon/target, mob/user)
+	set waitfor = FALSE
+	playsound(user.loc, 'sound/weapons/handcuffs.ogg', 30, TRUE)
+	user.visible_message(span_danger("[user] begins forming manacles around [target]'s wrists!"), \
+	("<span class='neovgre_small'>You begin shaping replicant alloy into manacles around [target]'s wrists...</span>"))
+	to_chat(target, span_userdanger("[user] begins forming manacles around your wrists!"))
+	if(do_after(user, 3 SECONDS, target))
+		if(!(istype(target.handcuffed, /obj/item/restraints/handcuffs/clockwork)))
+			var/obj/item/restraints/handcuffs/clockwork/restraints = new(target)
+			if (!restraints.apply_cuffs(target, user))
+				qdel(restraints)
+				return TRUE
+			restraints.item_flags |= DROPDEL
+
+			to_chat(user, "<span class='neovgre_small'>You shackle [target].</span>")
+			log_combat(user, target, "handcuffed")
+	else
+		to_chat(user, span_warning("You fail to shackle [target]."))
 
 /obj/item/restraints/handcuffs/clockwork
 	name = "replicant manacles"

--- a/code/modules/antagonists/clock_cult/scriptures/slab_empowerments/kindle.dm
+++ b/code/modules/antagonists/clock_cult/scriptures/slab_empowerments/kindle.dm
@@ -14,32 +14,35 @@
 	use_time = 150
 	cogs_required = 1
 	category = SPELLTYPE_SERVITUDE
-	empowerment = KINDLE
 
 //For the Kindle scripture; stuns and mutes a clicked_on non-servant.
 
-/datum/clockcult/scripture/slab/proc/kindle(mob/living/clicker, mob/living/clicked_on)
-	empowerment = null
-	to_chat(clicker, ("<span class='brass'>You release the light of Ratvar!</span>"))
-	clockwork_say(clicker, text2ratvar("Purge all untruths and honor Engine!"))
-	if(isliving(clicked_on))
-		var/mob/living/L = clicked_on
-		if(IS_SERVANT_OF_RATVAR(L) || L.stat)
-			return BULLET_ACT_HIT
-		var/atom/O = L.can_block_magic(MAGIC_RESISTANCE_HOLY)
-		playsound(L, 'sound/magic/fireball.ogg', 50, TRUE, frequency = 1.25)
-		if(O)
-			if(isitem(O))
-				L.visible_message(("<span class='warning'>[L]'s eyes flare with dim light!</span>"), \
-				("<span class='userdanger'>Your [O] glows white-hot against you as it absorbs [src]'s power!</span>"))
-			else if(ismob(O))
-				L.visible_message(("<span class='warning'>[L]'s eyes flare with dim light!</span>"))
-			playsound(L, 'sound/weapons/sear.ogg', 50, TRUE)
-		else
-			L.visible_message(("<span class='warning'>[L]'s eyes blaze with brilliant light!</span>"), \
-			("<span class='userdanger'>Your vision suddenly screams with white-hot light!</span>"))
-			L.Paralyze(5 SECONDS)
-			L.flash_act(1, 1)
-			if(IS_CULTIST(L))
-				L.adjustFireLoss(15)
+/datum/clockcult/scripture/slab/kindle/on_slab_attack(atom/target, mob/user, ranged_attack)
+	if (ranged_attack)
+		return FALSE
+	if(!isliving(target))
+		return FALSE
+	var/mob/living/L = target
+	if(IS_SERVANT_OF_RATVAR(L) || L.stat)
+		return FALSE
+	to_chat(user, span_brass("You release the light of Ratvar!"))
+	clockwork_say(user, text2ratvar("Purge all untruths and honor Engine!"))
+	var/atom/O = L.can_block_magic(MAGIC_RESISTANCE_HOLY)
+	playsound(L, 'sound/magic/fireball.ogg', 50, TRUE, frequency = 1.25)
+	if(O)
+		if(isitem(O))
+			L.visible_message(("<span class='warning'>[L]'s eyes flare with dim light!</span>"), \
+			("<span class='userdanger'>Your [O] glows white-hot against you as it absorbs [src]'s power!</span>"))
+		else if(ismob(O))
+			L.visible_message(("<span class='warning'>[L]'s eyes flare with dim light!</span>"))
+		playsound(L, 'sound/weapons/sear.ogg', 50, TRUE)
+	else
+		L.visible_message(("<span class='warning'>[L]'s eyes blaze with brilliant light!</span>"), \
+		("<span class='userdanger'>Your vision suddenly screams with white-hot light!</span>"))
+		L.Paralyze(5 SECONDS)
+		L.flash_act(1, 1)
+		L.adjust_silence(5 SECONDS)
+		L.adjust_stutter(10 SECONDS)
+		if(IS_CULTIST(L))
+			L.adjustFireLoss(15)
 	return TRUE

--- a/code/modules/antagonists/clock_cult/scriptures/slab_empowerments/sentinels_compromise.dm
+++ b/code/modules/antagonists/clock_cult/scriptures/slab_empowerments/sentinels_compromise.dm
@@ -9,55 +9,59 @@
 	category = SPELLTYPE_PRESERVATION
 	cogs_required = 1
 	power_cost = 80
-	empowerment = COMPROMISE
 
 //For the Sentinel's Compromise scripture; heals a clicked_on servant.
 
-/datum/clockcult/scripture/slab/proc/sentinels_compromise(mob/living/clicker, atom/clicked_on)
-	empowerment = null
-	var/turf/T = clicker.loc
+/datum/clockcult/scripture/slab/sentinelscompromise/on_slab_attack(atom/target, mob/user, ranged_attack)
+	var/turf/T = user.loc
 	if(!isturf(T))
 		return FALSE
 
-	if(isliving(clicked_on) && (clicked_on in view(7, get_turf(clicker))))
-		var/mob/living/L = clicked_on
-		if(!IS_SERVANT_OF_RATVAR(L))
-			to_chat(clicker, ("<span class='inathneq'>\"[L] does not yet serve Ratvar.\"</span>"))
-			return TRUE
-		if(L.stat == DEAD)
-			to_chat(clicker, ("<span class='inathneq'>\"[L.p_Theyre()] dead. [text2ratvar("Oh, child. To have your life cut short...")]\"</span>"))
-			return TRUE
+	if(!isliving(target))
+		return FALSE
+	var/mob/living/L = target
+	if(!IS_SERVANT_OF_RATVAR(L))
+		to_chat(user, ("<span class='inathneq'>\"[L] does not yet serve Ratvar.\"</span>"))
+		return FALSE
+	if(L.stat == DEAD)
+		to_chat(user, ("<span class='inathneq'>\"[L.p_Theyre()] dead. [text2ratvar("Oh, child. To have your life cut short...")]\"</span>"))
+		return FALSE
+	var/mob/living/living_user = user
+	if (!istype(living_user))
+		return
 
-		var/brutedamage = L.getBruteLoss()
-		var/burndamage = L.getFireLoss()
-		var/oxydamage = L.getOxyLoss()
-		var/totaldamage = brutedamage + burndamage + oxydamage
-		if(!totaldamage && (!L.reagents || !L.reagents.has_reagent(/datum/reagent/water/holywater)))
-			to_chat(clicker, ("<span class='inathneq'>\"[L] is unhurt and untainted.\"</span>"))
-			return TRUE
-		to_chat(clicker, ("<span class='brass'>You bathe [L == clicker ? "yourself":"[L]"] in Inath-neq's power!</span>"))
-		var/clicked_onturf = get_turf(L)
-		var/has_holy_water = (L.reagents && L.reagents.has_reagent(/datum/reagent/water/holywater))
-		var/healseverity = max(round(totaldamage*0.05, 1), 1) //shows the general severity of the damage you just healed, 1 glow per 20
-		for(var/i in 1 to healseverity)
-			new /obj/effect/temp_visual/heal(clicked_onturf, "#1E8CE1")
-		if(totaldamage)
-			L.adjustBruteLoss(-brutedamage, TRUE, FALSE)
-			L.adjustFireLoss(-burndamage, TRUE, FALSE)
-			L.adjustOxyLoss(-oxydamage)
-			clicker.adjustToxLoss(totaldamage * 0.5, TRUE, TRUE)
-			clockwork_say(clicker, text2ratvar("[has_holy_water ? "Heal tainted" : "Mend wounded"] flesh!"))
-			log_combat(clicker, L, "healed with Sentinel's Compromise")
-			L.visible_message(("<span class='warning'>A blue light washes over [L], [has_holy_water ? "causing [L.p_them()] to briefly glow as it mends" : " mending"] [L.p_their()] bruises and burns!</span>"), \
-			("<span class='heavy_brass'>You feel Inath-neq's power healing your wounds[has_holy_water ? " and purging the darkness within you" : ""], but a deep nausea overcomes you!</span>"))
-		else
-			clockwork_say(clicker, text2ratvar("Purge foul darkness!"))
-			log_combat(clicker, L, "purged of holy water with Sentinel's Compromise")
-			L.visible_message(("<span class='warning'>A blue light washes over [L], causing [L.p_them()] to briefly glow!</span>"), \
-			("<span class='heavy_brass'>You feel Inath-neq's power purging the darkness within you!</span>"))
-		playsound(clicked_onturf, 'sound/magic/staff_healing.ogg', 50, 1)
+	var/brutedamage = L.getBruteLoss()
+	var/burndamage = L.getFireLoss()
+	var/oxydamage = L.getOxyLoss()
+	var/totaldamage = brutedamage + burndamage + oxydamage
+	if(!totaldamage && (!L.reagents || !L.reagents.has_reagent(/datum/reagent/water/holywater)))
+		to_chat(user, ("<span class='inathneq'>\"[L] is unhurt and untainted.\"</span>"))
+		return FALSE
+	to_chat(user, ("<span class='brass'>You bathe [L == user ? "yourself":"[L]"] in Inath-neq's power!</span>"))
+	var/clicked_onturf = get_turf(L)
+	var/has_holy_water = (L.reagents && L.reagents.has_reagent(/datum/reagent/water/holywater))
+	var/healseverity = max(round(totaldamage*0.05, 1), 1) //shows the general severity of the damage you just healed, 1 glow per 20
+	for(var/i in 1 to healseverity)
+		new /obj/effect/temp_visual/heal(clicked_onturf, "#1E8CE1")
+	if(totaldamage)
+		L.adjustBruteLoss(-brutedamage, TRUE, FALSE)
+		L.adjustFireLoss(-burndamage, TRUE, FALSE)
+		L.adjustOxyLoss(-oxydamage)
+		// Don't allow them to kill themselves with this spell
+		var/damage_to_deal = min(living_user.health - 1, totaldamage * 0.5)
+		living_user.adjustToxLoss(damage_to_deal, TRUE, TRUE)
+		clockwork_say(user, text2ratvar("[has_holy_water ? "Heal tainted" : "Mend wounded"] flesh!"))
+		log_combat(user, L, "healed with Sentinel's Compromise")
+		L.visible_message(("<span class='warning'>A blue light washes over [L], [has_holy_water ? "causing [L.p_them()] to briefly glow as it mends" : " mending"] [L.p_their()] bruises and burns!</span>"), \
+		("<span class='heavy_brass'>You feel Inath-neq's power healing your wounds[has_holy_water ? " and purging the darkness within you" : ""], but a deep nausea overcomes you!</span>"))
+	else
+		clockwork_say(user, text2ratvar("Purge foul darkness!"))
+		log_combat(user, L, "purged of holy water with Sentinel's Compromise")
+		L.visible_message(("<span class='warning'>A blue light washes over [L], causing [L.p_them()] to briefly glow!</span>"), \
+		("<span class='heavy_brass'>You feel Inath-neq's power purging the darkness within you!</span>"))
+	playsound(clicked_onturf, 'sound/magic/staff_healing.ogg', 50, 1)
 
-		if(has_holy_water)
-			L.reagents.remove_reagent(/datum/reagent/water/holywater, 1000)
+	if(has_holy_water)
+		L.reagents.remove_reagent(/datum/reagent/water/holywater, 1000)
 
 	return TRUE

--- a/code/modules/tgui/states/clockcult_held_state.dm
+++ b/code/modules/tgui/states/clockcult_held_state.dm
@@ -1,0 +1,10 @@
+GLOBAL_DATUM_INIT(clockcult_held_state, /datum/ui_state/clockcult_held_state, new)
+
+/datum/ui_state/clockcult_held_state/can_use_topic(src_object, mob/user)
+	// Requires clockcultist
+	if(!IS_SERVANT_OF_RATVAR(user))
+		return UI_CLOSE
+	// Hands state
+	. = user.shared_ui_interaction(src_object)
+	if(. >= UI_CLOSE)
+		return min(., user.hands_can_use_topic(src_object))

--- a/code/modules/tgui/states/clockcult_state.dm
+++ b/code/modules/tgui/states/clockcult_state.dm
@@ -1,6 +1,0 @@
-GLOBAL_DATUM_INIT(clockcult_state, /datum/ui_state/clockcult_state, new)
-
-/datum/ui_state/clockcult_state/can_use_topic(src_object, mob/user)
-	if(IS_SERVANT_OF_RATVAR(user))
-		return UI_INTERACTIVE
-	return UI_CLOSE

--- a/code/modules/unit_tests/_unit_tests.dm
+++ b/code/modules/unit_tests/_unit_tests.dm
@@ -22,6 +22,7 @@
 #include "bloody_footprints.dm"
 #include "breath.dm"
 #include "check_adjustable_clothing.dm"
+#include "clockcult_tests.dm"
 #include "closets.dm"
 #include "combat.dm"
 #include "component_tests.dm"

--- a/code/modules/unit_tests/clockcult_tests.dm
+++ b/code/modules/unit_tests/clockcult_tests.dm
@@ -4,7 +4,7 @@
 	clockie.mind_initialize()
 	clockie.mind.add_antag_datum(/datum/antagonist/servant_of_ratvar)
 	clockie.drop_all_held_items()
-	var/obj/item/clockwork/clockwork_slab/slab = allocate(/mob/living/carbon/human/consistent)
+	var/obj/item/clockwork/clockwork_slab/slab = allocate(/obj/item/clockwork/clockwork_slab)
 	clockie.put_in_active_hand(slab)
 	usr = clockie
 	slab.cogs = 1

--- a/code/modules/unit_tests/clockcult_tests.dm
+++ b/code/modules/unit_tests/clockcult_tests.dm
@@ -21,6 +21,14 @@
 	// Attack the target
 	clockie.ClickOn(target)
 	TEST_ASSERT(target.incapacitated(), "Expected target to be stunned when clicked on with kindle.")
+	// Invoke the scripture
+	slab.ui_act("invoke", list(
+		"scriptureName" = /datum/clockcult/scripture/slab/kindle::name
+	))
+	TEST_ASSERT(istype(slab.active_scripture, /datum/clockcult/scripture/slab/kindle), "Expected kindle to be bound to the slab.")
+	// Attack the target
+	clockie.ClickOn(target)
+	TEST_ASSERT(target.incapacitated(), "Expected target to be stunned when clicked on with kindle.")
 
 /datum/unit_test/clockcult_slab_bind/Run()
 	var/mob/living/carbon/human/consistent/clockie = allocate(/mob/living/carbon/human/consistent)
@@ -37,6 +45,14 @@
 		"scriptureName" = /datum/clockcult/scripture/slab/hateful_manacles::name
 	))
 	TEST_ASSERT(/datum/clockcult/scripture/slab/hateful_manacles in slab.purchased_scriptures, "Expected hateful_manacles to be unlocked")
+	// Invoke the scripture
+	slab.ui_act("invoke", list(
+		"scriptureName" = /datum/clockcult/scripture/slab/hateful_manacles::name
+	))
+	TEST_ASSERT(istype(slab.active_scripture, /datum/clockcult/scripture/slab/hateful_manacles), "Expected hateful_manacles to be bound to the slab.")
+	// Attack the target
+	clockie.ClickOn(target)
+	TEST_ASSERT(target.handcuffed, "Expected target to be cuffed when hateful_manacles was used.")
 	// Invoke the scripture
 	slab.ui_act("invoke", list(
 		"scriptureName" = /datum/clockcult/scripture/slab/hateful_manacles::name

--- a/code/modules/unit_tests/clockcult_tests.dm
+++ b/code/modules/unit_tests/clockcult_tests.dm
@@ -28,7 +28,7 @@
 	clockie.mind_initialize()
 	clockie.mind.add_antag_datum(/datum/antagonist/servant_of_ratvar)
 	clockie.drop_all_held_items()
-	var/obj/item/clockwork/clockwork_slab/slab = allocate(/mob/living/carbon/human/consistent)
+	var/obj/item/clockwork/clockwork_slab/slab = allocate(/obj/item/clockwork/clockwork_slab)
 	clockie.put_in_active_hand(slab)
 	usr = clockie
 	slab.cogs = 1

--- a/code/modules/unit_tests/clockcult_tests.dm
+++ b/code/modules/unit_tests/clockcult_tests.dm
@@ -1,0 +1,48 @@
+/datum/unit_test/clockcult_slab_kindle/Run()
+	var/mob/living/carbon/human/consistent/clockie = allocate(/mob/living/carbon/human/consistent)
+	var/mob/living/carbon/human/consistent/target = allocate(/mob/living/carbon/human/consistent)
+	clockie.mind_initialize()
+	clockie.mind.add_antag_datum(/datum/antagonist/servant_of_ratvar)
+	clockie.drop_all_held_items()
+	var/obj/item/clockwork/clockwork_slab/slab = allocate(/mob/living/carbon/human/consistent)
+	clockie.put_in_active_hand(slab)
+	usr = clockie
+	slab.cogs = 1
+	// Buy the scripture
+	slab.ui_act("invoke", list(
+		"scriptureName" = /datum/clockcult/scripture/slab/kindle::name
+	))
+	TEST_ASSERT(/datum/clockcult/scripture/slab/kindle in slab.purchased_scriptures, "Expected kindle to be unlocked")
+	// Invoke the scripture
+	slab.ui_act("invoke", list(
+		"scriptureName" = /datum/clockcult/scripture/slab/kindle::name
+	))
+	TEST_ASSERT(istype(slab.active_scripture, /datum/clockcult/scripture/slab/kindle), "Expected kindle to be bound to the slab.")
+	// Attack the target
+	clockie.ClickOn(target)
+	TEST_ASSERT(target.incapacitated(), "Expected target to be stunned when clicked on with kindle.")
+
+/datum/unit_test/clockcult_slab_bind/Run()
+	var/mob/living/carbon/human/consistent/clockie = allocate(/mob/living/carbon/human/consistent)
+	var/mob/living/carbon/human/consistent/target = allocate(/mob/living/carbon/human/consistent)
+	clockie.mind_initialize()
+	clockie.mind.add_antag_datum(/datum/antagonist/servant_of_ratvar)
+	clockie.drop_all_held_items()
+	var/obj/item/clockwork/clockwork_slab/slab = allocate(/mob/living/carbon/human/consistent)
+	clockie.put_in_active_hand(slab)
+	usr = clockie
+	slab.cogs = 1
+	// Buy the scripture
+	slab.ui_act("invoke", list(
+		"scriptureName" = /datum/clockcult/scripture/slab/hateful_manacles::name
+	))
+	TEST_ASSERT(/datum/clockcult/scripture/slab/hateful_manacles in slab.purchased_scriptures, "Expected hateful_manacles to be unlocked")
+	// Invoke the scripture
+	slab.ui_act("invoke", list(
+		"scriptureName" = /datum/clockcult/scripture/slab/hateful_manacles::name
+	))
+	TEST_ASSERT(istype(slab.active_scripture, /datum/clockcult/scripture/slab/hateful_manacles), "Expected hateful_manacles to be bound to the slab.")
+	// Attack the target
+	clockie.ClickOn(target)
+	TEST_ASSERT(target.handcuffed, "Expected target to be cuffed when hateful_manacles was used.")
+


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

- Cleans up the code of clockwork slab spells.
- Clockwork slab spells no longer permanently break the slab upon use.
- The clockwork slab UI no longer remains usable when you switch to a different slab.
- Implements unit testing for some clockcult attacks

## Why It's Good For The Game

Clockcult is a fun, but rare gamemode. Its rarity means that it doesn't get a whole lot of testing so this is a quick update to ensure that it both works and will resist breaking in the future due to better testing.

## Testing Photographs and Procedure

https://github.com/user-attachments/assets/e506c535-e686-4a12-a3a5-434e6efcb473

https://github.com/user-attachments/assets/0101ece1-a2dc-477e-b821-41c5c684d5b3

https://github.com/user-attachments/assets/0d0cc57e-e86f-4c06-aa6d-b45dee1b319f

## Changelog
:cl:
fix: Fixes clockwork slab UI remaining open even after dropped.
fix: Fixes clockwork slab spells only being usable once.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
