### PR TITLE
Cleans up a bunch of unnecessary initialization qdels. Saves ~0.2 seconds of init

### DIFF
--- a/code/datums/components/squeak.dm
+++ b/code/datums/components/squeak.dm
@@ -59,6 +59,9 @@
 	if(isnum(fallof_distance))
 		sound_falloff_distance = fallof_distance
 
+/datum/component/squeak/Destroy()
+	return ..()
+
 /datum/component/squeak/UnregisterFromParent()
 	. = ..()
 	qdel(GetComponent(/datum/component/connect_loc_behalf))

--- a/code/datums/components/squeak.dm
+++ b/code/datums/components/squeak.dm
@@ -59,9 +59,6 @@
 	if(isnum(fallof_distance))
 		sound_falloff_distance = fallof_distance
 
-/datum/component/squeak/Destroy()
-	return ..()
-
 /datum/component/squeak/UnregisterFromParent()
 	. = ..()
 	qdel(GetComponent(/datum/component/connect_loc_behalf))

--- a/code/game/atom/atom_materials.dm
+++ b/code/game/atom/atom_materials.dm
@@ -15,6 +15,8 @@
 
 ///Sets the custom materials for an item.
 /atom/proc/set_custom_materials(list/materials, multiplier = 1)
+	if((custom_materials == materials) && multiplier == 1) //Easy way to know no changes are being made.
+		return
 
 	if(custom_materials) //Only runs if custom materials existed at first. Should usually be the case but check anyways
 		for(var/i in custom_materials)

--- a/code/game/atom/atom_storage.dm
+++ b/code/game/atom/atom_storage.dm
@@ -16,6 +16,7 @@
 	list/canthold,
 	storage_type = /datum/storage,
 )
+	RETURN_TYPE(/datum/storage)
 
 	if(atom_storage)
 		QDEL_NULL(atom_storage)
@@ -29,6 +30,8 @@
 
 /// A quick and easy way to /clone/ a storage datum for an atom (does not copy over contents, only the datum details)
 /atom/proc/clone_storage(datum/storage/cloning)
+	RETURN_TYPE(/datum/storage)
+
 	if(atom_storage)
 		QDEL_NULL(atom_storage)
 

--- a/code/game/objects/items/crayons.dm
+++ b/code/game/objects/items/crayons.dm
@@ -523,8 +523,8 @@
 	custom_price = 15
 
 /obj/item/storage/crayons/Initialize(mapload)
-	. = ..()
 	create_storage(canhold = list(/obj/item/toy/crayon))
+	return ..()
 
 /obj/item/storage/crayons/PopulateContents()
 	new /obj/item/toy/crayon/red(src)

--- a/code/game/objects/items/stacks/stack.dm
+++ b/code/game/objects/items/stacks/stack.dm
@@ -54,9 +54,11 @@
 
 CREATION_TEST_IGNORE_SUBTYPES(/obj/item/stack)
 
-/obj/item/stack/Initialize(mapload, new_amount, merge = TRUE, mob/user = null)
-	if(new_amount != null)
-		amount = new_amount
+/obj/item/stack/Initialize(mapload, new_amount = amount, merge = TRUE, mob/user = null)
+	amount = new_amount
+	if(amount <= 0)
+		stack_trace("invalid amount [amount]!")
+		return INITIALIZE_HINT_QDEL
 	if(user)
 		add_fingerprint(user)
 	check_max_amount()
@@ -69,27 +71,31 @@ CREATION_TEST_IGNORE_SUBTYPES(/obj/item/stack)
 		set_mats_per_unit(custom_materials, amount ? 1/amount : 1)
 
 	. = ..()
+
 	if(merge)
-		for(var/obj/item/stack/item_stack in loc)
-			if(item_stack == src)
-				continue
-			if(can_merge(item_stack))
-				INVOKE_ASYNC(src, PROC_REF(merge_without_del), item_stack)
-				if(is_zero_amount(delete_if_zero = FALSE))
-					return INITIALIZE_HINT_QDEL
+		. = INITIALIZE_HINT_LATELOAD
 
 	update_weight()
 	update_appearance()
-	var/static/list/loc_connections = list(
-		COMSIG_ATOM_ENTERED = PROC_REF(on_movable_entered_occupied_turf),
-	)
-	AddElement(/datum/element/connect_loc, loc_connections)
+
+/obj/item/stack/LateInitialize()
+	merge_with_loc()
+
+/obj/item/stack/Destroy()
+	mats_per_unit = null
+	return ..()
 
 /obj/item/stack/add_context_self(datum/screentip_context/context, mob/user)
 	context.use_cache()
 	context.add_left_click_action("Open stack crafting")
 	context.add_right_click_action("Split Stack")
 
+/obj/item/stack/Moved(atom/old_loc, dir)
+	. = ..()
+	if((!throwing || throwing.target_turf == loc) && old_loc != loc && (flags_1 & INITIALIZED_1))
+		merge_with_loc(merge_into_ourselves = !isnull(pulledby))
+	if(ismob(loc) || ismob(old_loc) || loc?.atom_storage || old_loc?.atom_storage)
+		update_appearance(UPDATE_NAME)
 
 /** Sets the amount of materials per unit for this stack.
   *
@@ -105,6 +111,36 @@ CREATION_TEST_IGNORE_SUBTYPES(/obj/item/stack)
   */
 /obj/item/stack/proc/update_custom_materials()
 	set_custom_materials(mats_per_unit, amount, is_update=TRUE)
+
+/obj/item/stack/proc/find_other_stack(list/already_found, merge_into_ourselves = FALSE)
+	if(QDELETED(src) || isnull(loc))
+		return
+	for(var/obj/item/stack/item_stack in loc)
+		if(item_stack == src || QDELING(item_stack) || (item_stack.amount >= item_stack.max_amount))
+			continue
+		if(!(item_stack.flags_1 & INITIALIZED_1))
+			continue
+		var/stack_ref = REF(item_stack)
+		if(already_found[stack_ref])
+			continue
+		if(merge_into_ourselves ? item_stack.can_merge(src) : can_merge(item_stack))
+			already_found[stack_ref] = TRUE
+			return item_stack
+
+/// Tries to merge the stack with everything on the same tile.
+/obj/item/stack/proc/merge_with_loc(merge_into_ourselves = FALSE)
+	var/list/already_found = list() // change to alist whenever dreamchecker and such finally supports that
+	var/obj/item/stack/other_stack = find_other_stack(already_found, merge_into_ourselves)
+	var/sanity = max_amount // just in case
+	while(other_stack && sanity > 0)
+		sanity--
+		if(!merge_into_ourselves)
+			if(merge(other_stack))
+				return FALSE
+		else if (other_stack.merge(src) && !QDELETED(other_stack))
+			return FALSE
+		other_stack = find_other_stack(already_found, TRUE)
+	return TRUE
 
 /**
  * Override to make things like metalgen accurately set custom materials
@@ -597,17 +633,6 @@ CREATION_TEST_IGNORE_SUBTYPES(/obj/item/stack)
 	. = merge_without_del(target_stack, limit)
 	is_zero_amount(delete_if_zero = TRUE)
 	ui_update() //merging into stack wont update stackcrafting menu otherwise
-
-/// Signal handler for connect_loc element. Called when a movable enters the turf we're currently occupying. Merges if possible.
-/obj/item/stack/proc/on_movable_entered_occupied_turf(datum/source, atom/movable/arrived)
-	SIGNAL_HANDLER
-
-	// Edge case. This signal will also be sent when src has entered the turf. Don't want to merge with ourselves.
-	if(arrived == src)
-		return
-
-	if(!arrived.throwing && can_merge(arrived))
-		INVOKE_ASYNC(src, PROC_REF(merge), arrived)
 
 /obj/item/stack/hitby(atom/movable/AM, skipcatch, hitpush, blocked, datum/thrownthing/throwingdatum)
 	if(can_merge(AM))

--- a/code/game/objects/items/storage/backpack.dm
+++ b/code/game/objects/items/storage/backpack.dm
@@ -24,8 +24,9 @@
 	custom_price = 50
 
 /obj/item/storage/backpack/Initialize(mapload)
-	. = ..()
-	create_storage(max_slots = 25, max_specific_storage = WEIGHT_CLASS_LARGE, max_total_storage = 28)
+	if(!istype(atom_storage))
+		create_storage(max_slots = 25, max_specific_storage = WEIGHT_CLASS_LARGE, max_total_storage = 28)
+	return ..()
 
 /*
  * Backpack Types
@@ -56,9 +57,9 @@
 	inhand_icon_state = "clownpack"
 
 /obj/item/storage/backpack/holding/Initialize(mapload)
-	. = ..()
 	create_storage(max_specific_storage = WEIGHT_CLASS_GIGANTIC, max_total_storage = 70, max_slots = 30, storage_type = /datum/storage/bag_of_holding)
 	atom_storage.allow_big_nesting = TRUE
+	return ..()
 
 /obj/item/storage/backpack/holding/suicide_act(mob/living/user)
 	user.visible_message(span_suicide("[user] is jumping into [src]! It looks like [user.p_theyre()] trying to commit suicide."))
@@ -93,12 +94,12 @@
 	acid = 100
 
 /obj/item/storage/backpack/hammerspace/Initialize(mapload)
-	. = ..()
 	create_storage(max_specific_storage = WEIGHT_CLASS_GIGANTIC, max_total_storage = 1000, max_slots = 200, storage_type = /datum/storage/bag_of_holding)
 	atom_storage.allow_big_nesting = TRUE
 	atom_storage.allow_quick_gather = TRUE
 	atom_storage.allow_quick_empty = TRUE
 	atom_storage.numerical_stacking = TRUE
+	return ..()
 
 /obj/item/storage/backpack/santabag
 	name = "Santa's Gift Bag"

--- a/code/game/objects/items/storage/boxes.dm
+++ b/code/game/objects/items/storage/boxes.dm
@@ -1255,38 +1255,42 @@
 
 /obj/item/storage/box/material/PopulateContents()
 	var/static/items_inside = list(
-		/obj/item/stack/sheet/iron/fifty=1, \
-		/obj/item/stack/sheet/glass/fifty=1,\
-		/obj/item/stack/sheet/rglass=50,\
-		/obj/item/stack/sheet/mineral/copper/fifty=1,\
-		/obj/item/stack/sheet/plasmaglass=50,\
-		/obj/item/stack/sheet/plasmarglass=50,\
-		/obj/item/stack/sheet/titaniumglass=50,\
-		/obj/item/stack/sheet/plastitaniumglass=50,\
-		/obj/item/stack/sheet/plasteel=50,\
-		/obj/item/stack/sheet/mineral/plastitanium=50,\
-		/obj/item/stack/sheet/mineral/titanium=50,\
-		/obj/item/stack/sheet/mineral/gold=50,\
-		/obj/item/stack/sheet/mineral/silver=50,\
-		/obj/item/stack/sheet/mineral/uranium=50,\
-		/obj/item/stack/sheet/mineral/plasma=50,\
-		/obj/item/stack/sheet/mineral/diamond=50,\
-		/obj/item/stack/ore/bluespace_crystal/refined=50,\
-		/obj/item/stack/sheet/mineral/bananium=50,\
-		/obj/item/stack/sheet/plastic/fifty=1,\
-		/obj/item/stack/sheet/runed_metal/fifty=1,\
-		/obj/item/stack/sheet/brass/fifty=1,\
-		/obj/item/stack/sheet/mineral/abductor=50,\
-		/obj/item/stack/sheet/mineral/adamantine=50,\
-		/obj/item/stack/sheet/wood=50,\
-		/obj/item/stack/sheet/cotton/cloth=50,\
-		/obj/item/stack/sheet/leather=50,\
-		/obj/item/stack/sheet/bone=12,\
-		/obj/item/stack/sheet/cardboard/fifty=1,\
-		/obj/item/stack/sheet/mineral/sandstone=50,\
-		/obj/item/stack/sheet/snow=50
-		)
-	generate_items_inside(items_inside,src)
+		/obj/item/stack/sheet/iron/fifty = 1,
+		/obj/item/stack/sheet/glass/fifty = 1,
+		/obj/item/stack/sheet/rglass = 50,
+		/obj/item/stack/sheet/mineral/copper/fifty = 1,
+		/obj/item/stack/sheet/plasmaglass = 50,
+		/obj/item/stack/sheet/plasmarglass = 50,
+		/obj/item/stack/sheet/titaniumglass = 50,
+		/obj/item/stack/sheet/plastitaniumglass = 50,
+		/obj/item/stack/sheet/plasteel = 50,
+		/obj/item/stack/sheet/mineral/plastitanium = 50,
+		/obj/item/stack/sheet/mineral/titanium = 50,
+		/obj/item/stack/sheet/mineral/gold = 50,
+		/obj/item/stack/sheet/mineral/silver = 50,
+		/obj/item/stack/sheet/mineral/uranium = 50,
+		/obj/item/stack/sheet/mineral/plasma = 50,
+		/obj/item/stack/sheet/mineral/diamond = 50,
+		/obj/item/stack/ore/bluespace_crystal/refined = 50,
+		/obj/item/stack/sheet/mineral/bananium = 50,
+		/obj/item/stack/sheet/plastic/fifty = 1,
+		/obj/item/stack/sheet/runed_metal/fifty = 1,
+		/obj/item/stack/sheet/brass/fifty = 1,
+		/obj/item/stack/sheet/mineral/abductor = 50,
+		/obj/item/stack/sheet/mineral/adamantine = 50,
+		/obj/item/stack/sheet/wood = 50,
+		/obj/item/stack/sheet/cotton/cloth = 50,
+		/obj/item/stack/sheet/leather = 50,
+		/obj/item/stack/sheet/bone = 12,
+		/obj/item/stack/sheet/cardboard/fifty = 1,
+		/obj/item/stack/sheet/mineral/sandstone = 50,
+		/obj/item/stack/sheet/snow = 50,
+	)
+	for(var/obj/item/stack/stack_type as anything in items_inside)
+		var/amt = items_inside[stack_type]
+		new stack_type(src, amt, FALSE)
+
+// except iron, glass, copper, plastic, runed metal, brass, and carboard
 
 /obj/item/storage/box/deputy
 	name = "box of deputy armbands"

--- a/code/game/objects/items/storage/storage.dm
+++ b/code/game/objects/items/storage/storage.dm
@@ -14,7 +14,8 @@
 /obj/item/storage/Initialize(mapload)
 	. = ..()
 
-	create_storage(storage_type = storage_type)
+	if(!istype(atom_storage))
+		create_storage(storage_type = storage_type)
 
 	if(empty)
 		return

--- a/code/modules/antagonists/nukeop/equipment/clown_weapons.dm
+++ b/code/modules/antagonists/nukeop/equipment/clown_weapons.dm
@@ -66,11 +66,10 @@
 
 /obj/item/clothing/shoes/clown_shoes/banana_shoes/combat/Initialize(mapload)
 	create_storage(storage_type = /datum/storage/pockets/shoes)
-
+	. = ..()
 	var/datum/component/material_container/bananium = GetComponent(/datum/component/material_container)
 	bananium.insert_amount_mat(BANANA_SHOES_MAX_CHARGE, /datum/material/bananium)
 	START_PROCESSING(SSobj, src)
-	return ..()
 
 /obj/item/clothing/shoes/clown_shoes/banana_shoes/combat/Destroy()
 	STOP_PROCESSING(SSobj, src)

--- a/code/modules/antagonists/nukeop/equipment/clown_weapons.dm
+++ b/code/modules/antagonists/nukeop/equipment/clown_weapons.dm
@@ -22,9 +22,9 @@
 	resistance_flags = NONE
 
 /obj/item/clothing/shoes/clown_shoes/combat/Initialize(mapload)
-	. = ..()
-
-	create_storage(storage_type = /datum/storage/pockets/shoes)
+	if(!istype(atom_storage))
+		create_storage(storage_type = /datum/storage/pockets/shoes)
+	return ..()
 
 /// Recharging rate in PPS (peels per second)
 #define BANANA_SHOES_RECHARGE_RATE 17
@@ -65,13 +65,12 @@
 	bleed = 40
 
 /obj/item/clothing/shoes/clown_shoes/banana_shoes/combat/Initialize(mapload)
-	. = ..()
-
 	create_storage(storage_type = /datum/storage/pockets/shoes)
 
 	var/datum/component/material_container/bananium = GetComponent(/datum/component/material_container)
 	bananium.insert_amount_mat(BANANA_SHOES_MAX_CHARGE, /datum/material/bananium)
 	START_PROCESSING(SSobj, src)
+	return ..()
 
 /obj/item/clothing/shoes/clown_shoes/banana_shoes/combat/Destroy()
 	STOP_PROCESSING(SSobj, src)

--- a/code/modules/aquarium/misc.dm
+++ b/code/modules/aquarium/misc.dm
@@ -24,12 +24,10 @@
 
 /obj/item/storage/fish_case/Initialize(mapload)
 	ADD_TRAIT(src, TRAIT_FISH_SAFE_STORAGE, TRAIT_GENERIC)
-
-	. = ..()
-
 	create_storage(max_slots = 1)
 	atom_storage.can_hold_trait = TRAIT_FISH_CASE_COMPATIBILE
 	atom_storage.can_hold_description = "fish and aquarium equipment"
+	return ..()
 
 /// Fish case with single random fish inside.
 /obj/item/storage/fish_case/random/PopulateContents()

--- a/code/modules/clothing/head/fedora.dm
+++ b/code/modules/clothing/head/fedora.dm
@@ -8,8 +8,8 @@
 
 /obj/item/clothing/head/fedora/Initialize(mapload)
 	. = ..()
-
-	create_storage(storage_type = /datum/storage/pockets/small/fedora)
+	if(!istype(atom_storage))
+		create_storage(storage_type = /datum/storage/pockets/small/fedora)
 
 /obj/item/clothing/head/fedora/suicide_act(mob/living/user)
 	if(user.gender == FEMALE)

--- a/code/modules/clothing/head/jobs.dm
+++ b/code/modules/clothing/head/jobs.dm
@@ -127,11 +127,9 @@
 	bleed = 20
 
 /obj/item/clothing/head/fedora/det_hat/Initialize(mapload)
-	. = ..()
-
 	create_storage(storage_type = /datum/storage/pockets/small/fedora/detective)
-
 	new /obj/item/reagent_containers/cup/glass/flask/det(src)
+	return ..()
 
 /obj/item/clothing/head/fedora/det_hat/examine(mob/user)
 	. = ..()

--- a/code/modules/clothing/shoes/cluwne.dm
+++ b/code/modules/clothing/shoes/cluwne.dm
@@ -9,7 +9,7 @@
 	var/footstep = 1
 
 /obj/item/clothing/shoes/cluwne/Initialize(mapload)
-	.=..()
+	. = ..()
 	create_storage(storage_type = /datum/storage/pockets/shoes/clown)
 	RegisterSignal(src, COMSIG_SHOES_STEP_ACTION, PROC_REF(on_step))
 	ADD_TRAIT(src, TRAIT_NODROP, CURSED_ITEM_TRAIT)

--- a/code/modules/clothing/shoes/miscellaneous.dm
+++ b/code/modules/clothing/shoes/miscellaneous.dm
@@ -173,6 +173,7 @@
 	. = ..()
 
 	create_storage(storage_type = /datum/storage/pockets/shoes)
+
 /obj/item/clothing/shoes/jackboots/fast
 	name = "modified jackboots"
 	desc = "Security combat boots for combat scenarios or combat situations. This pair seems to be modified with lighter materials."

--- a/code/modules/clothing/suits/_suits.dm
+++ b/code/modules/clothing/suits/_suits.dm
@@ -24,7 +24,7 @@
 
 /obj/item/clothing/suit/Initialize(mapload)
 	. = ..()
-	if(pockets)
+	if(!istype(atom_storage) && pockets)
 		create_storage(storage_type = /datum/storage/pockets/exo)
 
 /obj/item/clothing/suit/worn_overlays(mutable_appearance/standing, isinhands = FALSE, icon_file, item_layer, atom/origin)

--- a/code/modules/clothing/suits/jobs.dm
+++ b/code/modules/clothing/suits/jobs.dm
@@ -26,8 +26,8 @@
 	)
 
 /obj/item/clothing/suit/apron/Initialize(mapload)
-	. = ..()
 	create_storage(storage_type = /datum/storage/pockets/exo/large)
+	return ..()
 
 //Captain
 /obj/item/clothing/suit/captunic
@@ -158,8 +158,8 @@
 	resistance_flags = NONE
 
 /obj/item/clothing/suit/hazardvest/Initialize(mapload)
-	. = ..()
 	create_storage(storage_type = /datum/storage/pockets/exo/large)
+	return ..()
 
 //Lawyer
 /obj/item/clothing/suit/toggle/lawyer

--- a/code/modules/research/stock_parts.dm
+++ b/code/modules/research/stock_parts.dm
@@ -15,8 +15,8 @@ If you create T5+ please take a pass at gene_modder.dm [L40]. Max_values MUST fi
 	var/alt_sound = null
 
 /obj/item/storage/part_replacer/Initialize(mapload)
-	. = ..()
 	create_storage(storage_type = /datum/storage/rped)
+	return ..()
 
 /obj/item/storage/part_replacer/pre_attack(obj/attacked_object, mob/living/user, params)
 	if(!istype(attacked_object, /obj/machinery) && !istype(attacked_object, /obj/structure/frame/machine))

--- a/code/modules/vehicles/mecha/equipment/tools/other_tools.dm
+++ b/code/modules/vehicles/mecha/equipment/tools/other_tools.dm
@@ -454,7 +454,7 @@
 	var/radrate = 1
 
 /obj/item/mecha_parts/mecha_equipment/generator/nuclear/generator_init()
-	fuel = new /obj/item/stack/sheet/mineral/uranium(src, 0)
+	fuel = new /obj/item/stack/sheet/mineral/uranium(src)
 
 /obj/item/mecha_parts/mecha_equipment/generator/nuclear/process(delta_time)
 	. = ..()

--- a/code/modules/vehicles/mecha/equipment/tools/other_tools.dm
+++ b/code/modules/vehicles/mecha/equipment/tools/other_tools.dm
@@ -372,7 +372,7 @@
 	return ..()
 
 /obj/item/mecha_parts/mecha_equipment/generator/proc/generator_init()
-	fuel = new /obj/item/stack/sheet/mineral/plasma(src, 0)
+	fuel = new /obj/item/stack/sheet/mineral/plasma(src)
 
 /obj/item/mecha_parts/mecha_equipment/generator/detach()
 	STOP_PROCESSING(SSobj, src)


### PR DESCRIPTION
## About The Pull Request

I randomly decided to look at the qdel log after roundstart and I was very surprised to see a few things so high up on the list. These were mainly storage datums and random components.

The storage datums were pretty straight forward, `/obj/item/storage` would create a storage, but if a subtype had more specific needs, it would delete the previous storage datum and replace it with its own. The simple solution is to check if `atom_storage` already exists before `/obj/item/storage` creates a storage datum. With this change `/obj/item/storage` subtypes now generate their specific storage datums before calling their base `Initialize()` behavior.

The random components took a little more time to figure out because of some rabbit holes I went down along the way, but the issue and fix ended up being pretty simple. For some horrible reason, instead of initializing item stacks via: `new /obj/item/stack(src, amount = AMOUNT)`, material boxes would initialize their item stacks like this: `new /obj/item/stack(src, amount = 1) * AMOUNT`. This meant that around a thousand item stacks were being initialized per single materials box and then the majority of them were qdeleted after being merged with the other stacks. The simple solution was to make use of the `amount` argument when initializing the materials. Thanks for coming.

This also ports:
- https://github.com/tgstation/tgstation/pull/91015
- https://github.com/tgstation/tgstation/pull/91656 (this has the added benefit of squashing the 0 amount item stack bug)

## Why It's Good For The Game

I hate this so much and I'm using my free will to remove it

## Testing Photographs and Procedure
<details>
<summary>Before/After Meta Station</summary>

### Before:

<img width="380" height="556" alt="image" src="https://github.com/user-attachments/assets/3c642629-a207-4273-b106-6bdf816279cc" />

### After:

<img width="397" height="549" alt="image" src="https://github.com/user-attachments/assets/d451ecce-8ee1-4504-9ff2-1328b9f96e6e" />

</details>

<details>
<summary>Before/After Runtime Station</summary>

### Before:

<img width="342" height="551" alt="image" src="https://github.com/user-attachments/assets/d42b88fb-6bd6-4e79-a238-f5d5d957fb8c" />

### After:

<img width="396" height="555" alt="image" src="https://github.com/user-attachments/assets/dafd00c8-37b6-48de-83eb-beef9607f441" />

</details>

## Changelog
:cl: mrmanlikesbt, Absolucy, SyncIt21
code: Subtypes of [/obj/item/storage] no longer delete their base storage datum, instead, the base storage datum isn't made in the first place. This saves ~0.1 seconds of init time
code: Material storage boxes now make use of the amount argument when initializing stacks. This saves ~0.1 seconds of init time when they are present
fix: Fixed item stacks sometimes having a zero amount
/:cl: