### PR TITLE
Berry Quick Radio Hotfix Take2

### DIFF
--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -49727,7 +49727,6 @@
 /area/science/mixing)
 "pda" = (
 /obj/item/radio/intercom{
-	broadcasting = 1;
 	frequency = 1447;
 	name = "Private AI Channel";
 	pixel_y = -28

--- a/_maps/map_files/RadStation/RadStation.dmm
+++ b/_maps/map_files/RadStation/RadStation.dmm
@@ -7288,7 +7288,6 @@
 	},
 /obj/effect/turf_decal/siding/dark/corner,
 /obj/item/radio/intercom{
-	broadcasting = 1;
 	frequency = 1447;
 	name = "Private AI Channel";
 	pixel_y = 24
@@ -19617,7 +19616,6 @@
 	},
 /obj/effect/turf_decal/siding/dark/corner,
 /obj/item/radio/intercom{
-	broadcasting = 1;
 	frequency = 1447;
 	name = "Private AI Channel";
 	pixel_x = -30
@@ -22889,7 +22887,6 @@
 	dir = 8
 	},
 /obj/item/radio/intercom{
-	broadcasting = 1;
 	frequency = 1447;
 	name = "Private AI Channel";
 	pixel_y = 24
@@ -27420,7 +27417,6 @@
 	dir = 5
 	},
 /obj/item/radio/intercom{
-	broadcasting = 1;
 	frequency = 1447;
 	name = "Private AI Channel";
 	pixel_x = 32
@@ -28052,12 +28048,6 @@
 /obj/machinery/camera/motion/directional/west,
 /obj/effect/turf_decal/siding/dark/corner{
 	dir = 4
-	},
-/obj/item/radio/intercom{
-	broadcasting = 1;
-	frequency = 1447;
-	name = "Private AI Channel";
-	pixel_x = -30
 	},
 /turf/open/floor/iron/dark/textured_large,
 /area/ai_monitored/turret_protected/ai)
@@ -55974,7 +55964,6 @@
 	},
 /obj/effect/turf_decal/bot,
 /obj/item/radio/intercom{
-	broadcasting = 1;
 	frequency = 1447;
 	name = "Private AI Channel";
 	pixel_y = 24
@@ -56271,7 +56260,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /obj/effect/turf_decal/edges/borderfloor,
 /obj/item/radio/intercom{
-	broadcasting = 1;
 	frequency = 1447;
 	name = "Private AI Channel";
 	pixel_y = -32
@@ -56685,9 +56673,9 @@
 	},
 /obj/effect/turf_decal/bot,
 /obj/item/radio/intercom{
-	broadcasting = 1;
 	frequency = 1447;
 	name = "Private AI Channel";
+	broadcasting = 1;
 	pixel_y = 24
 	},
 /turf/open/floor/iron/dark/smooth_large,
@@ -63440,7 +63428,6 @@
 	dir = 1
 	},
 /obj/item/radio/intercom{
-	broadcasting = 1;
 	frequency = 1447;
 	name = "Private AI Channel";
 	pixel_x = 32
@@ -65122,7 +65109,6 @@
 	dir = 1
 	},
 /obj/item/radio/intercom{
-	broadcasting = 1;
 	frequency = 1447;
 	name = "Private AI Channel";
 	pixel_y = 24
@@ -65718,7 +65704,6 @@
 	dir = 4
 	},
 /obj/item/radio/intercom{
-	broadcasting = 1;
 	frequency = 1447;
 	name = "Private AI Channel";
 	pixel_y = -32


### PR DESCRIPTION
## About The Pull Request

Not to mothsplain, but Radios have a 3 tile range to pickup audio at the moment, this coupled with automatic muting systems and overlapping radio's is a recipe for disaster and have caused issue's as of late in particular areas. This PR attempts to put a band-aid on that open wound by just _turning off some of the radios broadcast feature via vv_

It is not the solution ultimately but it will prevent, _hopefully_, any immediate issues in these areas until a proper fix can be made

## Why It's Good For The Game

As mentioned, people are being muted because they are unluckily within range of enough radios, which are all turned **on** at round start. This doesn't solve the issue, but it will atleast mitigate it and hopefully give some relief to administration and fix some unnecessary play annoyance 

## Testing Photographs and Procedure

I've highlighted all the radios turned **OFF**, the unpainted ones will broadcast like normal (color vv was removed after photo)
<details>
<summary>Screenshots&Videos</summary>

<img width="758" height="663" alt="Screenshot 2026-02-02 143421" src="https://github.com/user-attachments/assets/f9abc6db-198a-4658-b5a6-c121c2cb3326" /> <br>
<img width="935" height="870" alt="Screenshot 2026-02-02 142145" src="https://github.com/user-attachments/assets/b9ee8457-2e5a-432d-aebd-b4dda6010430" /> 


</details>

## Changelog
:cl:
map: Turns Off Duplicate Round Start Broadcasting on Radios in Radstation AI Sat, and Kilostation Ai Upload
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
