### PR TITLE
Cult Doors Fix/Addition

### DIFF
--- a/code/__DEFINES/cult.dm
+++ b/code/__DEFINES/cult.dm
@@ -12,6 +12,9 @@
 #define BLOOD_BARRAGE_COST 300
 #define BLOOD_BEAM_COST 500
 #define IRON_TO_CONSTRUCT_SHELL_CONVERSION 50
+
+GLOBAL_LIST_INIT(cult_airlock_cooldown, list())
+
 // misc
 #define SOULS_TO_REVIVE 3
 #define BLOODCULT_EYE COLOR_RED

--- a/code/__DEFINES/cult.dm
+++ b/code/__DEFINES/cult.dm
@@ -13,8 +13,6 @@
 #define BLOOD_BEAM_COST 500
 #define IRON_TO_CONSTRUCT_SHELL_CONVERSION 50
 
-GLOBAL_LIST_INIT(cult_airlock_cooldown, list())
-
 // misc
 #define SOULS_TO_REVIVE 3
 #define BLOODCULT_EYE COLOR_RED

--- a/code/game/machinery/doors/airlock_types.dm
+++ b/code/game/machinery/doors/airlock_types.dm
@@ -614,7 +614,7 @@
 
 /obj/machinery/door/airlock/cult/weak
 	name = "brittle cult airlock"
-	desc = span_cult("An airlock hastily corrupted by blood magic, it is unusually brittle in this state. You feel a sense of dread just by looking it, best avert your gaze.")
+	desc = span_cult("An airlock hastily corrupted by blood magic, it is unusually brittle in this state.")
 	normal_integrity = 150
 	damage_deflection = 5
 	armor_type = /datum/armor/none

--- a/code/game/machinery/doors/airlock_types.dm
+++ b/code/game/machinery/doors/airlock_types.dm
@@ -488,6 +488,7 @@
 
 /obj/machinery/door/airlock/cult
 	name = "cult airlock"
+	desc = span_cult("A heavy airlock inscribed with shifting, rhythmic runes. Just looking at it gives you a sense of dread, best to avert your gaze.")
 	icon = 'icons/obj/doors/airlocks/cult/runed/cult.dmi'
 	overlays_file = 'icons/obj/doors/airlocks/cult/runed/overlays.dmi'
 	assemblytype = /obj/structure/door_assembly/door_assembly_cult
@@ -517,23 +518,28 @@
 /obj/machinery/door/airlock/cult/hasPower()
 	return TRUE
 
-/obj/machinery/door/airlock/cult/allowed(mob/living/L)
+/obj/machinery/door/airlock/cult/allowed(mob/living/target)
 	if(!density)
 		return 1
-	if(friendly || IS_CULTIST(L) || istype(L, /mob/living/simple_animal/shade) || isconstruct(L))
+	if(friendly || IS_CULTIST(target) || isshade(target) || isconstruct(target)) // Are they a cultist?, if so open the door
 		if(!stealthy)
 			new openingoverlaytype(loc)
 		return 1
-	else
-		if(!stealthy)
-			new /obj/effect/temp_visual/cult/sac(loc)
-			var/atom/throwtarget
-			throwtarget = get_edge_target_turf(src, get_dir(src, get_step_away(L, src)))
-			SEND_SOUND(L, sound(pick('sound/hallucinations/turn_around1.ogg','sound/hallucinations/turn_around2.ogg'),0,1,50))
-			flash_color(L, flash_color="#960000", flash_time=20)
-			L.Paralyze(40)
-			L.throw_at(throwtarget, 5, 1,src)
+	var/datum/weakref/W = WEAKREF(target)
+	if(GLOB.cult_airlock_cooldown[W] && GLOB.cult_airlock_cooldown[W] > world.time) // They aren't a cultist, check for antimagic and trigger cooldown
 		return 0
+	GLOB.cult_airlock_cooldown[W] = world.time + 5 SECONDS // Fully aware this also places a cooldown upon bumping, i dont mind it however, just looking at the airlock will yeet you
+	var/anti_magic_source = target.can_block_magic(MAGIC_RESISTANCE_HOLY)
+	if(anti_magic_source)
+		return 0
+	if(!stealthy)
+		new /obj/effect/temp_visual/cult/sac(loc)
+		var/atom/throwtarget = get_edge_target_turf(src, get_dir(src, get_step_away(target, src)))
+		SEND_SOUND(target, sound(pick('sound/hallucinations/turn_around1.ogg','sound/hallucinations/turn_around2.ogg'),0,1,50))
+		flash_color(target, flash_color="#960000", flash_time=20)
+		target.Knockdown(4 SECONDS)
+		target.throw_at(throwtarget, 5, 1) // Yeeet
+	return 0
 
 /obj/machinery/door/airlock/cult/proc/conceal()
 	icon = 'icons/obj/doors/airlocks/station/maintenance.dmi'
@@ -585,7 +591,7 @@
 
 /obj/machinery/door/airlock/cult/weak
 	name = "brittle cult airlock"
-	desc = "An airlock hastily corrupted by blood magic, it is unusually brittle in this state."
+	desc = span_cult("An airlock hastily corrupted by blood magic, it is unusually brittle in this state. You feel a sense of dread just by looking it, best avert your gaze.")
 	normal_integrity = 150
 	damage_deflection = 5
 	armor_type = /datum/armor/none

--- a/code/game/machinery/doors/airlock_types.dm
+++ b/code/game/machinery/doors/airlock_types.dm
@@ -488,7 +488,7 @@
 
 /obj/machinery/door/airlock/cult
 	name = "cult airlock"
-	desc = span_cult("A heavy airlock inscribed with shifting, rhythmic runes. Just looking at it gives you a sense of dread, best to avert your gaze.")
+	desc = span_cult("A heavy airlock inscribed with shifting, rhythmic runes.")
 	icon = 'icons/obj/doors/airlocks/cult/runed/cult.dmi'
 	overlays_file = 'icons/obj/doors/airlocks/cult/runed/overlays.dmi'
 	assemblytype = /obj/structure/door_assembly/door_assembly_cult
@@ -500,6 +500,7 @@
 	var/friendly = FALSE
 	var/stealthy = FALSE
 	allow_repaint = FALSE
+	var/static/list/cultdoor_punish_cooldown = list()
 
 /obj/machinery/door/airlock/cult/Initialize(mapload)
 	. = ..()
@@ -507,6 +508,13 @@
 
 /obj/machinery/door/airlock/cult/canAIControl(mob/user)
 	return (IS_CULTIST(user) && !isAllPowerCut())
+
+/obj/machinery/door/airlock/cult/examine(mob/user)
+	var/original_desc = desc
+	if(!stealthy && !IS_CULTIST(user))
+		desc += " [span_cult("Just looking at it gives you a sense of dread, best to avert your gaze.")]" // You might wanna stop looking at the airlock bud
+	. = ..()
+	desc = original_desc // Im not sure if this is correct, otherwise you'd get repeating text
 
 /obj/machinery/door/airlock/cult/on_break()
 	if(!panel_open)
@@ -520,26 +528,41 @@
 
 /obj/machinery/door/airlock/cult/allowed(mob/living/target)
 	if(!density)
-		return 1
-	if(friendly || IS_CULTIST(target) || isshade(target) || isconstruct(target)) // Are they a cultist?, if so open the door
+		return TRUE
+	if(friendly || IS_CULTIST(target) || isshade(target) || isconstruct(target))
 		if(!stealthy)
 			new openingoverlaytype(loc)
-		return 1
-	var/datum/weakref/W = WEAKREF(target)
-	if(GLOB.cult_airlock_cooldown[W] && GLOB.cult_airlock_cooldown[W] > world.time) // They aren't a cultist, check for antimagic and trigger cooldown
-		return 0
-	GLOB.cult_airlock_cooldown[W] = world.time + 5 SECONDS // Fully aware this also places a cooldown upon bumping, i dont mind it however, just looking at the airlock will yeet you
+		return TRUE
+	on_denied(target)
+	return FALSE
+
+/obj/machinery/door/airlock/cult/proc/on_denied(mob/living/target)
 	var/anti_magic_source = target.can_block_magic(MAGIC_RESISTANCE_HOLY)
 	if(anti_magic_source)
-		return 0
+		return FALSE
+	var/datum/weakref/target_ref = WEAKREF(target)
+	if(cultdoor_punish_cooldown[target_ref] && cultdoor_punish_cooldown[target_ref] > world.time)
+		return FALSE
+	cultdoor_punish_cooldown[target_ref] = world.time + 10 SECONDS // Maybe this prevents cult doors from being spammed in hallways?
 	if(!stealthy)
 		new /obj/effect/temp_visual/cult/sac(loc)
 		var/atom/throwtarget = get_edge_target_turf(src, get_dir(src, get_step_away(target, src)))
-		SEND_SOUND(target, sound(pick('sound/hallucinations/turn_around1.ogg','sound/hallucinations/turn_around2.ogg'),0,1,50))
-		flash_color(target, flash_color="#960000", flash_time=20)
 		target.Knockdown(4 SECONDS)
-		target.throw_at(throwtarget, 5, 1) // Yeeet
-	return 0
+		target.throw_at(throwtarget, 5, 1) // Yeet
+		SEND_SOUND(target, sound(pick('sound/hallucinations/turn_around1.ogg','sound/hallucinations/turn_around2.ogg'),0,1,50))
+		flash_color(target, flash_color = "#960000", flash_time = 20)
+	return TRUE
+
+/obj/machinery/door/airlock/cult/on_mouse_enter(client/player)
+	if(stealthy)
+		return ..()
+	var/mob/living/onlooker = player.mob
+	if(!istype(onlooker))
+		return ..()
+	if(!IS_CULTIST(onlooker) && !isshade(onlooker) && !isconstruct(onlooker))
+		if(on_denied(onlooker))
+			to_chat(onlooker, span_cultlarge("The runes glow blood-red as you gaze upon the door."))
+	return ..()
 
 /obj/machinery/door/airlock/cult/proc/conceal()
 	icon = 'icons/obj/doors/airlocks/station/maintenance.dmi'


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This "fixes" a bug that the cult doors had if you looked at it, you were thrown since it activated as if you were bumping into them by screentips

On request however, it's being kept and added as a feature, it properly goes on cooldown when touched/looked at, which is shared globally by all cult doors, so you cant get stunned at the same time by 4 different doors you just looked at

It now also respects antimagic holy so you're not getting stunned by a cultist door just for looking at it if you have proper antimagic

Closes https://github.com/BeeStation/BeeStation-Hornet/issues/13985

## Why It's Good For The Game

Bug fix good?
Also, turning a bug into a feature

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

https://github.com/user-attachments/assets/92a9e161-f654-4986-a99f-e1a2ec50ea5f

https://github.com/user-attachments/assets/a0f4c88c-34f6-4855-83c2-7b79403cb083

https://github.com/user-attachments/assets/3bf19514-bfb6-4b8f-b069-3ad695443f0b



</details>

## Changelog
:cl:
fix: Cult door no longer throws you away just for looking at it, now it respects a certain cooldown after doing so
balance: Cult door now respects antimagic upon trying to knock you away
balance: Cult door now knocks you down instead of outright paralyze
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
