### PR TITLE
Fixes the hundreds of viewport runtimes on live

### DIFF
--- a/code/modules/client/login/client_login.dm
+++ b/code/modules/client/login/client_login.dm
@@ -305,6 +305,7 @@
 		view_size = new(src, getScreenSize(mob))
 	view_size.resetFormat()
 	view_size.setZoomMode()
+	view_size.apply()
 	fit_viewport()
 
 	if(first_run)

--- a/code/modules/client/preferences/entries/player/fullscreen.dm
+++ b/code/modules/client/preferences/entries/player/fullscreen.dm
@@ -5,52 +5,17 @@
 	default_value = FALSE
 
 /datum/preference/toggle/fullscreen/apply_to_client(client/client, value)
-	if(client.byond_version <= 515 || client.byond_build <= 1630)
-		if (value)
-			// Delete the menu
-			winset(client, "mainwindow", "menu=\"\"")
-			// Switch to the cool status bar
-			winset(client, "mainwindow", "on-status=\".winset \\\"\[\[*]]=\\\"\\\" ? status_bar.text=\[\[*]] status_bar.is-visible=true : status_bar.is-visible=false\\\"\"")
-			winset(client, "status_bar_wide", "is-visible=false")
-			// Switch to fullscreen mode
-			winset(client, "mainwindow","titlebar=false")
-			winset(client, "mainwindow","can-resize=false")
-			// Set it to minimized first because otherwise it doesn't enter fullscreen properly
-			// This line is important, and the game won't properly enter fullscreen mode otherwise
-			winset(client, "mainwindow","is-minimized=true")
-			winset(client, "mainwindow","is-maximized=true")
-			// Set the main window's size
-			winset(client, null, "split.size=mainwindow.size")
-			// Fit the viewport
-			INVOKE_ASYNC(client, TYPE_PROC_REF(/client, fit_viewport))
-		else
-			// Restore the menu
-			winset(client, "mainwindow", "menu=\"menu\"")
-			// Switch to the lame status bar
-			winset(client, "mainwindow", "on-status=\".winset \\\"status_bar_wide.text = \[\[*]]\\\"\"")
-			winset(client, "status_bar", "is-visible=false")
-			winset(client, "status_bar_wide", "is-visible=true")
-			// Exit fullscreen mode
-			winset(client, "mainwindow","titlebar=true")
-			winset(client, "mainwindow","can-resize=true")
-			winset(client, "mainwindow","is-maximized=true")
-			// Fix the mapsize, turning off statusbar doesn't update scaling
-			INVOKE_ASYNC(src, PROC_REF(fix_mapsize), client)
+	if(value)
+		winset(client, "mainwindow", "menu=;is-fullscreen=true")
+		winset(client, "status_bar_wide", "is-visible=false")
+		winset(client, "mainwindow", "on-status=\".winset \\\"\[\[*]]=\\\"\\\" ? status_bar.text=\[\[*]] status_bar.is-visible=true : status_bar.is-visible=false\\\"\"")
 	else
-		if(value)
-			winset(client, "mainwindow", "menu=;is-fullscreen=true")
-			winset(client, "status_bar_wide", "is-visible=false")
-			winset(client, "mainwindow", "on-status=\".winset \\\"\[\[*]]=\\\"\\\" ? status_bar.text=\[\[*]] status_bar.is-visible=true : status_bar.is-visible=false\\\"\"")
-		else
-			winset(client, "mainwindow", "menu=\"menu\";is-fullscreen=false")
-			winset(client, "status_bar_wide", "is-visible=true")
-			winset(client, "mainwindow", "on-status=\".winset \\\"status_bar_wide.text = \[\[*]]\\\"\"")
-			winset(client, "status_bar", "is-visible=false")
+		winset(client, "mainwindow", "menu=\"menu\";is-fullscreen=false")
+		winset(client, "status_bar_wide", "is-visible=true")
+		winset(client, "mainwindow", "on-status=\".winset \\\"status_bar_wide.text = \[\[*]]\\\"\"")
+		winset(client, "status_bar", "is-visible=false")
 
-		if(client.fully_created)
-			INVOKE_ASYNC(client, TYPE_PROC_REF(/client, fit_viewport))
-		else
-			addtimer(CALLBACK(client, TYPE_PROC_REF(/client, fit_viewport), 1 SECONDS))
+	attempt_auto_fit_viewport()
 
 /datum/preference/toggle/fullscreen/proc/fix_mapsize(client/client)
 	var/windowsize = winget(client, "split", "size")

--- a/code/modules/client/preferences/entries/player/fullscreen.dm
+++ b/code/modules/client/preferences/entries/player/fullscreen.dm
@@ -15,7 +15,7 @@
 		winset(client, "mainwindow", "on-status=\".winset \\\"status_bar_wide.text = \[\[*]]\\\"\"")
 		winset(client, "status_bar", "is-visible=false")
 
-	attempt_auto_fit_viewport()
+	client.attempt_auto_fit_viewport()
 
 /datum/preference/toggle/fullscreen/proc/fix_mapsize(client/client)
 	var/windowsize = winget(client, "split", "size")

--- a/code/modules/client/verbs/ooc.dm
+++ b/code/modules/client/verbs/ooc.dm
@@ -335,7 +335,7 @@ AUTH_CLIENT_VERB(fit_viewport)
 	var/aspect_ratio = view_size[1] / view_size[2]
 
 	// Calculate desired pixel width using window size and aspect ratio
-	var/sizes = params2list(winget(src, "mainwindow.split;mapwindow", "size"))
+	var/list/sizes = params2list(winget(src, "mainwindow.split;mapwindow", "size"))
 
 	// Client closed the window? Some other error? This is unexpected behaviour, let's
 	// CRASH with some info.
@@ -397,10 +397,9 @@ AUTH_CLIENT_VERB(fit_viewport)
 /client/proc/attempt_auto_fit_viewport()
 	if (!prefs || !prefs.read_preference(/datum/preference/toggle/auto_fit_viewport))
 		return
+	// No need to attempt to fit the viewport on non-initialized clients as they'll auto-fit viewport right before finishing init
 	if(fully_created)
 		INVOKE_ASYNC(src, PROC_REF(fit_viewport))
-	else //Delayed to avoid wingets from Login calls.
-		addtimer(CALLBACK(src, PROC_REF(fit_viewport), 1 SECONDS))
 
 AUTH_CLIENT_VERB(view_runtimes_minimal)
 	set name = "View Minimal Runtimes"


### PR DESCRIPTION
## About The Pull Request

Ports https://github.com/tgstation/tgstation/pull/93065

and removes some 515 logic from fullscreen pref code

## Why It's Good For The Game

I like seeing as few runtimes as possible

## Testing Photographs and Procedure

https://github.com/user-attachments/assets/f89f4c74-a879-47ce-b223-cee020fda0d0

## Changelog
:cl: mrmanlikesbt, SmArtKar
fix: fixed viewport runtimes
fix: fixed delayed viewport fitting when connecting to the server
/:cl:
