### PR TITLE
Lizards (and psyphozas?) can now get their species mutations

### DIFF
--- a/code/datums/mutations/fire_breath.dm
+++ b/code/datums/mutations/fire_breath.dm
@@ -10,9 +10,7 @@
 	instability = 30
 	energy_coeff = 1
 	power_coeff = 1
-	species_allowed = list(
-		/datum/species/lizard,
-	)
+	species_allowed = list(SPECIES_LIZARD)
 
 /datum/mutation/firebreath/modify()
 	. = ..()

--- a/code/datums/mutations/spores.dm
+++ b/code/datums/mutations/spores.dm
@@ -9,9 +9,7 @@
 	instability = 30
 	energy_coeff = 1
 	power_coeff = 1
-	species_allowed = list(
-		/datum/species/psyphoza,
-	)
+	species_allowed = list(SPECIES_PSYPHOZA)
 
 /datum/action/spell/spores
 	name = "Release Spores"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
I noticed a bug when trying to find the lizard's fire breath mutation that when you complete the gene's sequence, there is no mutation unlock. After finding a fix for this, I noticed similar code for psyphozas and decided to change that as well. 
I could not find an issue opened about this, but feel free to let me know if there is one.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->
Bug bad
## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

<img width="630" height="569" alt="Screenshot 2026-03-09 202751" src="https://github.com/user-attachments/assets/486b7b7d-6c78-4bbd-bff8-47f64746e0a6" />

This is what would happen before the fix. The sequence is fully correct (checked by using joker on all base pairs) but the mutation is not unlocking. This PR fixes that (I forgot to take a screenshot of it working but please dont make me do genetics privately and reproduce it).

</details>

## Changelog
:cl:
fix: Lizards and psyphozas can get their mutations unlocked again
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
