### PR TITLE
Sanitizes keybinds

### DIFF
--- a/code/modules/client/preferences/serialization/preferences_database.dm
+++ b/code/modules/client/preferences/serialization/preferences_database.dm
@@ -29,7 +29,7 @@
 /datum/preferences/proc/ready_to_save_player()
 	return dirty_undatumized_preferences_player || length(player_data.dirty_prefs)
 
-/// checks keybindings for non-existant keybinds and removes them
+/// checks keybindings for nonexistent keybinds and removes them
 /datum/preferences/proc/sanitize_keybinds()
 	if(!parent)
 		return

--- a/code/modules/client/preferences/serialization/preferences_database.dm
+++ b/code/modules/client/preferences/serialization/preferences_database.dm
@@ -116,7 +116,7 @@
 	lastchangelog = sanitize_text(lastchangelog, initial(lastchangelog))
 	default_slot = sanitize_integer(default_slot, 1, TRUE_MAX_SAVE_SLOTS, initial(default_slot))
 	ignoring = SANITIZE_LIST(ignoring)
-	purchased_gear	= SANITIZE_LIST(purchased_gear)
+	purchased_gear = SANITIZE_LIST(purchased_gear)
 	role_preferences_global = SANITIZE_LIST(role_preferences_global)
 
 	pai_name = sanitize_text(pai_name, initial(pai_name))

--- a/code/modules/client/preferences/serialization/preferences_database.dm
+++ b/code/modules/client/preferences/serialization/preferences_database.dm
@@ -29,6 +29,18 @@
 /datum/preferences/proc/ready_to_save_player()
 	return dirty_undatumized_preferences_player || length(player_data.dirty_prefs)
 
+/// checks keybindings for non-existant keybinds and removes them
+/datum/preferences/proc/sanitize_keybinds()
+	if(!parent)
+		return
+
+	for(var/key, keybinds_list in key_bindings)
+		for(var/keybind in keybinds_list)
+			if(isnull(GLOB.keybindings_by_name[keybind]))
+				keybinds_list -= keybind
+
+	save_preferences()
+
 // Defines for list sanity
 #define READPREF_STR(target, tag) if(prefmap[tag]) target = prefmap[tag]
 #define READPREF_INT(target, tag) if(prefmap[tag]) target = text2num(prefmap[tag])
@@ -101,17 +113,18 @@
 	READPREF_JSONDEC(key_bindings, PREFERENCE_TAG_KEYBINDS)
 
 	//Sanitize
-	lastchangelog	= sanitize_text(lastchangelog, initial(lastchangelog))
-	default_slot	= sanitize_integer(default_slot, 1, TRUE_MAX_SAVE_SLOTS, initial(default_slot))
-	ignoring		= SANITIZE_LIST(ignoring)
+	lastchangelog = sanitize_text(lastchangelog, initial(lastchangelog))
+	default_slot = sanitize_integer(default_slot, 1, TRUE_MAX_SAVE_SLOTS, initial(default_slot))
+	ignoring = SANITIZE_LIST(ignoring)
 	purchased_gear	= SANITIZE_LIST(purchased_gear)
 	role_preferences_global = SANITIZE_LIST(role_preferences_global)
 
-	pai_name		= sanitize_text(pai_name, initial(pai_name))
+	pai_name = sanitize_text(pai_name, initial(pai_name))
 	pai_description	= sanitize_text(pai_description, initial(pai_description))
-	pai_comment		= sanitize_text(pai_comment, initial(pai_comment))
+	pai_comment = sanitize_text(pai_comment, initial(pai_comment))
 
-	key_bindings 	= sanitize_islist(key_bindings, deep_copy_list(GLOB.keybindings_by_name_to_key))
+	sanitize_keybinds()
+	key_bindings = sanitize_islist(key_bindings, deep_copy_list(GLOB.keybindings_by_name_to_key))
 	key_bindings_by_key = get_key_bindings_by_key(key_bindings)
 
 	// Remove any invalid role preference entries

--- a/code/modules/client/preferences/serialization/preferences_database.dm
+++ b/code/modules/client/preferences/serialization/preferences_database.dm
@@ -34,10 +34,28 @@
 	if(!parent)
 		return
 
-	for(var/key, keybinds_list in key_bindings)
-		for(var/keybind in keybinds_list)
-			if(isnull(GLOB.keybindings_by_name[keybind]))
-				keybinds_list -= keybind
+	/**
+	 * Real world example of invalid keybinds:
+	 * (To avoid confusion between list index keys and keys on a keyboard, I will be referring to keys on a keyboard as buttons)
+	 *
+	 * key_bindings = list(
+	 * 	"admin_say" = list("F3"), <--- This is correct. The bind's string form as the index's key and the list of buttons as the index's value.
+	 *  "F3" = list("admin_say"), <--- This is incorrect. Buttons shouldn't ever be keys.
+	 *  "select_help_intent" = list("1"), <--- This is incorrect. "select_help_intent" is not apart of GLOB.keybindings_by_name.
+ 	 * 	...
+	 * )
+	 *
+	 * Sample GLOB.keybindings_by_name:
+	 *
+	 * keybindings_by_name = list(
+	 *  "admin_say" = /datum/keybinding/admin/admin_say, <--- Not really relevant here, but these are instances, not typepaths.
+	 *  ...
+	 * )
+	 */
+	for(var/bind, buttons_list in key_bindings)
+		// Prunes buttons as index keys and deprecated binds.
+		if(isnull(GLOB.keybindings_by_name[bind]))
+			key_bindings -= bind
 
 // Defines for list sanity
 #define READPREF_STR(target, tag) if(prefmap[tag]) target = prefmap[tag]

--- a/code/modules/client/preferences/serialization/preferences_database.dm
+++ b/code/modules/client/preferences/serialization/preferences_database.dm
@@ -39,9 +39,9 @@
 	 * (To avoid confusion between list index keys and keys on a keyboard, I will be referring to keys on a keyboard as buttons)
 	 *
 	 * key_bindings = list(
-	 * 	"admin_say" = list("F3"), <--- This is correct. The bind's string form as the index's key and the list of buttons as the index's value.
-	 *  "F3" = list("admin_say"), <--- This is incorrect. Buttons shouldn't ever be keys.
-	 *  "select_help_intent" = list("1"), <--- This is incorrect. "select_help_intent" is not apart of GLOB.keybindings_by_name.
+	 * 	"admin_say" = list("F3"), <--- This is correct. The bind's string form as the index's key and a list of buttons as the index's value.
+	 *  "F3" = list("admin_say"), <--- This is incorrect. Buttons shouldn't ever be index keys.
+	 *  "select_help_intent" = list("1"), <--- This is incorrect. "select_help_intent" is not a valid index key as it is not apart of GLOB.keybindings_by_name.
  	 * 	...
 	 * )
 	 *

--- a/code/modules/client/preferences/serialization/preferences_database.dm
+++ b/code/modules/client/preferences/serialization/preferences_database.dm
@@ -42,7 +42,7 @@
 	 * 	"admin_say" = list("F3"), <--- This is correct. The bind's string form as the index's key and a list of buttons as the index's value.
 	 *  "F3" = list("admin_say"), <--- This is incorrect. Buttons shouldn't ever be index keys.
 	 *  "select_help_intent" = list("1"), <--- This is incorrect. "select_help_intent" is not a valid index key as it is not apart of GLOB.keybindings_by_name.
- 	 * 	...
+	 * 	...
 	 * )
 	 *
 	 * Sample GLOB.keybindings_by_name:

--- a/code/modules/client/preferences/serialization/preferences_database.dm
+++ b/code/modules/client/preferences/serialization/preferences_database.dm
@@ -39,8 +39,6 @@
 			if(isnull(GLOB.keybindings_by_name[keybind]))
 				keybinds_list -= keybind
 
-	save_preferences()
-
 // Defines for list sanity
 #define READPREF_STR(target, tag) if(prefmap[tag]) target = prefmap[tag]
 #define READPREF_INT(target, tag) if(prefmap[tag]) target = text2num(prefmap[tag])

--- a/code/modules/client/preferences/serialization/preferences_database.dm
+++ b/code/modules/client/preferences/serialization/preferences_database.dm
@@ -120,7 +120,7 @@
 	role_preferences_global = SANITIZE_LIST(role_preferences_global)
 
 	pai_name = sanitize_text(pai_name, initial(pai_name))
-	pai_description	= sanitize_text(pai_description, initial(pai_description))
+	pai_description = sanitize_text(pai_description, initial(pai_description))
 	pai_comment = sanitize_text(pai_comment, initial(pai_comment))
 
 	sanitize_keybinds()


### PR DESCRIPTION
## About The Pull Request

Sanitizes player keybinds for invalid keybindings.

## Why It's Good For The Game

Any player that played before combat mode has the old intent keybinds saved in their preferences. Every time they press an invalid keybind, it runtimes (twice).

## Testing Photographs and Procedure

https://github.com/user-attachments/assets/4006e7e7-b41a-4298-92b0-c4463c4e4c36

## Changelog
:cl:
fix: Player keybinds are now sanitized. What this really means is that people who played before combat-mode no longer cause 2 runtimes every time they press 1.
/:cl: