### PR TITLE
Confied Space Permit Required: New ~punishments~ toys for engineering: Gas Masquerading and a Toxic gas

### DIFF
--- a/code/__DEFINES/atmospherics/atmos_core.dm
+++ b/code/__DEFINES/atmospherics/atmos_core.dm
@@ -34,6 +34,13 @@
 #define META_GAS_RIG_SHIELDING_POWER 13
 ///Gas advanced gas rig shielding modifier
 #define META_GAS_RIG_SHIELDING_MODIFIER 14
+///This gas can be directly filtered by scrubbers and filters
+#define META_GAS_FILTERABLE 15
+///The gasses that masquerade as this gas
+#define META_GAS_MASQUERADED_BY 16
+
+//The length of the list of gas meta properties. If more gas properties are added, make sure to increase this constant.
+#define META_GAS_LIST_LENGTH (META_GAS_MASQUERADED_BY + 1)
 
 //ATMOS
 //stuff you should probably leave well alone!

--- a/code/__DEFINES/atmospherics/atmos_gasses.dm
+++ b/code/__DEFINES/atmospherics/atmos_gasses.dm
@@ -10,3 +10,4 @@
 #define GAS_TRITIUM "tritium"
 #define GAS_HYPER_NOBLIUM "hypernoblium"
 #define GAS_PLUOXIUM "pluoxium"
+#define GAS_TOXIC "toxic"

--- a/code/__DEFINES/reactions.dm
+++ b/code/__DEFINES/reactions.dm
@@ -160,3 +160,9 @@
 #define PLASMIC_FUSION_MIDDLE_ENERGY_REFERENCE 1e6
 /// Increase this to cull unrobust fusions faster
 #define PLASMIC_FUSION_BUFFER_DIVISOR 1
+
+
+/// Toxic gas neutralization energy released from N2O and Toxic gas converting to CO2 and N2
+#define TOXIC_NEUTRALIZATION_ENERGY 250
+/// The maximum amount of toxic gas that can be neutralized per reaction tick.
+#define TOXIC_NEUTRALIZATION_MAX_RATE 5

--- a/code/_globalvars/lists/canisters.dm
+++ b/code/_globalvars/lists/canisters.dm
@@ -16,5 +16,6 @@ GLOBAL_LIST_INIT(gas_id_to_canister, init_gas_id_to_canister())
 		GAS_TRITIUM = /obj/machinery/portable_atmospherics/canister/tritium,
 		GAS_HYPER_NOBLIUM = /obj/machinery/portable_atmospherics/canister/nob,
 		GAS_PLUOXIUM = /obj/machinery/portable_atmospherics/canister/pluoxium,
+		GAS_TOXIC =  /obj/machinery/portable_atmospherics/canister/toxic,
 		"caution" = /obj/machinery/portable_atmospherics/canister,
 	))

--- a/code/_onclick/hud/alert.dm
+++ b/code/_onclick/hud/alert.dm
@@ -165,6 +165,11 @@
 	desc = "There's highly flammable, toxic plasma in the air and you're breathing it in. Find some fresh air. The box in your backpack has an oxygen tank and gas mask in it."
 	icon_state = ALERT_TOO_MUCH_PLASMA
 
+/atom/movable/screen/alert/too_much_toxic
+	name = "Choking (Toxic)"
+	desc = "There's an invisible toxic gas in the air and you're breathing it in. Find some fresh air. The box in your backpack has an oxygen tank and gas mask in it."
+	icon_state = ALERT_TOO_MUCH_PLASMA
+
 //End gas alerts
 
 

--- a/code/modules/atmospherics/gasmixtures/gas_types.dm
+++ b/code/modules/atmospherics/gasmixtures/gas_types.dm
@@ -3,7 +3,7 @@ GLOBAL_LIST_INIT(hardcoded_gases, list(/datum/gas/oxygen, /datum/gas/nitrogen, /
 /proc/meta_gas_list()
 	. = subtypesof(/datum/gas)
 	for(var/gas_path in .)
-		var/list/gas_info = new(15)
+		var/list/gas_info = new(META_GAS_LIST_LENGTH)
 		var/datum/gas/gas = gas_path
 
 		gas_info[META_GAS_SPECIFIC_HEAT] = initial(gas.specific_heat)
@@ -19,7 +19,15 @@ GLOBAL_LIST_INIT(hardcoded_gases, list(/datum/gas/oxygen, /datum/gas/nitrogen, /
 		gas_info[META_GAS_DANGER] = initial(gas.dangerous)
 		gas_info[META_GAS_ID] = initial(gas.id)
 		gas_info[META_GAS_DESC] = initial(gas.desc)
+		gas_info[META_GAS_FILTERABLE] = initial(gas.filterable)
+		LAZYINITLIST(gas_info[META_GAS_MASQUERADED_BY])
 		.[gas_path] = gas_info
+	//Initialize the back links to all the gasses that masquerade as something else. For instance, toxic gas that masquerades as oxygen is stored in the oxygen meta list.
+	for(var/gas_path in .)
+		var/datum/gas/gas = gas_path
+		if(!initial(gas.masquerades_as))
+			continue
+		.[initial(gas.masquerades_as)][META_GAS_MASQUERADED_BY] += gas
 
 /proc/generate_gas_overlay(datum/gas/gas_type)
 	var/fill = list()
@@ -74,6 +82,11 @@ GLOBAL_LIST_INIT(hardcoded_gases, list(/datum/gas/oxygen, /datum/gas/nitrogen, /
 
 	///Maximum demand when exporting in MOLES
 	var/max_demand = 5000
+
+	///This gas can be filtered in filters and scrubbers
+	var/filterable = TRUE
+	///This gas is sneaky, and filters through gas filters and scrubbers as another gas type
+	var/masquerades_as = null
 
 /datum/gas/oxygen
 	id = GAS_O2
@@ -219,6 +232,20 @@ GLOBAL_LIST_INIT(hardcoded_gases, list(/datum/gas/oxygen, /datum/gas/nitrogen, /
 	base_value = 2.5
 	desc = "A gas that could supply even more oxygen to the bloodstream when inhaled, without being an oxidizer."
 	primary_color = "#7b68ee"
+
+/datum/gas/toxic
+	id = GAS_TOXIC
+	specific_heat = 20
+	name = "Toxic"
+	dangerous = TRUE
+	gasrig_shielding_modifier = 3
+	rarity = 900 //Only adminbus, so rarity is doesn't matter
+	purchaseable = FALSE
+	base_value = 0.2
+	desc = "Don't breathe this. Warning: Behaves like Oxygen"
+	primary_color = "#940303"
+	masquerades_as = /datum/gas/oxygen
+	filterable = FALSE
 
 /obj/effect/overlay/gas
 	icon = 'icons/effects/atmospherics.dmi'

--- a/code/modules/atmospherics/gasmixtures/gas_types.dm
+++ b/code/modules/atmospherics/gasmixtures/gas_types.dm
@@ -233,6 +233,8 @@ GLOBAL_LIST_INIT(hardcoded_gases, list(/datum/gas/oxygen, /datum/gas/nitrogen, /
 	desc = "A gas that could supply even more oxygen to the bloodstream when inhaled, without being an oxidizer."
 	primary_color = "#7b68ee"
 
+// This gas is designed to be extremely toxic and used as an environmental hazard for adminbus. Extremely quick toxin damage at low concentrations,
+// and just to be a pain for engineering, can't be scrubbed out because it masquerades as oxygen.
 /datum/gas/toxic
 	id = GAS_TOXIC
 	specific_heat = 20

--- a/code/modules/atmospherics/gasmixtures/reactions.dm
+++ b/code/modules/atmospherics/gasmixtures/reactions.dm
@@ -702,4 +702,49 @@
 			air.temperature = clamp(thermal_energy/new_heat_capacity, TCMB, INFINITY) //THIS SHOULD STAY OR FUSION WILL EAT YOUR FACE
 		return REACTING
 
+
+/**
+ * Toxic Gas Neutralization:
+ *
+ * Neutralize Toxic gas into CO2 and N2 with the application of N2O
+ * The reaction rate is dependent on the temperature of the gasmix.
+ * May produce either tritium or carbon dioxide and water vapor depending on the fuel/oxydizer ratio of the gasmix.
+ */
+/datum/gas_reaction/toxic_neutralization
+	priority_group = PRIORITY_FORMATION
+	name = "Toxic Neutralization"
+	id = "toxic_neutralization"
+	desc = "Neutralizes toxic gas into Nitrogen and CO2."
+
+/datum/gas_reaction/toxic_neutralization/init_reqs()
+	requirements = list(
+		/datum/gas/toxic = MINIMUM_MOLE_COUNT,
+		/datum/gas/nitrous_oxide = MINIMUM_MOLE_COUNT,
+	)
+
+/datum/gas_reaction/toxic_neutralization/react(datum/gas_mixture/air, datum/holder)
+	var/list/cached_gases = air.gases
+	var/produced_amount = min(TOXIC_NEUTRALIZATION_MAX_RATE, cached_gases[/datum/gas/toxic][MOLES], cached_gases[/datum/gas/nitrous_oxide][MOLES])
+	if (produced_amount <= 0 || cached_gases[/datum/gas/toxic][MOLES] - produced_amount < 0 || cached_gases[/datum/gas/nitrous_oxide][MOLES] - produced_amount < 0 )
+		return NO_REACTION
+
+	var/old_heat_capacity = air.heat_capacity()
+	cached_gases[/datum/gas/toxic][MOLES] -= produced_amount
+	cached_gases[/datum/gas/nitrous_oxide][MOLES] -= produced_amount
+	ASSERT_GAS(/datum/gas/carbon_dioxide, air)
+	ASSERT_GAS(/datum/gas/nitrogen, air)
+	cached_gases[/datum/gas/carbon_dioxide][MOLES] += produced_amount
+	cached_gases[/datum/gas/nitrogen][MOLES] += produced_amount
+	//ASSERT_GAS(/datum/gas/hydrogen, air)
+	//cached_gases[/datum/gas/hydrogen][MOLES] += produced_amount * 0.01
+
+	SET_REACTION_RESULTS(produced_amount)
+	var/energy_released = produced_amount * TOXIC_NEUTRALIZATION_ENERGY
+	var/new_heat_capacity = air.heat_capacity()
+	if(new_heat_capacity > MINIMUM_HEAT_CAPACITY)
+		air.temperature = max((air.temperature * old_heat_capacity + energy_released) / new_heat_capacity, TCMB)
+	return REACTING
+
+
+
 #undef SET_REACTION_RESULTS

--- a/code/modules/atmospherics/machinery/air_alarm/_air_alarm.dm
+++ b/code/modules/atmospherics/machinery/air_alarm/_air_alarm.dm
@@ -354,7 +354,8 @@ DEFINE_BUFFER_HANDLER(/obj/machinery/airalarm)
 			var/list/filter_types = list()
 			for (var/path in GLOB.meta_gas_info)
 				var/list/gas = GLOB.meta_gas_info[path]
-				filter_types += list(list("gas_id" = gas[META_GAS_ID], "gas_name" = gas[META_GAS_NAME], "enabled" = (path in scrubber.filter_types)))
+				if(gas[META_GAS_FILTERABLE])
+					filter_types += list(list("gas_id" = gas[META_GAS_ID], "gas_name" = gas[META_GAS_NAME], "enabled" = (path in scrubber.filter_types)))
 			data["scrubbers"] += list(list(
 				"refID" = REF(scrubber),
 				"long_name" = sanitize(scrubber.name),

--- a/code/modules/atmospherics/machinery/components/trinary_devices/filter.dm
+++ b/code/modules/atmospherics/machinery/components/trinary_devices/filter.dm
@@ -128,7 +128,8 @@
 	data["filter_types"] = list()
 	for(var/path in GLOB.meta_gas_info)
 		var/list/gas = GLOB.meta_gas_info[path]
-		data["filter_types"] += list(list("gas_id" = gas[META_GAS_ID], "enabled" = (path in filter_type)))
+		if(gas[META_GAS_FILTERABLE])
+			data["filter_types"] += list(list("gas_id" = gas[META_GAS_ID], "enabled" = (path in filter_type)))
 
 	return data
 
@@ -159,11 +160,15 @@
 			if(!gas_id2path(params["val"]))
 				return TRUE
 			filter_type ^= gas_id2path(params["val"])
+			var/list/meta_information = GLOB.meta_gas_info[gas_id2path(params["val"])]
 			var/change
 			if(gas_id2path(params["val"]) in filter_type)
 				change = "added"
+				filter_type += meta_information[META_GAS_MASQUERADED_BY]
 			else
 				change = "removed"
+				filter_type -= meta_information[META_GAS_MASQUERADED_BY]
+
 			var/gas_name = GLOB.meta_gas_info[gas_id2path(params["val"])][META_GAS_NAME]
 			investigate_log("[key_name(usr)] [change] [gas_name] from the filter type.", INVESTIGATE_ATMOS)
 			. = TRUE

--- a/code/modules/atmospherics/machinery/components/unary_devices/vent_scrubber.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/vent_scrubber.dm
@@ -111,10 +111,13 @@
 		var/translated_gas = istext(gas_to_filter) ? gas_id2path(gas_to_filter) : gas_to_filter
 
 		if(ispath(translated_gas, /datum/gas))
+			var/list/meta_information = GLOB.meta_gas_info[translated_gas]
 			if(translated_gas in filter_types)
 				filter_types -= translated_gas
+				filter_types -= meta_information[META_GAS_MASQUERADED_BY]
 			else
 				filter_types |= translated_gas
+				filter_types |= meta_information[META_GAS_MASQUERADED_BY]
 
 	atmos_conditions_changed()
 	return TRUE

--- a/code/modules/atmospherics/machinery/portable/canister.dm
+++ b/code/modules/atmospherics/machinery/portable/canister.dm
@@ -610,6 +610,12 @@ CREATION_TEST_IGNORE_SUBTYPES(/obj/machinery/portable_atmospherics/canister)
 	greyscale_config = /datum/greyscale_config/canister/hazard
 	greyscale_colors = "#3fcd40#000000"
 
+/obj/machinery/portable_atmospherics/canister/toxic
+	name = "toxic canister"
+	gas_type = /datum/gas/toxic
+	greyscale_config = /datum/greyscale_config/canister/hazard
+	greyscale_colors = "#3fcd40#930093"
+
 /obj/machinery/portable_atmospherics/canister/water_vapor
 	name = "water vapor canister"
 	gas_type = /datum/gas/water_vapor

--- a/code/modules/atmospherics/machinery/portable/scrubber.dm
+++ b/code/modules/atmospherics/machinery/portable/scrubber.dm
@@ -131,6 +131,7 @@
 	data["id_tag"] = -1 //must be defined in order to reuse code between portable and vent scrubbers
 	data["filter_types"] = list()
 	for(var/gas_type in subtypesof(/datum/gas))
+		var/list/gas = GLOB.meta_gas_info[gas_type]
 		if(gas[META_GAS_FILTERABLE])
 			data["filter_types"] += list(list("gas_id" = GLOB.meta_gas_info[gas_type][META_GAS_ID], "gas_name" = GLOB.meta_gas_info[gas_type][META_GAS_NAME], "enabled" = (gas_type in scrubbing)))
 
@@ -169,10 +170,10 @@
 		if("toggle_filter")
 			scrubbing ^= gas_id2path(params["val"])
 			var/list/meta_information = GLOB.meta_gas_info[gas_id2path(params["val"])]
-			if(gas_id2path(params["val"]) in filter_type)
-				filter_type += meta_information[META_GAS_MASQUERADED_BY]
+			if(gas_id2path(params["val"]) in scrubbing)
+				scrubbing += meta_information[META_GAS_MASQUERADED_BY]
 			else
-				filter_type -= meta_information[META_GAS_MASQUERADED_BY]
+				scrubbing -= meta_information[META_GAS_MASQUERADED_BY]
 			. = TRUE
 	if(.)
 		update_appearance()

--- a/code/modules/atmospherics/machinery/portable/scrubber.dm
+++ b/code/modules/atmospherics/machinery/portable/scrubber.dm
@@ -131,7 +131,8 @@
 	data["id_tag"] = -1 //must be defined in order to reuse code between portable and vent scrubbers
 	data["filter_types"] = list()
 	for(var/gas_type in subtypesof(/datum/gas))
-		data["filter_types"] += list(list("gas_id" = GLOB.meta_gas_info[gas_type][META_GAS_ID], "gas_name" = GLOB.meta_gas_info[gas_type][META_GAS_NAME], "enabled" = (gas_type in scrubbing)))
+		if(gas[META_GAS_FILTERABLE])
+			data["filter_types"] += list(list("gas_id" = GLOB.meta_gas_info[gas_type][META_GAS_ID], "gas_name" = GLOB.meta_gas_info[gas_type][META_GAS_NAME], "enabled" = (gas_type in scrubbing)))
 
 	if(holding)
 		data["holding"] = list()
@@ -167,6 +168,11 @@
 				. = TRUE
 		if("toggle_filter")
 			scrubbing ^= gas_id2path(params["val"])
+			var/list/meta_information = GLOB.meta_gas_info[gas_id2path(params["val"])]
+			if(gas_id2path(params["val"]) in filter_type)
+				filter_type += meta_information[META_GAS_MASQUERADED_BY]
+			else
+				filter_type -= meta_information[META_GAS_MASQUERADED_BY]
 			. = TRUE
 	if(.)
 		update_appearance()

--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -159,15 +159,18 @@
 
 	var/safe_oxy_min = 16
 	var/safe_co2_max = 10
-	var/safe_tox_max = 0.05
+	var/safe_plasma_max = 0.05
+	var/safe_toxic_max = 0.5
+	var/toxic_gas_damage_lungs = 4
 	var/SA_para_min = 1
 	var/SA_sleep_min = 5
 	var/oxygen_used = 0
 	var/moles = breath.total_moles()
 	var/breath_pressure = (moles*R_IDEAL_GAS_EQUATION*breath.return_temperature())/BREATH_VOLUME
 	var/O2_partialpressure = ((GET_MOLES(/datum/gas/oxygen, breath)/moles)*breath_pressure) + (((GET_MOLES(/datum/gas/pluoxium, breath)*8)/moles)*breath_pressure)
-	var/Toxins_partialpressure = (GET_MOLES(/datum/gas/plasma, breath)/moles)*breath_pressure
+	var/plasma_partialpressure = (GET_MOLES(/datum/gas/plasma, breath)/moles)*breath_pressure
 	var/CO2_partialpressure = (GET_MOLES(/datum/gas/carbon_dioxide, breath)/moles)*breath_pressure
+	var/toxic_partialpressure = (GET_MOLES(/datum/gas/toxic, breath)/moles)*breath_pressure
 
 
 	//OXYGEN
@@ -209,13 +212,13 @@
 	else
 		co2overloadtime = 0
 
-	//TOXINS/PLASMA
-	if(Toxins_partialpressure > safe_tox_max)
-		var/ratio = (GET_MOLES(/datum/gas/plasma, breath)/safe_tox_max) * 10
+	//PLASMA
+	if(plasma_partialpressure > safe_plasma_max)
+		var/ratio = (GET_MOLES(/datum/gas/plasma, breath)/safe_plasma_max) * 10
 		adjustToxLoss(clamp(ratio, MIN_TOXIC_GAS_DAMAGE, MAX_TOXIC_GAS_DAMAGE))
-		throw_alert("too_much_tox", /atom/movable/screen/alert/too_much_plas)
+		throw_alert("too_much_plasma", /atom/movable/screen/alert/too_much_plas)
 	else
-		clear_alert("too_much_tox")
+		clear_alert("too_much_plasma")
 
 	//NITROUS OXIDE
 	if(GET_MOLES(/datum/gas/nitrous_oxide, breath))
@@ -246,6 +249,17 @@
 			adjustFireLoss(nitrium_partialpressure * 0.15)
 		if(nitrium_partialpressure > 5)
 			adjustToxLoss(nitrium_partialpressure * 0.05)
+
+	//TOXIC
+	if(toxic_partialpressure > safe_toxic_max)
+		adjustToxLoss(30+rand(-10,10)) //Flat heavy damage. This gas is intended to kill quickly and force internals. Should bring to crit in about 4 breaths (8 seconds?)
+		if(toxic_partialpressure > toxic_gas_damage_lungs) //Do we start to get messages in chat?
+			if(prob(40))
+				to_chat(src, span_userdanger("[pick("Your head hurts!", "You feel a pressure on your chest!", "Your throat burns!")]"))
+				adjustOrganLoss(ORGAN_SLOT_LUNGS, 40)
+		throw_alert("too_much_tox", /atom/movable/screen/alert/too_much_toxic)
+	else
+		clear_alert("too_much_tox")
 
 	//BREATH TEMPERATURE
 	handle_breath_temperature(breath)

--- a/code/modules/surgery/organs/lungs.dm
+++ b/code/modules/surgery/organs/lungs.dm
@@ -55,6 +55,8 @@
 	var/BZ_trip_balls_min = 0.1 //BZ gas
 	var/BZ_brain_damage_min = 1
 	var/gas_stimulation_min = 0.002 //nitrium and Freon
+	var/toxic_gas_damage_min 	  = 0.5 //Toxic Gas Damage Threshold
+	var/toxic_gas_damage_lungs 	  = 4 //Toxic Gas Lung Damage
 
 	var/cold_message = "your face freezing and an icicle forming"
 	var/cold_level_1_threshold = 260
@@ -297,6 +299,20 @@
 			H.reagents.add_reagent(/datum/reagent/nitrium, 2) //Triggers overdose message primarily, so players aren't stuck in extreme slowdown for too long.
 
 		REMOVE_MOLES(/datum/gas/nitrium, breath, gas_breathed)
+
+	//TOXIC
+		var/toxic_partialpressure = PP(breath, /datum/gas/toxic)
+		if(toxic_partialpressure > toxic_gas_damage_min)
+			//var/ratio = (GET_MOLES(/datum/gas/toxic, breath)/toxic_gas_damage_min) * 20
+			H.adjustToxLoss(30+rand(-10,10)) //Flat heavy damage. This gas is intended to kill quickly and force internals. Should bring to crit in about 4 breaths (8 seconds?)
+			if(toxic_partialpressure > toxic_gas_damage_lungs) //Do we start to get messages in chat?
+				if(prob(40))
+					to_chat(H, span_userdanger("[pick("Your head hurts!", "You feel a pressure on your chest!", "Your throat burns!")]"))
+					H.adjustOrganLoss(ORGAN_SLOT_LUNGS, 40)
+			H.throw_alert("too_much_tox", /atom/movable/screen/alert/too_much_toxic)
+		else
+			H.clear_alert("too_much_tox")
+
 
 		handle_breath_temperature(breath, H)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

One of the things that's somewhat bugged me about the atmos simulation, is that the gas filters and scrubbers are chemically perfect, with the ability to perfectly sort atoms from each other.

This PR aims to annoy engineering by providing the ability to have gases masquerade as one another, IE, certain gasses behave in filters like other gasses.

<img width="512" height="384" alt="image" src="https://github.com/user-attachments/assets/37b69165-22b0-44b1-a2f8-9ecb598ec10d" />

To demonstrate this, I've created a (currently placeholder named) "toxic" gas, which is designed to be an admin bus environmental hazard for engineering. It deals LARGE amounts of toxin and lung damage (targeting crit in 20 to 25 seconds), and it masquerades as Oxygen. Thus, any filters that filter Oxygen, will also filter out this gas, making cleanup a bit more difficult. The high amount of damage is to make you reconsider just barging in and RCDing the floor. 12 to 15 seconds should be enough time to drop tools in hand and pull out mask + internals if you aren't already using them. 

In addition, I've added a neutralization reaction to this. If this gas comes into contact with an equal amount of N2O, the N2O and the gas will neutralize themselves into equal parts of CO2 and N2. This allows for multiple methods of clean up (spacing or decontaminating).

## Why It's Good For The Game

Gas masquerading adds a bit of depth to engineering, because you can't just slap a gas filter in a pipe and then have it magically sort out the toxic chemical. Right now, this toxic gas is the only thing that masquerades, but if the expanded atmos gasses ever come through, perhaps they might benefit from this.

The added gas is designed for admin bus as a dangerous, invisible environmental hazard that won't burn down the place if a lamp bursts. For instance, set up a ruined cruiser with an engine malfunction where the plasma heaters overheated and exploded, releasing a bunch of this gas from the decomposing plasma. Annoy engineering by providing a canister to a tot and have them fill distro with it (especially with the gas rig changes.... lose all the air in distro, or deal with decontaminating your air supply... choices, choices). The possibilities are (not really) endless.

## Reason this is still a Draft
I need a better name for the gas. I've got writer's block. That's about it. 
Thoughts on the damage dealt is also probably a good idea. I'm not really sure what it should be. Currently, it is just set to 30 +- 10 per breath, and a 30 percent chance of dealing 20 lung damage if high concentrations are in the air. This results in crit in 20 to 30 seconds depending on your luck, and some serious lung damage.

Mostly, I just want to get this off my project list.

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

Gas filter setup for masquerade testing

<img width="1028" height="427" alt="filter setup" src="https://github.com/user-attachments/assets/e447be68-20d7-4505-9c4d-43c412b235ee" />

Filtering O2 + Toxic

<img width="484" height="241" alt="toxic filter output" src="https://github.com/user-attachments/assets/60146cbc-d4db-4f55-be52-a51d97375984" />

CO2 passes through just fine

<img width="458" height="189" alt="toxic co2 output" src="https://github.com/user-attachments/assets/70612c43-8d9c-43c5-84ab-b28e54492be3" />

Porta Scrubbers

<img width="963" height="896" alt="porta scrubbers" src="https://github.com/user-attachments/assets/077ddf4a-453b-4f3d-ad2e-cff2193b2d0e" />

Toxic Neutralization (90 mols each to 90 mols CO2 + N2)

<img width="388" height="260" alt="Toxic +n20 decomposing to co2 and N2 (90 mols)" src="https://github.com/user-attachments/assets/b2152a85-c5be-4130-b501-9214f0247521" />

No "Toxic" gas listed on scrubber controls...

<img width="597" height="725" alt="image" src="https://github.com/user-attachments/assets/aa84f55f-a6e4-49c9-8fe0-6afdbb1c335f" />

But still has limits on the air alarm....

<img width="626" height="636" alt="image" src="https://github.com/user-attachments/assets/9741e1ec-38a8-4259-99e9-ac31a05b2520" />

Tests:
17 seconds to crit, 0 lung damage (14 damage at death)
25 seconds to crit, 40 lung damage (35 damage at death)
28 seconds to crit, 40 lung damage (75 damage at death)
26 seconds to crit, 40 lung damage (37 damage at death)



</details>

## Changelog
:cl:
add: Atmos gasses can now be configured to be filtered as a different gas
add: Atmos gasses can now be set to not be filterable on scrubbers.
add: Added an adminbus toxic gas as an environmental hazard for engineering. Masquerades as O2.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
