### PR TITLE
Fixes directional windows preventing buckling 

### DIFF
--- a/code/game/objects/buckling.dm
+++ b/code/game/objects/buckling.dm
@@ -253,7 +253,7 @@
 		return FALSE
 
 	var/turf/turf = get_turf(src)
-	if(turf.is_blocked_turf(source_atom = target, ignore_atoms = list(/obj/vehicle), type_list = TRUE))
+	if(turf.is_blocked_turf(source_atom = target, ignore_atoms = list(src))
 		to_chat(target, span_warning("Something is in the way"))
 		return FALSE
 

--- a/code/game/objects/buckling.dm
+++ b/code/game/objects/buckling.dm
@@ -252,7 +252,7 @@
 	if(!target.can_buckle_to && !force)
 		return FALSE
 
-	// Check if there's something blocking the way to buckle yourself
+	// Check if there's something blocking the way to buckle
 	var/turf/turf = get_turf(src)
 	if(turf.is_blocked_turf(source_atom = target, ignore_atoms = list(src)))
 		to_chat(target, span_warning("Something is in the way"))

--- a/code/game/objects/buckling.dm
+++ b/code/game/objects/buckling.dm
@@ -252,8 +252,9 @@
 	if(!target.can_buckle_to && !force)
 		return FALSE
 
+	// Check if there's something blocking the way to buckle yourself
 	var/turf/turf = get_turf(src)
-	if(turf.is_blocked_turf(source_atom = target, ignore_atoms = list(src))
+	if(turf.is_blocked_turf(source_atom = target, ignore_atoms = list(src)))
 		to_chat(target, span_warning("Something is in the way"))
 		return FALSE
 

--- a/code/game/objects/buckling.dm
+++ b/code/game/objects/buckling.dm
@@ -253,7 +253,7 @@
 		return FALSE
 
 	var/turf/turf = get_turf(src)
-	if(turf.is_blocked_turf(source_atom = target))
+	if(turf.is_blocked_turf(source_atom = target, ignore_atoms = list(/obj/vehicle), type_list = TRUE))
 		to_chat(target, span_warning("Something is in the way"))
 		return FALSE
 

--- a/code/game/objects/buckling.dm
+++ b/code/game/objects/buckling.dm
@@ -252,13 +252,10 @@
 	if(!target.can_buckle_to && !force)
 		return FALSE
 
-	var/turf/source_turf = get_turf(src)
-	for(var/atom/movable/blocking_atom in source_turf)	// Check for blocking objects on the turf
-		if(blocking_atom == src || blocking_atom == target)
-			continue
-		if(blocking_atom.density) // Something is in the way that is dense, stop them from buckling
-			to_chat(target, span_warning("Something is in the way."))
-			return FALSE
+	var/turf/turf = get_turf(src)
+	if(turf.is_blocked_turf(source_atom = target))
+		to_chat(target, span_warning("Something is in the way"))
+		return FALSE
 
 	return TRUE
 /**


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This fixes a bug i introduced in https://github.com/BeeStation/BeeStation-Hornet/pull/14205

## Why It's Good For The Game

Whoopsie daisy

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

Stasis bed, buckled with a directional window on the other side

<img width="235" height="179" alt="image" src="https://github.com/user-attachments/assets/30391a25-2196-4bcf-a791-97aa3da3ab8f" />

Cant buckle with a closet ontop of it (Ignore the message)

<img width="1497" height="626" alt="image" src="https://github.com/user-attachments/assets/fbc7815c-912e-4fcb-b89a-06ab988b87c3" />

</details>

## Changelog
:cl: Isaac
fix: You can buckle onto objects if there's a directional window on the same tile again
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
