### PR TITLE
Exploration Mapping Fixes/Changes

### DIFF
--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -22956,6 +22956,23 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/maintenance/aft)
+"djE" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/delivery,
+/obj/machinery/button/shieldwallgen/directional/east{
+	color = "#00ff00";
+	pixel_y = 2;
+	id = "HolofieldDock";
+	pixel_x = 26
+	},
+/obj/machinery/button/door/directional/east{
+	pixel_y = -6;
+	id = "Explodockdoors";
+	pixel_x = 26
+	},
+/obj/machinery/light/floor,
+/turf/open/floor/iron,
+/area/hallway/secondary/entry)
 "djF" = (
 /turf/closed/wall/r_wall,
 /area/science/nanite)
@@ -42913,6 +42930,12 @@
 	},
 /turf/open/floor/carpet/grimy,
 /area/chapel/main)
+"iNc" = (
+/obj/item/kirbyplants{
+	icon_state = "plant-22"
+	},
+/turf/open/floor/iron,
+/area/hallway/secondary/entry)
 "iNg" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
 /obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
@@ -48270,7 +48293,8 @@
 /area/crew_quarters/dorms)
 "kJv" = (
 /obj/machinery/power/shieldwallgen/atmos/strong/roundstart{
-	dir = 1
+	dir = 1;
+	id = "HolofieldDock"
 	},
 /obj/structure/fans/tiny/invisible,
 /obj/structure/cable/yellow{
@@ -48279,7 +48303,10 @@
 /obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
-/turf/open/floor/plating,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "Explodockdoors"
+	},
+/turf/open/floor/iron/large,
 /area/hallway/secondary/entry)
 "kJx" = (
 /obj/structure/table/wood,
@@ -53017,13 +53044,16 @@
 /area/holodeck/rec_center)
 "mvd" = (
 /obj/machinery/power/shieldwallgen/atmos/strong/roundstart{
-	id = 2
+	id = "HolofieldDock"
 	},
 /obj/structure/fans/tiny/invisible,
 /obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
-/turf/open/floor/plating,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "Explodockdoors"
+	},
+/turf/open/floor/iron/large,
 /area/hallway/secondary/entry)
 "mve" = (
 /obj/effect/decal/cleanable/dirt,
@@ -66495,6 +66525,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "reP" = (
@@ -84964,6 +84995,12 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
 /turf/open/floor/iron,
 /area/engine/atmospherics_engine)
+"xpw" = (
+/obj/effect/turf_decal/delivery,
+/obj/machinery/light/floor,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron,
+/area/hallway/secondary/entry)
 "xpy" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
@@ -116214,7 +116251,7 @@ cYD
 aaO
 aeR
 aft
-aeb
+iNc
 agj
 aaO
 uVR
@@ -116983,10 +117020,10 @@ aaO
 aaO
 aaO
 aaO
-xtq
+djE
 aeb
 reN
-agk
+xpw
 aaO
 aaO
 aaO

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -8263,6 +8263,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /obj/machinery/firealarm/directional/east,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "biI" = (
@@ -10938,6 +10941,23 @@
 	},
 /turf/open/floor/iron,
 /area/security/checkpoint/medical)
+"bCk" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/machinery/light_switch{
+	pixel_x = 21;
+	pixel_y = 22
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
+/turf/open/floor/iron/white/corner{
+	dir = 1
+	},
+/area/hallway/secondary/entry)
 "bCn" = (
 /obj/machinery/light{
 	dir = 8
@@ -38611,6 +38631,9 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
 /turf/open/floor/iron/white/corner{
 	dir = 1
 	},
@@ -47151,9 +47174,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "kno" = (
@@ -48248,22 +48269,17 @@
 /turf/open/floor/carpet/grimy,
 /area/crew_quarters/dorms)
 "kJv" = (
-/obj/machinery/status_display/evac{
-	pixel_x = 32
+/obj/machinery/power/shieldwallgen/atmos/strong/roundstart{
+	dir = 1
 	},
-/obj/machinery/light{
-	dir = 4
+/obj/structure/fans/tiny/invisible,
+/obj/structure/cable/yellow{
+	icon_state = "1-8"
 	},
-/obj/machinery/camera/directional/east{
-	c_tag = "Arrivals Dock - Aft";
-	name = "arrivals camera"
+/obj/structure/cable/yellow{
+	icon_state = "0-8"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
-/turf/open/floor/iron,
+/turf/open/floor/plating,
 /area/hallway/secondary/entry)
 "kJx" = (
 /obj/structure/table/wood,
@@ -50456,6 +50472,17 @@
 	},
 /turf/open/floor/iron,
 /area/maintenance/port)
+"lDc" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "2-4"
+	},
+/turf/open/floor/iron,
+/area/hallway/secondary/entry)
 "lDf" = (
 /obj/machinery/atmospherics/pipe/smart/simple/general/visible{
 	dir = 5
@@ -52988,6 +53015,16 @@
 	name = "Holodeck Projector Floor"
 	},
 /area/holodeck/rec_center)
+"mvd" = (
+/obj/machinery/power/shieldwallgen/atmos/strong/roundstart{
+	id = 2
+	},
+/obj/structure/fans/tiny/invisible,
+/obj/structure/cable/yellow{
+	icon_state = "0-2"
+	},
+/turf/open/floor/plating,
+/area/hallway/secondary/entry)
 "mve" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/yellow{
@@ -53857,6 +53894,17 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
 /turf/open/floor/iron,
 /area/hallway/secondary/exit/departure_lounge)
+"mLd" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/turf/open/floor/iron,
+/area/hallway/secondary/entry)
 "mLp" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -55349,6 +55397,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "nkM" = (
@@ -63558,6 +63607,9 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
 /turf/open/floor/iron/white/corner{
 	dir = 1
 	},
@@ -66438,6 +66490,13 @@
 	dir = 1
 	},
 /area/engine/atmos)
+"reN" = (
+/obj/effect/turf_decal/delivery,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/turf/open/floor/iron,
+/area/hallway/secondary/entry)
 "reP" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 10
@@ -72405,6 +72464,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "tbO" = (
@@ -74073,6 +74133,16 @@
 	},
 /turf/open/floor/iron,
 /area/medical/chemistry)
+"tGs" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/hallway/secondary/entry)
 "tGJ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
@@ -77306,6 +77376,9 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
 /turf/open/floor/iron/white/corner{
 	dir = 1
 	},
@@ -78376,6 +78449,22 @@
 /obj/machinery/holopad,
 /turf/open/floor/iron/dark,
 /area/security/main)
+"vlj" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/turf/open/floor/iron/white/corner{
+	dir = 1
+	},
+/area/hallway/secondary/entry)
 "vll" = (
 /obj/item/kirbyplants{
 	icon_state = "plant-21"
@@ -79396,6 +79485,9 @@
 /obj/machinery/light_switch{
 	pixel_x = 21;
 	pixel_y = 22
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
 	},
 /turf/open/floor/iron/white/corner{
 	dir = 1
@@ -81275,6 +81367,19 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/wall,
 /area/maintenance/starboard/aft)
+"wiC" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/turf/open/floor/iron/white/corner{
+	dir = 1
+	},
+/area/hallway/secondary/entry)
 "wiO" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -86956,6 +87061,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "xZE" = (
@@ -116622,18 +116728,18 @@ pPW
 pPW
 pPW
 pPW
-pPW
-pPW
-pPW
-uUh
-pPW
-pPW
-kJv
-pPW
-sdI
+lDc
+uyz
+uyz
+mLd
+uyz
+uyz
+eKy
+uyz
+rsB
 biC
-jwJ
-xEQ
+sXx
+bCk
 yhb
 eHD
 qfW
@@ -116878,8 +116984,8 @@ aaO
 aaO
 aaO
 xtq
-afu
-afx
+aeb
+reN
 agk
 aaO
 aaO
@@ -116890,7 +116996,7 @@ aaO
 aaO
 abf
 abf
-fxq
+wiC
 xSF
 eHD
 xTN
@@ -117135,8 +117241,8 @@ aaa
 aaa
 aaO
 aaO
-aaO
-aaO
+mvd
+kJv
 aaO
 aaO
 aaa
@@ -117404,7 +117510,7 @@ aaa
 aaa
 aaa
 aaO
-fxq
+wiC
 ajX
 eHD
 eHD
@@ -117918,7 +118024,7 @@ aaa
 aaa
 aaa
 abf
-fxq
+wiC
 ajY
 eHD
 lZe
@@ -118175,7 +118281,7 @@ aaa
 aaa
 aaa
 aaO
-fxq
+wiC
 voB
 eHD
 eHD
@@ -118432,7 +118538,7 @@ aaa
 aaa
 aaa
 aaO
-fxq
+wiC
 pGC
 eHD
 hpt
@@ -118689,7 +118795,7 @@ aaa
 aaa
 aaa
 aaO
-fxq
+wiC
 dsQ
 gFA
 sKW
@@ -118946,7 +119052,7 @@ aaa
 aaa
 aaa
 aaO
-fxq
+wiC
 yhb
 eHD
 eHD
@@ -119203,7 +119309,7 @@ aaa
 aaa
 aaa
 abf
-vjw
+vlj
 xSF
 eHD
 vbY
@@ -119460,7 +119566,7 @@ aad
 aad
 aad
 aaO
-fxq
+wiC
 xSF
 eHD
 vPc
@@ -119717,7 +119823,7 @@ aaa
 aaa
 aaa
 abf
-fxq
+wiC
 xSF
 eHD
 xer
@@ -120222,7 +120328,7 @@ abC
 abC
 hOz
 abC
-adt
+tGs
 knk
 abC
 abC
@@ -120231,7 +120337,7 @@ abC
 abC
 eOw
 abZ
-fxq
+wiC
 xSF
 alf
 alU

--- a/_maps/shuttles/exploration/exploration_delta.dmm
+++ b/_maps/shuttles/exploration/exploration_delta.dmm
@@ -82,9 +82,11 @@
 	},
 /obj/structure/wall_closet/tool/directional/north,
 /obj/item/multitool,
-/obj/item/storage/toolbox/mechanical,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/effect/decal/cleanable/dirt/dust,
+/obj/item/storage/toolbox/mechanical,
+/obj/machinery/atmospherics/components/binary/valve/layer2{
+	dir = 8
+	},
 /turf/open/floor/mineral/titanium,
 /area/shuttle/exploration)
 "ir" = (
@@ -101,8 +103,10 @@
 /obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 4
+	},
 /turf/open/floor/mineral/titanium,
 /area/shuttle/exploration)
 "kp" = (
@@ -161,10 +165,7 @@
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/atmospherics/components/tank/air{
-	dir = 8;
-	piping_layer = 2
-	},
+/obj/machinery/atmospherics/components/tank/air,
 /turf/open/floor/mineral/titanium,
 /area/shuttle/exploration)
 "qi" = (
@@ -290,10 +291,10 @@
 /turf/open/floor/mineral/titanium,
 /area/shuttle/exploration)
 "zN" = (
+/obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 1
 	},
-/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/mineral/titanium,
 /area/shuttle/exploration)
 "Ax" = (
@@ -477,13 +478,6 @@
 /obj/structure/wall_closet/science/directional/south,
 /turf/open/floor/mineral/titanium,
 /area/shuttle/exploration)
-"OU" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/mineral/titanium,
-/area/shuttle/exploration)
 "PA" = (
 /obj/structure/cable/yellow{
 	icon_state = "2-8"
@@ -551,13 +545,13 @@
 /turf/closed/wall/mineral/plastitanium,
 /area/shuttle/exploration)
 "Xj" = (
-/obj/machinery/atmospherics/components/binary/valve/layer2{
-	dir = 8
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/atmospherics/pipe/layer_manifold/general/hidden/layer2{
+	dir = 8
+	},
 /turf/open/floor/mineral/titanium,
 /area/shuttle/exploration)
 "Yi" = (
@@ -636,7 +630,7 @@ rQ
 vi
 Ax
 jR
-zN
+SA
 gU
 Rk
 hl
@@ -654,7 +648,7 @@ kp
 ZX
 DM
 Vj
-SA
+zN
 GH
 Rk
 hl
@@ -672,7 +666,7 @@ IS
 tq
 Ax
 hY
-OU
+SA
 GH
 Rk
 hl

--- a/_maps/shuttles/exploration/exploration_delta.dmm
+++ b/_maps/shuttles/exploration/exploration_delta.dmm
@@ -1,42 +1,49 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "aR" = (
 /obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/template_noop,
 /area/shuttle/exploration)
 "cg" = (
-/obj/machinery/airalarm/directional/north{
-	pixel_y = 23
+/obj/structure/table,
+/obj/machinery/recharger{
+	pixel_y = 4;
+	pixel_x = 6
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden{
-	dir = 4
+/obj/machinery/recharger{
+	pixel_y = 4;
+	pixel_x = -6
 	},
-/obj/structure/chair/fancy/shuttle,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/mineral/titanium,
 /area/shuttle/exploration)
 "cu" = (
 /obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/components/unary/outlet_injector/on,
+/obj/machinery/atmospherics/components/unary/outlet_injector/on/layer4,
 /turf/template_noop,
 /area/shuttle/exploration)
 "cH" = (
-/obj/item/radio/intercom{
-	frequency = 1453;
-	pixel_y = 24
+/obj/machinery/airalarm/directional/north{
+	pixel_y = 23
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden{
-	dir = 6
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/mineral/titanium,
 /area/shuttle/exploration)
 "da" = (
 /turf/closed/wall/mineral/titanium,
 /area/shuttle/exploration)
 "fr" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden{
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 8
+	},
+/obj/machinery/portable_atmospherics/canister/plasma,
+/obj/effect/turf_decal/bot,
+/obj/machinery/light/small{
 	dir = 4
 	},
-/turf/closed/wall/mineral/titanium/nodiagonal,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/mineral/titanium,
 /area/shuttle/exploration)
 "fF" = (
 /obj/machinery/door/airlock/external/glass,
@@ -46,7 +53,22 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
 	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/stripes{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /turf/open/floor/mineral/plastitanium,
+/area/shuttle/exploration)
+"gU" = (
+/obj/machinery/atmospherics/pipe/smart/manifold/purple/visible{
+	dir = 1
+	},
+/obj/effect/turf_decal/delivery,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/mineral/titanium,
 /area/shuttle/exploration)
 "hl" = (
 /obj/machinery/shuttle/engine/plasma{
@@ -58,13 +80,11 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/structure/cable/yellow{
-	icon_state = "0-8"
-	},
-/obj/machinery/power/apc/auto_name/directional/east,
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden{
-	dir = 8
-	},
+/obj/structure/wall_closet/tool/directional/north,
+/obj/item/multitool,
+/obj/item/storage/toolbox/mechanical,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/mineral/titanium,
 /area/shuttle/exploration)
 "ir" = (
@@ -77,27 +97,26 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/structure/cable/yellow{
+	icon_state = "0-8"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/mineral/titanium,
 /area/shuttle/exploration)
 "kp" = (
-/mob/living/simple_animal/turkey{
-	atmos_requirements = list("min_oxy" = 0, "max_oxy" = 0, "min_tox" = 0, "max_tox" = 0, "min_co2" = 0, "max_co2" = 0, "min_n2" = 0, "max_n2" = 0);
-	desc = "A veteran of Nanotrasen's Animal Experimentation Program that attempted to replicate the organic space suit that some hostile entities are known to have exhibited, Tom now serves Nanotrasen as the mascot of the Exploration Crew.";
-	health = 200;
-	maxHealth = 200;
-	melee_damage = 5;
-	minbodytemp = 2.7;
-	name = "Tom"
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/mineral/titanium,
 /area/shuttle/exploration)
 "ll" = (
 /obj/machinery/telecomms/relay/preset/exploration,
 /obj/effect/turf_decal/delivery,
-/obj/machinery/light/small{
-	dir = 8
-	},
 /turf/open/floor/mineral/titanium,
 /area/shuttle/exploration)
 "oC" = (
@@ -105,13 +124,26 @@
 /turf/open/floor/plating,
 /area/shuttle/exploration)
 "oH" = (
-/obj/machinery/atmospherics/components/binary/dp_vent_pump{
-	dir = 8
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
 	},
+/obj/structure/wall_closet/emergency/directional/north,
+/obj/effect/turf_decal/stripes,
+/obj/effect/turf_decal/stripes{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
+/obj/machinery/light/small,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/item/clothing/suit/space/hardsuit/skinsuit,
+/obj/item/tank/internals/emergency_oxygen,
+/obj/item/clothing/mask/breath,
+/obj/item/flashlight/oxycandle,
+/obj/item/flashlight/oxycandle,
 /turf/open/floor/mineral/plastitanium,
 /area/shuttle/exploration)
 "po" = (
-/obj/machinery/computer/crew,
+/obj/machinery/computer/objective,
 /turf/open/floor/mineral/plastitanium,
 /area/shuttle/exploration)
 "pG" = (
@@ -119,44 +151,88 @@
 	dir = 8
 	},
 /obj/machinery/portable_atmospherics/canister/plasma,
+/obj/effect/turf_decal/bot,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/mineral/titanium,
 /area/shuttle/exploration)
 "qa" = (
-/obj/machinery/atmospherics/components/tank/air{
-	dir = 3;
-	initialize_directions = 3
+/obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
 	},
-/obj/machinery/light/small,
-/turf/open/floor/mineral/plastitanium,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/atmospherics/components/tank/air{
+	dir = 8;
+	piping_layer = 2
+	},
+/turf/open/floor/mineral/titanium,
 /area/shuttle/exploration)
 "qi" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden{
-	dir = 9
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 4
 	},
-/turf/closed/wall/mineral/titanium/nodiagonal,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/mineral/titanium,
+/area/shuttle/exploration)
+"qE" = (
+/obj/machinery/computer/arcade/orion_trail{
+	dir = 4
+	},
+/obj/effect/turf_decal/bot_red,
+/obj/item/toy/plush/runtime{
+	pixel_y = 17
+	},
+/turf/open/floor/mineral/titanium,
 /area/shuttle/exploration)
 "qX" = (
-/obj/structure/table,
-/obj/machinery/recharger,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/loading_area{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/mineral/titanium,
 /area/shuttle/exploration)
 "rQ" = (
-/obj/structure/table,
-/obj/item/trash/syndi_cakes{
-	pixel_x = -3;
-	pixel_y = 5
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/chair/stool/directional/west,
+/turf/open/floor/mineral/titanium,
+/area/shuttle/exploration)
+"sx" = (
+/obj/effect/turf_decal/loading_area{
+	dir = 4
 	},
-/obj/item/broken_bottle{
-	pixel_x = 8;
-	pixel_y = -2
+/obj/effect/turf_decal/stripes{
+	dir = 8
 	},
-/obj/item/gps/mining/exploration,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/mineral/titanium,
 /area/shuttle/exploration)
 "sz" = (
-/obj/machinery/computer/objective,
 /obj/machinery/light{
 	dir = 8
+	},
+/obj/item/radio/intercom{
+	frequency = 1453;
+	pixel_y = 24
+	},
+/obj/machinery/gear_requisition/exploration,
+/obj/machinery/button/door/directional/west{
+	pixel_y = -6;
+	pixel_x = -22;
+	name = "Exploration Shutters";
+	id = "exploshutters"
+	},
+/obj/machinery/button/shieldwallgen/directional/west{
+	id = "HolofieldExplo";
+	pixel_y = 3;
+	color = "#00ff00";
+	pixel_x = -22;
+	name = "Holofield Generator"
 	},
 /turf/open/floor/mineral/titanium,
 /area/shuttle/exploration)
@@ -171,82 +247,88 @@
 /turf/open/floor/mineral/titanium,
 /area/shuttle/exploration)
 "sY" = (
-/obj/structure/table,
-/obj/item/trash/sosjerky,
-/obj/item/trash/popcorn{
-	pixel_y = 11
+/obj/structure/chair/fancy/shuttle{
+	dir = 1
 	},
-/obj/item/paper/crumpled{
-	default_raw_text = "<p>I bought you some food, but I ate it all before you came, sorry.</p><p>- RTH</p>";
-	name = "scribbled note"
-	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/mineral/titanium,
 /area/shuttle/exploration)
 "tq" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden,
-/obj/machinery/atmospherics/pipe/bridge_pipe/scrubbers/hidden{
-	dir = 8
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /turf/open/floor/mineral/titanium,
 /area/shuttle/exploration)
 "ts" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 4
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/mineral/titanium,
 /area/shuttle/exploration)
 "tz" = (
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
 /area/shuttle/exploration)
 "vc" = (
-/obj/machinery/computer/arcade/orion_trail,
-/obj/effect/turf_decal/bot,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/mineral/titanium,
 /area/shuttle/exploration)
 "vd" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/structure/chair/fancy/shuttle{
-	dir = 1
-	},
+/obj/structure/wall_closet/med/directional/east,
+/obj/item/storage/firstaid,
+/obj/item/reagent_containers/medspray/silver_sulf,
+/obj/item/reagent_containers/medspray/synthflesh,
 /turf/open/floor/mineral/titanium,
 /area/shuttle/exploration)
 "vi" = (
-/obj/structure/tank_dispenser/oxygen,
+/obj/structure/extinguisher_cabinet/directional/south,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/mineral/titanium,
 /area/shuttle/exploration)
 "zN" = (
-/obj/effect/turf_decal/bot,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 4
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 1
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/mineral/titanium,
 /area/shuttle/exploration)
 "Ax" = (
 /turf/closed/wall/mineral/titanium/nodiagonal,
 /area/shuttle/exploration)
 "BF" = (
-/obj/machinery/light/small{
+/obj/structure/table,
+/obj/machinery/light{
 	dir = 4
 	},
-/obj/structure/chair/fancy/shuttle,
+/obj/machinery/microwave{
+	pixel_y = 9
+	},
+/obj/item/storage/box/donkpockets,
+/obj/item/storage/box/donkpockets,
 /turf/open/floor/mineral/titanium,
 /area/shuttle/exploration)
 "CU" = (
 /obj/machinery/atmospherics/components/unary/plasma_refiner{
 	dir = 4
 	},
-/turf/open/floor/plating,
+/turf/open/floor/mineral/titanium,
 /area/shuttle/exploration)
 "Dl" = (
 /obj/effect/spawner/structure/window/reinforced/shuttle,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/plating,
 /area/shuttle/exploration)
 "DM" = (
-/obj/machinery/door/airlock/shuttle,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/airlock/shuttle/glass,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/mineral/titanium,
 /area/shuttle/exploration)
 "GH" = (
@@ -257,9 +339,25 @@
 /turf/open/floor/mineral/titanium,
 /area/shuttle/exploration)
 "Hf" = (
+/obj/structure/tank_dispenser/oxygen,
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/effect/turf_decal/bot,
 /turf/open/floor/mineral/titanium,
 /area/shuttle/exploration)
 "HD" = (
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/obj/machinery/door/airlock/external/glass,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/stripes{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/docking_port/mobile{
 	dir = 8;
 	dwidth = 6;
@@ -270,33 +368,66 @@
 	shuttle_object_type = /datum/orbital_object/shuttle/custom_shuttle;
 	width = 16
 	},
-/obj/machinery/door/airlock/external/glass,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden{
-	dir = 10
+/turf/open/floor/mineral/plastitanium,
+/area/shuttle/exploration)
+"HO" = (
+/obj/structure/cable/yellow{
+	icon_state = "0-2"
 	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
+/obj/machinery/power/shieldwallgen/atmos{
+	id = "HolofieldExplo"
+	},
+/obj/machinery/door/poddoor/shutters{
+	id = "exploshutters"
 	},
 /turf/open/floor/mineral/plastitanium,
 /area/shuttle/exploration)
 "In" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
+/obj/effect/decal/cleanable/dirt/dust,
+/mob/living/simple_animal/turkey{
+	atmos_requirements = list("min_oxy" = 0, "max_oxy" = 0, "min_tox" = 0, "max_tox" = 0, "min_co2" = 0, "max_co2" = 0, "min_n2" = 0, "max_n2" = 0);
+	desc = "A veteran of Nanotrasen's Animal Experimentation Program that attempted to replicate the organic space suit that some hostile entities are known to have exhibited, Tom now serves Nanotrasen as the mascot of the Exploration Crew.";
+	health = 200;
+	maxHealth = 200;
+	melee_damage = 5;
+	minbodytemp = 2.7;
+	name = "Tom"
+	},
 /turf/open/floor/mineral/titanium,
 /area/shuttle/exploration)
 "IP" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/purple/visible,
 /obj/effect/turf_decal/delivery,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/mineral/titanium,
 /area/shuttle/exploration)
 "IQ" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden{
-	dir = 9
+/obj/structure/table,
+/obj/item/trash/popcorn{
+	pixel_y = 11
 	},
-/obj/structure/chair/fancy/shuttle,
+/obj/item/paper/crumpled{
+	default_raw_text = "<p>I bought you some food, but I ate it all before you came, sorry.</p><p>- RTH</p>";
+	name = "scribbled note"
+	},
+/obj/item/trash/sosjerky{
+	pixel_x = -6
+	},
+/obj/item/broken_bottle{
+	pixel_x = 8;
+	pixel_y = -2
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/mineral/titanium,
 /area/shuttle/exploration)
 "IS" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/camera/directional/east,
 /turf/open/floor/mineral/titanium,
 /area/shuttle/exploration)
 "KU" = (
@@ -308,12 +439,12 @@
 	},
 /obj/machinery/power/port_gen/pacman,
 /obj/item/wrench,
-/obj/item/stack/sheet/mineral/plasma/fifty,
-/turf/open/floor/plating,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/mineral/titanium,
 /area/shuttle/exploration)
 "Nc" = (
-/obj/machinery/holopad,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/mineral/titanium,
 /area/shuttle/exploration)
 "Nx" = (
@@ -330,44 +461,57 @@
 /turf/open/floor/mineral/plastitanium,
 /area/shuttle/exploration)
 "NT" = (
-/obj/structure/table,
-/obj/item/trash/pistachios,
-/obj/item/trash/canned/beans{
-	pixel_y = 10
+/obj/machinery/light{
+	dir = 4
 	},
+/obj/machinery/computer/rdconsole/core{
+	dir = 8
+	},
+/obj/effect/turf_decal/bot,
 /turf/open/floor/mineral/titanium,
 /area/shuttle/exploration)
 "OE" = (
-/obj/structure/closet/emcloset/anchored,
-/turf/open/floor/mineral/plastitanium,
+/obj/structure/chair/fancy/shuttle{
+	dir = 4
+	},
+/obj/structure/wall_closet/science/directional/south,
+/turf/open/floor/mineral/titanium,
 /area/shuttle/exploration)
 "OU" = (
-/obj/effect/turf_decal/bot,
-/obj/item/storage/toolbox/mechanical,
-/obj/item/multitool,
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 1
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/mineral/titanium,
 /area/shuttle/exploration)
 "PA" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden{
-	dir = 4
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
 	},
+/obj/machinery/holopad,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/mineral/titanium,
 /area/shuttle/exploration)
 "Qb" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden,
-/turf/closed/wall/mineral/titanium/nodiagonal,
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
+/obj/structure/cable/yellow,
+/obj/machinery/power/shieldwallgen/atmos{
+	dir = 1;
+	id = "HolofieldExplo"
+	},
+/obj/machinery/door/poddoor/shutters{
+	id = "exploshutters"
+	},
+/turf/open/floor/mineral/plastitanium,
 /area/shuttle/exploration)
 "Qy" = (
 /obj/machinery/atmospherics/pipe/smart/simple/purple/visible{
 	dir = 6
 	},
-/obj/effect/turf_decal/bot,
-/obj/machinery/light/small{
-	dir = 1
-	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/mineral/titanium,
 /area/shuttle/exploration)
 "Rk" = (
@@ -378,21 +522,18 @@
 /turf/open/floor/plating,
 /area/shuttle/exploration)
 "Rp" = (
-/obj/machinery/door/airlock/shuttle,
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/obj/machinery/door/airlock/shuttle/glass,
 /turf/open/floor/mineral/plastitanium,
 /area/shuttle/exploration)
 "RQ" = (
 /turf/template_noop,
 /area/template_noop)
 "SA" = (
-/obj/effect/turf_decal/bot,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden{
-	dir = 9
-	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/mineral/titanium,
 /area/shuttle/exploration)
 "Vj" = (
@@ -400,19 +541,24 @@
 	dir = 1
 	},
 /obj/structure/cable/yellow{
-	icon_state = "4-8"
+	icon_state = "1-8"
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/mineral/titanium,
 /area/shuttle/exploration)
 "Vl" = (
 /turf/closed/wall/mineral/plastitanium,
 /area/shuttle/exploration)
 "Xj" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden{
-	dir = 4
+/obj/machinery/atmospherics/components/binary/valve/layer2{
+	dir = 8
 	},
-/turf/closed/wall/mineral/titanium/nodiagonal,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/mineral/titanium,
 /area/shuttle/exploration)
 "Yi" = (
 /obj/structure/closet/crate,
@@ -425,12 +571,19 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
-/turf/open/floor/plating,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/mineral/titanium,
 /area/shuttle/exploration)
 "ZX" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden{
-	dir = 8
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
 	},
+/obj/structure/cable/yellow{
+	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/mineral/titanium,
 /area/shuttle/exploration)
 
@@ -440,9 +593,9 @@ da
 da
 da
 Ax
-oC
+HO
+Qb
 Ax
-oC
 Ax
 Ax
 Ax
@@ -458,10 +611,10 @@ sE
 Nx
 da
 sz
-sT
+sx
 qX
 Hf
-Hf
+qE
 ll
 Ax
 KU
@@ -475,16 +628,16 @@ oC
 po
 ir
 Rp
-Hf
-Hf
+SA
+SA
 ts
-Hf
-Hf
+qi
+rQ
 vi
 Ax
 jR
 zN
-GH
+gU
 Rk
 hl
 "}
@@ -510,14 +663,14 @@ hl
 RQ
 RQ
 RQ
-da
+oC
 cg
-rQ
-sT
+sY
+SA
 vc
 IS
 tq
-Qb
+Ax
 hY
 OU
 GH
@@ -531,8 +684,8 @@ aR
 Dl
 IQ
 sY
-sT
-Ax
+SA
+OE
 Ax
 fF
 Ax
@@ -548,14 +701,14 @@ RQ
 RQ
 oC
 BF
-NT
+sT
 vd
+NT
 Ax
-OE
 oH
+Ax
 qa
-Xj
-pG
+fr
 pG
 tz
 Vl
@@ -571,8 +724,8 @@ Ax
 Ax
 Ax
 HD
-fr
-qi
+Ax
+Ax
 Ax
 tz
 Vl

--- a/_maps/shuttles/exploration/exploration_delta.dmm
+++ b/_maps/shuttles/exploration/exploration_delta.dmm
@@ -80,13 +80,11 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/structure/wall_closet/tool/directional/north,
-/obj/item/multitool,
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/item/storage/toolbox/mechanical,
 /obj/machinery/atmospherics/components/binary/valve/layer2{
 	dir = 8
 	},
+/obj/structure/extinguisher_cabinet/directional/north,
 /turf/open/floor/mineral/titanium,
 /area/shuttle/exploration)
 "ir" = (
@@ -165,7 +163,9 @@
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/atmospherics/components/tank/air,
+/obj/machinery/atmospherics/components/tank/air{
+	dir = 8
+	},
 /turf/open/floor/mineral/titanium,
 /area/shuttle/exploration)
 "qi" = (
@@ -216,10 +216,6 @@
 "sz" = (
 /obj/machinery/light{
 	dir = 8
-	},
-/obj/item/radio/intercom{
-	frequency = 1453;
-	pixel_y = 24
 	},
 /obj/machinery/gear_requisition/exploration,
 /obj/machinery/button/door/directional/west{
@@ -283,11 +279,6 @@
 /obj/item/storage/firstaid,
 /obj/item/reagent_containers/medspray/silver_sulf,
 /obj/item/reagent_containers/medspray/synthflesh,
-/turf/open/floor/mineral/titanium,
-/area/shuttle/exploration)
-"vi" = (
-/obj/structure/extinguisher_cabinet/directional/south,
-/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/mineral/titanium,
 /area/shuttle/exploration)
 "zN" = (
@@ -376,7 +367,8 @@
 	icon_state = "0-2"
 	},
 /obj/machinery/power/shieldwallgen/atmos{
-	id = "HolofieldExplo"
+	id = "HolofieldExplo";
+	anchored = 1
 	},
 /obj/machinery/door/poddoor/shutters{
 	id = "exploshutters"
@@ -494,7 +486,8 @@
 /obj/structure/cable/yellow,
 /obj/machinery/power/shieldwallgen/atmos{
 	dir = 1;
-	id = "HolofieldExplo"
+	id = "HolofieldExplo";
+	anchored = 1
 	},
 /obj/machinery/door/poddoor/shutters{
 	id = "exploshutters"
@@ -549,7 +542,13 @@
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/atmospherics/pipe/layer_manifold/general/hidden/layer2{
+/obj/structure/wall_closet/tool/directional/north,
+/obj/item/storage/toolbox/mechanical,
+/obj/item/multitool,
+/obj/item/storage/belt/utility{
+	pixel_y = -3
+	},
+/obj/machinery/atmospherics/pipe/layer_manifold/general/visible/layer2{
 	dir = 8
 	},
 /turf/open/floor/mineral/titanium,
@@ -627,7 +626,7 @@ SA
 ts
 qi
 rQ
-vi
+SA
 Ax
 jR
 SA

--- a/_maps/shuttles/exploration/exploration_shuttle.dmm
+++ b/_maps/shuttles/exploration/exploration_shuttle.dmm
@@ -188,10 +188,10 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/machinery/door/airlock/shuttle,
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
+/obj/machinery/door/airlock/shuttle/glass,
 /turf/open/floor/mineral/plastitanium,
 /area/shuttle/exploration)
 "B" = (

--- a/_maps/shuttles/exploration/exploration_shuttle.dmm
+++ b/_maps/shuttles/exploration/exploration_shuttle.dmm
@@ -48,7 +48,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
-/turf/open/floor/plating,
+/turf/open/floor/mineral/titanium,
 /area/shuttle/exploration)
 "e" = (
 /obj/machinery/light/floor,
@@ -258,7 +258,8 @@
 	name = "Exploration Shuttle Shutters";
 	pixel_y = 24
 	},
-/turf/open/floor/plating,
+/obj/structure/fans/tiny,
+/turf/open/floor/mineral/plastitanium,
 /area/shuttle/exploration)
 "I" = (
 /turf/closed/wall/mineral/plastitanium,
@@ -312,7 +313,8 @@
 /obj/machinery/door/poddoor/shutters/window{
 	id = "exploration"
 	},
-/turf/open/floor/plating,
+/obj/structure/fans/tiny,
+/turf/open/floor/mineral/plastitanium,
 /area/shuttle/exploration)
 "P" = (
 /obj/structure/chair/fancy/shuttle{

--- a/code/modules/shuttle/super_cruise/orbital_poi_generator/objective_types/recover_blackbox.dm
+++ b/code/modules/shuttle/super_cruise/orbital_poi_generator/objective_types/recover_blackbox.dm
@@ -49,9 +49,8 @@
 		return COMPONENT_INCOMPATIBLE
 	linked_obj = _linked_obj
 	RegisterSignal(parent, COMSIG_ITEM_ATTACK_SELF, PROC_REF(attack_self))
-	var/atom/movable/M = parent
-	M.AddComponent(/datum/component/gps, "BLACKBOX #[rand(1000,9999)]", TRUE)
-	M.AddComponent(/datum/component/tracking_beacon, EXPLORATION_TRACKING, null, null, TRUE, "#ecdf94", TRUE, TRUE)
+	parent.AddComponent(/datum/component/gps, "BLACKBOX #[rand(1000,9999)]", TRUE)
+	parent.AddComponent(/datum/component/tracking_beacon, EXPLORATION_TRACKING, null, null, TRUE, "#ecdf94", TRUE, TRUE)
 
 /datum/component/recoverable/proc/attack_self(mob/user)
 	var/atom/movable/pA = parent

--- a/code/modules/shuttle/super_cruise/orbital_poi_generator/objective_types/recover_blackbox.dm
+++ b/code/modules/shuttle/super_cruise/orbital_poi_generator/objective_types/recover_blackbox.dm
@@ -49,8 +49,9 @@
 		return COMPONENT_INCOMPATIBLE
 	linked_obj = _linked_obj
 	RegisterSignal(parent, COMSIG_ITEM_ATTACK_SELF, PROC_REF(attack_self))
-	AddComponent(/datum/component/gps, "BLACKBOX #[rand(1000, 9999)]", TRUE)
-	AddComponent(/datum/component/tracking_beacon, EXPLORATION_TRACKING, null, null, TRUE, "#ecdf94", TRUE, TRUE)
+	var/atom/movable/M = parent
+	M.AddComponent(/datum/component/gps, "BLACKBOX #[rand(1000,9999)]", TRUE)
+	M.AddComponent(/datum/component/tracking_beacon, EXPLORATION_TRACKING, null, null, TRUE, "#ecdf94", TRUE, TRUE)
 
 /datum/component/recoverable/proc/attack_self(mob/user)
 	var/atom/movable/pA = parent

--- a/code/modules/shuttle/super_cruise/orbital_poi_generator/objective_types/vip_extraction.dm
+++ b/code/modules/shuttle/super_cruise/orbital_poi_generator/objective_types/vip_extraction.dm
@@ -85,7 +85,7 @@
 	uniform = /obj/item/clothing/under/color/random
 	shoes = /obj/item/clothing/shoes/sneakers/black
 	back = /obj/item/storage/backpack
-	r_hand = /obj/item/gps/off
+	r_hand = /obj/item/gps
 
 /datum/outfit/vip_target/post_equip(mob/living/carbon/human/H, visuals_only = FALSE)
 	if(visuals_only)

--- a/code/modules/shuttle/super_cruise/orbital_poi_generator/objective_types/vip_extraction.dm
+++ b/code/modules/shuttle/super_cruise/orbital_poi_generator/objective_types/vip_extraction.dm
@@ -85,7 +85,7 @@
 	uniform = /obj/item/clothing/under/color/random
 	shoes = /obj/item/clothing/shoes/sneakers/black
 	back = /obj/item/storage/backpack
-	r_hand = /obj/item/gps
+	r_hand = /obj/item/gps/off
 
 /datum/outfit/vip_target/post_equip(mob/living/carbon/human/H, visuals_only = FALSE)
 	if(visuals_only)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Modernizes the Delta shuttle fixing an issue where it could plasmaflood itself upon landing, aswell as removing the big airlock it had and adding a secondary exit via shutters
also fixes the issue where blackboxes couldn't be tracked by GPS or suit tracker
and some other minor mapping changes to explo shuttles

## Why It's Good For The Game

Bug are bad for the game, plasmaflooding your own shuttle just because you landed in the wrong direction is bad
The delta shuttle was always an ugly one, hopefully this makes it less painful to play on

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>


New

<img width="426" height="780" alt="image" src="https://github.com/user-attachments/assets/7d95e421-ee0b-4c2e-a1c4-eb2816c65fc5" />

Old
<img width="256" height="512" alt="image" src="https://github.com/user-attachments/assets/4f2cfb40-093c-4447-9fc6-2547d8eb8cd4" />

Working as intended

<img width="938" height="920" alt="image" src="https://github.com/user-attachments/assets/b435c4d2-43d2-4173-869b-406d75c0b0ea" />

Docking port changes in Delta

<img width="224" height="256" alt="image" src="https://github.com/user-attachments/assets/a14e6dbf-3e7c-499a-909c-e4a101872cf6" />




</details>

Closes https://github.com/BeeStation/BeeStation-Hornet/issues/14120

## Changelog
:cl:
map: Meta shuttle has tiny fans under the shutters at the back again
fix: Exploration blackbox objectives can be tracked by GPS/Hardsuits once again
map: Delta exploration shuttle no longer plasmafloods itself, aswell as having a better look

/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
