### PR TITLE
Fix digital clocks processing on the wrong subsystem

### DIFF
--- a/code/game/machinery/digital_clock.dm
+++ b/code/game/machinery/digital_clock.dm
@@ -9,6 +9,7 @@
 	max_integrity = 250
 	density = FALSE
 	layer = ABOVE_WINDOW_LAYER
+	subsystem_type = /datum/controller/subsystem/processing/digital_clock
 	var/station_minutes
 	var/station_hours
 
@@ -79,14 +80,6 @@
 			new /obj/item/shard(loc)
 			new /obj/item/shard(loc)
 	qdel(src)
-
-/obj/machinery/digital_clock/Initialize(mapload)
-	. = ..()
-	START_PROCESSING(SSdigital_clock, src)
-
-/obj/machinery/digital_clock/Destroy()
-	STOP_PROCESSING(SSdigital_clock, src)
-	return ..()
 
 /obj/machinery/digital_clock/process()
 	if(machine_stat & NOPOWER)


### PR DESCRIPTION
## About The Pull Request

Port of https://github.com/tgstation/tgstation/pull/92633

due to how machines work, all machines will be added to `SSmachines` processing by default. you are supposed to set `subsystem_type` if you want them to process on a different subsystem... so the digital clocks subsystem literally never worked bc it would start processing on SSmachines _first_ when `/obj/machinery/Initialize()` called `begin_processing()`, and thus `START_PROCESSING(SSdigital_clock, src)` wouldn't do anything at all.

## Why It's Good For The Game

things working as intended is good

## Changelog

:cl:
fix: Digital clocks now process on the correct subsystem.
/:cl: