### PR TITLE
Adds a engineering pop requirement to supermatter surge

### DIFF
--- a/code/controllers/subsystem/job.dm
+++ b/code/controllers/subsystem/job.dm
@@ -890,3 +890,26 @@ SUBSYSTEM_DEF(job)
 	new /obj/effect/pod_landingzone(loc, /obj/structure/closet/supplypod/centcompod, new /obj/item/paper/fluff/spare_id_safe_code/emergency_spare_id_safe_code())
 	safe_code_timer_id = null
 	safe_code_request_loc = null
+
+/**
+ * Check if the station manifest has at least a certain amount of this staff type.
+ * If a matching head of staff is on the manifest, automatically passes (returns TRUE)
+ *
+ * Arguments:
+ * * crew_threshold - amount of crew to meet the requirement
+ * * jobs - a list of jobs that qualify the requirement
+ * * head_jobs - a list of head jobs that qualify the requirement
+ *
+*/
+/datum/controller/subsystem/job/proc/has_minimum_jobs(crew_threshold, list/jobs = list(), list/head_jobs = list())
+	var/employees = 0
+	for(var/datum/record/crew/target in GLOB.manifest.general)
+		if(target.rank in head_jobs)
+			return TRUE
+		if(target.rank in jobs)
+			employees++
+
+	if(employees > crew_threshold)
+		return TRUE
+
+	return FALSE

--- a/code/controllers/subsystem/job.dm
+++ b/code/controllers/subsystem/job.dm
@@ -909,7 +909,7 @@ SUBSYSTEM_DEF(job)
 		if(target.rank in jobs)
 			employees++
 
-	if(employees > crew_threshold)
+	if(employees >= crew_threshold)
 		return TRUE
 
 	return FALSE

--- a/code/modules/events/supermatter_surge.dm
+++ b/code/modules/events/supermatter_surge.dm
@@ -39,6 +39,8 @@
 		return FALSE
 	if(GLOB.main_supermatter_engine.get_status() == SUPERMATTER_INACTIVE)
 		return FALSE
+	if(!SSjob.has_minimum_jobs(crew_threshold = 3, jobs = list(JOB_NAME_STATIONENGINEER, JOB_NAME_ATMOSPHERICTECHNICIAN), head_jobs = JOB_NAME_CHIEFENGINEER))
+		return FALSE
 
 /datum/round_event/supermatter_surge
 	announceWhen = 4

--- a/code/modules/events/supermatter_surge.dm
+++ b/code/modules/events/supermatter_surge.dm
@@ -39,7 +39,7 @@
 		return FALSE
 	if(GLOB.main_supermatter_engine.get_status() == SUPERMATTER_INACTIVE)
 		return FALSE
-	if(!SSjob.has_minimum_jobs(crew_threshold = 2, jobs = list(JOB_NAME_STATIONENGINEER, JOB_NAME_ATMOSPHERICTECHNICIAN), head_jobs = JOB_NAME_CHIEFENGINEER))
+	if(!SSjob.has_minimum_jobs(crew_threshold = 2, jobs = list(JOB_NAME_STATIONENGINEER, JOB_NAME_ATMOSPHERICTECHNICIAN), head_jobs = list(JOB_NAME_CHIEFENGINEER)))
 		return FALSE
 
 /datum/round_event/supermatter_surge

--- a/code/modules/events/supermatter_surge.dm
+++ b/code/modules/events/supermatter_surge.dm
@@ -39,7 +39,7 @@
 		return FALSE
 	if(GLOB.main_supermatter_engine.get_status() == SUPERMATTER_INACTIVE)
 		return FALSE
-	if(!SSjob.has_minimum_jobs(crew_threshold = 3, jobs = list(JOB_NAME_STATIONENGINEER, JOB_NAME_ATMOSPHERICTECHNICIAN), head_jobs = JOB_NAME_CHIEFENGINEER))
+	if(!SSjob.has_minimum_jobs(crew_threshold = 2, jobs = list(JOB_NAME_STATIONENGINEER, JOB_NAME_ATMOSPHERICTECHNICIAN), head_jobs = JOB_NAME_CHIEFENGINEER))
 		return FALSE
 
 /datum/round_event/supermatter_surge


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Makes the supermatter surge only happen if there's a chief engineer or 2 other engi staff present.

Mostly ripped from https://github.com/tgstation/tgstation/pull/78244

## Why It's Good For The Game
For anyone that doesn't know too much about the SM setting it might as well be griefing because it will delete engineering and some more the moment the SM surge fires on an otherwise stable setup, they will not be fixing this because they don't know how. This makes the SM less hostile for such people which I think is preferable to having them rely on a more boring power generator like solars.

However supermatter surges are pretty fun to deal with if you're an engineer and know what you're doing thus they will only happen when there's a CE on, or 2 engi staff(atmos tech and station engi). This way when a surge does happen there will theoretically be people to deal with it, and if they fail to deal with it then it will be perceived as a failure of their own and not like events griefing them.

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>

Surge soon to fail to fire because there's only 1 engineer:

<img width="1231" height="294" alt="Code_VJUK0GIxHM" src="https://github.com/user-attachments/assets/224bda34-0012-4852-a114-6cb78dfeb037" />

<summary>Screenshots&Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>

## Changelog
:cl: r1ks-iwnl, lessthnthree
tweak: Supermatter surge will happen only with a Chief Engineer or 2 other engineering staff present.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
