### PR TITLE
Fixes random accents

### DIFF
--- a/code/datums/traits/_quirk.dm
+++ b/code/datums/traits/_quirk.dm
@@ -20,8 +20,6 @@
 	var/datum/mind/quirk_holder // The mind that contains this quirk
 	var/mob/living/quirk_target // The mob that will be affected by this quirk
 	var/abstract_parent_type = /datum/quirk
-	/// Accent to be used in accent traits
-	var/accent_to_use = null
 
 /datum/quirk/New(datum/mind/quirk_mind, mob/living/quirk_mob, spawn_effects)
 	..()

--- a/code/datums/traits/neutral_quirk.dm
+++ b/code/datums/traits/neutral_quirk.dm
@@ -197,13 +197,15 @@
 	name = "Accent"
 	desc = "You have a distinct way of speaking! (Select one in character creation)"
 	icon = "comment-dots"
-	gain_text = span_notice("You are aflicted with an accent.")
-	lose_text = span_danger("You are no longer aflicted with an accent.")
+	gain_text = span_notice("You are afflicted with an accent.")
+	lose_text = span_danger("You are no longer afflicted with an accent.")
 	medical_record_text = "Patient has a distinct accent."
+	/// Accent to be used in accent traits
+	var/accent_to_use = null
 
 /datum/quirk/accent/add()
 	var/chosen = read_choice_preference(/datum/preference/choiced/quirk/accent)
-	accent_to_use = GLOB.accents[chosen]
+	accent_to_use = GLOB.accents[chosen || pick(GLOB.accents)]
 	var/mob/living/carbon/human/H = quirk_target
 	RegisterSignal(H, COMSIG_MOB_SAY, PROC_REF(handle_speech))
 

--- a/code/datums/traits/neutral_quirk.dm
+++ b/code/datums/traits/neutral_quirk.dm
@@ -206,12 +206,10 @@
 /datum/quirk/accent/add()
 	var/chosen = read_choice_preference(/datum/preference/choiced/quirk/accent)
 	accent_to_use = GLOB.accents[chosen || pick(GLOB.accents)]
-	var/mob/living/carbon/human/H = quirk_target
-	RegisterSignal(H, COMSIG_MOB_SAY, PROC_REF(handle_speech))
+	RegisterSignal(quirk_target, COMSIG_MOB_SAY, PROC_REF(handle_speech))
 
 /datum/quirk/accent/remove()
-	var/mob/living/carbon/human/H = quirk_target
-	UnregisterSignal(H, COMSIG_MOB_SAY)
+	UnregisterSignal(quirk_target, COMSIG_MOB_SAY)
 
 /datum/quirk/accent/proc/handle_speech(datum/source, list/speech_args)
 	SIGNAL_HANDLER


### PR DESCRIPTION
## About The Pull Request

This took me longer to fix than I care to admit. Preference code is awful and I had to jump through several procs and layers of obfuscation to get to the source.

Anyways- when a quirk preference is set to "Random" the return value of `read_choice_preference()` is always null and the logic for randomized accents was just... never implemented.

This also moves the `accent_to_use` var from the `/datum/quirk` level up to `/datum/quirk/accent`

## Why It's Good For The Game

This is very spammy with runtimes considering there are surprisingly several people with a random accents and it spits out two runtimes every time X person speaks.

## Testing Photographs and Procedure

https://github.com/user-attachments/assets/09b2c854-9e10-476c-a009-ade3465ba4a4

## Changelog
:cl:
fix: Fixed randomized accents not applying an accent. If your character starts speaking strangely, check to see if you have the accent quirk.
spellcheck: Fixed a typo in the accent quirk gain/remove text
/:cl:
