### PR TITLE
Fixes the spam filter

### DIFF
--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -263,7 +263,7 @@
 		return
 	if(wires.is_cut(WIRE_TX))  // Permacell and otherwise tampered-with radios
 		return
-	if(!talking_movable.try_speak(message))
+	if(!talking_movable.try_speak(message, ignore_spam = TRUE))
 		return
 
 	if(!radio_silent)//Radios make small static noises now

--- a/code/modules/mob/living/emote.dm
+++ b/code/modules/mob/living/emote.dm
@@ -486,7 +486,7 @@
 	if(QDELETED(user))
 		return FALSE
 
-	if(user.client && user.client.player_details.muted & MUTE_IC)
+	if(user.client && (user.client.player_details.muted & MUTE_IC))
 		to_chat(user, "You cannot send IC messages (muted).")
 		return FALSE
 

--- a/code/modules/mob/living/living_say.dm
+++ b/code/modules/mob/living/living_say.dm
@@ -128,6 +128,9 @@ GLOBAL_LIST_INIT(department_radio_keys, list(
 	if(saymode && saymode.early && !saymode.handle_message(src, message, language))
 		return
 
+	if(!try_speak(original_message, ignore_spam, forced))
+		return
+
 	if(!language) // get_message_mods() proc finds a language key, and add the language to LANGUAGE_EXTENSION
 		language = message_mods[LANGUAGE_EXTENSION] || get_selected_language()
 


### PR DESCRIPTION
## About The Pull Request

There are actually two issues here:
- `/mob/living` overrides `/mob/proc/say()`, but does not include the necessary `try_speak()` which handles auto-mute. This means that when living mob speaks they are, by default, completely exempt from the spam filter.
- Speaking into radios does **not** ignore the spam filter even though it should. This is incorrect because a player may not be in control or even aware of the amount of radios nearby them. Additionally, having multiple spam filter violations for one message sent is ridiculous.

## Why It's Good For The Game

People are being auto-muted 4noraisin

## Testing Photographs and Procedure

(The mute message is a little misleading, you're only muted from custom emotes, not any of the default ones)

https://github.com/user-attachments/assets/d92e7387-653d-41e3-beda-15f42ed5a5d0

## Changelog
:cl:
fix: Fixed living creatures being exempt from the spam filter
fix: Speaking near multiple active radios will no longer trigger the spam filter and auto-mute you
/:cl: