### PR TITLE
Fixes a really small spelling mistake on poison directive

### DIFF
--- a/code/modules/antagonists/traitor/directives/steal/steal.dm
+++ b/code/modules/antagonists/traitor/directives/steal/steal.dm
@@ -88,7 +88,7 @@
 /datum/priority_directive/steal/proc/poison_applied(datum/source, atom/target, mob/living/user)
 	SIGNAL_HANDLER
 	if (!istype(target, steal_target_path))
-		mission_update("The posion has been applied to the wrong target, directive failed.")
+		mission_update("The poison has been applied to the wrong target, directive failed.")
 		finish()
 		return
 	grant_universal_victory()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Changes "posion" to poison

## Why It's Good For The Game

Minor spelling mistake nuked

Closes https://github.com/BeeStation/BeeStation-Hornet/issues/14198

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

bet

<img width="694" height="56" alt="image" src="https://github.com/user-attachments/assets/301d7a4e-900b-4fa3-a221-a9b681dded56" />



</details>

## Changelog
:cl:
spellcheck: Poison is spelled correctly upon failling the poison directive
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
