### PR TITLE
Brings the guardian cyborg gun a bit closer to security's new power level

### DIFF
--- a/code/modules/exploration_crew/exploration_laser_gun.dm
+++ b/code/modules/exploration_crew/exploration_laser_gun.dm
@@ -112,9 +112,8 @@
 /obj/item/gun/energy/e_gun/mini/exploration/cyborg
 	name = "multi-purpose energy gun"
 	desc = "An energy gun with three firing modes useful in a variety of situations, it is not capable of causing substantial harm to crew on any setting."
-	ammo_type = list(/obj/item/ammo_casing/energy/disabler/cyborg, /obj/item/ammo_casing/energy/laser/cutting/cyborg, /obj/item/ammo_casing/energy/laser/anti_creature/cyborg)
+	ammo_type = list(/obj/item/ammo_casing/energy/electrode/cyborg, /obj/item/ammo_casing/energy/laser/cutting/cyborg, /obj/item/ammo_casing/energy/laser/anti_creature/cyborg)
 	gun_charge = 10 KILOWATT
-	fire_rate = 1		//One shots per second
 	charge_delay = 9	//Fully charged in 90 seconds
 	w_class = WEIGHT_CLASS_LARGE //Same weight as disabler, for the slightly higher slowdown while active
 	can_charge = FALSE
@@ -143,18 +142,18 @@
 		R.apply_status_effect(/datum/status_effect/cyborg_sentry)
 	. = ..()
 
-//Standard disabler round
-/obj/item/ammo_casing/energy/disabler/cyborg
-	e_cost = 500 WATT	//20 shot capacity
+//Standard taser round
+/obj/item/ammo_casing/energy/electrode/cyborg
+	e_cost = 5000 WATT	//2 shot capacity, aim carefully.
 
 //Does 5 damage to mobs and 70 to objects, with exception to blobs
 /obj/item/ammo_casing/energy/laser/cutting/cyborg
 	e_cost = 250 WATT	//40 shot capacity
 
-//Does 5 damage to humans, 30 damage to all other mobs.
+//Does 15 damage to humans, 30 damage to all other mobs.
 /obj/item/ammo_casing/energy/laser/anti_creature/cyborg
-	projectile_type = /obj/projectile/beam/laser/anti_creature/cyborg
-	e_cost = 500 WATT	//20 shot capacity
+	projectile_type = /obj/projectile/beam/laser/anti_creature
+	e_cost = 1000 WATT	//10 shot capacity
 
-/obj/projectile/beam/laser/anti_creature/cyborg
-	damage = 5  //15 is too much given this can be used on station
+/obj/item/ammo_casing/energy/disabler/cyborg
+	e_cost = 500 WATT  //20 shot capacity


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

* Increases the recharge rate of the cyborg gun by 50% (60 seconds to fully charge from fully depleted, down from 90)
* Removes the disabler mode from the cyborg gun
* Adds a taser mode to the gun, with two shot capacity (30 seconds to recharge each taser shot)
* Triples the damage of the anti-creature gun against humanoids (15 up from 5) 
* Doubles the cost of the anti-creature gun so cyborgs can hold 10 charges instead of 20 (6 seconds per charge)
* The cyborg gun now has the same rate of fire as other energy guns. 

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Security as a whole has been significantly buffed since the introduction of this module, leaving it somewhat in the dust when it comes to being able to subdue crew and threats to the station. This module was intentionally kept on the weaker side to prevent it from being too powerful, but enough time has now passed that it is clear it wasn't powerful enough to continue being used for its intended purpose. 

The cyborg still has a significant slowdown after firing, maintaining their focus on repelling from and defending an area rather than directly pursuing and finishing a takedown, although a successful taser hit will prevent escape just like it does for officers. 

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

<img width="439" height="408" alt="image" src="https://github.com/user-attachments/assets/80f6f0a3-a8db-41b1-88fc-eae6315d26a8" />

<img width="343" height="388" alt="image" src="https://github.com/user-attachments/assets/68b72179-ea79-4e45-aa7a-a40374a4f014" />

<img width="422" height="231" alt="image" src="https://github.com/user-attachments/assets/fd5a2a9a-b07b-48d6-b357-5f1f66a0b355" />

</details>

## Changelog
:cl:
balance: The guardian cyborg module has had its primary weapon rebalanced, recharging 50% faster and now firing at the same rate as other energy weapons
del: The disabler firing mode has been entirely removed from the guardian's gun
add: A taser mode with a two shot capacity has been added to the guardian's gun. This draws from the same energy pool as other firing modes, so you will not have a fallback if both of these miss. 
balance: The anti-creature firing mode has been changed from 20 shot capacity to 10, but now deals 15 damage to humanoids up from 5. 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
