### PR TITLE
Wizardstation event PR

### DIFF
--- a/code/__DEFINES/antagonists.dm
+++ b/code/__DEFINES/antagonists.dm
@@ -138,7 +138,7 @@ GLOBAL_LIST_INIT(ai_employers, list(
 /// Checks if the given mob is a wizard
 #define IS_TRAITOR(mob) (mob?.mind?.has_antag_datum(/datum/antagonist/traitor))
 /// Checks if the given mob is a wizard
-#define IS_WIZARD(mob) (mob?.mind?.has_antag_datum(/datum/antagonist/wizard))
+#define IS_WIZARD(mob) ishuman(mob)
 /// Checks if given mob is a hive host
 #define IS_HIVEHOST(mob) (mob.mind?.has_antag_datum(/datum/antagonist/hivemind))
 /// Checks if given mob is an awakened vessel

--- a/code/datums/brain_damage/magic.dm
+++ b/code/datums/brain_damage/magic.dm
@@ -51,7 +51,7 @@
 			throwing = I
 	if(throwing)
 		throwing.throw_at(owner, 8, 2)
-
+/*
 /datum/brain_trauma/magic/antimagic
 	name = "Athaumasia"
 	desc = "Patient is completely inert to magical forces."
@@ -71,7 +71,7 @@
 		if (anti_magic.source == TRAUMA_TRAIT)
 			qdel(anti_magic)
 	..()
-
+*/
 /datum/brain_trauma/magic/stalker
 	name = "Stalking Phantom"
 	desc = "Patient is stalked by a phantom only they can see."

--- a/code/datums/brain_damage/special.dm
+++ b/code/datums/brain_damage/special.dm
@@ -2,7 +2,7 @@
 //they are the easiest to cure, which means that if you want
 //to keep them, you can't cure your other traumas
 /datum/brain_trauma/special
-
+/*
 /datum/brain_trauma/special/godwoken
 	name = "Godwoken Syndrome"
 	desc = "Patient occasionally and uncontrollably channels an eldritch god when speaking."
@@ -34,7 +34,7 @@
 		if (anti_magic.source == TRAUMA_TRAIT)
 			qdel(anti_magic)
 	..()
-
+*/
 /datum/brain_trauma/special/godwoken/proc/speak(type, include_owner = FALSE)
 	var/message
 	switch(type)

--- a/code/datums/components/anti_magic.dm
+++ b/code/datums/components/anti_magic.dm
@@ -40,6 +40,7 @@
  * * MAGIC_RESISTANCE_HOLY - Holy magic resistance that blocks unholy magic (revenant, cult, vampire, voice of god)
 **/
 
+/*
 /datum/component/anti_magic/Initialize(
 	_source,
 	antimagic_flags = MAGIC_RESISTANCE,
@@ -72,7 +73,7 @@
 
 	else
 		return COMPONENT_INCOMPATIBLE
-
+*/
 /datum/component/anti_magic/proc/register_antimagic_signals(datum/on_what)
 	RegisterSignal(on_what, COMSIG_MOB_RECEIVE_MAGIC, PROC_REF(block_receiving_magic), override = TRUE)
 	RegisterSignal(on_what, COMSIG_MOB_RESTRICT_MAGIC, PROC_REF(restrict_casting_magic), override = TRUE)

--- a/code/datums/mutations/antenna.dm
+++ b/code/datums/mutations/antenna.dm
@@ -57,7 +57,7 @@
 	button_icon_state = "mindread"
 	cooldown_time = 5 SECONDS
 	spell_requirements = SPELL_REQUIRES_NO_ANTIMAGIC
-	antimagic_flags = MAGIC_RESISTANCE_MIND
+//	antimagic_flags = MAGIC_RESISTANCE_MIND
 	mindbound = FALSE
 	ranged_mousepointer = 'icons/effects/mouse_pointers/mindswap_target.dmi'
 

--- a/code/game/objects/items/holy_weapons.dm
+++ b/code/game/objects/items/holy_weapons.dm
@@ -162,10 +162,10 @@
 
 /obj/item/nullrod/Initialize(mapload)
 	. = ..()
-	AddComponent(/datum/component/anti_magic, \
+/*	AddComponent(/datum/component/anti_magic, \
 		_source = INNATE_TRAIT, \
 		antimagic_flags = MAGIC_RESISTANCE | MAGIC_RESISTANCE_HOLY \
-	)
+	)*/
 	AddComponent(/datum/component/effect_remover, \
 		success_feedback = "You disrupt the magic of %THEEFFECT with %THEWEAPON.", \
 		success_forcesay = "BEGONE FOUL MAGIKS!!", \

--- a/code/game/objects/items/storage/book.dm
+++ b/code/game/objects/items/storage/book.dm
@@ -36,14 +36,14 @@
 	var/mob/affecting = null
 	var/deity_name = "Christ"
 	force_string = "holy"
-
+/*
 /obj/item/storage/book/bible/Initialize(mapload)
 	. = ..()
 	AddComponent(/datum/component/anti_magic, \
 		_source = src, \
 		antimagic_flags = (MAGIC_RESISTANCE|MAGIC_RESISTANCE_HOLY) \
 	)
-
+*/
 /obj/item/storage/book/bible/suicide_act(mob/living/user)
 	user.visible_message(span_suicide("[user] is offering [user.p_them()]self to [deity_name]! It looks like [user.p_theyre()] trying to commit suicide!"))
 	return BRUTELOSS

--- a/code/game/objects/items/storage/boxes.dm
+++ b/code/game/objects/items/storage/boxes.dm
@@ -165,7 +165,7 @@
 	w_class = WEIGHT_CLASS_SMALL //So the roundstart box takes up less space.
 	var/mask_type = /obj/item/clothing/mask/breath
 	var/internal_type = /obj/item/tank/internals/emergency_oxygen
-	var/medipen_type = /obj/item/reagent_containers/hypospray/medipen
+	var/medipen_type = /obj/item/gun/magic/wand/healing
 
 /obj/item/storage/box/survival/Initialize(mapload)
 	. = ..()
@@ -180,6 +180,8 @@
 		/obj/item/reagent_containers/hypospray/medipen,
 		/obj/item/tank/internals/emergency_oxygen,
 		/obj/item/tank/internals/plasmaman/belt,
+		/obj/item/gun/magic/wand,
+		/obj/item/spellbook,
 	))
 	atom_storage.exception_hold = exception_hold
 
@@ -196,6 +198,8 @@
 	if(HAS_TRAIT(SSstation, STATION_TRAIT_PREMIUM_INTERNALS))
 		new /obj/item/flashlight/flare(src)
 		new /obj/item/radio/off(src)
+
+	new /obj/item/spellbook(src)
 
 /obj/item/storage/box/survival/proc/wardrobe_removal()
 	if(!isplasmaman(loc)) //We need to specially fill the box with plasmaman gear, since it's intended for one

--- a/code/modules/antagonists/wizard/equipment/spellbook_entries/assistance.dm
+++ b/code/modules/antagonists/wizard/equipment/spellbook_entries/assistance.dm
@@ -65,7 +65,7 @@
 	desc = "A Necromantic stone is able to resurrect three dead individuals as armed skeletal thralls for you to command."
 	item_path = /obj/item/necromantic_stone
 	category = "Assistance"
-
+/*
 /datum/spellbook_entry/item/contract
 	name = "Contract of Apprenticeship"
 	desc = "A magical contract binding an apprentice wizard to your service, using it will summon them to your side."
@@ -79,6 +79,7 @@
 	It would be wise to avoid buying these with anything capable of causing you to swap bodies with others."
 	item_path = /obj/item/holoparasite_creator/wizard
 	category = "Assistance"
+
 
 /datum/spellbook_entry/item/blood_contract
 	name = "Blood Contract"
@@ -98,7 +99,7 @@
 	limit = 3
 	category = "Assistance"
 	refundable = TRUE
-
+*/
 /datum/spellbook_entry/item/hugbottle
 	name = "Bottle of Tickles"
 	desc = "A bottle of magically infused fun, the smell of which will \

--- a/code/modules/antagonists/wizard/equipment/spellbook_entries/challenges.dm
+++ b/code/modules/antagonists/wizard/equipment/spellbook_entries/challenges.dm
@@ -1,6 +1,7 @@
 // THESE ARE NOT PURCHASABLE SPELLS!
 // They're flavor references to old spells that got removed +
 // shit that sounds stupid but fun so we can painfully lock behind a dimmer
+/*
 /datum/spellbook_entry/challenge/multiverse
 	name = "Multiverse Sword"
 	desc = "The Station gets a multiverse sword to stop you. Can you withstand the hordes of multiverse realities?"
@@ -8,3 +9,4 @@
 /datum/spellbook_entry/challenge/antiwizard
 	name = "Friendly Wizard Scum"
 	desc = "A \"Friendly\" Wizard will protect the station, and try to kill you. They get a spellbook much like you, but will use it for \"GOOD\"."
+*/

--- a/code/modules/antagonists/wizard/equipment/spellbook_entries/defensive.dm
+++ b/code/modules/antagonists/wizard/equipment/spellbook_entries/defensive.dm
@@ -110,7 +110,7 @@
 	new /obj/item/camera_film(get_turf(user))
 	new /obj/item/camera_film(get_turf(user))
 	. = ..()
-
+/*
 /datum/spellbook_entry/item/armor
 	name = "Mastercrafted Armour Set"
 	desc = "An artefact suit of armour that allows you to cast spells while providing more protection against attacks and the void of space."
@@ -138,7 +138,7 @@
 	item_path = /obj/item/wizard_armour_charge
 	category = "Defensive"
 	cost = 1
-
+*/
 /datum/spellbook_entry/item/healing_wand
 	name = "Wand of Healing"
 	desc = "A wand that can close any wound, though it cannot restore limbs or organs. You can use it on yourself."

--- a/code/modules/antagonists/wizard/equipment/spellbook_entries/defensive.dm
+++ b/code/modules/antagonists/wizard/equipment/spellbook_entries/defensive.dm
@@ -139,6 +139,50 @@
 	category = "Defensive"
 	cost = 1
 */
+/datum/spellbook_entry/item/robes
+	name = "Blue Wizard Robes"
+	desc = "A set of blue wizard robes, necessary to cast certain spells"
+	item_path = /obj/item/clothing/suit/wizrobe
+	category = "Defensive"
+	cost = 0
+
+/datum/spellbook_entry/item/hat
+	name = "Blue Wizard Hat"
+	desc = "A blue wizard hat, necessary for looking proper and nothing else"
+	item_path = /obj/item/clothing/head/wizard
+	category = "Defensive"
+	cost = 0
+
+/datum/spellbook_entry/item/robes/red
+	name = "Red Wizard Robes"
+	desc = "A set of red wizard robes, necessary to cast certain spells"
+	item_path = /obj/item/clothing/suit/wizrobe/red
+
+/datum/spellbook_entry/item/hat/red
+	name = "Red Wizard Hat"
+	desc = "A red wizard hat, necessary for looking proper and nothing else"
+	item_path = /obj/item/clothing/head/wizard/red
+
+/datum/spellbook_entry/item/robes/yellow
+	name = "Yellow Wizard Robes"
+	desc = "A set of yellow wizard robes, necessary to cast certain spells"
+	item_path = /obj/item/clothing/suit/wizrobe/yellow
+
+/datum/spellbook_entry/item/hat/yellow
+	name = "Yellow Wizard Hat"
+	desc = "A yellow wizard hat, necessary for looking proper and nothing else"
+	item_path = /obj/item/clothing/head/wizard/yellow
+
+/datum/spellbook_entry/item/robes/black
+	name = "Black Wizard Robes"
+	desc = "A set of black wizard robes, necessary to cast certain spells"
+	item_path = /obj/item/clothing/suit/wizrobe/black
+
+/datum/spellbook_entry/item/hat/black
+	name = "Black Wizard Hat"
+	desc = "A black wizard hat, necessary for looking proper and nothing else"
+	item_path = /obj/item/clothing/head/wizard/black
+
 /datum/spellbook_entry/item/healing_wand
 	name = "Wand of Healing"
 	desc = "A wand that can close any wound, though it cannot restore limbs or organs. You can use it on yourself."

--- a/code/modules/antagonists/wizard/equipment/spellbook_entries/summons.dm
+++ b/code/modules/antagonists/wizard/equipment/spellbook_entries/summons.dm
@@ -2,6 +2,7 @@
 /// How much threat we need to let these rituals happen on dynamic
 #define MINIMUM_THREAT_FOR_RITUALS 100
 
+/*
 /datum/spellbook_entry/summon/guns
 	name = "Summon Guns"
 	desc = "Nothing could possibly go wrong with arming a crew of lunatics just itching for an excuse to kill you. \
@@ -64,5 +65,5 @@
 	curse_of_madness(user, message)
 	playsound(user, 'sound/magic/mandswap.ogg', 50, TRUE)
 	return ..()
-
+*/
 #undef MINIMUM_THREAT_FOR_RITUALS

--- a/code/modules/antagonists/wizard/equipment/wizard_spellbook.dm
+++ b/code/modules/antagonists/wizard/equipment/wizard_spellbook.dm
@@ -76,7 +76,7 @@
 
 /obj/item/spellbook/attackby(obj/item/O, mob/user, params)
 	// This can be generalized in the future, but for now it stays
-	if(istype(O, /obj/item/antag_spawner/contract))
+/*	if(istype(O, /obj/item/antag_spawner/contract))
 		var/datum/spellbook_entry/item/contract/contract_entry = locate() in entries
 		if(!istype(contract_entry))
 			to_chat(user, ("<span class='warning'>[src] doesn't seem to want to refund [O].</span>"))
@@ -93,8 +93,8 @@
 		uses += contract_entry.cost
 		contract_entry.times--
 		qdel(O)
-
-	else if(istype(O, /obj/item/antag_spawner/slaughter_demon/laughter))
+*/
+	if(istype(O, /obj/item/antag_spawner/slaughter_demon/laughter))
 		var/datum/spellbook_entry/item/hugbottle/demon_entry = locate() in entries
 		if(!istype(demon_entry))
 			to_chat(user, ("<span class='warning'>[src] doesn't seem to want to refund [O].</span>"))
@@ -107,7 +107,7 @@
 		uses += demon_entry.cost
 		demon_entry.times--
 		qdel(O)
-
+/*
 	else if(istype(O, /obj/item/antag_spawner/slaughter_demon))
 		var/datum/spellbook_entry/item/bloodbottle/demon_entry = locate() in entries
 		if(!istype(demon_entry))
@@ -121,7 +121,7 @@
 		uses += demon_entry.cost
 		demon_entry.times--
 		qdel(O)
-
+*/
 	return ..()
 
 /// Instantiates our list of spellbook entries.

--- a/code/modules/hydroponics/grown/melon.dm
+++ b/code/modules/hydroponics/grown/melon.dm
@@ -97,13 +97,14 @@
 	var/uses = 1
 	if(seed)
 		uses = round(seed.potency / 20)
+/*
 	AddComponent(/datum/component/anti_magic, \
 	_source = src, \
 	antimagic_flags = (MAGIC_RESISTANCE|MAGIC_RESISTANCE_HOLY),\
 	charges = uses, \
 	drain_antimagic = CALLBACK(src, PROC_REF(block_magic)),\
 	expiration = CALLBACK(src, PROC_REF(expire))) //deliver us from evil o melon god
-
+*/
 /obj/item/food/grown/holymelon/proc/block_magic(mob/user, major)
 	if(major)
 		to_chat(user, span_warning("[src] hums slightly, and seems to decay a bit."))

--- a/code/modules/hydroponics/grown/melon.dm
+++ b/code/modules/hydroponics/grown/melon.dm
@@ -94,7 +94,6 @@
 
 /obj/item/food/grown/holymelon/Initialize(mapload)
 	. = ..()
-	var/uses = 1
 	if(seed)
 		uses = round(seed.potency / 20)
 /*

--- a/code/modules/hydroponics/grown/melon.dm
+++ b/code/modules/hydroponics/grown/melon.dm
@@ -94,8 +94,6 @@
 
 /obj/item/food/grown/holymelon/Initialize(mapload)
 	. = ..()
-	if(seed)
-		uses = round(seed.potency / 20)
 /*
 	AddComponent(/datum/component/anti_magic, \
 	_source = src, \

--- a/code/modules/projectiles/projectile/magic.dm
+++ b/code/modules/projectiles/projectile/magic.dm
@@ -247,7 +247,7 @@
 	damage = 0
 	damage_type = OXY
 	nodamage = TRUE
-	martial_arts_no_deflect = FALSE
+//	martial_arts_no_deflect = FALSE
 	///Heal this much of each damage type if revival and limb regeneration aren't applicable
 	var/amount_healed = 25
 
@@ -351,7 +351,7 @@
 	damage = 0
 	damage_type = OXY
 	nodamage = TRUE
-	martial_arts_no_deflect = FALSE
+//	martial_arts_no_deflect = FALSE
 	var/inner_tele_radius = 0
 	var/outer_tele_radius = 6
 
@@ -404,7 +404,7 @@
 	damage = 0
 	damage_type = BURN
 	nodamage = TRUE
-	martial_arts_no_deflect = FALSE
+//	martial_arts_no_deflect = FALSE
 	/// If set, this projectile will only do a certain wabbajack effect
 	var/set_wabbajack_effect
 	/// If set, this projectile will only pass certain changeflags to wabbajack
@@ -468,7 +468,7 @@
 	damage_type = BURN
 	dismemberment = 50
 	nodamage = FALSE
-	martial_arts_no_deflect = FALSE
+//	martial_arts_no_deflect = FALSE
 
 /obj/projectile/magic/arcane_barrage
 	name = "arcane bolt"
@@ -477,13 +477,13 @@
 	damage_type = BURN
 	nodamage = FALSE
 	hitsound = 'sound/weapons/barragespellhit.ogg'
-	martial_arts_no_deflect = FALSE
+//	martial_arts_no_deflect = FALSE
 
 /obj/projectile/magic/locker
 	name = "locker bolt"
 	icon_state = "locker"
 	nodamage = TRUE
-	martial_arts_no_deflect = FALSE
+//	martial_arts_no_deflect = FALSE
 	var/weld = TRUE
 	var/created = FALSE //prevents creation of more then one locker if it has multiple hits
 	var/locker_suck = TRUE
@@ -573,7 +573,7 @@
 /obj/projectile/magic/flying
 	name = "bolt of flying"
 	icon_state = "flight"
-	martial_arts_no_deflect = FALSE
+//	martial_arts_no_deflect = FALSE
 
 /obj/projectile/magic/flying/on_hit(mob/living/target)
 	. = ..()
@@ -584,7 +584,7 @@
 /obj/projectile/magic/bounty
 	name = "bolt of bounty"
 	icon_state = "bounty"
-	martial_arts_no_deflect = FALSE
+//	martial_arts_no_deflect = FALSE
 
 /obj/projectile/magic/bounty/on_hit(mob/living/target)
 	. = ..()
@@ -594,7 +594,7 @@
 /obj/projectile/magic/antimagic
 	name = "bolt of antimagic"
 	icon_state = "antimagic"
-	martial_arts_no_deflect = FALSE
+//	martial_arts_no_deflect = FALSE
 
 /obj/projectile/magic/antimagic/on_hit(mob/living/target)
 	. = ..()
@@ -604,7 +604,7 @@
 /obj/projectile/magic/fetch
 	name = "bolt of fetching"
 	icon_state = "fetch"
-	martial_arts_no_deflect = FALSE
+//	martial_arts_no_deflect = FALSE
 
 /obj/projectile/magic/fetch/on_hit(mob/living/target)
 	. = ..()
@@ -615,7 +615,7 @@
 /obj/projectile/magic/sapping
 	name = "bolt of sapping"
 	icon_state = "sapping"
-	martial_arts_no_deflect = FALSE
+//	martial_arts_no_deflect = FALSE
 
 /obj/projectile/magic/sapping/on_hit(mob/living/target)
 	. = ..()
@@ -625,7 +625,7 @@
 /obj/projectile/magic/necropotence
 	name = "bolt of necropotence"
 	icon_state = "necropotence"
-	martial_arts_no_deflect = FALSE
+//	martial_arts_no_deflect = FALSE
 
 /obj/projectile/magic/necropotence/on_hit(target)
 	. = ..()
@@ -643,7 +643,7 @@
 /obj/projectile/magic/wipe
 	name = "bolt of possession"
 	icon_state = "wipe"
-	martial_arts_no_deflect = FALSE
+//	martial_arts_no_deflect = FALSE
 
 /obj/projectile/magic/wipe/on_hit(mob/living/carbon/target)
 	. = ..()

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -284,7 +284,7 @@
 	name = "glass of holy water"
 	desc = "A glass of holy water."
 	icon_state = "glass_clear"
-
+/*
 /datum/reagent/water/holywater/on_mob_metabolize(mob/living/carbon/affected_mob)
 	. = ..()
 	affected_mob.AddComponent(/datum/component/anti_magic, type, MAGIC_RESISTANCE_HOLY)
@@ -294,7 +294,7 @@
 	for(var/datum/component/anti_magic/anti_magic in affected_mob.GetComponents(/datum/component/anti_magic))
 		if(anti_magic.source == type)
 			qdel(anti_magic)
-
+*/
 /datum/reagent/water/holywater/on_mob_life(mob/living/carbon/affected_mob, delta_time, times_fired)
 	. = ..()
 	if(!data)

--- a/code/modules/unit_tests/antimagic_test.dm
+++ b/code/modules/unit_tests/antimagic_test.dm
@@ -1,7 +1,9 @@
 /// Verifies that antag datums have banning_keys.
+/*
 /datum/unit_test/antimagic_test/Run()
 	var/mob/living/carbon/human/consistent/priest = allocate(/mob/living/carbon/human/consistent)
 	var/obj/nullrod = new /obj/item/nullrod()
 	priest.put_in_active_hand(nullrod)
 	var/result = priest.can_block_magic()
 	TEST_ASSERT(result, "Antimagic failed despite nullrod being equipped")
+*/


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This PR is just a quick and dirty setup for a wizard event round. 

* All humanoids will be treated as wizards for wizard check
* All crew will spawn with a spellbook inside their emergency box, as well as having the epi pen replaced with a healing wand
* Null rods, bibles, holy melons and holy water no longer grant magic immunity 
* Sleeping carp no longer deflects magic projectiles
* Spellbook entries have been modified to include wizard garbs for free
* Certain spellbook entries have been disabled for a variety of reasons (such as modsuit due to granting magic immunity)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

### It's not, please for the love of god don't fully merge this. 

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>

## Changelog
:cl:
add: Wizard event has been enabled
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
