### PR TITLE
Fixes legion sprite being offset away from the hitbox, fixes legion invisiblity

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/megafauna/legion.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/legion.dm
@@ -125,7 +125,7 @@ Difficulty: Medium
 	if(health > 0)
 		return
 	if(size > 1)
-		adjustHealth(-maxHealth) //heal ourself to full in prep for splitting
+		adjustHealth(-(maxHealth * 2)) //heal ourself to full in prep for splitting, 2x multiplier otherwise health gets wonky when we overkill
 		var/mob/living/simple_animal/hostile/megafauna/legion/L = new(loc)
 
 		L.maxHealth = round(maxHealth * 0.6,DAMAGE_PRECISION)

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/legion.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/legion.dm
@@ -35,7 +35,7 @@ Difficulty: Medium
 	achievement_type = /datum/award/achievement/boss/legion_kill
 	crusher_achievement_type = /datum/award/achievement/boss/legion_crusher
 	score_achievement_type = /datum/award/score/legion_score
-	SET_BASE_PIXEL(-32, -16)
+	SET_BASE_PIXEL(-75, -90)
 	loot = list(/obj/item/stack/sheet/bone = 3)
 	vision_range = 13
 	wander = FALSE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
<img width="451" height="137" alt="firefox_yu34qi436c" src="https://github.com/user-attachments/assets/53cd0145-fd57-47d3-8573-20fc2688bfc2" />

We have been using the wrong offset for 3 years.

Makes the adjustHealth() actually heal to full all the time, if you overkill the legion hard enough you can make it die multiple times in one hit due to it having 0 health after "healing", at lower sizes this can cause the legions to just go invisible by reaching a size of zero without being killed.

Closes https://github.com/BeeStation/BeeStation-Hornet/issues/10848

## Why It's Good For The Game

Fix

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>

The behavior right now has the hitbox exist where you see those pulse rifle hit markers show up, and it remains there every time the legion resizes, this video still has the adjustHealth logic error.

https://github.com/user-attachments/assets/fde30d2a-6aa7-4ea5-a8cd-d09445d44d21

Fix of adjustHealth(), none of the legions get overkilled into invisibility.

https://github.com/user-attachments/assets/e379228e-720d-4bfc-bb32-291c9c8783f6


<summary>Screenshots&Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>

## Changelog
:cl:
fix: Fixed megafauna legion sprite offset being wrong.
fix: Fixed megafauna legion going invisible.
fix: Fixed megafauna legion splitting into 3 instead of 2 in rare cases.
balance: The mentioned invisibility fix also means that the Legion will have slightly more health than before upon splitting but only in the cases where it gets overkilled.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
