### PR TITLE
Small PR for today's event

### DIFF
--- a/code/game/objects/items/storage/boxes.dm
+++ b/code/game/objects/items/storage/boxes.dm
@@ -163,7 +163,7 @@
 	illustration = "survival"
 	desc = "A compact box that is designed to hold specific emergency supplies"
 	w_class = WEIGHT_CLASS_SMALL //So the roundstart box takes up less space.
-	var/mask_type = /obj/item/clothing/mask/breath
+	var/mask_type = /obj/item/clothing/mask/gas/old
 	var/internal_type = /obj/item/tank/internals/emergency_oxygen
 	var/medipen_type = /obj/item/reagent_containers/hypospray/medipen
 

--- a/code/modules/jobs/job_types/assistant.dm
+++ b/code/modules/jobs/job_types/assistant.dm
@@ -43,7 +43,7 @@ Assistant
 	return ..()
 
 /datum/job/assistant/get_access()
-	return FALSE
+	return base_access.Copy()
 
 /datum/outfit/job/assistant
 	name = JOB_NAME_ASSISTANT

--- a/code/modules/jobs/job_types/assistant.dm
+++ b/code/modules/jobs/job_types/assistant.dm
@@ -43,22 +43,15 @@ Assistant
 	return ..()
 
 /datum/job/assistant/get_access()
-	. = ..()
-	if(CONFIG_GET(flag/assistants_have_maint_access)) //Config has assistant maint access set
-		. |= ACCESS_MAINT_TUNNELS
-	if (SSjob.initial_players_to_assign < LOWPOP_JOB_LIMIT)
-		. |= list(ACCESS_EVA, ACCESS_MAINT_TUNNELS, ACCESS_AUX_BASE)
-	LOWPOP_GRANT_ACCESS(JOB_NAME_BARTENDER, ACCESS_BAR)
-	LOWPOP_GRANT_ACCESS(JOB_NAME_BARTENDER, ACCESS_JANITOR)
-	LOWPOP_GRANT_ACCESS(JOB_NAME_COOK, ACCESS_KITCHEN)
-	LOWPOP_GRANT_ACCESS(JOB_NAME_BOTANIST, ACCESS_HYDROPONICS)
-	LOWPOP_GRANT_ACCESS(JOB_NAME_CLOWN, ACCESS_THEATRE)
-	LOWPOP_GRANT_ACCESS(JOB_NAME_CURATOR, ACCESS_LIBRARY)
+	return FALSE
 
 /datum/outfit/job/assistant
 	name = JOB_NAME_ASSISTANT
 	jobtype = /datum/job/assistant
 	belt = /obj/item/modular_computer/tablet/pda/preset/assistant
+	gloves = /obj/item/clothing/gloves/color/fyellow/old
+	r_hand = /obj/item/storage/toolbox/mechanical
+	r_pocket = /obj/item/multitool
 
 /datum/outfit/job/assistant/pre_equip(mob/living/carbon/human/H)
 	..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

* Assistants spawn with worn out insulated gloves, toolbox in hand, multitool in pocket and an old style gas mask in their emergency box
* All lowpop and extra access removed from assistants

## Why It's Good For The Game

It's not, though I might make a PR that gives assistants the old gas mask in their emergency box

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>

## Changelog
:cl:
add: Assistants spawn with worn out insulated gloves, multitool, a toolbox and have an old style gas mask in their survival box
del: Assistants have no ID access
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
