### PR TITLE
Fixes binary vitals jumpsuit sensor option

### DIFF
--- a/code/game/machinery/computer/crew.dm
+++ b/code/game/machinery/computer/crew.dm
@@ -280,7 +280,7 @@ GLOBAL_DATUM_INIT(crewmonitor, /datum/crewmonitor, new)
 
 		// Binary living/dead status
 		if (nanite_sensors || uniform.sensor_mode >= SENSOR_LIVING)
-			entry["life_status"] = !tracked_human.stat
+			entry["life_status"] = (tracked_human.stat == DEAD) ? DEAD : CONSCIOUS
 
 		// Damage
 		if (nanite_sensors || uniform.sensor_mode >= SENSOR_VITALS)

--- a/code/game/machinery/computer/crew.dm
+++ b/code/game/machinery/computer/crew.dm
@@ -288,6 +288,7 @@ GLOBAL_DATUM_INIT(crewmonitor, /datum/crewmonitor, new)
 			entry["toxdam"] = round(tracked_human.getToxLoss(), 1)
 			entry["burndam"] = round(tracked_human.getFireLoss(), 1)
 			entry["brutedam"] = round(tracked_human.getBruteLoss(), 1)
+			entry["life_status"] = tracked_human.stat
 
 		// Area
 		if (pos && (nanite_sensors || uniform.sensor_mode >= SENSOR_COORDS))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
We were giving TGUI a boolean value with !tracked_human.stat, however the TGUI code expects the raw stat value as shown by 
`const STAT_LIVING = 0;`
`const STAT_DEAD = 4;`
which are then compared against life_status which before this fix would only be 0/1.
Fixing this will also make dead people have a skull icon instead of a red heart next to them when they die.

Also gives the exact stat value when exact vitals are on, this will influence sorting by health a little.

Closes https://github.com/BeeStation/BeeStation-Hornet/issues/13883
Closes #14069
Closes https://github.com/BeeStation/BeeStation-Hornet/issues/13181

## Why It's Good For The Game
Fix

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>

<img width="937" height="488" alt="WKZaTdSlN6" src="https://github.com/user-attachments/assets/516786a6-fbad-4b59-8f20-ace51f6b1d10" />

<summary>Screenshots&Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>

## Changelog
:cl:

fix: Fixes binary vitals jumpsuit sensor option
fix: Fixes crew monitor status icons showing incorrectly

/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
