### PR TITLE
Fixes growth serum twice over

### DIFF
--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -1920,12 +1920,13 @@
 	var/current_size = RESIZE_DEFAULT_SIZE
 
 /datum/reagent/growthserum/on_mob_life(mob/living/carbon/affected_mob, delta_time, times_fired)
-	. = ..()
 	var/newsize = current_size
 	switch(volume)
-		if(0 to 19)
+		if(0 to 9)
+			newsize = RESIZE_DEFAULT_SIZE
+		if(10 to 29)
 			newsize = 1.25 * RESIZE_DEFAULT_SIZE
-		if(20 to 49)
+		if(30 to 49)
 			newsize = 1.5 * RESIZE_DEFAULT_SIZE
 		if(50 to 99)
 			newsize = 2 * RESIZE_DEFAULT_SIZE
@@ -1937,6 +1938,7 @@
 	affected_mob.resize = newsize/current_size
 	current_size = newsize
 	affected_mob.update_transform()
+	..()
 
 /datum/reagent/growthserum/on_mob_end_metabolize(mob/living/carbon/affected_mob)
 	. = ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Closes #13730 

* Removes the ability to microdose growth serum by making it do nothing special until at least 10u is present. This *should* ensure that people are always their normal size again before growth serum finishes metabolizing via any normal method. 
* Fixes the order of operations in growth serum (`on_mob_life()` calls `on_mob_end_metabolize()` after it has adjusted someone's size now, instead of before) so that even if something very unusual happens with metabolization, such as an admin deleting the reagent manually, size is still properly reset when it's done. 

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

It's an extremely obnoxious bug. 

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>
There is no meaningful way to demonstrate testing evidence for this. 
Growth isn't infinite anymore, and smoking the reagent doesn't cause growth at all now.
</details>

## Changelog
:cl:
fix: Growth serum no longer stacks infinitely when smoked and requires at least 10u to have a noticable effect
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
