### PR TITLE
Renames to "GLOB.active_antagonists", Prevent prototype antagonists from populating active_antagonists

### DIFF
--- a/code/__HELPERS/roundend.dm
+++ b/code/__HELPERS/roundend.dm
@@ -112,7 +112,7 @@ GLOBAL_VAR(survivor_report) //! Contains shared survivor report for roundend rep
 
 	var/list/greentexters = list()
 
-	for(var/datum/antagonist/A as() in GLOB.antagonists)
+	for(var/datum/antagonist/A as anything in GLOB.active_antagonists)
 		if(!A.owner)
 			continue
 
@@ -263,7 +263,7 @@ GLOBAL_VAR(survivor_report) //! Contains shared survivor report for roundend rep
 	//Print a list of antagonists to the server log
 	var/list/total_antagonists = list()
 	//Look into all mobs in world, dead or alive
-	for(var/datum/antagonist/A in GLOB.antagonists)
+	for(var/datum/antagonist/A as anything in GLOB.active_antagonists)
 		if(!A.owner)
 			continue
 		if(!(A.name in total_antagonists))
@@ -584,7 +584,7 @@ GLOBAL_VAR(survivor_report) //! Contains shared survivor report for roundend rep
 			continue
 		all_teams |= A
 
-	for(var/datum/antagonist/A in GLOB.antagonists)
+	for(var/datum/antagonist/A as anything in GLOB.active_antagonists)
 		if(!A.owner)
 			continue
 		all_antagonists |= A
@@ -832,7 +832,7 @@ GLOBAL_VAR(survivor_report) //! Contains shared survivor report for roundend rep
 
 	// Unaccounted for antagonists
 	var/list/unaccounted_antagonists = list()
-	for (var/datum/antagonist/antagonist in GLOB.antagonists)
+	for (var/datum/antagonist/antagonist as anything in GLOB.active_antagonists)
 		if (antagonist.spawning_ruleset || !antagonist.name)
 			continue
 		if (unaccounted_antagonists[antagonist.name])

--- a/code/controllers/subsystem/dynamic/dynamic.dm
+++ b/code/controllers/subsystem/dynamic/dynamic.dm
@@ -933,7 +933,7 @@ SUBSYSTEM_DEF(dynamic)
 			continue
 		gamemode_executed = TRUE
 	// Check if a gamemode antagonist is in existance, even if not spawned through us
-	for (var/datum/antagonist/antagonist in GLOB.antagonists)
+	for (var/datum/antagonist/antagonist as anything in GLOB.active_antagonists)
 		for (var/datum/dynamic_ruleset/gamemode/gamemode_antagonist as anything in subtypesof(/datum/dynamic_ruleset/gamemode))
 			if (gamemode_antagonist::antag_datum && ispath(antagonist.type, gamemode_antagonist))
 				gamemode_executed = TRUE

--- a/code/controllers/subsystem/dynamic/dynamic_rulesets.dm
+++ b/code/controllers/subsystem/dynamic/dynamic_rulesets.dm
@@ -52,7 +52,7 @@
 	// Check to see if we just nuked a ruleset
 	var/last_remaining_from_ruleset = TRUE
 	var/last_remaining_of_type = TRUE
-	for (var/datum/antagonist/antagonist in GLOB.antagonists)
+	for (var/datum/antagonist/antagonist as anything in GLOB.active_antagonists)
 		// This antagonist has been removed from its owner
 		if (!antagonist.owner)
 			continue

--- a/code/modules/admin/antag_panel.dm
+++ b/code/modules/admin/antag_panel.dm
@@ -22,7 +22,7 @@ GLOBAL_VAR(antag_prototypes)
 		qdel(new_antag)
 
 /datum/antagonist/proc/antag_panel()
-	var/antag_panel_title = "<span style='font-size: 20px; margin: 8px; height: 0px; display: block;'><b> Antagonist Info : [name];</b></span>"
+	var/antag_panel_title = "<span style='font-size: 20px; margin: 8px; height: 0px; display: block;'><b> Antagonist Info : [name]</b></span>"
 	var/list/commands = list()
 	for(var/command in get_admin_commands())
 		commands += "<a href='byond://?src=[REF(src)];command=[command]'>[command]</a>"

--- a/code/modules/admin/antag_panel.dm
+++ b/code/modules/admin/antag_panel.dm
@@ -102,15 +102,16 @@ GLOBAL_VAR(antag_prototypes)
 		out += " - Special Statuses: [special_statuses]<br>"
 
 	//// Initializing antag panel texts ////
-	if(!GLOB.antag_prototypes)
+	if(!length(GLOB.antag_prototypes))
 		GLOB.antag_prototypes = list()
 		for(var/antag_type in subtypesof(/datum/antagonist))
-			var/datum/antagonist/A = new antag_type
-			var/cat_id = A.antagpanel_category
+			var/datum/antagonist/each_antag = new antag_type
+			GLOB.active_antagonists -= each_antag // This is automatically added by /datum/antagonist/New - manually removing this.
+			var/cat_id = each_antag.antagpanel_category
 			if(!GLOB.antag_prototypes[cat_id])
-				GLOB.antag_prototypes[cat_id] = list(A)
+				GLOB.antag_prototypes[cat_id] = list(each_antag)
 			else
-				GLOB.antag_prototypes[cat_id] += A
+				GLOB.antag_prototypes[cat_id] += each_antag
 	sortTim(GLOB.antag_prototypes,GLOBAL_PROC_REF(cmp_text_asc),associative=TRUE)
 
 	var/list/sections = list()

--- a/code/modules/admin/check_antagonists.dm
+++ b/code/modules/admin/check_antagonists.dm
@@ -51,7 +51,7 @@
 
 /datum/team/proc/get_team_antags(antag_type,specific = FALSE)
 	. = list()
-	for(var/datum/antagonist/A in GLOB.antagonists)
+	for(var/datum/antagonist/A as anything in GLOB.active_antagonists)
 		if(A.get_team() == src && (!antag_type || !specific && istype(A,antag_type) || specific && A.type == antag_type))
 			. += A
 
@@ -84,7 +84,7 @@
 	var/list/all_teams = list()
 	var/list/all_antagonists = list()
 
-	for(var/datum/antagonist/A in GLOB.antagonists)
+	for(var/datum/antagonist/A as anything in GLOB.active_antagonists)
 		if(!A.owner)
 			continue
 		all_teams |= A.get_team()

--- a/code/modules/antagonists/_common/antag_datum.dm
+++ b/code/modules/antagonists/_common/antag_datum.dm
@@ -1,4 +1,4 @@
-GLOBAL_LIST_EMPTY(antagonists)
+GLOBAL_LIST_EMPTY(active_antagonists)
 GLOBAL_LIST(admin_antag_list)
 
 /datum/antagonist
@@ -66,11 +66,13 @@ GLOBAL_LIST(admin_antag_list)
 	return SSassets.transport.get_asset_url(match)
 
 /datum/antagonist/New()
-	GLOB.antagonists += src
+	GLOB.active_antagonists += src
+	// Note : "GLOB.antag_prototypes += src" is executed in antag_panel.dm
 	typecache_datum_blacklist = typecacheof(typecache_datum_blacklist)
 
 /datum/antagonist/Destroy()
-	GLOB.antagonists -= src
+	GLOB.active_antagonists -= src
+	GLOB.antag_prototypes -= src // Removing that just in case
 	if(owner)
 		LAZYREMOVE(owner.antag_datums, src)
 	owner = null

--- a/code/modules/antagonists/_common/antag_helpers.dm
+++ b/code/modules/antagonists/_common/antag_helpers.dm
@@ -1,7 +1,7 @@
 //Returns MINDS of the assigned antags of given type/subtypes
 /proc/get_antag_minds(antag_type,specific = FALSE)
 	. = list()
-	for(var/datum/antagonist/A in GLOB.antagonists)
+	for(var/datum/antagonist/A as anything in GLOB.active_antagonists)
 		if(!A.owner)
 			continue
 		if(!antag_type || !specific && istype(A,antag_type) || specific && A.type == antag_type)
@@ -10,8 +10,7 @@
 //Get all teams [of type team_type]
 /proc/get_all_teams(team_type)
 	. = list()
-	for(var/V in GLOB.antagonists)
-		var/datum/antagonist/A = V
+	for(var/datum/antagonist/A as anything in GLOB.active_antagonists)
 		if(!A.owner)
 			continue
 		var/datum/team/T = A.get_team()

--- a/code/modules/antagonists/changeling/changeling.dm
+++ b/code/modules/antagonists/changeling/changeling.dm
@@ -109,7 +109,7 @@
 
 /datum/antagonist/changeling/New()
 	. = ..()
-	for(var/datum/antagonist/changeling/other_ling as anything in GLOB.active_antagonists)
+	for(var/datum/antagonist/changeling/other_ling in GLOB.active_antagonists)
 		if(!other_ling.owner || other_ling.owner == owner)
 			continue
 		competitive_objectives = TRUE

--- a/code/modules/antagonists/changeling/changeling.dm
+++ b/code/modules/antagonists/changeling/changeling.dm
@@ -109,7 +109,7 @@
 
 /datum/antagonist/changeling/New()
 	. = ..()
-	for(var/datum/antagonist/changeling/other_ling in GLOB.antagonists)
+	for(var/datum/antagonist/changeling/other_ling as anything in GLOB.active_antagonists)
 		if(!other_ling.owner || other_ling.owner == owner)
 			continue
 		competitive_objectives = TRUE

--- a/code/modules/antagonists/clock_cult/servant_of_ratvar.dm
+++ b/code/modules/antagonists/clock_cult/servant_of_ratvar.dm
@@ -175,7 +175,7 @@ GLOBAL_VAR(clockcult_eminence)
 		. = is_convertable_to_clockcult(new_owner.current)
 
 /datum/antagonist/servant_of_ratvar/create_team()
-	for(var/datum/antagonist/servant_of_ratvar/H as anything in GLOB.active_antagonists)
+	for(var/datum/antagonist/servant_of_ratvar/H in GLOB.active_antagonists)
 		if(!H.owner)
 			continue
 		if(H.team)

--- a/code/modules/antagonists/clock_cult/servant_of_ratvar.dm
+++ b/code/modules/antagonists/clock_cult/servant_of_ratvar.dm
@@ -175,7 +175,7 @@ GLOBAL_VAR(clockcult_eminence)
 		. = is_convertable_to_clockcult(new_owner.current)
 
 /datum/antagonist/servant_of_ratvar/create_team()
-	for(var/datum/antagonist/servant_of_ratvar/H in GLOB.antagonists)
+	for(var/datum/antagonist/servant_of_ratvar/H as anything in GLOB.active_antagonists)
 		if(!H.owner)
 			continue
 		if(H.team)

--- a/code/modules/antagonists/cult/cult.dm
+++ b/code/modules/antagonists/cult/cult.dm
@@ -22,7 +22,7 @@
 /datum/antagonist/cult/create_team(datum/team/cult/new_team)
 	if(!new_team)
 		//todo remove this and allow admin buttons to create more than one cult
-		for(var/datum/antagonist/cult/H in GLOB.antagonists)
+		for(var/datum/antagonist/cult/H as anything in GLOB.active_antagonists)
 			if(!H.owner)
 				continue
 			if(H.cult_team)

--- a/code/modules/antagonists/cult/cult.dm
+++ b/code/modules/antagonists/cult/cult.dm
@@ -22,7 +22,7 @@
 /datum/antagonist/cult/create_team(datum/team/cult/new_team)
 	if(!new_team)
 		//todo remove this and allow admin buttons to create more than one cult
-		for(var/datum/antagonist/cult/H as anything in GLOB.active_antagonists)
+		for(var/datum/antagonist/cult/H in GLOB.active_antagonists)
 			if(!H.owner)
 				continue
 			if(H.cult_team)

--- a/code/modules/antagonists/cult/narsie.dm
+++ b/code/modules/antagonists/cult/narsie.dm
@@ -39,7 +39,7 @@ GLOBAL_DATUM(narsie, /obj/eldritch/narsie)
 	GLOB.narsie = src
 	var/list/all_cults = list()
 
-	for(var/datum/antagonist/cult/cultist in GLOB.antagonists)
+	for(var/datum/antagonist/cult/cultist as anything in GLOB.active_antagonists)
 		if(!cultist.owner)
 			continue
 		all_cults |= cultist.cult_team
@@ -77,7 +77,7 @@ GLOBAL_DATUM(narsie, /obj/eldritch/narsie)
 
 	var/list/all_cults = list()
 
-	for(var/datum/antagonist/cult/cultist in GLOB.antagonists)
+	for(var/datum/antagonist/cult/cultist as anything in GLOB.active_antagonists)
 		if (!cultist.owner)
 			continue
 		all_cults |= cultist.cult_team

--- a/code/modules/antagonists/cult/narsie.dm
+++ b/code/modules/antagonists/cult/narsie.dm
@@ -39,7 +39,7 @@ GLOBAL_DATUM(narsie, /obj/eldritch/narsie)
 	GLOB.narsie = src
 	var/list/all_cults = list()
 
-	for(var/datum/antagonist/cult/cultist as anything in GLOB.active_antagonists)
+	for(var/datum/antagonist/cult/cultist in GLOB.active_antagonists)
 		if(!cultist.owner)
 			continue
 		all_cults |= cultist.cult_team
@@ -77,7 +77,7 @@ GLOBAL_DATUM(narsie, /obj/eldritch/narsie)
 
 	var/list/all_cults = list()
 
-	for(var/datum/antagonist/cult/cultist as anything in GLOB.active_antagonists)
+	for(var/datum/antagonist/cult/cultist in GLOB.active_antagonists)
 		if (!cultist.owner)
 			continue
 		all_cults |= cultist.cult_team

--- a/code/modules/antagonists/fugitive/fugitive.dm
+++ b/code/modules/antagonists/fugitive/fugitive.dm
@@ -35,7 +35,7 @@
 
 /datum/antagonist/fugitive/create_team(datum/team/fugitive/new_team)
 	if(!new_team)
-		for(var/datum/antagonist/fugitive/H as anything in GLOB.active_antagonists)
+		for(var/datum/antagonist/fugitive/H in GLOB.active_antagonists)
 			if(!H.owner)
 				continue
 			if(H.fugitive_team)

--- a/code/modules/antagonists/fugitive/fugitive.dm
+++ b/code/modules/antagonists/fugitive/fugitive.dm
@@ -35,7 +35,7 @@
 
 /datum/antagonist/fugitive/create_team(datum/team/fugitive/new_team)
 	if(!new_team)
-		for(var/datum/antagonist/fugitive/H in GLOB.antagonists)
+		for(var/datum/antagonist/fugitive/H as anything in GLOB.active_antagonists)
 			if(!H.owner)
 				continue
 			if(H.fugitive_team)

--- a/code/modules/antagonists/fugitive/fugitive_ship.dm
+++ b/code/modules/antagonists/fugitive/fugitive_ship.dm
@@ -140,7 +140,7 @@
 		data["prisoner_valid"] = !!prisoner.mind?.has_antag_datum(/datum/antagonist/fugitive)
 		data["prisoner_ref"] = REF(prisoner.mind)
 	var/fugitives = list()
-	for(var/datum/antagonist/fugitive/A in GLOB.antagonists)
+	for(var/datum/antagonist/fugitive/A as anything in GLOB.active_antagonists)
 		if(!A.owner)
 			continue
 		var/list/entry = list()

--- a/code/modules/antagonists/fugitive/fugitive_ship.dm
+++ b/code/modules/antagonists/fugitive/fugitive_ship.dm
@@ -140,7 +140,7 @@
 		data["prisoner_valid"] = !!prisoner.mind?.has_antag_datum(/datum/antagonist/fugitive)
 		data["prisoner_ref"] = REF(prisoner.mind)
 	var/fugitives = list()
-	for(var/datum/antagonist/fugitive/A as anything in GLOB.active_antagonists)
+	for(var/datum/antagonist/fugitive/A in GLOB.active_antagonists)
 		if(!A.owner)
 			continue
 		var/list/entry = list()

--- a/code/modules/antagonists/fugitive/hunter.dm
+++ b/code/modules/antagonists/fugitive/hunter.dm
@@ -31,7 +31,7 @@
 
 /datum/antagonist/fugitive_hunter/create_team(datum/team/fugitive_hunters/new_team)
 	if(!new_team)
-		for(var/datum/antagonist/fugitive_hunter/H as anything in GLOB.active_antagonists)
+		for(var/datum/antagonist/fugitive_hunter/H in GLOB.active_antagonists)
 			if(!H.owner)
 				continue
 			if(H.hunter_team)
@@ -76,7 +76,7 @@
 	return backstory.multiple_name
 
 /datum/team/fugitive_hunters/proc/forge_team_objectives()
-	for(var/datum/antagonist/fugitive/A as anything in GLOB.active_antagonists)
+	for(var/datum/antagonist/fugitive/A in GLOB.active_antagonists)
 		if(!A.owner)
 			continue
 		var/datum/objective/capture_fugitive/capture = new()

--- a/code/modules/antagonists/fugitive/hunter.dm
+++ b/code/modules/antagonists/fugitive/hunter.dm
@@ -31,7 +31,7 @@
 
 /datum/antagonist/fugitive_hunter/create_team(datum/team/fugitive_hunters/new_team)
 	if(!new_team)
-		for(var/datum/antagonist/fugitive_hunter/H in GLOB.antagonists)
+		for(var/datum/antagonist/fugitive_hunter/H as anything in GLOB.active_antagonists)
 			if(!H.owner)
 				continue
 			if(H.hunter_team)
@@ -76,7 +76,7 @@
 	return backstory.multiple_name
 
 /datum/team/fugitive_hunters/proc/forge_team_objectives()
-	for(var/datum/antagonist/fugitive/A in GLOB.antagonists)
+	for(var/datum/antagonist/fugitive/A as anything in GLOB.active_antagonists)
 		if(!A.owner)
 			continue
 		var/datum/objective/capture_fugitive/capture = new()

--- a/code/modules/antagonists/nukeop/nukeop.dm
+++ b/code/modules/antagonists/nukeop/nukeop.dm
@@ -139,7 +139,7 @@
 /datum/antagonist/nukeop/create_team(datum/team/nuclear/new_team)
 	if(!new_team)
 		if(!always_new_team)
-			for(var/datum/antagonist/nukeop/N as anything in GLOB.active_antagonists)
+			for(var/datum/antagonist/nukeop/N in GLOB.active_antagonists)
 				if(!N.owner)
 					continue
 				if(N.nuke_team)

--- a/code/modules/antagonists/nukeop/nukeop.dm
+++ b/code/modules/antagonists/nukeop/nukeop.dm
@@ -139,7 +139,7 @@
 /datum/antagonist/nukeop/create_team(datum/team/nuclear/new_team)
 	if(!new_team)
 		if(!always_new_team)
-			for(var/datum/antagonist/nukeop/N in GLOB.antagonists)
+			for(var/datum/antagonist/nukeop/N as anything in GLOB.active_antagonists)
 				if(!N.owner)
 					continue
 				if(N.nuke_team)

--- a/code/modules/antagonists/pirate/pirate.dm
+++ b/code/modules/antagonists/pirate/pirate.dm
@@ -43,7 +43,7 @@
 
 /datum/antagonist/pirate/create_team(datum/team/pirate/new_team)
 	if(!new_team)
-		for(var/datum/antagonist/pirate/P in GLOB.antagonists)
+		for(var/datum/antagonist/pirate/P as anything in GLOB.active_antagonists)
 			if(!P.owner)
 				continue
 			if(P.crew)

--- a/code/modules/antagonists/pirate/pirate.dm
+++ b/code/modules/antagonists/pirate/pirate.dm
@@ -43,7 +43,7 @@
 
 /datum/antagonist/pirate/create_team(datum/team/pirate/new_team)
 	if(!new_team)
-		for(var/datum/antagonist/pirate/P as anything in GLOB.active_antagonists)
+		for(var/datum/antagonist/pirate/P in GLOB.active_antagonists)
 			if(!P.owner)
 				continue
 			if(P.crew)

--- a/code/modules/antagonists/revolution/revolution.dm
+++ b/code/modules/antagonists/revolution/revolution.dm
@@ -58,7 +58,7 @@
 /datum/antagonist/rev/create_team(datum/team/revolution/new_team)
 	if(!new_team)
 		//For now only one revolution at a time
-		for(var/datum/antagonist/rev/head/H as anything in GLOB.active_antagonists)
+		for(var/datum/antagonist/rev/head/H in GLOB.active_antagonists)
 			if(!H.owner)
 				continue
 			if(H.rev_team)

--- a/code/modules/antagonists/revolution/revolution.dm
+++ b/code/modules/antagonists/revolution/revolution.dm
@@ -58,7 +58,7 @@
 /datum/antagonist/rev/create_team(datum/team/revolution/new_team)
 	if(!new_team)
 		//For now only one revolution at a time
-		for(var/datum/antagonist/rev/head/H in GLOB.antagonists)
+		for(var/datum/antagonist/rev/head/H as anything in GLOB.active_antagonists)
 			if(!H.owner)
 				continue
 			if(H.rev_team)

--- a/code/modules/antagonists/spider/spider.dm
+++ b/code/modules/antagonists/spider/spider.dm
@@ -54,7 +54,7 @@
 
 /datum/antagonist/spider/create_team(datum/team/spiders/new_team)
 	if(!new_team)
-		for(var/datum/antagonist/spider/spooder in GLOB.antagonists)
+		for(var/datum/antagonist/spider/spooder as anything in GLOB.active_antagonists)
 			if(!spooder.owner || !spooder.spider_team)
 				continue
 			spider_team = spooder.spider_team //if we can find any existing team, use that one

--- a/code/modules/antagonists/spider/spider.dm
+++ b/code/modules/antagonists/spider/spider.dm
@@ -54,7 +54,7 @@
 
 /datum/antagonist/spider/create_team(datum/team/spiders/new_team)
 	if(!new_team)
-		for(var/datum/antagonist/spider/spooder as anything in GLOB.active_antagonists)
+		for(var/datum/antagonist/spider/spooder in GLOB.active_antagonists)
 			if(!spooder.owner || !spooder.spider_team)
 				continue
 			spider_team = spooder.spider_team //if we can find any existing team, use that one

--- a/code/modules/antagonists/swarmer/swarmer.dm
+++ b/code/modules/antagonists/swarmer/swarmer.dm
@@ -765,7 +765,7 @@
 /datum/antagonist/swarmer/create_team(datum/team/swarmer/new_team)
 	if(!new_team)
 		//For now only one swarm at a time
-		for(var/datum/antagonist/swarmer/S as anything in GLOB.active_antagonists)
+		for(var/datum/antagonist/swarmer/S in GLOB.active_antagonists)
 			if(!S.owner)
 				continue
 			if(S.swarm)

--- a/code/modules/antagonists/swarmer/swarmer.dm
+++ b/code/modules/antagonists/swarmer/swarmer.dm
@@ -765,7 +765,7 @@
 /datum/antagonist/swarmer/create_team(datum/team/swarmer/new_team)
 	if(!new_team)
 		//For now only one swarm at a time
-		for(var/datum/antagonist/swarmer/S in GLOB.antagonists)
+		for(var/datum/antagonist/swarmer/S as anything in GLOB.active_antagonists)
 			if(!S.owner)
 				continue
 			if(S.swarm)

--- a/code/modules/antagonists/vampire/vassals/datum_vassal.dm
+++ b/code/modules/antagonists/vampire/vassals/datum_vassal.dm
@@ -148,7 +148,7 @@
 	var/list/datum/mind/possible_vampires = list()
 
 	// Get possible vampires
-	for(var/datum/antagonist/vampire/vampire in GLOB.antagonists)
+	for(var/datum/antagonist/vampire/vampire as anything in GLOB.active_antagonists)
 		var/datum/mind/vampire_mind = vampire.owner
 		if(QDELETED(vampire_mind?.current) || vampire_mind.current.stat == DEAD)
 			continue

--- a/code/modules/antagonists/vampire/vassals/datum_vassal.dm
+++ b/code/modules/antagonists/vampire/vassals/datum_vassal.dm
@@ -148,7 +148,7 @@
 	var/list/datum/mind/possible_vampires = list()
 
 	// Get possible vampires
-	for(var/datum/antagonist/vampire/vampire as anything in GLOB.active_antagonists)
+	for(var/datum/antagonist/vampire/vampire in GLOB.active_antagonists)
 		var/datum/mind/vampire_mind = vampire.owner
 		if(QDELETED(vampire_mind?.current) || vampire_mind.current.stat == DEAD)
 			continue

--- a/code/modules/antagonists/wizard/equipment/soulstone.dm
+++ b/code/modules/antagonists/wizard/equipment/soulstone.dm
@@ -314,7 +314,7 @@
 
 				make_new_construct_from_class(construct_class, theme, contained_shade, user, FALSE, T.loc)
 
-				for(var/datum/antagonist/cult/cultist as anything in GLOB.active_antagonists)
+				for(var/datum/antagonist/cult/cultist in GLOB.active_antagonists)
 					if(cultist.owner == contained_shade.mind)
 						cultist.remove_antag_hud(ANTAG_HUD_CULT, cultist.owner.current)
 				qdel(T)

--- a/code/modules/antagonists/wizard/equipment/soulstone.dm
+++ b/code/modules/antagonists/wizard/equipment/soulstone.dm
@@ -314,7 +314,7 @@
 
 				make_new_construct_from_class(construct_class, theme, contained_shade, user, FALSE, T.loc)
 
-				for(var/datum/antagonist/cult/cultist in GLOB.antagonists)
+				for(var/datum/antagonist/cult/cultist as anything in GLOB.active_antagonists)
 					if(cultist.owner == contained_shade.mind)
 						cultist.remove_antag_hud(ANTAG_HUD_CULT, cultist.owner.current)
 				qdel(T)

--- a/code/modules/antagonists/xeno/xeno.dm
+++ b/code/modules/antagonists/xeno/xeno.dm
@@ -23,7 +23,7 @@
 
 /datum/antagonist/xeno/create_team(datum/team/xeno/new_team)
 	if(!new_team)
-		for(var/datum/antagonist/xeno/X in GLOB.antagonists)
+		for(var/datum/antagonist/xeno/X as anything in GLOB.active_antagonists)
 			if(!X.owner || !X.xeno_team)
 				continue
 			xeno_team = X.xeno_team

--- a/code/modules/antagonists/xeno/xeno.dm
+++ b/code/modules/antagonists/xeno/xeno.dm
@@ -23,7 +23,7 @@
 
 /datum/antagonist/xeno/create_team(datum/team/xeno/new_team)
 	if(!new_team)
-		for(var/datum/antagonist/xeno/X as anything in GLOB.active_antagonists)
+		for(var/datum/antagonist/xeno/X in GLOB.active_antagonists)
 			if(!X.owner || !X.xeno_team)
 				continue
 			xeno_team = X.xeno_team

--- a/code/modules/zombie/organs.dm
+++ b/code/modules/zombie/organs.dm
@@ -31,7 +31,7 @@
 		return .
 	START_PROCESSING(SSobj, src)
 	// Find all antag datums and mark romerol objectives as complete
-	for (var/datum/antagonist/antagonist in GLOB.antagonists)
+	for (var/datum/antagonist/antagonist as anything in GLOB.active_antagonists)
 		for (var/datum/objective/romerol/objective in antagonist.objectives)
 			objective.released = TRUE
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
"GLOB.antagonists" is bit ambiguous - we don't know which kind of antagonists the list has. with renaming that into "GLOB.active_antagonists", it now hints that it means ingame antagonists of the current round.
Also, manually removed created antags (prototype) from GLOB.active_antagonists so that opening antag panel won't populate sample antag instances.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
* closes #14191
* helps #14201
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->

<img width="1895" height="859" alt="image" src="https://github.com/user-attachments/assets/8427a989-d417-4b21-9389-75183bda55c9" />

Made my character a cultist

## Changelog
:cl:
code: renamed GLOB.antagonists into GLOB.active_antagonists
fix: Opening antag panel no longer populates OOC antag list
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
