### PR TITLE
Autogenerates python pathing

### DIFF
--- a/tools/bootstrap/python.bat
+++ b/tools/bootstrap/python.bat
@@ -1,1 +1,2 @@
-@call powershell.exe -NoLogo -ExecutionPolicy Bypass -File "%~dp0\python_.ps1" %*
+@echo off
+call powershell.exe -NoLogo -ExecutionPolicy Bypass -File "%~dp0\python_.ps1" %*

--- a/tools/bootstrap/python311._pth
+++ b/tools/bootstrap/python311._pth
@@ -1,6 +1,0 @@
-python311.zip
-.
-..\..\..
-
-# Uncomment to run site.main() automatically
-import site

--- a/tools/bootstrap/python_.ps1
+++ b/tools/bootstrap/python_.ps1
@@ -50,8 +50,13 @@ if (!(Test-Path $PythonExe -PathType Leaf)) {
 
 	[System.IO.Compression.ZipFile]::ExtractToDirectory($Archive, $PythonDir)
 
+	$PythonVersionArray = $PythonVersion.Split(".")
+	$PythonVersionString = "python$($PythonVersionArray[0])$($PythonVersionArray[1])"
+	Write-Output "Generating PATH descriptor."
+	New-Item "$Cache/$PythonVersionString._pth" | Out-Null
+	Set-Content "$Cache/$PythonVersionString._pth" "$PythonVersionString.zip`n.`n..\..\..`nimport site`n"
 	# Copy a ._pth file without "import site" commented, so pip will work
-	Copy-Item "$Bootstrap/python311._pth" $PythonDir `
+	Copy-Item "$Cache/$PythonVersionString._pth" $PythonDir `
 		-ErrorAction Stop
 
 	Remove-Item $Archive


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

also removes ensurepip dependency that keeps failing

- https://github.com/tgstation/tgstation/pull/72488

# ALL CONTRIBUTORS
After this is merged, do the following;
1. Delete this folder
<img width="296" height="175" alt="image" src="https://github.com/user-attachments/assets/df559155-8497-4380-8af0-db0891795f0e" />

2. Recompile


<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

```
Generating PATH descriptor.
Collecting pip
  Using cached pip-26.0.1-py3-none-any.whl.metadata (4.7 kB)
Collecting setuptools
  Using cached setuptools-82.0.0-py3-none-any.whl.metadata (6.6 kB)
Collecting wheel
  Using cached wheel-0.46.3-py3-none-any.whl.metadata (2.4 kB)
Collecting packaging>=24.0 (from wheel)
  Using cached packaging-26.0-py3-none-any.whl.metadata (3.3 kB)
Using cached pip-26.0.1-py3-none-any.whl (1.8 MB)
Using cached setuptools-82.0.0-py3-none-any.whl (1.0 MB)
Using cached wheel-0.46.3-py3-none-any.whl (30 kB)
Using cached packaging-26.0-py3-none-any.whl (74 kB)
Installing collected packages: setuptools, pip, packaging, wheel
Successfully installed packaging-26.0 pip-26.0.1 setuptools-82.0.0 wheel-0.46.3
Requirement already satisfied: pip in C:\Users\boneyards\Documents\Cloned Repos\BeeStation-Salatland\tools\bootstrap\.cache\python-3.11.2\Lib\site-packages (26.0.1)
Collecting pygit2==1.19.0 (from -r C:\Users\boneyards\Documents\Cloned Repos\BeeStation-Salatland\tools/requirements.txt (line 1))
  Using cached pygit2-1.19.0-cp311-cp311-win_amd64.whl.metadata (3.8 kB)
Collecting bidict==0.23.1 (from -r C:\Users\boneyards\Documents\Cloned Repos\BeeStation-Salatland\tools/requirements.txt (line 2))
  Using cached bidict-0.23.1-py3-none-any.whl.metadata (8.7 kB)
Collecting Pillow==11.1.0 (from -r C:\Users\boneyards\Documents\Cloned Repos\BeeStation-Salatland\tools/requirements.txt (line 3))
  Using cached pillow-11.1.0-cp311-cp311-win_amd64.whl.metadata (9.3 kB)
Collecting PyYaml==6.0.3 (from -r C:\Users\boneyards\Documents\Cloned Repos\BeeStation-Salatland\tools/requirements.txt (line 6))
  Using cached pyyaml-6.0.3-cp311-cp311-win_amd64.whl.metadata (2.4 kB)
Collecting beautifulsoup4==4.14.3 (from -r C:\Users\boneyards\Documents\Cloned Repos\BeeStation-Salatland\tools/requirements.txt (line 7))
  Using cached beautifulsoup4-4.14.3-py3-none-any.whl.metadata (3.8 kB)
Collecting numpy==2.3.5 (from -r C:\Users\boneyards\Documents\Cloned Repos\BeeStation-Salatland\tools/requirements.txt (line 10))
  Using cached numpy-2.3.5-cp311-cp311-win_amd64.whl.metadata (60 kB)
Collecting cffi>=2.0 (from pygit2==1.19.0->-r C:\Users\boneyards\Documents\Cloned Repos\BeeStation-Salatland\tools/requirements.txt (line 1))
  Using cached cffi-2.0.0-cp311-cp311-win_amd64.whl.metadata (2.6 kB)
Collecting soupsieve>=1.6.1 (from beautifulsoup4==4.14.3->-r C:\Users\boneyards\Documents\Cloned Repos\BeeStation-Salatland\tools/requirements.txt (line 7))
  Using cached soupsieve-2.8.3-py3-none-any.whl.metadata (4.6 kB)
Collecting typing-extensions>=4.0.0 (from beautifulsoup4==4.14.3->-r C:\Users\boneyards\Documents\Cloned Repos\BeeStation-Salatland\tools/requirements.txt (line 7))
  Using cached typing_extensions-4.15.0-py3-none-any.whl.metadata (3.3 kB)
Collecting pycparser (from cffi>=2.0->pygit2==1.19.0->-r C:\Users\boneyards\Documents\Cloned Repos\BeeStation-Salatland\tools/requirements.txt (line 1))
  Using cached pycparser-3.0-py3-none-any.whl.metadata (8.2 kB)
Using cached pygit2-1.19.0-cp311-cp311-win_amd64.whl (1.2 MB)
Using cached bidict-0.23.1-py3-none-any.whl (32 kB)
Using cached pillow-11.1.0-cp311-cp311-win_amd64.whl (2.6 MB)
Using cached pyyaml-6.0.3-cp311-cp311-win_amd64.whl (158 kB)
Using cached beautifulsoup4-4.14.3-py3-none-any.whl (107 kB)
Using cached numpy-2.3.5-cp311-cp311-win_amd64.whl (13.1 MB)
Using cached cffi-2.0.0-cp311-cp311-win_amd64.whl (182 kB)
Using cached soupsieve-2.8.3-py3-none-any.whl (37 kB)
Using cached typing_extensions-4.15.0-py3-none-any.whl (44 kB)
Using cached pycparser-3.0-py3-none-any.whl (48 kB)
Installing collected packages: typing-extensions, soupsieve, PyYaml, pycparser, Pillow, numpy, bidict, cffi, beautifulsoup4, pygit2
   ━━━━━━━━━━━━━━━━━━━━╺━━━━━━━━━━━━━━━━━━━  5/10 [numpy]  WARNING: The scripts f2py.exe and numpy-config.exe are installed in 'C:\Users\boneyards\Documents\Cloned Repos\BeeStation-Salatland\tools\bootstrap\.cache\python-3.11.2\Scripts' which is not on PATH.
  Consider adding this directory to PATH or, if you prefer to suppress this warning, use --no-warn-script-location.
Successfully installed Pillow-11.1.0 PyYaml-6.0.3 beautifulsoup4-4.14.3 bidict-0.23.1 cffi-2.0.0 numpy-2.3.5 pycparser-3.0 pygit2-1.19.0 soupsieve-2.8.3 typing-extensions-4.15.0

---

Installing hook: pre-commit
Installing merge driver: dmi
Installing merge driver: dmm
Press any key to continue . . .
```

</details>

## Changelog
:cl: rkz, zephyr
server: autogenerates python path
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
