### PR TITLE
Fixes malf humans

### DIFF
--- a/code/controllers/subsystem/dynamic/dynamic_rulesets_gamemode.dm
+++ b/code/controllers/subsystem/dynamic/dynamic_rulesets_gamemode.dm
@@ -149,7 +149,7 @@
 
 /datum/dynamic_ruleset/gamemode/malf/trim_candidates()
 	. = ..()
-	var/datum/job/posibrain/ai_job = SSjob.GetJob(JOB_NAME_AI)
+	var/datum/job/ai/ai_job = SSjob.GetJob(JOB_NAME_AI)
 	for(var/mob/candidate in candidates)
 		// Must have enough hours to play AI
 		if(ai_job.required_playtime_remaining(candidate.client))

--- a/code/controllers/subsystem/dynamic/dynamic_rulesets_gamemode.dm
+++ b/code/controllers/subsystem/dynamic/dynamic_rulesets_gamemode.dm
@@ -147,6 +147,15 @@
 	restricted_roles = list(JOB_NAME_CYBORG)
 	ruleset_flags = SHOULD_USE_ANTAG_REP | CANNOT_REPEAT | REQUIRED_POP_ALLOW_UNREADY
 
+/datum/dynamic_ruleset/gamemode/malf/trim_candidates()
+	. = ..()
+	var/datum/job/posibrain/ai_job = SSjob.GetJob(JOB_NAME_AI)
+	for(var/mob/candidate in candidates)
+		// Must have enough hours to play AI
+		if(ai_job.required_playtime_remaining(candidate.client))
+			candidates -= candidate
+			continue
+
 /datum/dynamic_ruleset/gamemode/malf/choose_candidates()
 	. = ..()
 	for(var/datum/mind/chosen_mind in chosen_candidates)


### PR DESCRIPTION
## About The Pull Request

Right now dynamic will choose the malf player first, and then force them into being an AI. **However,** it doesn't actually check if the chosen player has enough hours to play as an AI.

Whenever a person without enough silicon hours is picked, dynamic will attempt to force their job as an AI, only for the job assignment to fail and the person to spawn in, as a human, with the malf antag datum applied.

## Why It's Good For The Game

It just is

## Testing Photographs and Procedure

I don't have the means to acquire testing evidence

## Changelog
:cl:
fix: Fixed dynamic sometimes picking humans for malfunctioning AI
/:cl: