### PR TITLE
Berry Small Mapping Fixes 

### DIFF
--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -13040,10 +13040,6 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
 /turf/open/floor/iron/white,
 /area/science/research)
-"cTo" = (
-/obj/machinery/airalarm/directional/west,
-/turf/open/floor/iron,
-/area/quartermaster/exploration_dock)
 "cTy" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -20063,6 +20059,12 @@
 	},
 /turf/open/floor/iron/techmaint,
 /area/security/brig)
+"fDu" = (
+/obj/effect/turf_decal/bot,
+/obj/machinery/power/apc/auto_name/directional/south,
+/obj/structure/cable/yellow,
+/turf/open/floor/iron,
+/area/quartermaster/exploration_dock)
 "fDG" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -22140,6 +22142,10 @@
 	},
 /turf/open/floor/carpet/green,
 /area/medical/exam_room)
+"gvW" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/science/aft)
 "gwm" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
@@ -27264,6 +27270,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/security/main)
+"iwH" = (
+/turf/closed/wall,
+/area/science/aft)
 "iwP" = (
 /obj/effect/spawner/structure/window/reinforced/tinted,
 /obj/machinery/door/poddoor/preopen{
@@ -27587,9 +27596,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/patients_rooms)
-"iDX" = (
-/turf/closed/wall,
-/area/science/aft)
 "iEk" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/smart/simple/dark/visible/layer4,
@@ -31422,6 +31428,12 @@
 /obj/structure/reagent_dispensers/peppertank/directional/north,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/security/armory)
+"kmZ" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/turf/open/floor/iron,
+/area/quartermaster/exploration_dock)
 "knd" = (
 /obj/machinery/airalarm/directional/north,
 /obj/effect/turf_decal/tile/techfloorgrid{
@@ -47212,10 +47224,6 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron/white,
 /area/maintenance/aft)
-"qOA" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/science/aft)
 "qOP" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -50728,6 +50736,10 @@
 /obj/structure/flora/ausbushes/brflowers,
 /turf/open/floor/grass,
 /area/hallway/primary/central)
+"smm" = (
+/obj/machinery/airalarm/directional/west,
+/turf/open/floor/iron,
+/area/quartermaster/exploration_dock)
 "smw" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -54651,6 +54663,9 @@
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
 /turf/open/floor/iron,
 /area/quartermaster/exploration_dock)
 "tKk" = (
@@ -116733,9 +116748,9 @@ aaa
 bky
 bky
 mnE
-iDX
-iDX
-iDX
+iwH
+iwH
+iwH
 qia
 gQd
 gQd
@@ -116988,16 +117003,16 @@ aaa
 aaa
 aaa
 aaa
-qOA
+gvW
 sDn
 hWo
 sGv
-iDX
+iwH
 xcE
 ict
 hjM
 uyV
-cTo
+smm
 cRa
 gQd
 atS
@@ -117245,17 +117260,17 @@ aaa
 aaa
 aaa
 aaa
-qOA
+gvW
 xXx
 yjs
 uAc
-qOA
+gvW
 duR
 jjp
 jjp
 tJF
-pqr
-ezu
+kmZ
+fDu
 gQd
 aaf
 aaa
@@ -117502,11 +117517,11 @@ aaa
 aaa
 aaa
 aaa
-qOA
+gvW
 szx
 miD
 sWW
-qOA
+gvW
 pqr
 pqr
 cBe
@@ -117759,11 +117774,11 @@ aaa
 aaa
 aaa
 aaa
-qOA
+gvW
 rKw
 eQc
 riO
-iDX
+iwH
 quX
 pqr
 xkR
@@ -118016,11 +118031,11 @@ aaa
 aaa
 aaa
 gXs
-qOA
-qOA
-qOA
-iDX
-iDX
+gvW
+gvW
+gvW
+iwH
+iwH
 tEj
 dOV
 xkR

--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -13040,6 +13040,10 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
 /turf/open/floor/iron/white,
 /area/science/research)
+"cTo" = (
+/obj/machinery/airalarm/directional/west,
+/turf/open/floor/iron,
+/area/quartermaster/exploration_dock)
 "cTy" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -18053,7 +18057,7 @@
 	},
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple,
 /turf/open/floor/iron/dark/telecomms,
-/area/quartermaster/exploration_dock)
+/area/science/aft)
 "eQv" = (
 /obj/structure/flora/ausbushes/brflowers,
 /obj/structure/window/spawner/directional/south,
@@ -26063,7 +26067,7 @@
 /obj/machinery/telecomms/server/presets/exploration,
 /obj/machinery/camera/directional/west,
 /turf/open/floor/circuit/telecomms/server,
-/area/quartermaster/exploration_dock)
+/area/science/aft)
 "hWq" = (
 /obj/effect/turf_decal/tile/green/opposingcorners,
 /obj/effect/mapping_helpers/tile_breaker,
@@ -27583,6 +27587,9 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/patients_rooms)
+"iDX" = (
+/turf/closed/wall,
+/area/science/aft)
 "iEk" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/smart/simple/dark/visible/layer4,
@@ -36116,7 +36123,7 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/iron/dark/telecomms,
-/area/quartermaster/exploration_dock)
+/area/science/aft)
 "miP" = (
 /obj/effect/landmark/event_spawn,
 /obj/effect/turf_decal/loading_area{
@@ -36479,7 +36486,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /turf/open/floor/plating,
-/area/quartermaster/exploration_dock)
+/area/science/aft)
 "mnF" = (
 /obj/effect/turf_decal/trimline/white/warning_offset{
 	dir = 1
@@ -47205,6 +47212,10 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron/white,
 /area/maintenance/aft)
+"qOA" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/science/aft)
 "qOP" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -48244,7 +48255,7 @@
 	dir = 9
 	},
 /turf/open/floor/circuit/green/telecomms/mainframe,
-/area/quartermaster/exploration_dock)
+/area/science/aft)
 "riU" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /turf/open/floor/plating,
@@ -49557,7 +49568,7 @@
 	dir = 10
 	},
 /turf/open/floor/circuit/green/telecomms/mainframe,
-/area/quartermaster/exploration_dock)
+/area/science/aft)
 "rLd" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/window/eastright{
@@ -51280,7 +51291,7 @@
 	dir = 4
 	},
 /turf/open/floor/circuit/green/telecomms/mainframe,
-/area/quartermaster/exploration_dock)
+/area/science/aft)
 "szA" = (
 /obj/structure/barricade/wooden/crude,
 /obj/machinery/door/airlock/maintenance{
@@ -51463,7 +51474,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /turf/open/floor/iron/dark/telecomms,
-/area/quartermaster/exploration_dock)
+/area/science/aft)
 "sDw" = (
 /obj/structure/window/reinforced/spawner/directional/south,
 /obj/machinery/door/window/eastright{
@@ -51601,7 +51612,7 @@
 	},
 /obj/effect/mapping_helpers/airalarm/tlv_no_checks,
 /turf/open/floor/circuit/telecomms/server,
-/area/quartermaster/exploration_dock)
+/area/science/aft)
 "sGB" = (
 /obj/effect/turf_decal/tile/red/half/contrasted{
 	dir = 8
@@ -52552,7 +52563,7 @@
 	dir = 4
 	},
 /turf/open/floor/circuit/green/telecomms/mainframe,
-/area/quartermaster/exploration_dock)
+/area/science/aft)
 "sXf" = (
 /obj/structure/table/wood,
 /obj/item/folder/blue,
@@ -56525,7 +56536,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron/dark/telecomms,
-/area/quartermaster/exploration_dock)
+/area/science/aft)
 "uAq" = (
 /obj/structure/sign/warning/securearea{
 	pixel_x = -32
@@ -64632,7 +64643,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark/telecomms,
-/area/quartermaster/exploration_dock)
+/area/science/aft)
 "xXP" = (
 /obj/effect/turf_decal/tile/red/half/contrasted,
 /obj/machinery/light{
@@ -65104,7 +65115,7 @@
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /turf/open/floor/iron/dark/telecomms,
-/area/quartermaster/exploration_dock)
+/area/science/aft)
 "yjx" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 4
@@ -116722,9 +116733,9 @@ aaa
 bky
 bky
 mnE
-gQd
-gQd
-gQd
+iDX
+iDX
+iDX
 qia
 gQd
 gQd
@@ -116977,16 +116988,16 @@ aaa
 aaa
 aaa
 aaa
-xkR
+qOA
 sDn
 hWo
 sGv
-gQd
+iDX
 xcE
 ict
 hjM
 uyV
-pqr
+cTo
 cRa
 gQd
 atS
@@ -117234,11 +117245,11 @@ aaa
 aaa
 aaa
 aaa
-xkR
+qOA
 xXx
 yjs
 uAc
-xkR
+qOA
 duR
 jjp
 jjp
@@ -117491,11 +117502,11 @@ aaa
 aaa
 aaa
 aaa
-xkR
+qOA
 szx
 miD
 sWW
-xkR
+qOA
 pqr
 pqr
 cBe
@@ -117748,11 +117759,11 @@ aaa
 aaa
 aaa
 aaa
-xkR
+qOA
 rKw
 eQc
 riO
-gQd
+iDX
 quX
 pqr
 xkR
@@ -118005,11 +118016,11 @@ aaa
 aaa
 aaa
 gXs
-xkR
-xkR
-xkR
-gQd
-gQd
+qOA
+qOA
+qOA
+iDX
+iDX
 tEj
 dOV
 xkR

--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -48841,7 +48841,6 @@
 /turf/open/floor/iron,
 /area/crew_quarters/dorms)
 "rux" = (
-/obj/effect/turf_decal/pool/corner,
 /obj/effect/turf_decal/tile/steelgrid/diagonal,
 /obj/effect/turf_decal/tile/steelgrid/diagonal,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,

--- a/_maps/map_files/CardinalStation/CardinalStation.dmm
+++ b/_maps/map_files/CardinalStation/CardinalStation.dmm
@@ -651,6 +651,9 @@
 	color = "#7fc1a2";
 	dir = 1
 	},
+/obj/structure/cable/orange{
+	icon_state = "4-8"
+	},
 /turf/open/floor/iron/white,
 /area/quartermaster/exploration_prep)
 "ahg" = (
@@ -5321,6 +5324,9 @@
 /obj/machinery/holopad{
 	pixel_y = -16
 	},
+/obj/structure/cable/orange{
+	icon_state = "4-8"
+	},
 /turf/open/floor/iron/white,
 /area/quartermaster/exploration_prep)
 "bfX" = (
@@ -5564,6 +5570,9 @@
 	alpha = 230;
 	color = "#7fc1a2";
 	dir = 1
+	},
+/obj/structure/cable/orange{
+	icon_state = "4-8"
 	},
 /turf/open/floor/iron/white,
 /area/quartermaster/exploration_prep)
@@ -11030,6 +11039,9 @@
 	},
 /obj/effect/turf_decal/siding/wideplating_new/light{
 	dir = 4
+	},
+/obj/structure/cable/orange{
+	icon_state = "4-8"
 	},
 /turf/open/floor/iron/white/textured_half{
 	dir = 1
@@ -17034,6 +17046,9 @@
 "dBO" = (
 /obj/structure/table,
 /obj/item/gun/energy/e_gun/mini/exploration,
+/obj/structure/cable/orange{
+	icon_state = "4-8"
+	},
 /turf/open/floor/carpet/cyan,
 /area/quartermaster/exploration_prep)
 "dBP" = (
@@ -18998,6 +19013,9 @@
 	dir = 8;
 	alpha = 230;
 	color = "#7fc1a2"
+	},
+/obj/structure/cable/orange{
+	icon_state = "4-8"
 	},
 /turf/open/floor/iron/white,
 /area/quartermaster/exploration_prep)
@@ -31704,6 +31722,9 @@
 /obj/effect/turf_decal/stripes/white/line{
 	dir = 4
 	},
+/obj/structure/cable/orange{
+	icon_state = "4-8"
+	},
 /turf/open/floor/iron/white/textured_half{
 	dir = 1
 	},
@@ -32651,6 +32672,9 @@
 	color = "#7fc1a2";
 	alpha = 230
 	},
+/obj/structure/cable/orange{
+	icon_state = "4-8"
+	},
 /turf/open/floor/iron/white,
 /area/quartermaster/exploration_prep)
 "heu" = (
@@ -33127,6 +33151,9 @@
 	alpha = 230;
 	color = "#7fc1a2";
 	dir = 1
+	},
+/obj/structure/cable/orange{
+	icon_state = "4-8"
 	},
 /turf/open/floor/iron/white,
 /area/quartermaster/exploration_prep)
@@ -65421,6 +65448,13 @@
 /obj/structure/window/reinforced/spawner/directional/east,
 /turf/open/floor/catwalk_floor/iron_smooth,
 /area/ai_monitored/turret_protected/aisat/hallway)
+"onl" = (
+/obj/structure/table,
+/obj/structure/cable/orange{
+	icon_state = "4-8"
+	},
+/turf/open/floor/carpet/cyan,
+/area/quartermaster/exploration_prep)
 "onr" = (
 /obj/machinery/disposal/deliveryChute,
 /obj/structure/disposalpipe/trunk{
@@ -68550,6 +68584,9 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
+/obj/structure/cable/orange{
+	icon_state = "1-8"
+	},
 /turf/open/floor/carpet/cyan,
 /area/quartermaster/exploration_prep)
 "oZh" = (
@@ -77867,6 +77904,9 @@
 	alpha = 230;
 	color = "#7fc1a2";
 	dir = 5
+	},
+/obj/structure/cable/orange{
+	icon_state = "4-8"
 	},
 /turf/open/floor/iron/white,
 /area/quartermaster/exploration_prep)
@@ -92588,6 +92628,22 @@
 /obj/machinery/requests_console/auto_name/directional/south,
 /turf/open/floor/iron/dark,
 /area/crew_quarters/fitness)
+"ulo" = (
+/obj/effect/turf_decal/trimline/white/filled/warning{
+	dir = 8;
+	alpha = 230;
+	color = "#7fc1a2"
+	},
+/obj/effect/turf_decal/trimline/white/filled/warning{
+	dir = 4;
+	alpha = 230;
+	color = "#7fc1a2"
+	},
+/obj/structure/cable/orange{
+	icon_state = "4-8"
+	},
+/turf/open/floor/iron/white,
+/area/quartermaster/exploration_prep)
 "ult" = (
 /obj/structure/sign/poster/official/random/directional/north,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
@@ -103683,6 +103739,9 @@
 	dir = 8;
 	alpha = 230;
 	color = "#7fc1a2"
+	},
+/obj/structure/cable/orange{
+	icon_state = "4-8"
 	},
 /turf/open/floor/iron/white,
 /area/quartermaster/exploration_prep)
@@ -128300,7 +128359,7 @@ nzj
 hyT
 adv
 biR
-eJc
+ulo
 eJc
 mLU
 gbg
@@ -131641,7 +131700,7 @@ sQF
 sQF
 doR
 gwF
-xNF
+onl
 mKM
 mhv
 xUT

--- a/_maps/map_files/CardinalStation/CardinalStation.dmm
+++ b/_maps/map_files/CardinalStation/CardinalStation.dmm
@@ -18381,17 +18381,16 @@
 /turf/open/floor/grass/no_border,
 /area/hallway/primary/central)
 "dUu" = (
-/obj/effect/turf_decal/trimline/blue/filled/warning,
-/obj/effect/turf_decal/trimline/neutral/warning,
-/obj/effect/turf_decal/trimline/purple/warning,
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
 /obj/structure/disposalpipe/segment{
-	dir = 2
+	dir = 8
 	},
-/turf/open/floor/iron/showroomfloor,
-/area/medical/genetics)
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/tile/neutral/opposingcorners,
+/obj/effect/turf_decal/siding/thinplating_new,
+/turf/open/floor/iron,
+/area/hallway/primary/starboard)
 "dUC" = (
 /obj/effect/turf_decal/edges/borderfloor{
 	dir = 6
@@ -22675,7 +22674,6 @@
 /obj/effect/turf_decal/trimline/purple/line{
 	dir = 1
 	},
-/obj/structure/table/glass,
 /obj/item/storage/box/bodybags{
 	pixel_x = -4;
 	pixel_y = 6
@@ -22684,6 +22682,7 @@
 	pixel_x = 5;
 	pixel_y = 5
 	},
+/obj/structure/rack,
 /turf/open/floor/iron/showroomfloor,
 /area/medical/genetics)
 "eWN" = (
@@ -28848,12 +28847,10 @@
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /obj/effect/turf_decal/trimline/neutral/line,
 /obj/effect/turf_decal/trimline/purple/line,
-/obj/structure/table/glass,
-/obj/item/storage/pill_bottle/mannitol{
-	pixel_x = 3;
-	pixel_y = 5
-	},
 /obj/machinery/light_switch/directional/west,
+/obj/machinery/computer/scan_consolenew{
+	dir = 4
+	},
 /turf/open/floor/iron/showroomfloor,
 /area/medical/genetics)
 "gpm" = (
@@ -36877,7 +36874,6 @@
 /obj/effect/turf_decal/guideline/guideline_in/purple{
 	dir = 1
 	},
-/obj/machinery/computer/scan_consolenew,
 /obj/effect/turf_decal/edges/techfloor{
 	dir = 1
 	},
@@ -36885,6 +36881,15 @@
 	department = "Genetics";
 	name = "Genetics Requests Console";
 	pixel_y = 30
+	},
+/obj/structure/table/glass,
+/obj/item/storage/pill_bottle/mannitol{
+	pixel_x = 7;
+	pixel_y = 5
+	},
+/obj/item/radio/headset/headset_med{
+	pixel_x = -3;
+	pixel_y = 1
 	},
 /turf/open/floor/iron/white/side,
 /area/medical/genetics)
@@ -37412,10 +37417,15 @@
 	},
 /area/security/brig)
 "ihi" = (
-/obj/effect/turf_decal/trimline/blue/filled/line,
-/obj/effect/turf_decal/trimline/neutral/line,
-/obj/effect/turf_decal/trimline/purple/line,
-/obj/item/kirbyplants/random,
+/obj/structure/disposalpipe/segment{
+	dir = 2
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/trimline/blue/filled/warning,
+/obj/effect/turf_decal/trimline/neutral/warning,
+/obj/effect/turf_decal/trimline/purple/warning,
 /turf/open/floor/iron/showroomfloor,
 /area/medical/genetics)
 "iht" = (
@@ -55597,12 +55607,16 @@
 /obj/effect/turf_decal/guideline/guideline_in/purple{
 	dir = 1
 	},
-/obj/machinery/dna_scannernew,
 /obj/effect/turf_decal/edges/techfloor{
 	dir = 1
 	},
 /obj/machinery/camera/directional/north,
 /obj/machinery/airalarm/directional/north,
+/obj/structure/table/glass,
+/obj/item/storage/pill_bottle/mutadone{
+	pixel_x = -8;
+	pixel_y = 2
+	},
 /turf/open/floor/iron/white/side,
 /area/medical/genetics)
 "mgR" = (
@@ -58194,12 +58208,9 @@
 /turf/open/floor/carpet/cyan,
 /area/quartermaster/exploration_prep)
 "mLa" = (
-/obj/structure/table/glass,
 /obj/effect/turf_decal/guideline/guideline_in/purple{
 	dir = 8
 	},
-/obj/structure/extinguisher_cabinet/directional/west,
-/obj/machinery/light/directional/west,
 /obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
@@ -58211,6 +58222,8 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
+/obj/machinery/vending/wardrobe/gene_wardrobe,
+/obj/machinery/light/directional/west,
 /turf/open/floor/iron/white/side{
 	dir = 4
 	},
@@ -67854,13 +67867,8 @@
 /turf/open/floor/iron/textured_half,
 /area/hallway/secondary/entry)
 "oQA" = (
-/obj/structure/table/glass,
 /obj/effect/turf_decal/guideline/guideline_in_alt/purple{
 	dir = 4
-	},
-/obj/item/radio/headset/headset_med{
-	pixel_x = -3;
-	pixel_y = 1
 	},
 /obj/effect/turf_decal/guideline/guideline_tri/_corner/purple{
 	dir = 8
@@ -67868,6 +67876,7 @@
 /obj/effect/turf_decal/edges/techfloor{
 	dir = 9
 	},
+/obj/structure/flora/bigplant,
 /turf/open/floor/iron/white/corner,
 /area/medical/genetics)
 "oQM" = (
@@ -78365,14 +78374,11 @@
 /area/medical/apothecary)
 "rdB" = (
 /obj/effect/landmark/start/geneticist,
-/obj/structure/cable/yellow{
-	icon_state = "2-4"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 4
+	},
+/obj/structure/chair/office/light{
+	dir = 8
 	},
 /turf/open/floor/iron/showroomfloor,
 /area/medical/genetics)
@@ -87566,6 +87572,7 @@
 /obj/effect/turf_decal/edges/techfloor{
 	dir = 5
 	},
+/obj/structure/extinguisher_cabinet/directional/north,
 /turf/open/floor/iron/white/corner{
 	dir = 8
 	},
@@ -95278,9 +95285,6 @@
 	},
 /area/crew_quarters/heads/hop)
 "uOS" = (
-/obj/structure/sign/departments/minsky/research/genetics{
-	pixel_y = 32
-	},
 /obj/machinery/light/directional/north,
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
@@ -96113,13 +96117,13 @@
 /turf/open/floor/iron/white,
 /area/science/lobby)
 "uYB" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/obj/structure/cable/yellow{
+	icon_state = "2-4"
+	},
 /turf/open/floor/iron/showroomfloor,
 /area/medical/genetics)
 "uYC" = (
@@ -96298,9 +96302,16 @@
 /obj/effect/turf_decal/trimline/purple/line{
 	dir = 1
 	},
-/obj/machinery/vending/wardrobe/gene_wardrobe,
 /obj/machinery/status_display/ai/directional/west,
 /obj/machinery/camera/directional/west,
+/obj/structure/table/glass,
+/obj/item/storage/box/disks{
+	pixel_x = -3;
+	pixel_y = 7
+	},
+/obj/item/toy/figure/geneticist{
+	pixel_x = 5
+	},
 /turf/open/floor/iron/showroomfloor,
 /area/medical/genetics)
 "vaO" = (
@@ -101834,13 +101845,9 @@
 /turf/open/floor/iron,
 /area/crew_quarters/dorms)
 "wir" = (
-/obj/structure/table/glass,
-/obj/item/storage/pill_bottle/mutadone{
-	pixel_x = -6;
-	pixel_y = -2
-	},
 /obj/structure/extinguisher_cabinet/directional/west,
 /obj/machinery/light/directional/west,
+/obj/machinery/dna_scannernew,
 /turf/open/floor/iron/showroomfloor,
 /area/medical/genetics)
 "wiy" = (
@@ -103733,15 +103740,8 @@
 /obj/effect/turf_decal/trimline/purple/line{
 	dir = 1
 	},
-/obj/structure/table/glass,
-/obj/item/storage/box/disks{
-	pixel_x = -3;
-	pixel_y = 7
-	},
-/obj/item/toy/figure/geneticist{
-	pixel_x = 5
-	},
 /obj/machinery/status_display/evac/directional/north,
+/obj/item/kirbyplants/random,
 /turf/open/floor/iron/showroomfloor,
 /area/medical/genetics)
 "wFg" = (
@@ -155506,10 +155506,10 @@ jhA
 vaH
 wir
 goN
-gEc
-oKV
-pGx
-csU
+jAn
+ljK
+oWd
+dUu
 oUE
 vgt
 wGV
@@ -155762,11 +155762,11 @@ gYi
 gWP
 fZK
 rdB
-dUu
-uWY
-svf
-epP
-wAr
+pqN
+gEc
+oKV
+pGx
+csU
 iNq
 eFO
 eZG
@@ -156019,11 +156019,11 @@ dMh
 aqR
 fZK
 uYB
-pqN
-gEc
-wrU
-oWd
-kYS
+ihi
+uWY
+svf
+epP
+wAr
 iWh
 xvt
 wGV
@@ -156276,9 +156276,9 @@ qft
 jhA
 eWF
 aOF
-ihi
-jAn
-ljK
+pqN
+gEc
+wrU
 oWd
 kYS
 qTd

--- a/_maps/map_files/CardinalStation/CardinalStation.dmm
+++ b/_maps/map_files/CardinalStation/CardinalStation.dmm
@@ -22692,15 +22692,15 @@
 /obj/effect/turf_decal/trimline/purple/line{
 	dir = 1
 	},
-/obj/item/storage/box/bodybags{
-	pixel_x = -4;
-	pixel_y = 6
-	},
-/obj/item/storage/box/gloves{
-	pixel_x = 5;
-	pixel_y = 5
-	},
 /obj/structure/rack,
+/obj/item/clothing/gloves/color/latex{
+	pixel_y = -1;
+	pixel_x = -1
+	},
+/obj/item/clothing/gloves/color/latex{
+	pixel_y = 4;
+	pixel_x = 4
+	},
 /turf/open/floor/iron/showroomfloor,
 /area/medical/genetics)
 "eWN" = (
@@ -28866,8 +28866,18 @@
 /obj/effect/turf_decal/trimline/neutral/line,
 /obj/effect/turf_decal/trimline/purple/line,
 /obj/machinery/light_switch/directional/west,
-/obj/machinery/computer/scan_consolenew{
-	dir = 4
+/obj/structure/table/glass,
+/obj/item/storage/box/gloves{
+	pixel_x = -4;
+	pixel_y = 19
+	},
+/obj/item/storage/pill_bottle/mutadone{
+	pixel_x = 7;
+	pixel_y = 4
+	},
+/obj/item/sticky_note_pile{
+	pixel_x = -7;
+	pixel_y = 2
 	},
 /turf/open/floor/iron/showroomfloor,
 /area/medical/genetics)
@@ -36909,15 +36919,7 @@
 	name = "Genetics Requests Console";
 	pixel_y = 30
 	},
-/obj/structure/table/glass,
-/obj/item/storage/pill_bottle/mannitol{
-	pixel_x = 7;
-	pixel_y = 5
-	},
-/obj/item/radio/headset/headset_med{
-	pixel_x = -3;
-	pixel_y = 1
-	},
+/obj/machinery/dna_scannernew,
 /turf/open/floor/iron/white/side,
 /area/medical/genetics)
 "iaY" = (
@@ -55639,11 +55641,7 @@
 	},
 /obj/machinery/camera/directional/north,
 /obj/machinery/airalarm/directional/north,
-/obj/structure/table/glass,
-/obj/item/storage/pill_bottle/mutadone{
-	pixel_x = -8;
-	pixel_y = 2
-	},
+/obj/machinery/computer/scan_consolenew,
 /turf/open/floor/iron/white/side,
 /area/medical/genetics)
 "mgR" = (
@@ -62694,6 +62692,13 @@
 	dir = 8
 	},
 /area/hallway/primary/fore)
+"nHU" = (
+/obj/structure/table,
+/obj/structure/cable/orange{
+	icon_state = "4-8"
+	},
+/turf/open/floor/carpet/cyan,
+/area/quartermaster/exploration_prep)
 "nHY" = (
 /obj/effect/turf_decal/siding/dark_blue{
 	dir = 8
@@ -65448,13 +65453,6 @@
 /obj/structure/window/reinforced/spawner/directional/east,
 /turf/open/floor/catwalk_floor/iron_smooth,
 /area/ai_monitored/turret_protected/aisat/hallway)
-"onl" = (
-/obj/structure/table,
-/obj/structure/cable/orange{
-	icon_state = "4-8"
-	},
-/turf/open/floor/carpet/cyan,
-/area/quartermaster/exploration_prep)
 "onr" = (
 /obj/machinery/disposal/deliveryChute,
 /obj/structure/disposalpipe/trunk{
@@ -78843,6 +78841,22 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/chapel)
+"rjj" = (
+/obj/effect/turf_decal/trimline/white/filled/warning{
+	dir = 8;
+	alpha = 230;
+	color = "#7fc1a2"
+	},
+/obj/effect/turf_decal/trimline/white/filled/warning{
+	dir = 4;
+	alpha = 230;
+	color = "#7fc1a2"
+	},
+/obj/structure/cable/orange{
+	icon_state = "4-8"
+	},
+/turf/open/floor/iron/white,
+/area/quartermaster/exploration_prep)
 "rjl" = (
 /obj/effect/turf_decal/siding/wideplating_new/dark{
 	dir = 8
@@ -87595,13 +87609,6 @@
 /area/medical/virology)
 "thb" = (
 /obj/structure/table/glass,
-/obj/item/clothing/gloves/color/latex{
-	pixel_y = -10
-	},
-/obj/item/storage/box/monkeycubes{
-	pixel_x = -6;
-	pixel_y = 5
-	},
 /obj/effect/turf_decal/guideline/guideline_in_alt/purple{
 	dir = 8
 	},
@@ -87613,6 +87620,14 @@
 	dir = 5
 	},
 /obj/structure/extinguisher_cabinet/directional/north,
+/obj/item/storage/pill_bottle/mannitol{
+	pixel_x = 8;
+	pixel_y = 7
+	},
+/obj/item/radio/headset/headset_med{
+	pixel_x = -3;
+	pixel_y = 1
+	},
 /turf/open/floor/iron/white/corner{
 	dir = 8
 	},
@@ -92628,22 +92643,6 @@
 /obj/machinery/requests_console/auto_name/directional/south,
 /turf/open/floor/iron/dark,
 /area/crew_quarters/fitness)
-"ulo" = (
-/obj/effect/turf_decal/trimline/white/filled/warning{
-	dir = 8;
-	alpha = 230;
-	color = "#7fc1a2"
-	},
-/obj/effect/turf_decal/trimline/white/filled/warning{
-	dir = 4;
-	alpha = 230;
-	color = "#7fc1a2"
-	},
-/obj/structure/cable/orange{
-	icon_state = "4-8"
-	},
-/turf/open/floor/iron/white,
-/area/quartermaster/exploration_prep)
 "ult" = (
 /obj/structure/sign/poster/official/random/directional/north,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
@@ -96360,14 +96359,10 @@
 	},
 /obj/machinery/status_display/ai/directional/west,
 /obj/machinery/camera/directional/west,
-/obj/structure/table/glass,
-/obj/item/storage/box/disks{
-	pixel_x = -3;
-	pixel_y = 7
-	},
 /obj/item/toy/figure/geneticist{
 	pixel_x = 5
 	},
+/obj/item/kirbyplants/random,
 /turf/open/floor/iron/showroomfloor,
 /area/medical/genetics)
 "vaO" = (
@@ -101903,7 +101898,15 @@
 "wir" = (
 /obj/structure/extinguisher_cabinet/directional/west,
 /obj/machinery/light/directional/west,
-/obj/machinery/dna_scannernew,
+/obj/structure/table/glass,
+/obj/item/storage/box/monkeycubes{
+	pixel_x = -4;
+	pixel_y = 7
+	},
+/obj/item/storage/box/bodybags{
+	pixel_x = 5;
+	pixel_y = 2
+	},
 /turf/open/floor/iron/showroomfloor,
 /area/medical/genetics)
 "wiy" = (
@@ -103800,7 +103803,6 @@
 	dir = 1
 	},
 /obj/machinery/status_display/evac/directional/north,
-/obj/item/kirbyplants/random,
 /turf/open/floor/iron/showroomfloor,
 /area/medical/genetics)
 "wFg" = (
@@ -110571,16 +110573,20 @@
 /area/space/nearstation)
 "yhG" = (
 /obj/structure/table/glass,
-/obj/item/storage/box/monkeycubes{
-	pixel_x = 5;
-	pixel_y = 7
-	},
 /obj/effect/turf_decal/guideline/guideline_in/purple{
 	dir = 4
 	},
 /obj/machinery/light/directional/east,
 /obj/effect/turf_decal/edges/techfloor{
 	dir = 4
+	},
+/obj/item/storage/box/monkeycubes{
+	pixel_x = -4;
+	pixel_y = 15
+	},
+/obj/item/storage/box/disks{
+	pixel_x = 4;
+	pixel_y = 5
 	},
 /turf/open/floor/iron/white/side{
 	dir = 8
@@ -128359,7 +128365,7 @@ nzj
 hyT
 adv
 biR
-ulo
+rjj
 eJc
 mLU
 gbg
@@ -131700,7 +131706,7 @@ sQF
 sQF
 doR
 gwF
-onl
+nHU
 mKM
 mhv
 xUT

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -1827,6 +1827,7 @@
 	dir = 1
 	},
 /obj/item/reagent_containers/chem_bag/triamed,
+/obj/machinery/airalarm/directional/south,
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
 "arB" = (
@@ -24792,7 +24793,6 @@
 	},
 /obj/machinery/chem_heater,
 /obj/effect/turf_decal/delivery,
-/obj/machinery/airalarm/directional/north,
 /turf/open/floor/iron,
 /area/medical/chemistry)
 "fHB" = (
@@ -27992,7 +27992,6 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
-/obj/structure/cable/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
 /obj/effect/turf_decal/siding/white{
@@ -30747,10 +30746,6 @@
 	},
 /turf/open/floor/iron,
 /area/hydroponics/garden/monastery)
-"hNL" = (
-/obj/effect/spawner/structure/window,
-/turf/open/floor/iron/dark,
-/area/crew_quarters/locker)
 "hNR" = (
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
 	dir = 1
@@ -36695,10 +36690,6 @@
 	},
 /obj/machinery/holopad,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
-/obj/machinery/door/window/northleft{
-	name = "Kitchen Delivery";
-	req_access_txt = "28"
-	},
 /turf/open/floor/iron/checker,
 /area/crew_quarters/kitchen)
 "jNv" = (
@@ -42372,7 +42363,6 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/machinery/light,
 /obj/item/stack/sheet/mineral/plasma{
 	pixel_x = 2;
 	pixel_y = 4
@@ -42391,6 +42381,17 @@
 /obj/item/storage/box/beakers{
 	pixel_x = -6;
 	pixel_y = 9
+	},
+/obj/machinery/light_switch/directional/south{
+	pixel_x = -7;
+	pixel_y = -24
+	},
+/obj/machinery/button/door/directional/south{
+	pixel_x = 5;
+	pixel_y = -25;
+	id = "chemistry_shutters_2";
+	name = "Lower Chemistry Shutter Control";
+	req_access_txt = "33"
 	},
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
@@ -43520,6 +43521,7 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 4
 	},
+/obj/machinery/light,
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
 "moI" = (
@@ -48611,9 +48613,6 @@
 "ocv" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/siding/white/corner{
-	dir = 4
 	},
 /obj/effect/turf_decal/siding/white/corner,
 /turf/open/floor/iron/techmaint,
@@ -66591,7 +66590,7 @@
 /area/security/main)
 "urS" = (
 /obj/effect/spawner/structure/window,
-/turf/open/floor/iron/dark,
+/turf/open/floor/plating,
 /area/hydroponics/garden)
 "usk" = (
 /obj/structure/railing/corner,
@@ -110241,7 +110240,7 @@ aHG
 aHG
 aHG
 eru
-hNL
+aSe
 ibS
 aUM
 tct

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -33586,6 +33586,7 @@
 /obj/machinery/light/small{
 	dir = 4
 	},
+/obj/effect/turf_decal/siding/white,
 /turf/open/floor/iron/techmaint,
 /area/security/main)
 "iKv" = (
@@ -48615,6 +48616,9 @@
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/siding/white/corner,
+/obj/effect/turf_decal/siding/white/corner{
+	dir = 4
+	},
 /turf/open/floor/iron/techmaint,
 /area/security/main)
 "ocx" = (
@@ -65689,6 +65693,9 @@
 /obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
+/obj/effect/turf_decal/siding/white{
+	dir = 4
+	},
 /turf/open/floor/iron/techmaint,
 /area/security/main)
 "ubQ" = (
@@ -66623,6 +66630,9 @@
 	},
 /obj/machinery/vending/wardrobe/sec_wardrobe,
 /obj/effect/turf_decal/siding/white,
+/obj/effect/turf_decal/siding/white{
+	dir = 1
+	},
 /turf/open/floor/iron/techmaint,
 /area/security/main)
 "usJ" = (

--- a/_maps/shuttles/exploration/exploration_card.dmm
+++ b/_maps/shuttles/exploration/exploration_card.dmm
@@ -48,6 +48,9 @@
 /obj/structure/cable/orange{
 	icon_state = "4-8"
 	},
+/obj/structure/cable/orange{
+	icon_state = "1-4"
+	},
 /turf/open/floor/plating,
 /area/shuttle/exploration)
 "es" = (
@@ -367,6 +370,9 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
+/obj/structure/cable/orange{
+	icon_state = "4-8"
+	},
 /turf/open/floor/iron/textured_half{
 	dir = 1
 	},
@@ -448,6 +454,9 @@
 	dir = 1
 	},
 /obj/machinery/light/small/directional/north,
+/obj/structure/cable/orange{
+	icon_state = "4-8"
+	},
 /turf/open/floor/iron/textured_half,
 /area/shuttle/exploration)
 "tQ" = (
@@ -616,6 +625,9 @@
 /area/shuttle/exploration)
 "HW" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden,
+/obj/structure/cable/orange{
+	icon_state = "1-2"
+	},
 /turf/open/floor/iron/smooth,
 /area/shuttle/exploration)
 "HZ" = (
@@ -791,6 +803,9 @@
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden{
 	dir = 1
 	},
+/obj/structure/cable/orange{
+	icon_state = "2-4"
+	},
 /turf/open/floor/iron/smooth,
 /area/shuttle/exploration)
 "NG" = (
@@ -856,6 +871,9 @@
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
+	},
+/obj/structure/cable/orange{
+	icon_state = "4-8"
 	},
 /turf/open/floor/iron/textured_half{
 	dir = 1
@@ -928,6 +946,9 @@
 /obj/machinery/light/directional/east,
 /obj/effect/turf_decal/edges/borderfloor/black/corner1,
 /obj/machinery/light_switch/directional/east,
+/obj/structure/cable/orange{
+	icon_state = "1-2"
+	},
 /turf/open/floor/iron/smooth,
 /area/shuttle/exploration)
 "Sp" = (


### PR DESCRIPTION
## About The Pull Request

Awoken from a feverish dream I saw the truth of reality, the perfection of it... and the imperfections. Such things which have no business existing, bumps in road, rocks in a shoe, or mapping issues!!

I found not many, but a few such issues with our stations, Meta, Cardinal, and Box - This PR attempts to address those issues and make the station a better place.

### Boxstation;
- A stray Pool Decal found its way into the showers near the Holodeck. It gets DELETED in this PR
- Changed apart of Exploration Dock, containing comms relay to Science Aft area rather then a shared space with the dock (See PR comment for details)

### Metastation;
- Outside of armory was a stray decal not attached to others - originally deleted it instead is FIXED to fully encircle the closet (see comment to PR for photo evidence)
- Also outside Armory was a spare wire, similarly getting DELETED
- Chemistry Air Alarm Overlapped with another tile in ghost view, therefore it gets moved to its own standalone tile
- A New Lightswitch/Button is added to the Southern Wall which when triggered will close the South/East Shutters
- Removes Black 4tile Floors UNDERNEATH windows located near dorm's and its entranceway
- Deletes a random windoor placed on a Kitchen table

### Cardinalstation;
- ~~Genetics Secondary Console gets moved up to the front room so both desks are visible to passerby's~~
- ~~Genetics rooms are adjusted to accommodate console movement~~
- Genetics console **WAS** moved- i have since reverted that change, but due to a lack of energy to get the original state Genetics remains slightly modified from its original state. Door's been pushed over, a table removed, plant added, etc. (Video test is in PR Comment. 
- Exploration Shuttle/Preperation Room are given new wires so shuttle APC will charge while docked (see comment for details)

## Why It's Good For The Game

As said with many other PR's which are meant to be bug fixes, these changes all bring the game to a state where it feels like it should be originally. The current state we are in _isnt_ to the standards of other locations aboard our various stations. As for the things which might be less of a change, and an addition, I dont feel are in abundance here;
- As for chemistry shutters: I **refuse** to believe there exists a set of shutters, with a separate ID vv not intended to be used. I dont believe this is adding something not intended to exist originally
- Cardinalstation Genetics: There is merit in having a console in the backroom, and while i dont disagree or dislike the design choice, it was brought up that one person, generally the later joined Genetics worker will often have to go work in the closet, leaving one person to have priority with any, and all interactions of people passingby. Moving the backroom console to the front i feel will create a better state for the players, preventing a sole-geneticist from hiding in the backrooms doing their work even if alone.

closes #14195 

## Testing Photographs and Procedure

<details>
<summary>Screenshots&Videos</summary>


https://github.com/user-attachments/assets/a89b0c41-e996-4f02-88e7-0f08ab1056a9

<img width="505" height="646" alt="Screenshot 2026-03-23 104420" src="https://github.com/user-attachments/assets/05a3d59d-11c2-4e20-b789-79ba1cdec37f" />
<img width="1137" height="857" alt="Screenshot 2026-03-23 105501" src="https://github.com/user-attachments/assets/056e1174-17b2-4056-93b1-f655f8315c5d" />
<img width="1000" height="657" alt="Screenshot 2026-03-23 111738" src="https://github.com/user-attachments/assets/78603da2-bdb6-46d3-9e5a-5481f5fa753b" />
<img width="583" height="731" alt="Screenshot 2026-03-23 112016" src="https://github.com/user-attachments/assets/544b1ed2-52b4-4076-935a-2e0df59b55d0" />
<img width="577" height="717" alt="Screenshot 2026-03-23 112619" src="https://github.com/user-attachments/assets/57cc4e40-f4a3-4bb3-b9a1-3ceec35293c1" />
<img width="637" height="866" alt="Screenshot 2026-03-23 113835" src="https://github.com/user-attachments/assets/bdc32f63-a842-440c-a33f-68a51e019fca" />

</details>

## Changelog
:cl:
map: Slight Changes to CardinalStation Genetics
map: Adds a power line connecting CardinalStation Exploration Shuttle and Station, allowing for the shuttle to charge while docked. 
map: Adds Shutter Controls to MetaStation Chemistry allowing the lower shutters to be closed.
map: Squashes A Few Minor Mapping Bugs
/:cl:

