### PR TITLE
Adds a linter grep for `var/list/static`

### DIFF
--- a/code/controllers/subsystem/input.dm
+++ b/code/controllers/subsystem/input.dm
@@ -22,7 +22,7 @@ SUBSYSTEM_DEF(input)
 
 // This is for when macro sets are eventualy datumized
 /datum/controller/subsystem/input/proc/setup_default_macro_sets()
-	var/list/static/default_macro_sets
+	var/static/list/default_macro_sets
 
 	if(default_macro_sets)
 		macro_sets = default_macro_sets
@@ -48,7 +48,7 @@ SUBSYSTEM_DEF(input)
 	// Because i'm lazy and don't want to type all these out twice
 	var/list/old_default = default_macro_sets["old_default"]
 
-	var/list/static/oldmode_keys = list(
+	var/static/list/oldmode_keys = list(
 		"North", "East", "South", "West",
 		"Northeast", "Southeast", "Northwest", "Southwest",
 		"Insert", "Delete", "Ctrl", "Alt",
@@ -60,7 +60,7 @@ SUBSYSTEM_DEF(input)
 		old_default[key] = "\"KeyDown [key]\""
 		old_default["[key]+UP"] = "\"KeyUp [key]\""
 
-	var/list/static/oldmode_ctrl_override_keys = list(
+	var/static/list/oldmode_ctrl_override_keys = list(
 		"W" = "W", "A" = "A", "S" = "S", "D" = "D", // movement
 		"1" = "1", "2" = "2", "3" = "3", "4" = "4", // intent
 		"B" = "B", // resist

--- a/code/datums/components/riding/riding.dm
+++ b/code/datums/components/riding/riding.dm
@@ -155,7 +155,7 @@
 				if(diroffsets.len == 3)
 					buckled_mob.layer = diroffsets[3]
 				break
-	var/list/static/default_vehicle_pixel_offsets = list(TEXT_NORTH = list(0, 0), TEXT_SOUTH = list(0, 0), TEXT_EAST = list(0, 0), TEXT_WEST = list(0, 0))
+	var/static/list/default_vehicle_pixel_offsets = list(TEXT_NORTH = list(0, 0), TEXT_SOUTH = list(0, 0), TEXT_EAST = list(0, 0), TEXT_WEST = list(0, 0))
 	var/px = default_vehicle_pixel_offsets[AM_dir]
 	var/py = default_vehicle_pixel_offsets[AM_dir]
 	if(directional_vehicle_offsets[AM_dir])

--- a/code/game/objects/items/RCD.dm
+++ b/code/game/objects/items/RCD.dm
@@ -1046,7 +1046,7 @@ GLOBAL_VAR_INIT(icon_holographic_window, init_holographic_window())
 	var/list/choices = list()
 	///index, used in the attack self to get the type. stored here since it doesnt change
 	///This list that holds all the plumbing design types the plumberer can construct. Its purpose is to make it easy to make new plumberer subtypes with a different selection of machines.
-	var/list/static/plumbing_design_types
+	var/static/list/plumbing_design_types
 
 	var/list/name_to_type = list()
 	///

--- a/code/game/objects/structures/flora.dm
+++ b/code/game/objects/structures/flora.dm
@@ -369,7 +369,7 @@
 /obj/item/kirbyplants/random
 	icon = 'icons/obj/flora/_flora.dmi'
 	icon_state = "random_plant"
-	var/list/static/states
+	var/static/list/states
 
 /obj/item/kirbyplants/random/Initialize(mapload)
 	. = ..()

--- a/code/game/objects/structures/traps.dm
+++ b/code/game/objects/structures/traps.dm
@@ -12,7 +12,7 @@
 	var/charges = INFINITY
 	var/antimagic_flags = MAGIC_RESISTANCE
 
-	var/list/static/ignore_typecache
+	var/static/list/ignore_typecache
 	var/list/mob/immune_minds = list()
 
 	var/sparks = TRUE

--- a/code/modules/research/nanites/nanite_programs/sensor.dm
+++ b/code/modules/research/nanites/nanite_programs/sensor.dm
@@ -270,7 +270,7 @@
 	trigger_cost = 0
 	trigger_cooldown = 5
 
-	var/list/static/allowed_species = list()
+	var/static/list/allowed_species = list()
 
 /datum/nanite_program/sensor/species/New()
 	if(!length(allowed_species))

--- a/code/modules/shuttle/shuttle.dm
+++ b/code/modules/shuttle/shuttle.dm
@@ -596,7 +596,7 @@ CREATION_TEST_IGNORE_SUBTYPES(/obj/docking_port)
 
 // Called after the shuttle is loaded from template
 /obj/docking_port/mobile/proc/linkup(datum/map_template/shuttle/template, obj/docking_port/stationary/dock)
-	var/list/static/shuttle_id = list()
+	var/static/list/shuttle_id = list()
 	var/idnum = ++shuttle_id[template]
 	if(idnum > 1)
 		if(id == initial(id))

--- a/tools/ci/check_grep.sh
+++ b/tools/ci/check_grep.sh
@@ -162,6 +162,13 @@ if $grep '^/*var/' $code_files; then
 	st=1
 fi;
 
+part "improperly pathed static lists"
+if $grep -i 'var/list/static/.*' $code_files; then
+	echo
+	echo -e "${RED}ERROR: Found incorrect static list definition 'var/list/static/', it should be 'var/static/list/' instead.${NC}"
+	st=1
+fi;
+
 part "can_perform_action argument check"
 if $grep 'can_perform_action\(\s*\)' $code_files; then
 	echo


### PR DESCRIPTION
## About The Pull Request

I saw this in kirbyplants code and I want it gone

- https://github.com/tgstation/tgstation/pull/87207

## Testing Photographs and Procedure

<img width="1368" height="292" alt="image" src="https://github.com/user-attachments/assets/974a2d40-971b-4197-b305-87626d324beb" />

## Changelog
:cl: vinylspiders
fix: fixed a bunch of improper static list declarations
server: added a grep check for var/list/static declarations
/:cl: