### PR TITLE
Syndicate Saboteur borgs are properly disguised once again

### DIFF
--- a/code/modules/antagonists/nukeop/equipment/borgchameleon.dm
+++ b/code/modules/antagonists/nukeop/equipment/borgchameleon.dm
@@ -87,7 +87,7 @@
 	src.user = user
 	savedName = user.name
 	user.name = friendlyName
-	user.model.name = disguise
+	user.model.name = capitalize("Engineering")
 	user.model.cyborg_base_icon = disguise
 	user.bubble_icon = "robot"
 	active = TRUE

--- a/code/modules/antagonists/nukeop/equipment/borgchameleon.dm
+++ b/code/modules/antagonists/nukeop/equipment/borgchameleon.dm
@@ -87,6 +87,7 @@
 	src.user = user
 	savedName = user.name
 	user.name = friendlyName
+	user.model.name = disguise
 	user.model.cyborg_base_icon = disguise
 	user.bubble_icon = "robot"
 	active = TRUE
@@ -106,6 +107,7 @@
 		listeningTo = null
 	do_sparks(5, FALSE, user)
 	user.name = savedName
+	user.model.name = initial(user.model.name)
 	user.model.cyborg_base_icon = initial(user.model.cyborg_base_icon)
 	user.bubble_icon = "syndibot"
 	active = FALSE

--- a/code/modules/antagonists/nukeop/equipment/borgchameleon.dm
+++ b/code/modules/antagonists/nukeop/equipment/borgchameleon.dm
@@ -13,6 +13,7 @@
 	var/active = FALSE
 	var/activationCost = 300
 	var/activationUpkeep = 50
+	var/disguise_name = "Engineering"
 	var/disguise = "engineer"
 	var/mob/listeningTo
 	var/static/list/signalCache = list( // list here all signals that should break the camouflage
@@ -87,7 +88,7 @@
 	src.user = user
 	savedName = user.name
 	user.name = friendlyName
-	user.model.name = capitalize("Engineering")
+	user.model.name = capitalize(disguise_name)
 	user.model.cyborg_base_icon = disguise
 	user.bubble_icon = "robot"
 	active = TRUE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Syndicate Cyborgs were being shown by their description saying they're a syndicate cyborg, even when disguised, this PR fixes that

## Why It's Good For The Game

Fix good

Closes https://github.com/BeeStation/BeeStation-Hornet/issues/13966

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>

Not hidden
<img width="683" height="109" alt="image" src="https://github.com/user-attachments/assets/ac197c54-c81a-400d-be63-57f1a458b57f" />

Hidden
<img width="1382" height="524" alt="image" src="https://github.com/user-attachments/assets/907e1aee-45d4-48f2-9f2b-498e9b4cbe01" />

Unhidden
<img width="691" height="99" alt="image" src="https://github.com/user-attachments/assets/1edae84f-c55d-4f96-94dc-33aa8e7588b5" />

Compared to
<img width="560" height="76" alt="image" src="https://github.com/user-attachments/assets/e8d1bc70-3451-47ea-809d-2711b1b36d0f" />




</details>

## Changelog
:cl:
fix: The syndicate has fixed their chameleon technology for engineering models
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
