### PR TITLE
Fixes the stray bullet hallucination

### DIFF
--- a/code/modules/hallucination/stray_bullet.dm
+++ b/code/modules/hallucination/stray_bullet.dm
@@ -4,7 +4,9 @@
 
 /datum/hallucination/stray_bullet/start()
 	var/list/turf/starting_locations = list()
-	for(var/turf/open/open_out_of_view in view(world.view + 1, hallucinator) - view(world.view, hallucinator))
+
+	var/used_view = hallucinator.client?.view || world.view
+	for(var/turf/open/open_out_of_view in view(getexpandedview(used_view, extra_x = 1, extra_y = 1), hallucinator) - view(used_view, hallucinator))
 		starting_locations += open_out_of_view
 	if(!length(starting_locations))
 		return FALSE


### PR DESCRIPTION
## About The Pull Request

Previously we were attempting to add `1` to `"17x15"`, which caused a runtime.

I changed it to prefer the hallucinator's view instead of `world.view` and just used the helper proc for getting an increased view range. The rest of the relevant code is the same.

## Why It's Good For The Game

Bugfix, annoying runtimes

## Testing Photographs and Procedure

https://github.com/user-attachments/assets/cfd889d8-e607-47a6-9e06-57fe666d23ed

## Changelog
:cl:
fix: Fixed the stray bullet hallucination
/:cl:
