### PR TITLE
Fixes modsuit sonar runtime

### DIFF
--- a/code/modules/mod/modules/modules_security.dm
+++ b/code/modules/mod/modules/modules_security.dm
@@ -400,7 +400,7 @@
 	var/oldgroup = keyed_creatures[creature]
 	var/newgroup = round(get_angle(mod.wearer, creature) / (360 / radar_slices)) + 1
 	if(oldgroup)
-		if(creature.stat == DEAD)
+		if(creature.stat == DEAD || get_dist(get_turf(mod.wearer), get_turf(creature)) > 7)
 			sorted_creatures[oldgroup] -= creature
 			keyed_creatures -= creature
 			UnregisterSignal(creature, COMSIG_MOVABLE_MOVED)

--- a/code/modules/mod/modules/modules_security.dm
+++ b/code/modules/mod/modules/modules_security.dm
@@ -400,7 +400,7 @@
 	var/oldgroup = keyed_creatures[creature]
 	var/newgroup = round(get_angle(mod.wearer, creature) / (360 / radar_slices)) + 1
 	if(oldgroup)
-		if(creature.stat == DEAD || get_dist(get_turf(mod.wearer), get_turf(creature)) > world.view)
+		if(creature.stat == DEAD)
 			sorted_creatures[oldgroup] -= creature
 			keyed_creatures -= creature
 			UnregisterSignal(creature, COMSIG_MOVABLE_MOVED)


### PR DESCRIPTION
## About The Pull Request

We were trying to do a greater than comparison with a number to `world.view` which caused a runtime. This was happening for every living mob in our view every 0.5 seconds. Ow.

We now compare against 7 (This is the magic border number for `world.view`, I wish there was a define for it)

## Why It's Good For The Game

closes #14062

## Testing Photographs and Procedure

https://github.com/user-attachments/assets/f967bfe1-7ffb-4e69-8953-37c3681e6d6d

## Changelog
:cl:
fix: Fixed the active sonar MOD runtiming on use
/:cl:
