### PR TITLE
Change armor penetration to a multiplicative calculation, Tiny adjustment to the NPS

### DIFF
--- a/code/game/atom/atom_defense.dm
+++ b/code/game/atom/atom_defense.dm
@@ -108,7 +108,8 @@
 		//	CRASH("/atom/proc/run_atom_armor returned a damage flag as a list. [damage_flag] returning list [length(damage_flag)]")
 		armor_protection = get_armor_rating(damage_flag)
 	if(armor_protection) //Only apply weak-against-armor/hollowpoint effects if there actually IS armor.
-		armor_protection = clamp(armor_protection - armour_penetration, min(armor_protection, 0), 100)
+		var/penetration_mult = 1 - clamp(armour_penetration, -100, 100) / 100
+		armor_protection = clamp(armor_protection * penetration_mult, min(armor_protection, 0), 100)
 	return round(damage_amount * (100 - armor_protection) * 0.01, DAMAGE_PRECISION)
 
 ///the sound played when the atom is damaged.

--- a/code/modules/projectiles/projectile/bullets/pistol.dm
+++ b/code/modules/projectiles/projectile/bullets/pistol.dm
@@ -50,5 +50,5 @@
 /obj/projectile/bullet/x200law
 	name = "x200 LAW bullet"
 	damage = 22
-	armour_penetration = 0
+	armour_penetration = -100
 	bleed_force = BLEED_CUT


### PR DESCRIPTION
## About The Pull Request

Bacon once told me not to make the NPS -100 armor pen, because the fact that that works was not intentional/just a weird quirk.

So i made it work! In theory this doesn't change anything for other guns. Some exact damage values may not match up exactly for guns that already were declared in the negative.

Testing showed that the NPS now does 4 less damage against a syndicate trooper. Not a lot, but that isn't the point.

## Why It's Good For The Game

I'm gonna be honest this is a pretty small change. Like, barely noticeable. But a fix is a fix! And more reliable math is better!

also this makes the NPS slightly less desireable in full out combat against an equal, which is exactly what we want out of it.

## Testing Photographs and Procedure
<details>
<summary>Screenshots&Videos</summary>

Testing AP WT550 ammo:
<img width="1685" height="780" alt="image" src="https://github.com/user-attachments/assets/1b8659bc-9664-4d56-a9e6-c86411db373b" />

The armored person took 4 points less damage and 1.2/s less bleed.

Compared to on live:

<img width="1555" height="824" alt="image" src="https://github.com/user-attachments/assets/5273cb29-bf45-4531-9cf4-2c3f52632e07" />

Exactly the same.

Now the NPS:
<img width="1539" height="785" alt="image" src="https://github.com/user-attachments/assets/e4bb0ef3-c113-4ab6-bd77-40021edb65b0" />

The guy in armor took 15 less damage, and 1.6/s less bleed.

Compared to on live:

<img width="607" height="591" alt="image" src="https://github.com/user-attachments/assets/6f3db5ec-15f9-48aa-9bd7-8e9adc1a083a" />

Where the armored person took 11 less damage instead of 15.

</details>

## Changelog
:cl:
balance: Made the NPS slightly worse against armor. Finally.
refactor: Armor penetration calculations are now based on a multiplicative model. Nothing should have changed from this.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
