### PR TITLE
Security sabre thing but no sprites

### DIFF
--- a/code/__DEFINES/inventory.dm
+++ b/code/__DEFINES/inventory.dm
@@ -232,7 +232,7 @@ GLOBAL_LIST_INIT(security_vest_allowed, (list(
 	/obj/item/melee/classic_baton/police/telescopic,
 	/obj/item/reagent_containers/peppercloud_deployer,
 	/obj/item/restraints/handcuffs,
-	/obj/item/storage/belt/sabre/carbon_fiber,
+	/obj/item/storage/belt/sabre/patrol,
 	/obj/item/tank/internals/emergency_oxygen,
 	/obj/item/tank/internals/plasmaman)))
 

--- a/code/game/objects/items/melee/misc.dm
+++ b/code/game/objects/items/melee/misc.dm
@@ -135,9 +135,9 @@
 		user.death(FALSE)
 	REMOVE_TRAIT(src, TRAIT_NODROP, SABRE_SUICIDE_TRAIT)
 
-/obj/item/melee/sabre/carbon_fiber
-	name = "carbon fiber sabre"
-	desc = "A sabre made of a sleek carbon fiber polymer with a reinforced blade."
+/obj/item/melee/sabre/patrol
+	name = "patrol sabre"
+	desc = "A standard-issue blade for security personnel. Polymer construction keeps it cheap and reliable. Cuts deep, but won't cut limbs without some effort."
 	icon_state = "sabre_fiber"
 	inhand_icon_state = "sabre_fiber"
 	force = 15

--- a/code/game/objects/items/storage/belt.dm
+++ b/code/game/objects/items/storage/belt.dm
@@ -997,15 +997,15 @@
 		return TRUE
 	. = ..()
 
-/obj/item/storage/belt/sabre/carbon_fiber
-	name = "carbon fiber sabre sheath"
-	desc = "A military grade sabre sheath. This one has special hooks to interface with the suit storage system of common armor classes."
+/obj/item/storage/belt/sabre/patrol
+	name = "patrol sabre sheath"
+	desc = "A polymer-clamshell sheath with quick-release. Built for field work, not ceremony."
 	icon_state = "sheath_fiber"
 	inhand_icon_state = "sheath_fiber"
 	worn_icon_state = "sheath_fiber"
 
-/obj/item/storage/belt/sabre/carbon_fiber/PopulateContents()
-	new /obj/item/melee/sabre/carbon_fiber(src)
+/obj/item/storage/belt/sabre/patrol/PopulateContents()
+	new /obj/item/melee/sabre/patrol(src)
 	update_appearance()
 
 /obj/item/storage/belt/sabre/mime

--- a/code/modules/mapping/mapping_items/armoury_spawners.dm
+++ b/code/modules/mapping/mapping_items/armoury_spawners.dm
@@ -48,7 +48,7 @@
 /obj/effect/loot_jobscale/armoury/pistols
 	icon = 'icons/obj/guns/projectile.dmi'
 	icon_state = "sec"
-	loot = list(/obj/item/gun/ballistic/automatic/pistol/security, /obj/item/storage/belt/sabre/carbon_fiber)
+	loot = list(/obj/item/gun/ballistic/automatic/pistol/security, /obj/item/storage/belt/sabre/patrol)
 	fan_out_items = TRUE
 	minimum = 2
 	linear_scaling_rate = 1

--- a/code/modules/vending/security.dm
+++ b/code/modules/vending/security.dm
@@ -56,15 +56,15 @@
 	// Supports single items or whole boxes.
 	var/atom/movable/spawned
 
-	var/items = list("Carbon Fibre Sabre", "NPS-10")
+	var/items = list("Patrol Sabre", "NPS-10")
 
 	var/selection = tgui_input_list(redeemer, "Pick your equipment", "Voucher Redemption", sort_list(items), "NPS-10")
 	if(!selection || !Adjacent(redeemer) || QDELETED(voucher) || voucher.loc != redeemer)
 		return
 
 	switch(selection)
-		if("Carbon Fibre Sabre")
-			spawned = new /obj/item/storage/belt/sabre/carbon_fiber(redeemer)
+		if("Patrol Sabre")
+			spawned = new /obj/item/storage/belt/sabre/patrol(redeemer)
 
 		if("NPS-10")
 			spawned = new /obj/item/storage/box/gearvend


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Direct copy of #13950

This alters the name and description of the carbon fiber sabre to be more in-line with it's new role as a standard security enforcement tool.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

The sabre was originally introduced as a sort of old piece of gear not intended to be actually used by security.

This reflavors the sword to be more in-line with established security gear to better fit it's actual usage in-game.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->

<img width="1819" height="269" alt="image" src="https://github.com/user-attachments/assets/951383d2-b5fa-4a68-bbce-2ad510946cd8" />

## Changelog
:cl:
tweak: tweaked the carbon fiber sabre
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
