### PR TITLE
Fixes flaky mecha damage test

### DIFF
--- a/code/modules/unit_tests/mecha_damage.dm
+++ b/code/modules/unit_tests/mecha_damage.dm
@@ -91,7 +91,7 @@
 	mag_type = /obj/item/ammo_box/magazine/internal/cylinder/accurate
 
 /obj/item/ammo_box/magazine/internal/cylinder/accurate
-	projectile_type = /obj/projectile/bullet/a357/accurate
+	ammo_type = /obj/projectile/bullet/a357/accurate
 
 /obj/projectile/bullet/a357/accurate
 	zone_accurate = TRUE

--- a/code/modules/unit_tests/mecha_damage.dm
+++ b/code/modules/unit_tests/mecha_damage.dm
@@ -5,90 +5,79 @@
 /datum/unit_test/mecha_damage
 
 /datum/unit_test/mecha_damage/Run()
-	var/obj/vehicle/sealed/mecha/demo_mech
-	var/mob/living/carbon/human/dummy
-	var/obj/item/dummy_melee
-	var/obj/item/gun/ballistic/dummy_gun
+	// "Loaded Mauler" was chosen deliberately here.
+	// We need a mech that starts with arm equipment and has fair enough armor.
+	var/obj/vehicle/sealed/mecha/demo_mech = allocate(/obj/vehicle/sealed/mecha/marauder/mauler/loaded)
+	// We need to face our guy explicitly, because mechs have directional armor
+	demo_mech.setDir(EAST)
 
-	for(var/i = 1 to 10)
-		// "Loaded Mauler" was chosen deliberately here.
-		// We need a mech that starts with arm equipment and has fair enough armor.
-		demo_mech = allocate(/obj/vehicle/sealed/mecha/marauder/mauler/loaded)
-		// We need to face our guy explicitly, because mechs have directional armor
-		demo_mech.setDir(EAST)
+	var/expected_melee_armor = demo_mech.get_armor_rating(MELEE)
+	//var/expected_laser_armor = demo_mech.get_armor_rating(LASER)
+	var/expected_bullet_armor = demo_mech.get_armor_rating(BULLET)
 
-		var/expected_melee_armor = demo_mech.get_armor_rating(MELEE)
-		//var/expected_laser_armor = demo_mech.get_armor_rating(LASER)
-		var/expected_bullet_armor = demo_mech.get_armor_rating(BULLET)
+	var/mob/living/carbon/human/dummy = allocate(/mob/living/carbon/human/consistent)
+	dummy.forceMove(locate(run_loc_floor_bottom_left.x + 1, run_loc_floor_bottom_left.y, run_loc_floor_bottom_left.z))
+	// The dummy needs to be targeting an arm. Left is chosen here arbitrarily.
+	dummy._set_zone_selected(BODY_ZONE_L_ARM)
+	// Not strictly necessary, but you never know
+	dummy.face_atom(demo_mech)
 
-		dummy = allocate(/mob/living/carbon/human/consistent)
-		dummy.forceMove(locate(run_loc_floor_bottom_left.x + 1, run_loc_floor_bottom_left.y, run_loc_floor_bottom_left.z))
-		// The dummy needs to be targeting an arm. Left is chosen here arbitrarily.
-		dummy._set_zone_selected(BODY_ZONE_L_ARM)
-		// Not strictly necessary, but you never know
-		dummy.face_atom(demo_mech)
+	// Get a sample "melee" weapon.
+	// The energy axe is chosen here due to having a high base force, to make sure we get over the equipment DT.
+	var/obj/item/dummy_melee = allocate(/obj/item/melee/energy/axe)
+	dummy_melee.force = 150
+	var/expected_melee_damage = round(dummy_melee.force * (1 - expected_melee_armor / 100) * demo_mech.facing_modifiers[MECHA_FRONT_ARMOUR], DAMAGE_PRECISION)
 
-		// Get a sample "melee" weapon.
-		// The energy axe is chosen here due to having a high base force, to make sure we get over the equipment DT.
-		dummy_melee = allocate(/obj/item/melee/energy/axe)
-		dummy_melee.force = 150
-		var/expected_melee_damage = round(dummy_melee.force * (1 - expected_melee_armor / 100) * demo_mech.facing_modifiers[MECHA_FRONT_ARMOUR], DAMAGE_PRECISION)
+	// Get a sample laser weapon.
+	// The captain's laser gun here is chosen primarily because it deals more damage than normal lasers.
+	//var/obj/item/gun/energy/laser/dummy_laser = allocate(/obj/item/gun/energy/laser/captain)
+	//var/obj/item/ammo_casing/laser_ammo = dummy_laser.ammo_type[1]
+	//var/obj/projectile/beam/laser_fired = initial(laser_ammo.projectile_type)
+	//var/expected_laser_damage = round(initial(laser_fired.damage) * (1 - expected_laser_armor / 100), DAMAGE_PRECISION)
 
-		// Get a sample laser weapon.
-		// The captain's laser gun here is chosen primarily because it deals more damage than normal lasers.
-		//var/obj/item/gun/energy/laser/dummy_laser = allocate(/obj/item/gun/energy/laser/captain)
-		//var/obj/item/ammo_casing/laser_ammo = dummy_laser.ammo_type[1]
-		//var/obj/projectile/beam/laser_fired = initial(laser_ammo.projectile_type)
-		//var/expected_laser_damage = round(initial(laser_fired.damage) * (1 - expected_laser_armor / 100), DAMAGE_PRECISION)
+	// Get a sample ballistic weapon.
+	// The syndicate .357 here is chosen because it does a lot of damage.
+	var/obj/item/gun/ballistic/dummy_gun = allocate(/obj/item/gun/ballistic/revolver/accurate)
+	var/obj/item/ammo_casing/ballistic_ammo = dummy_gun.magazine.ammo_type
+	var/obj/projectile/bullet_fired = initial(ballistic_ammo.projectile_type)
+	var/expected_bullet_damage = round(initial(bullet_fired.damage) * (1 - expected_bullet_armor / 100), DAMAGE_PRECISION)
 
-		// Get a sample ballistic weapon.
-		// The syndicate .357 here is chosen because it does a lot of damage.
-		dummy_gun = allocate(/obj/item/gun/ballistic/revolver/accurate)
-		var/obj/item/ammo_casing/ballistic_ammo = dummy_gun.magazine.ammo_type
-		var/obj/projectile/bullet_fired = initial(ballistic_ammo.projectile_type)
-		var/expected_bullet_damage = round(initial(bullet_fired.damage) * (1 - expected_bullet_armor / 100), DAMAGE_PRECISION)
+	var/obj/item/mecha_parts/mecha_equipment/left_arm_equipment = demo_mech.equip_by_category[MECHA_L_ARM]
+	TEST_ASSERT_NOTNULL(left_arm_equipment, "[demo_mech] spawned without any equipment in their left arm slot.")
 
-		var/obj/item/mecha_parts/mecha_equipment/left_arm_equipment = demo_mech.equip_by_category[MECHA_L_ARM]
-		TEST_ASSERT_NOTNULL(left_arm_equipment, "[demo_mech] spawned without any equipment in their left arm slot.")
+	// Now it's time to actually beat the heck out of the mech to see if it takes damage correctly.
+	TEST_ASSERT_EQUAL(demo_mech.get_integrity(), demo_mech.max_integrity, "[demo_mech] was spawned at not its maximum integrity.")
+	TEST_ASSERT_EQUAL(left_arm_equipment.get_integrity(), left_arm_equipment.max_integrity, "[left_arm_equipment] ([demo_mech]'s left arm) spawned at not its maximum integrity.")
 
-		// Now it's time to actually beat the heck out of the mech to see if it takes damage correctly.
-		TEST_ASSERT_EQUAL(demo_mech.get_integrity(), demo_mech.max_integrity, "[demo_mech] was spawned at not its maximum integrity.")
-		TEST_ASSERT_EQUAL(left_arm_equipment.get_integrity(), left_arm_equipment.max_integrity, "[left_arm_equipment] ([demo_mech]'s left arm) spawned at not its maximum integrity.")
+	// SMACK IT
+	var/pre_melee_integrity = demo_mech.get_integrity()
+	var/pre_melee_arm_integrity = left_arm_equipment.get_integrity()
+	demo_mech.attacked_by(dummy_melee, dummy)
 
-		// SMACK IT
-		var/pre_melee_integrity = demo_mech.get_integrity()
-		var/pre_melee_arm_integrity = left_arm_equipment.get_integrity()
-		demo_mech.attacked_by(dummy_melee, dummy)
+	check_integrity(demo_mech, pre_melee_integrity, expected_melee_damage, "hit with a melee item")
+	check_integrity(left_arm_equipment, pre_melee_arm_integrity, expected_melee_damage, "hit with a melee item")
 
-		check_integrity(demo_mech, pre_melee_integrity, expected_melee_damage, "hit with a melee item")
-		check_integrity(left_arm_equipment, pre_melee_arm_integrity, expected_melee_damage, "hit with a melee item")
+	// BLAST IT
+	//var/pre_laser_integrity = demo_mech.get_integrity()
+	//var/pre_laser_arm_integrity = left_arm_equipment.get_integrity()
+	//dummy_laser.fire_gun(demo_mech, dummy, FALSE)
 
-		// BLAST IT
-		//var/pre_laser_integrity = demo_mech.get_integrity()
-		//var/pre_laser_arm_integrity = left_arm_equipment.get_integrity()
-		//dummy_laser.fire_gun(demo_mech, dummy, FALSE)
+	//We do not handle destruction modifiers the same way as TG does. Lasers don't damage as bullets/pulse beams do
+	//check_integrity(demo_mech, pre_laser_integrity, expected_laser_damage, "shot with a laser")
+	//check_integrity(left_arm_equipment, pre_laser_arm_integrity, expected_laser_damage, "shot with a laser")
 
-		//We do not handle destruction modifiers the same way as TG does. Lasers don't damage as bullets/pulse beams do
-		//check_integrity(demo_mech, pre_laser_integrity, expected_laser_damage, "shot with a laser")
-		//check_integrity(left_arm_equipment, pre_laser_arm_integrity, expected_laser_damage, "shot with a laser")
+	// SHOOT IT
+	var/pre_bullet_integrity = demo_mech.get_integrity()
+	var/pre_bullet_arm_integrity = left_arm_equipment.get_integrity()
+	dummy_gun.pull_trigger(demo_mech, dummy, FALSE)
 
-		// SHOOT IT
-		var/pre_bullet_integrity = demo_mech.get_integrity()
-		var/pre_bullet_arm_integrity = left_arm_equipment.get_integrity()
-		dummy_gun.pull_trigger(demo_mech, dummy, FALSE)
+	check_integrity(demo_mech, pre_bullet_integrity, expected_bullet_damage, "shot with a bullet")
+	check_integrity(left_arm_equipment, pre_bullet_arm_integrity, expected_bullet_damage, "shot with a bullet")
 
-		check_integrity(demo_mech, pre_bullet_integrity, expected_bullet_damage, "shot with a bullet")
-		check_integrity(left_arm_equipment, pre_bullet_arm_integrity, expected_bullet_damage, "shot with a bullet")
-
-		// Additional check: The right arm of the mech should have taken no damage by this point.
-		var/obj/item/mecha_parts/mecha_equipment/right_arm_equipment = demo_mech.equip_by_category[MECHA_R_ARM]
-		TEST_ASSERT_NOTNULL(right_arm_equipment, "[demo_mech] spawned without any equipment in their right arm slot.")
-		TEST_ASSERT_EQUAL(right_arm_equipment.get_integrity(), right_arm_equipment.max_integrity, "[demo_mech] somehow took damage to its right arm, despite not being targeted.")
-
-		qdel(demo_mech)
-		qdel(dummy)
-		qdel(dummy_melee)
-		qdel(dummy_gun)
+	// Additional check: The right arm of the mech should have taken no damage by this point.
+	var/obj/item/mecha_parts/mecha_equipment/right_arm_equipment = demo_mech.equip_by_category[MECHA_R_ARM]
+	TEST_ASSERT_NOTNULL(right_arm_equipment, "[demo_mech] spawned without any equipment in their right arm slot.")
+	TEST_ASSERT_EQUAL(right_arm_equipment.get_integrity(), right_arm_equipment.max_integrity, "[demo_mech] somehow took damage to its right arm, despite not being targeted.")
 
 /// Simple helper to check if the integrity of an atom involved has taken damage, and if they took the amount of damage it should have.
 /datum/unit_test/mecha_damage/proc/check_integrity(atom/checking, pre_integrity, expected_damage, hit_by_phrase)

--- a/code/modules/unit_tests/mecha_damage.dm
+++ b/code/modules/unit_tests/mecha_damage.dm
@@ -5,79 +5,90 @@
 /datum/unit_test/mecha_damage
 
 /datum/unit_test/mecha_damage/Run()
-	// "Loaded Mauler" was chosen deliberately here.
-	// We need a mech that starts with arm equipment and has fair enough armor.
-	var/obj/vehicle/sealed/mecha/demo_mech = allocate(/obj/vehicle/sealed/mecha/marauder/mauler/loaded)
-	// We need to face our guy explicitly, because mechs have directional armor
-	demo_mech.setDir(EAST)
+	var/obj/vehicle/sealed/mecha/demo_mech
+	var/mob/living/carbon/human/dummy
+	var/obj/item/dummy_melee
+	var/obj/item/gun/ballistic/dummy_gun
 
-	var/expected_melee_armor = demo_mech.get_armor_rating(MELEE)
-	//var/expected_laser_armor = demo_mech.get_armor_rating(LASER)
-	var/expected_bullet_armor = demo_mech.get_armor_rating(BULLET)
+	for(var/i = 1 to 10)
+		// "Loaded Mauler" was chosen deliberately here.
+		// We need a mech that starts with arm equipment and has fair enough armor.
+		demo_mech = allocate(/obj/vehicle/sealed/mecha/marauder/mauler/loaded)
+		// We need to face our guy explicitly, because mechs have directional armor
+		demo_mech.setDir(EAST)
 
-	var/mob/living/carbon/human/dummy = allocate(/mob/living/carbon/human/consistent)
-	dummy.forceMove(locate(run_loc_floor_bottom_left.x + 1, run_loc_floor_bottom_left.y, run_loc_floor_bottom_left.z))
-	// The dummy needs to be targeting an arm. Left is chosen here arbitrarily.
-	dummy._set_zone_selected(BODY_ZONE_L_ARM)
-	// Not strictly necessary, but you never know
-	dummy.face_atom(demo_mech)
+		var/expected_melee_armor = demo_mech.get_armor_rating(MELEE)
+		//var/expected_laser_armor = demo_mech.get_armor_rating(LASER)
+		var/expected_bullet_armor = demo_mech.get_armor_rating(BULLET)
 
-	// Get a sample "melee" weapon.
-	// The energy axe is chosen here due to having a high base force, to make sure we get over the equipment DT.
-	var/obj/item/dummy_melee = allocate(/obj/item/melee/energy/axe)
-	dummy_melee.force = 150
-	var/expected_melee_damage = round(dummy_melee.force * (1 - expected_melee_armor / 100) * demo_mech.facing_modifiers[MECHA_FRONT_ARMOUR], DAMAGE_PRECISION)
+		dummy = allocate(/mob/living/carbon/human/consistent)
+		dummy.forceMove(locate(run_loc_floor_bottom_left.x + 1, run_loc_floor_bottom_left.y, run_loc_floor_bottom_left.z))
+		// The dummy needs to be targeting an arm. Left is chosen here arbitrarily.
+		dummy._set_zone_selected(BODY_ZONE_L_ARM)
+		// Not strictly necessary, but you never know
+		dummy.face_atom(demo_mech)
 
-	// Get a sample laser weapon.
-	// The captain's laser gun here is chosen primarily because it deals more damage than normal lasers.
-	//var/obj/item/gun/energy/laser/dummy_laser = allocate(/obj/item/gun/energy/laser/captain)
-	//var/obj/item/ammo_casing/laser_ammo = dummy_laser.ammo_type[1]
-	//var/obj/projectile/beam/laser_fired = initial(laser_ammo.projectile_type)
-	//var/expected_laser_damage = round(initial(laser_fired.damage) * (1 - expected_laser_armor / 100), DAMAGE_PRECISION)
+		// Get a sample "melee" weapon.
+		// The energy axe is chosen here due to having a high base force, to make sure we get over the equipment DT.
+		dummy_melee = allocate(/obj/item/melee/energy/axe)
+		dummy_melee.force = 150
+		var/expected_melee_damage = round(dummy_melee.force * (1 - expected_melee_armor / 100) * demo_mech.facing_modifiers[MECHA_FRONT_ARMOUR], DAMAGE_PRECISION)
 
-	// Get a sample ballistic weapon.
-	// The syndicate .357 here is chosen because it does a lot of damage.
-	var/obj/item/gun/ballistic/dummy_gun = allocate(/obj/item/gun/ballistic/revolver/accurate)
-	var/obj/item/ammo_casing/ballistic_ammo = dummy_gun.magazine.ammo_type
-	var/obj/projectile/bullet_fired = initial(ballistic_ammo.projectile_type)
-	var/expected_bullet_damage = round(initial(bullet_fired.damage) * (1 - expected_bullet_armor / 100), DAMAGE_PRECISION)
+		// Get a sample laser weapon.
+		// The captain's laser gun here is chosen primarily because it deals more damage than normal lasers.
+		//var/obj/item/gun/energy/laser/dummy_laser = allocate(/obj/item/gun/energy/laser/captain)
+		//var/obj/item/ammo_casing/laser_ammo = dummy_laser.ammo_type[1]
+		//var/obj/projectile/beam/laser_fired = initial(laser_ammo.projectile_type)
+		//var/expected_laser_damage = round(initial(laser_fired.damage) * (1 - expected_laser_armor / 100), DAMAGE_PRECISION)
 
-	var/obj/item/mecha_parts/mecha_equipment/left_arm_equipment = demo_mech.equip_by_category[MECHA_L_ARM]
-	TEST_ASSERT_NOTNULL(left_arm_equipment, "[demo_mech] spawned without any equipment in their left arm slot.")
+		// Get a sample ballistic weapon.
+		// The syndicate .357 here is chosen because it does a lot of damage.
+		dummy_gun = allocate(/obj/item/gun/ballistic/revolver/accurate)
+		var/obj/item/ammo_casing/ballistic_ammo = dummy_gun.magazine.ammo_type
+		var/obj/projectile/bullet_fired = initial(ballistic_ammo.projectile_type)
+		var/expected_bullet_damage = round(initial(bullet_fired.damage) * (1 - expected_bullet_armor / 100), DAMAGE_PRECISION)
 
-	// Now it's time to actually beat the heck out of the mech to see if it takes damage correctly.
-	TEST_ASSERT_EQUAL(demo_mech.get_integrity(), demo_mech.max_integrity, "[demo_mech] was spawned at not its maximum integrity.")
-	TEST_ASSERT_EQUAL(left_arm_equipment.get_integrity(), left_arm_equipment.max_integrity, "[left_arm_equipment] ([demo_mech]'s left arm) spawned at not its maximum integrity.")
+		var/obj/item/mecha_parts/mecha_equipment/left_arm_equipment = demo_mech.equip_by_category[MECHA_L_ARM]
+		TEST_ASSERT_NOTNULL(left_arm_equipment, "[demo_mech] spawned without any equipment in their left arm slot.")
 
-	// SMACK IT
-	var/pre_melee_integrity = demo_mech.get_integrity()
-	var/pre_melee_arm_integrity = left_arm_equipment.get_integrity()
-	demo_mech.attacked_by(dummy_melee, dummy)
+		// Now it's time to actually beat the heck out of the mech to see if it takes damage correctly.
+		TEST_ASSERT_EQUAL(demo_mech.get_integrity(), demo_mech.max_integrity, "[demo_mech] was spawned at not its maximum integrity.")
+		TEST_ASSERT_EQUAL(left_arm_equipment.get_integrity(), left_arm_equipment.max_integrity, "[left_arm_equipment] ([demo_mech]'s left arm) spawned at not its maximum integrity.")
 
-	check_integrity(demo_mech, pre_melee_integrity, expected_melee_damage, "hit with a melee item")
-	check_integrity(left_arm_equipment, pre_melee_arm_integrity, expected_melee_damage, "hit with a melee item")
+		// SMACK IT
+		var/pre_melee_integrity = demo_mech.get_integrity()
+		var/pre_melee_arm_integrity = left_arm_equipment.get_integrity()
+		demo_mech.attacked_by(dummy_melee, dummy)
 
-	// BLAST IT
-	//var/pre_laser_integrity = demo_mech.get_integrity()
-	//var/pre_laser_arm_integrity = left_arm_equipment.get_integrity()
-	//dummy_laser.fire_gun(demo_mech, dummy, FALSE)
+		check_integrity(demo_mech, pre_melee_integrity, expected_melee_damage, "hit with a melee item")
+		check_integrity(left_arm_equipment, pre_melee_arm_integrity, expected_melee_damage, "hit with a melee item")
 
-	//We do not handle destruction modifiers the same way as TG does. Lasers don't damage as bullets/pulse beams do
-	//check_integrity(demo_mech, pre_laser_integrity, expected_laser_damage, "shot with a laser")
-	//check_integrity(left_arm_equipment, pre_laser_arm_integrity, expected_laser_damage, "shot with a laser")
+		// BLAST IT
+		//var/pre_laser_integrity = demo_mech.get_integrity()
+		//var/pre_laser_arm_integrity = left_arm_equipment.get_integrity()
+		//dummy_laser.fire_gun(demo_mech, dummy, FALSE)
 
-	// SHOOT IT
-	var/pre_bullet_integrity = demo_mech.get_integrity()
-	var/pre_bullet_arm_integrity = left_arm_equipment.get_integrity()
-	dummy_gun.pull_trigger(demo_mech, dummy, FALSE)
+		//We do not handle destruction modifiers the same way as TG does. Lasers don't damage as bullets/pulse beams do
+		//check_integrity(demo_mech, pre_laser_integrity, expected_laser_damage, "shot with a laser")
+		//check_integrity(left_arm_equipment, pre_laser_arm_integrity, expected_laser_damage, "shot with a laser")
 
-	check_integrity(demo_mech, pre_bullet_integrity, expected_bullet_damage, "shot with a bullet")
-	check_integrity(left_arm_equipment, pre_bullet_arm_integrity, expected_bullet_damage, "shot with a bullet")
+		// SHOOT IT
+		var/pre_bullet_integrity = demo_mech.get_integrity()
+		var/pre_bullet_arm_integrity = left_arm_equipment.get_integrity()
+		dummy_gun.pull_trigger(demo_mech, dummy, FALSE)
 
-	// Additional check: The right arm of the mech should have taken no damage by this point.
-	var/obj/item/mecha_parts/mecha_equipment/right_arm_equipment = demo_mech.equip_by_category[MECHA_R_ARM]
-	TEST_ASSERT_NOTNULL(right_arm_equipment, "[demo_mech] spawned without any equipment in their right arm slot.")
-	TEST_ASSERT_EQUAL(right_arm_equipment.get_integrity(), right_arm_equipment.max_integrity, "[demo_mech] somehow took damage to its right arm, despite not being targeted.")
+		check_integrity(demo_mech, pre_bullet_integrity, expected_bullet_damage, "shot with a bullet")
+		check_integrity(left_arm_equipment, pre_bullet_arm_integrity, expected_bullet_damage, "shot with a bullet")
+
+		// Additional check: The right arm of the mech should have taken no damage by this point.
+		var/obj/item/mecha_parts/mecha_equipment/right_arm_equipment = demo_mech.equip_by_category[MECHA_R_ARM]
+		TEST_ASSERT_NOTNULL(right_arm_equipment, "[demo_mech] spawned without any equipment in their right arm slot.")
+		TEST_ASSERT_EQUAL(right_arm_equipment.get_integrity(), right_arm_equipment.max_integrity, "[demo_mech] somehow took damage to its right arm, despite not being targeted.")
+
+		qdel(demo_mech)
+		qdel(dummy)
+		qdel(dummy_melee)
+		qdel(dummy_gun)
 
 /// Simple helper to check if the integrity of an atom involved has taken damage, and if they took the amount of damage it should have.
 /datum/unit_test/mecha_damage/proc/check_integrity(atom/checking, pre_integrity, expected_damage, hit_by_phrase)

--- a/code/modules/unit_tests/mecha_damage.dm
+++ b/code/modules/unit_tests/mecha_damage.dm
@@ -37,7 +37,7 @@
 
 	// Get a sample ballistic weapon.
 	// The syndicate .357 here is chosen because it does a lot of damage.
-	var/obj/item/gun/ballistic/dummy_gun = allocate(/obj/item/gun/ballistic/revolver)
+	var/obj/item/gun/ballistic/dummy_gun = allocate(/obj/item/gun/ballistic/revolver/accurate)
 	var/obj/item/ammo_casing/ballistic_ammo = dummy_gun.magazine.ammo_type
 	var/obj/projectile/bullet_fired = initial(ballistic_ammo.projectile_type)
 	var/expected_bullet_damage = round(initial(bullet_fired.damage) * (1 - expected_bullet_armor / 100), DAMAGE_PRECISION)
@@ -86,3 +86,12 @@
 
 	var/damage_taken = round(pre_integrity - post_hit_health, DAMAGE_PRECISION)
 	TEST_ASSERT(damage_taken <= expected_damage && damage_taken >= round(expected_damage / 2, DAMAGE_PRECISION), "[checking] didn't take the expected amount of damage when [hit_by_phrase]. (Expected damage: [expected_damage], received damage: [damage_taken])")
+
+/obj/item/gun/ballistic/revolver/accurate
+	mag_type = /obj/item/ammo_box/magazine/internal/cylinder/accurate
+
+/obj/item/ammo_box/magazine/internal/cylinder/accurate
+	projectile_type = /obj/projectile/bullet/a357/accurate
+
+/obj/projectile/bullet/a357/accurate
+	zone_accurate = TRUE

--- a/code/modules/unit_tests/mecha_damage.dm
+++ b/code/modules/unit_tests/mecha_damage.dm
@@ -102,7 +102,10 @@
 	mag_type = /obj/item/ammo_box/magazine/internal/cylinder/accurate
 
 /obj/item/ammo_box/magazine/internal/cylinder/accurate
-	ammo_type = /obj/projectile/bullet/a357/accurate
+	ammo_type = /obj/item/ammo_casing/a357/accurate
+
+/obj/item/ammo_casing/a357/accurate
+	projectile_type = /obj/projectile/bullet/a357/accurate
 
 /obj/projectile/bullet/a357/accurate
 	zone_accurate = TRUE


### PR DESCRIPTION
## About The Pull Request

This one was surprisingly pretty fun to fix, don't ask me why, but I enjoyed it.

Anyways, the issue was that bullets lose body zone accuracy over distance. To be more specific, there was a 28% chance for the revolver's bullet to miss the targeted zone (`BODY_ZONE_L_ARM` in this case) and then hit a random one.

```dm
/obj/projectile/proc/Impact(atom/A)
	...
	if (!zone_accurate)
		def_zone = ran_zone(def_zone, max(100-(7*distance), 5)) //Lower accurancy/longer range tradeoff. 7 is a balanced number to use.
	...
```

The solution was pretty simple- I just ended up making an `/accurate` sub-type for the revolver with `zone_accurate` set to `TRUE`.

closes #14218
closes #14222

## Testing Photographs and Procedure

To procure testing evidence I've set the `mecha_damage` unit test to run 10x. If it was still flaky, there would only be a 3.74% chance of it succeeding (that's only for a single run, the number goes waaay down for the full 10 integration tests)

<img width="666" height="290" alt="image" src="https://github.com/user-attachments/assets/b6c1c061-c97e-4e6f-8e2c-5f512df36d22" />

## Changelog
:cl:
fix: Fixed a flaky mecha_damage unit test
/:cl: