### PR TITLE
Add development override configuration system

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,8 @@
 ###Files and folders specified here will never be tracked.
 
+# Local overrides--you can use this to change the config for your dev environment (like setting up SQL) without worrying about committing it
+/config/dev_overrides.txt
+
 #Ignore everything in datafolder and subdirectories
 /data/**/*
 /tmp/**/*

--- a/code/controllers/configuration/configuration.dm
+++ b/code/controllers/configuration/configuration.dm
@@ -50,6 +50,8 @@
 				for(var/J in legacy_configs)
 					LoadEntries(J)
 				break
+	if(fexists("[directory]/dev_overrides.txt"))
+		LoadEntries("dev_overrides.txt")
 	loadmaplist(CONFIG_MAPS_FILE)
 	LoadTopicRateWhitelist()
 	LoadProtectedIDs()

--- a/config/dev_overrides_readme.txt
+++ b/config/dev_overrides_readme.txt
@@ -1,0 +1,5 @@
+# Make a new file named dev_overrides.txt in order to be able to add your own configuration
+# without worrying about committing. These are applied after config.txt.
+# You do not need this if you are a server operator! You should instead use the $include system.
+
+#STATIONNAME My Dev World


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Ports https://github.com/tgstation/tgstation/pull/71427

> Config system will now load `dev_overrides.txt` automatically if it exists, but this file is in gitignore. I want to use this for configuring SQL and such easier.

## Why It's Good For The Game

so i don't have to mess with `git update-index` to setup SQL without accidentally committing my config

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

<img width="1279" height="472" alt="2026-03-01 (1772391903) ~ dreamseeker" src="https://github.com/user-attachments/assets/bedb3e78-f158-44f6-bd31-6adb3665e8ec" />

</details>

## Changelog

No user-facing changes, or even production server changes - this only affects (or well, should only be used for) local development.