### PR TITLE
Mech techshell rebalance

### DIFF
--- a/code/game/objects/items/storage/firstaid.dm
+++ b/code/game/objects/items/storage/firstaid.dm
@@ -563,11 +563,10 @@
 
 /obj/item/storage/pill_bottle/Initialize(mapload)
 	. = ..()
+
 	if(prob(pill_variance))
 		icon_state = "[pill_type][rand(0,6)]"
 
-/obj/item/storage/pill_bottle/Initialize(mapload)
-	. = ..()
 	atom_storage.allow_quick_gather = TRUE
 	atom_storage.set_holdable(list(/obj/item/reagent_containers/pill))
 

--- a/code/game/objects/items/storage/firstaid.dm
+++ b/code/game/objects/items/storage/firstaid.dm
@@ -563,7 +563,6 @@
 
 /obj/item/storage/pill_bottle/Initialize(mapload)
 	. = ..()
-
 	if(prob(pill_variance))
 		icon_state = "[pill_type][rand(0,6)]"
 

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -296,7 +296,7 @@
 
 /datum/reagent/water/holywater/on_mob_metabolize(mob/living/carbon/affected_mob)
 	. = ..()
-	affected_mob.AddComponent(/datum/component/anti_magic, type, MAGIC_RESISTANCE_HOLY)
+	affected_mob.AddComponent(/datum/component/anti_magic, type, MAGIC_RESISTANCE_HOLY | MAGIC_RESISTANCE)
 
 /datum/reagent/water/holywater/on_mob_end_metabolize(mob/living/carbon/affected_mob)
 	. = ..()

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -296,7 +296,7 @@
 
 /datum/reagent/water/holywater/on_mob_metabolize(mob/living/carbon/affected_mob)
 	. = ..()
-	affected_mob.AddComponent(/datum/component/anti_magic, type, MAGIC_RESISTANCE_HOLY | MAGIC_RESISTANCE)
+	affected_mob.AddComponent(/datum/component/anti_magic, type, MAGIC_RESISTANCE_HOLY)
 
 /datum/reagent/water/holywater/on_mob_end_metabolize(mob/living/carbon/affected_mob)
 	. = ..()

--- a/code/modules/research/designs/weapon_designs.dm
+++ b/code/modules/research/designs/weapon_designs.dm
@@ -368,7 +368,7 @@
 	desc = "A high-tech shotgun shell which can be loaded with materials to produce unique effects."
 	id = "techshotshell"
 	build_type = PROTOLATHE
-	materials = list(/datum/material/iron = 2000, /datum/material/diamond = 2000, /datum/material/bluespace = 2000)
+	materials = list(/datum/material/iron = 2000, /datum/material/diamond = 1200, /datum/material/bluespace = 1200)
 	build_path = /obj/item/ammo_casing/shotgun/techshell
 	category = list("Ammo")
 	departmental_flags = DEPARTMENTAL_FLAG_SECURITY | DEPARTMENTAL_FLAG_SCIENCE

--- a/code/modules/vehicles/mecha/mecha_defense.dm
+++ b/code/modules/vehicles/mecha/mecha_defense.dm
@@ -176,7 +176,7 @@
 
 	if(!equipment_disabled && LAZYLEN(occupants)) //prevent spamming this message with back-to-back EMPs
 		to_chat(occupants, span_danger("Error -- Connection to equipment control unit has been lost."))
-	addtimer(CALLBACK(src, TYPE_PROC_REF(/obj/vehicle/sealed/mecha, restore_equipment)), 3 SECONDS, TIMER_UNIQUE | TIMER_OVERRIDE)
+	addtimer(CALLBACK(src, TYPE_PROC_REF(/obj/vehicle/sealed/mecha, restore_equipment)), 6 SECONDS, TIMER_UNIQUE | TIMER_OVERRIDE)
 	equipment_disabled = TRUE
 	set_mouse_pointer()
 
@@ -386,10 +386,10 @@
 		return
 	. = TRUE
 	if(atom_integrity < max_integrity)
-		if(!W.use_tool(src, user, 0, volume=50, amount=1))
-			return
-		user.visible_message(span_notice("[user] repairs some damage to [name]."), span_notice("You repair some damage to [src]."))
-		atom_integrity += min(10, max_integrity-atom_integrity)
+		while(atom_integrity < max_integrity && W.tool_start_check(user, amount=1) && W.use_tool(src, user, 2 SECONDS, volume=50, amount=1)) // Do after, repeats itself if the mech is damaged until full health
+			user.visible_message(span_notice("[user] repairs some damage to [name]."), span_notice("You repair some damage to [src]."))
+			atom_integrity += min(10, max_integrity - atom_integrity)
+			diag_hud_set_mechhealth() // Apparently mech hp didn't get updated until they received damage
 		if(atom_integrity == max_integrity)
 			to_chat(user, span_notice("It looks to be fully repaired now."))
 		return

--- a/code/modules/vehicles/mecha/mecha_defense.dm
+++ b/code/modules/vehicles/mecha/mecha_defense.dm
@@ -384,16 +384,20 @@
 	. = ..()
 	if(user.combat_mode)
 		return
-	. = TRUE
-	if(atom_integrity < max_integrity)
-		while(atom_integrity < max_integrity && W.tool_start_check(user, amount=1) && W.use_tool(src, user, 2 SECONDS, volume=50, amount=1)) // Do after, repeats itself if the mech is damaged until full health
-			user.visible_message(span_notice("[user] repairs some damage to [name]."), span_notice("You repair some damage to [src]."))
-			atom_integrity += min(10, max_integrity - atom_integrity)
-			diag_hud_set_mechhealth() // Apparently mech hp didn't get updated until they received damage
+	if(atom_integrity >= max_integrity)
+		to_chat(user, span_warning("[src] is at full integrity!"))
+		return TRUE
+	while(atom_integrity < max_integrity) // Check for welder and the fact it's on
+		if(!W.tool_start_check(user, amount=1))
+			break
+		if(!W.use_tool(src, user, 2 SECONDS, volume=30, amount=1)) // Time to wait two seconds per repair
+			break
+		user.visible_message(span_notice("[user] repairs some damage to [name]."), span_notice("You repair some damage to [src]."))
+		atom_integrity = min(max_integrity, atom_integrity + 10)
+		diag_hud_set_mechhealth() // Apparently, this fixed a small issue where mechs wouldn't update their HUD health when being welded
 		if(atom_integrity == max_integrity)
 			to_chat(user, span_notice("It looks to be fully repaired now."))
-		return
-	to_chat(user, span_warning("[src] is at full integrity!"))
+	return TRUE
 
 /obj/vehicle/sealed/mecha/proc/full_repair(charge_cell)
 	atom_integrity = max_integrity


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Does 4 things

Reverts the change that lowered the mech time which prevented weaponry usage  to 6 seconds again
Second mech change, now you're forced to sit still and wait a few seconds to repair the mech, also fixes a small issue it had where it's health wouldn't show on the hud unless it received damage

Lowers the price for techshell ammunition
costing 1 bluespace crystal and 1 diamond per shell, was absolutely diabolical, even if they have some strong ammo nobody bothers using them for the price
at maximum parts, it was lowered to 0.5 which is still a huge amount
Lowers it to 0.6 per default
0.24 at maximum upgraded parts

Pill change, just deletes an extra initialize it had

## Why It's Good For The Game

Mechs are less opressive once again
Pills didn't need that second initialize
Techshells are fucking expensive, at the point of nobody using them

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

<img width="731" height="107" alt="image" src="https://github.com/user-attachments/assets/632507e4-13df-493b-887a-4342628f26c4" />

<img width="728" height="96" alt="image" src="https://github.com/user-attachments/assets/1fe7d40a-a9dd-42e8-926c-12a123be14b9" />

https://github.com/user-attachments/assets/919ef9f6-78bd-4a56-a231-3bb2a855ab4d

<img width="488" height="170" alt="image" src="https://github.com/user-attachments/assets/44c7ce83-5e74-4d1a-90c3-687cb8e0d5d1" />


</details>

## Changelog
:cl: Isaac
balance: Mech now has a do_after per fixing attempt, requiring 2 seconds per welding
fix: Mech equipment is once again disabled for 6 seconds when hit with an EMP
balance: Techshells cost reduced to 0.6 at 100% efficiency
code: Removed an extra initialize pill bottles had
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
