### PR TITLE
Super Energy Chainsaw and Eshield Module Nerfs

### DIFF
--- a/code/game/objects/items/chainsaw.dm
+++ b/code/game/objects/items/chainsaw.dm
@@ -151,14 +151,7 @@
 	attack_weight = 3
 	armour_penetration = 75
 	light_range = 6
-	active_force = 60
-
-	/// How much time someone is knocked down for when attacking them
-	var/knockdown_time = 1 SECONDS
-
-/obj/item/chainsaw/energy/doom/attack(mob/living/target)
-	. = ..()
-	target.Knockdown(knockdown_time)
+	active_force = 50
 
 /datum/action/item_action/startchainsaw
 	name = "Pull The Starting Cord"

--- a/code/game/objects/items/chainsaw.dm
+++ b/code/game/objects/items/chainsaw.dm
@@ -64,6 +64,7 @@
 		attack_verb_simple_on = list("saw", "tear", "lacerate", "cut", "chop", "dice"), \
 	)
 	RegisterSignal(src, COMSIG_TRANSFORMING_ON_TRANSFORM, PROC_REF(on_transform))
+	RegisterSignal(src, COMSIG_ITEM_DROPPED, PROC_REF(on_dropped))
 
 /obj/item/chainsaw/proc/on_transform(obj/item/source, mob/user, active)
 	SIGNAL_HANDLER
@@ -83,6 +84,12 @@
 	update_appearance(UPDATE_ICON_STATE)
 
 	return COMPONENT_NO_DEFAULT_MESSAGE
+
+/obj/item/chainsaw/proc/on_dropped(obj/item/source, mob/user)
+	SIGNAL_HANDLER
+	var/datum/component/transforming/T = GetComponent(/datum/component/transforming)
+	if(T && T.active)
+		SEND_SIGNAL(src, COMSIG_ITEM_ATTACK_SELF, user)
 
 /obj/item/chainsaw/suicide_act(mob/living/carbon/user)
 	var/datum/component/transforming/transforming = src.GetComponent(/datum/component/transforming)
@@ -151,7 +158,14 @@
 	attack_weight = 3
 	armour_penetration = 75
 	light_range = 6
-	active_force = 50
+	active_force = 45
+
+	/// How much time someone is knocked down for when attacking them
+	var/knockdown_time = 1 SECONDS
+
+/obj/item/chainsaw/energy/doom/attack(mob/living/target)
+	. = ..()
+	target.Knockdown(knockdown_time)
 
 /datum/action/item_action/startchainsaw
 	name = "Pull The Starting Cord"

--- a/code/game/objects/items/weaponry.dm
+++ b/code/game/objects/items/weaponry.dm
@@ -628,7 +628,7 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 /obj/item/mounted_chainsaw/super
 	name = "mounted super energy chainsaw"
 	desc = "A super energy chainsaw that has replaced your arm."
-	force = 60
+	force = 50
 	armour_penetration = 75
 	hitsound = 'sound/weapons/energychainsaw_hit1.ogg'
 
@@ -643,10 +643,6 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 	. = ..()
 	if(part)
 		part.drop_limb()
-
-/obj/item/mounted_chainsaw/super/attack(mob/living/target)
-	..()
-	target.Knockdown(4)
 
 /obj/item/statuebust
 	name = "bust"

--- a/code/game/objects/items/weaponry.dm
+++ b/code/game/objects/items/weaponry.dm
@@ -628,7 +628,7 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 /obj/item/mounted_chainsaw/super
 	name = "mounted super energy chainsaw"
 	desc = "A super energy chainsaw that has replaced your arm."
-	force = 50
+	force = 45
 	armour_penetration = 75
 	hitsound = 'sound/weapons/energychainsaw_hit1.ogg'
 
@@ -643,6 +643,10 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 	. = ..()
 	if(part)
 		part.drop_limb()
+
+/obj/item/mounted_chainsaw/super/attack(mob/living/target)
+	..()
+	target.Knockdown(1 SECONDS)
 
 /obj/item/statuebust
 	name = "bust"

--- a/code/modules/mod/modules/modules_antag.dm
+++ b/code/modules/mod/modules/modules_antag.dm
@@ -119,7 +119,7 @@
 	use_power_cost = DEFAULT_CHARGE_DRAIN * 2
 	incompatible_modules = list(/obj/item/mod/module/energy_shield)
 	required_slots = list(ITEM_SLOT_BACK)
-	max_integrity = 60 	/// Max integrity of the shield.
+	max_integrity = 30 	/// Max integrity of the shield.
 	/// How long we have to avoid being hit to start replenishing integrity.
 	var/recharge_start_delay = 5 SECONDS
 	/// Once we go unhit long enough to recharge, we replenish integrity this often.


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

It nerfs slightly the Super Energy Chainsaw and Energy Shield Module

## Why It's Good For The Game

https://github.com/BeeStation/BeeStation-Hornet/pull/13938 did it's job at making the energy shield a lot more viable for nuclear operatives, however it made it **Too viable** to the point it's being bought by every single nukie team, specially when combined with the super energy chainsaw
lowering the amount of maximum shield to 30 from 60 should make it less viable to rush people head on without any drawbacks

As for the super energy chainsaw, people complained about 1 hit delimbing, the damage was reduced to 45, it takes 3 hits to crit and 5 to fully kill someone, keeping it's knockdown intact


## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>
<img width="703" height="236" alt="image" src="https://github.com/user-attachments/assets/342285f8-0bda-4b4f-a618-0e903a478044" />

</details>

## Changelog
:cl: Isaac
balance: Super energy chainsaw damage reduced to 45, roughly fully kills you in 5 hits, 3 to crit
balance: Energy Shield Module HP reduced to 30
fix: Chainsaws turn themselves off when dropped on the ground, preventing cases where the damage was reset to 0 when dropped
/:cl:
<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
