### PR TITLE
Fix BoxStation wires

### DIFF
--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -51442,6 +51442,9 @@
 	id = "auxsolareast";
 	name = "Port Auxiliary Solar Array"
 	},
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
 /turf/open/floor/iron/solarpanel/airless,
 /area/solar/port/fore)
 "sEG" = (


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Not sure how, but this specific solar array didn't get cables.

## Why It's Good For The Game

This needs cables

## Testing Photographs and Procedure

<img width="1035" height="880" alt="image" src="https://github.com/user-attachments/assets/49c0783d-1eb2-4681-b036-4aa7a3bc7e1e" />


## Changelog
:cl:
fix: Fixes boxstation north west solar array not having north facing cables
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
