### PR TITLE
Removes healing code from BDM trophy and fixes a few things as a result

### DIFF
--- a/code/datums/status_effects/buffs.dm
+++ b/code/datums/status_effects/buffs.dm
@@ -170,13 +170,6 @@
 	duration = 10
 	tick_interval = STATUS_EFFECT_NO_TICK
 	alert_type = /atom/movable/screen/alert/status_effect/blooddrunk
-	var/last_health = 0
-	var/last_bruteloss = 0
-	var/last_fireloss = 0
-	var/last_toxloss = 0
-	var/last_oxyloss = 0
-	var/last_cloneloss = 0
-	var/last_staminaloss = 0
 
 /atom/movable/screen/alert/status_effect/blooddrunk
 	name = "Blood-Drunk"
@@ -184,108 +177,29 @@
 	icon_state = "blooddrunk"
 
 /datum/status_effect/blooddrunk/on_apply()
-	. = ..()
-	if(.)
-		ADD_TRAIT(owner, TRAIT_IGNOREDAMAGESLOWDOWN, "blooddrunk")
-		owner.maxHealth *= 10
-		owner.bruteloss *= 10
-		owner.fireloss *= 10
-		if(iscarbon(owner))
-			var/mob/living/carbon/C = owner
-			for(var/X in C.bodyparts)
-				var/obj/item/bodypart/BP = X
-				BP.max_damage *= 10
-				BP.brute_dam *= 10
-				BP.burn_dam *= 10
-		owner.toxloss *= 10
-		owner.oxyloss *= 10
-		owner.cloneloss *= 10
-		owner.staminaloss *= 10
-		owner.updatehealth()
-		last_health = owner.health
-		last_bruteloss = owner.getBruteLoss()
-		last_fireloss = owner.getFireLoss()
-		last_toxloss = owner.getToxLoss()
-		last_oxyloss = owner.getOxyLoss()
-		last_cloneloss = owner.getCloneLoss()
-		last_staminaloss = owner.getStaminaLoss()
-		owner.log_message("gained blood-drunk stun immunity", LOG_ATTACK)
-		owner.add_stun_absorption("blooddrunk", INFINITY, 4)
-		owner.playsound_local(get_turf(owner), 'sound/effects/singlebeat.ogg', 40, 1, use_reverb = FALSE)
-
-/datum/status_effect/blooddrunk/tick() //multiply the effect of healing by 10
-	if(owner.health > last_health)
-		var/needs_health_update = FALSE
-		var/new_bruteloss = owner.getBruteLoss()
-		if(new_bruteloss < last_bruteloss)
-			var/heal_amount = (new_bruteloss - last_bruteloss) * 10
-			owner.adjustBruteLoss(heal_amount, updating_health = FALSE)
-			new_bruteloss = owner.getBruteLoss()
-			needs_health_update = TRUE
-		last_bruteloss = new_bruteloss
-
-		var/new_fireloss = owner.getFireLoss()
-		if(new_fireloss < last_fireloss)
-			var/heal_amount = (new_fireloss - last_fireloss) * 10
-			owner.adjustFireLoss(heal_amount, updating_health = FALSE)
-			new_fireloss = owner.getFireLoss()
-			needs_health_update = TRUE
-		last_fireloss = new_fireloss
-
-		var/new_toxloss = owner.getToxLoss()
-		if(new_toxloss < last_toxloss)
-			var/heal_amount = (new_toxloss - last_toxloss) * 10
-			owner.adjustToxLoss(heal_amount, updating_health = FALSE)
-			new_toxloss = owner.getToxLoss()
-			needs_health_update = TRUE
-		last_toxloss = new_toxloss
-
-		var/new_oxyloss = owner.getOxyLoss()
-		if(new_oxyloss < last_oxyloss)
-			var/heal_amount = (new_oxyloss - last_oxyloss) * 10
-			owner.adjustOxyLoss(heal_amount, updating_health = FALSE)
-			new_oxyloss = owner.getOxyLoss()
-			needs_health_update = TRUE
-		last_oxyloss = new_oxyloss
-
-		var/new_cloneloss = owner.getCloneLoss()
-		if(new_cloneloss < last_cloneloss)
-			var/heal_amount = (new_cloneloss - last_cloneloss) * 10
-			owner.adjustCloneLoss(heal_amount, updating_health = FALSE)
-			new_cloneloss = owner.getCloneLoss()
-			needs_health_update = TRUE
-		last_cloneloss = new_cloneloss
-
-		var/new_staminaloss = owner.getStaminaLoss()
-		if(new_staminaloss < last_staminaloss)
-			var/heal_amount = (new_staminaloss - last_staminaloss) * 10
-			owner.adjustStaminaLoss(heal_amount, updating_stamina = FALSE)
-			new_staminaloss = owner.getStaminaLoss()
-			needs_health_update = TRUE
-		last_staminaloss = new_staminaloss
-
-		if(needs_health_update)
-			owner.updatehealth()
-			owner.playsound_local(get_turf(owner), 'sound/effects/singlebeat.ogg', 40, 1)
-	last_health = owner.health
+	ADD_TRAIT(owner, TRAIT_IGNOREDAMAGESLOWDOWN, "blooddrunk")
+	if(ishuman(owner))
+		var/mob/living/carbon/human/H = owner
+		H.physiology.brute_mod *= 0.1
+		H.physiology.burn_mod *= 0.1
+		H.physiology.tox_mod *= 0.1
+		H.physiology.oxy_mod *= 0.1
+		H.physiology.clone_mod *= 0.1
+		H.physiology.stamina_mod *= 0.1
+	owner.log_message("gained blood-drunk stun immunity", LOG_ATTACK)
+	owner.add_stun_absorption("blooddrunk", INFINITY, 4)
+	owner.playsound_local(get_turf(owner), 'sound/effects/singlebeat.ogg', 40, 1, use_reverb = FALSE)
+	return TRUE
 
 /datum/status_effect/blooddrunk/on_remove()
-	tick()
-	owner.maxHealth *= 0.1
-	owner.bruteloss *= 0.1
-	owner.fireloss *= 0.1
-	if(iscarbon(owner))
-		var/mob/living/carbon/C = owner
-		for(var/X in C.bodyparts)
-			var/obj/item/bodypart/BP = X
-			BP.brute_dam *= 0.1
-			BP.burn_dam *= 0.1
-			BP.max_damage /= 10
-	owner.toxloss *= 0.1
-	owner.oxyloss *= 0.1
-	owner.cloneloss *= 0.1
-	owner.staminaloss *= 0.1
-	owner.updatehealth()
+	if(ishuman(owner))
+		var/mob/living/carbon/human/H = owner
+		H.physiology.brute_mod *= 10
+		H.physiology.burn_mod *= 10
+		H.physiology.tox_mod *= 10
+		H.physiology.oxy_mod *= 10
+		H.physiology.clone_mod *= 10
+		H.physiology.stamina_mod *= 10
 	owner.log_message("lost blood-drunk stun immunity", LOG_ATTACK)
 	REMOVE_TRAIT(owner, TRAIT_IGNOREDAMAGESLOWDOWN, "blooddrunk");
 	if(islist(owner.stun_absorption) && owner.stun_absorption["blooddrunk"])


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Ports https://github.com/tgstation/tgstation/pull/50824
Instead of multiplying our health and damage taken by 10  and as a result causing damage overlays to show up and more importantly causing near blindness and going unconscious when you have any oxy damage we just use damage modifiers.

## Why It's Good For The Game
Aside from the bug fixes I don't think the balance implications of removing the healing from this matter much considering that the healing multiplier only takes place in a 1 second interval that has to happen at the same time as whatever healing effects you have going on.

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>

Took 10 hits from bdm's 6 damage attacks, got less than half of that damage(some attacks got in while my trophy wasn't active)
<img width="1337" height="830" alt="dreamseeker_nFCUIojx3s" src="https://github.com/user-attachments/assets/fc6be3e0-4b4c-4366-8f96-3227fc08354c" />


<summary>Screenshots&Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>

## Changelog
:cl: Fikou, r1ks-iwnl
balance: Removed healing amplification from BDM's trophy.
fix: Fixed BDM trophy damage overlay making you near blind if you have oxy damage.
fix: Fixed BDM trophy making you unconscious if you have 5 or more oxy damage.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
