### PR TITLE
Fix obey component hovering, and lasso runtimes

### DIFF
--- a/code/datums/components/pet_commands/obeys_commands.dm
+++ b/code/datums/components/pet_commands/obeys_commands.dm
@@ -58,6 +58,7 @@
 /datum/component/obeys_commands/proc/on_key_unpressed(mob/living/source)
 	SIGNAL_HANDLER
 	UnregisterSignal(source, COMSIG_ATOM_MOUSE_ENTERED)
+	remove_from_viewers(source)
 
 /datum/component/obeys_commands/proc/remove_from_viewers(mob/living/source)
 	radial_viewers -= REF(source)
@@ -92,7 +93,8 @@
 	if(mouse_hovered == parent)
 		display_menu(friend)
 		return
-	if(isliving(mouse_hovered))
+	var/mob/living/owner = parent
+	if(isliving(mouse_hovered) && mouse_hovered.loc != owner.loc)
 		remove_from_viewers(friend)
 
 /// Displays a radial menu of commands

--- a/code/game/objects/items/carp_lasso.dm
+++ b/code/game/objects/items/carp_lasso.dm
@@ -66,8 +66,9 @@
 		return
 	if(!user.combat_mode && C == mob_target) //if trying to tie up previous target
 		to_chat(user, span_notice("You begin to untie [C]"))
-		if(proximity_flag && do_after(user, 2 SECONDS, target, timed_action_flags = IGNORE_HELD_ITEM))
+		if(istype(C))
 			C.toggle_ai(AI_ON)
+		if(proximity_flag && do_after(user, 2 SECONDS, target, timed_action_flags = IGNORE_HELD_ITEM))
 			C.transform = C.transform.Turn(-180)
 		//Riding and Tamed
 			C.tamed()
@@ -75,6 +76,8 @@
 				C.AddElement(/datum/element/ridable, /datum/component/riding/creature)
 				C.can_buckle = TRUE
 				C.buckle_lying = 0
+			if(C.ai_controller)
+				QDEL_NULL(C.ai_controller)
 			C.ai_controller = C.ai_controller || new /datum/ai_controller/basic_controller/dog(C) //This should be fine, we want them to act like dogs anyway
 			C.AddComponent(/datum/component/obeys_commands, pet_commands)
 			C.befriend(user)
@@ -104,7 +107,8 @@
 	mob_target = C
 	C.throw_at(get_turf(src), 9, 2, user, FALSE, force = 0)
 	C.transform = transform.Turn(180)
-	C.toggle_ai(AI_OFF)
+	if(istype(C))
+		C.toggle_ai(AI_OFF)
 	RegisterSignal(C, COMSIG_QDELETING, PROC_REF(handle_hard_del), override=TRUE)
 	to_chat(user, span_notice("You lasso [C]!"))
 	timer = addtimer(CALLBACK(src, PROC_REF(fail_ally)), 6 SECONDS, TIMER_STOPPABLE) //after 6 seconds set the carp back


### PR DESCRIPTION
## About The Pull Request

Ports https://github.com/tgstation/tgstation/pull/92788

Ports a fix from TG for the obey commands component, makes the radial menu disappear when you release the examine key
Fixes runtimes in the lasso code caused by lack of type checks

## Why It's Good For The Game

Bugs

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

https://github.com/user-attachments/assets/80f9d925-852f-4f18-be1f-f8e825b97eff

</details>

## Changelog
:cl: SmArtKar, Racc-Off
fix: Fix lasso runtime
qol: Letting go of the pet command hotkey (Shift by default) will instantly close the menu
fix: Hovering over things on the same tile no longer closes the pet command menu
/:cl: