### PR TITLE
Cult door Screentip Fix

### DIFF
--- a/code/game/machinery/doors/airlock_types.dm
+++ b/code/game/machinery/doors/airlock_types.dm
@@ -517,23 +517,35 @@
 /obj/machinery/door/airlock/cult/hasPower()
 	return TRUE
 
-/obj/machinery/door/airlock/cult/allowed(mob/living/L)
+/obj/machinery/door/airlock/cult/allowed(mob/living/creature)
 	if(!density)
-		return 1
-	if(friendly || IS_CULTIST(L) || istype(L, /mob/living/simple_animal/shade) || isconstruct(L))
+		return TRUE
+
+	if(friendly || IS_CULTIST(creature) || isshade(creature) || isconstruct(creature))
 		if(!stealthy)
 			new openingoverlaytype(loc)
-		return 1
-	else
-		if(!stealthy)
-			new /obj/effect/temp_visual/cult/sac(loc)
-			var/atom/throwtarget
-			throwtarget = get_edge_target_turf(src, get_dir(src, get_step_away(L, src)))
-			SEND_SOUND(L, sound(pick('sound/hallucinations/turn_around1.ogg','sound/hallucinations/turn_around2.ogg'),0,1,50))
-			flash_color(L, flash_color="#960000", flash_time=20)
-			L.Paralyze(40)
-			L.throw_at(throwtarget, 5, 1,src)
-		return 0
+		return TRUE
+	return FALSE
+
+/obj/machinery/door/airlock/cult/Bumped(atom/movable/bumper)
+	. = ..()
+	if(!density)
+		return
+
+	if(isliving(bumper))
+		var/mob/living/victim = bumper
+		if(!allowed(victim))
+			deny_effect(victim)
+
+/obj/machinery/door/airlock/cult/proc/deny_effect(mob/living/victim)
+	if(stealthy)
+		return
+	new /obj/effect/temp_visual/cult/sac(loc)
+	var/atom/throwtarget = get_edge_target_turf(src, get_dir(src, get_step_away(victim, src)))
+	SEND_SOUND(victim, sound(pick('sound/hallucinations/turn_around1.ogg','sound/hallucinations/turn_around2.ogg'),0,1,50))
+	flash_color(victim, flash_color="#960000", flash_time=20)
+	victim.Knockdown(4 SECONDS) // This will still stun you if you hit a wall
+	victim.throw_at(throwtarget, 5, 1, src)
 
 /obj/machinery/door/airlock/cult/proc/conceal()
 	icon = 'icons/obj/doors/airlocks/station/maintenance.dmi'

--- a/code/game/machinery/doors/airlock_types.dm
+++ b/code/game/machinery/doors/airlock_types.dm
@@ -535,17 +535,14 @@
 	if(isliving(bumper))
 		var/mob/living/victim = bumper
 		if(!allowed(victim))
-			deny_effect(victim)
-
-/obj/machinery/door/airlock/cult/proc/deny_effect(mob/living/victim)
-	if(stealthy)
-		return
-	new /obj/effect/temp_visual/cult/sac(loc)
-	var/atom/throwtarget = get_edge_target_turf(src, get_dir(src, get_step_away(victim, src)))
-	SEND_SOUND(victim, sound(pick('sound/hallucinations/turn_around1.ogg','sound/hallucinations/turn_around2.ogg'),0,1,50))
-	flash_color(victim, flash_color="#960000", flash_time=20)
-	victim.Knockdown(4 SECONDS) // This will still stun you if you hit a wall
-	victim.throw_at(throwtarget, 5, 1, src)
+			if(stealthy)
+				return
+			new /obj/effect/temp_visual/cult/sac(loc)
+			var/atom/throwtarget = get_edge_target_turf(src, get_dir(src, get_step_away(victim, src)))
+			SEND_SOUND(victim, sound(pick('sound/hallucinations/turn_around1.ogg','sound/hallucinations/turn_around2.ogg'),0,1,50))
+			flash_color(victim, flash_color="#960000", flash_time=20)
+			victim.Knockdown(4 SECONDS) // This will still stun you if you hit a wall
+			victim.throw_at(throwtarget, 5, 1, src)
 
 /obj/machinery/door/airlock/cult/proc/conceal()
 	icon = 'icons/obj/doors/airlocks/station/maintenance.dmi'


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This fixes a bug that the cult doors had if you looked at it, you were thrown since it activated as if you were bumping into them by screentips

Closes https://github.com/BeeStation/BeeStation-Hornet/issues/13985

## Why It's Good For The Game

Bugs Bad

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

https://github.com/user-attachments/assets/96bc9683-e6fe-4ef8-9281-5031d3b75007

https://github.com/user-attachments/assets/8edce3db-159b-44a1-97fc-49794a73eb83

</details>

## Changelog
:cl:
balance: Cult doors no longer paralyze you upon being thrown, now they knock you down
fix: Cult doors will no longer throw you away just for looking at them
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
