### PR TITLE
Fixes the discord ooc message sometimes not sending

### DIFF
--- a/code/__HELPERS/roundend.dm
+++ b/code/__HELPERS/roundend.dm
@@ -833,7 +833,7 @@ GLOBAL_VAR(survivor_report) //! Contains shared survivor report for roundend rep
 	// Unaccounted for antagonists
 	var/list/unaccounted_antagonists = list()
 	for (var/datum/antagonist/antagonist in GLOB.antagonists)
-		if (antagonist.spawning_ruleset || !antagonist.name)
+		if (antagonist.spawning_ruleset || !antagonist.name || !antagonist.owner)
 			continue
 		if (unaccounted_antagonists[antagonist.name])
 			unaccounted_antagonists[antagonist.name] = unaccounted_antagonists[antagonist.name] + 1

--- a/code/__HELPERS/roundend.dm
+++ b/code/__HELPERS/roundend.dm
@@ -832,7 +832,7 @@ GLOBAL_VAR(survivor_report) //! Contains shared survivor report for roundend rep
 
 	// Unaccounted for antagonists
 	var/list/unaccounted_antagonists = list()
-	for (var/datum/antagonist/antagonist in GLOB.antagonists)
+	for (var/datum/antagonist/antagonist as anything in GLOB.antagonists)
 		if (antagonist.spawning_ruleset || !antagonist.name || !antagonist.owner)
 			continue
 		if (unaccounted_antagonists[antagonist.name])
@@ -842,8 +842,7 @@ GLOBAL_VAR(survivor_report) //! Contains shared survivor report for roundend rep
 
 	if (length(unaccounted_antagonists))
 		discordmsg += "Other Antagonists:\n"
-		for (var/antag_name in unaccounted_antagonists)
-			var/count = unaccounted_antagonists[antag_name]
+		for (var/antag_name, count in unaccounted_antagonists)
 			if (count > 1)
 				discordmsg += "- **[antag_name]** (x[count]):\n"
 			else


### PR DESCRIPTION
## About The Pull Request

The traitor panel pollutes `GLOB.antagonists` with every single `/datum/antag` sub-type. This should be refactored to not create antag instances and instead make use of either `initial()` or `::`. However, I can't be asked.

Regardless, there was another issue: antagonists without a linked mind were being included in the discord message. For obvious reasons, we don't want that.

The reason this only happens sometimes is because it requires an admin to open the traitor panel on a mob at least once.

## Why It's Good For The Game

closes #14191

## Testing Photographs and Procedure

I don't have the means with which to test this

## Changelog
:cl:
fix: Fixed the roundend message sometimes not being sent to the discord OOC channel
/:cl: