### PR TITLE
Implements `abstract_type` across the codebase

### DIFF
--- a/beestation.dme
+++ b/beestation.dme
@@ -314,6 +314,7 @@
 #include "code\__HELPERS\_lists.dm"
 #include "code\__HELPERS\_logging.dm"
 #include "code\__HELPERS\_string_lists.dm"
+#include "code\__HELPERS\abstract_types.dm"
 #include "code\__HELPERS\admin.dm"
 #include "code\__HELPERS\ai.dm"
 #include "code\__HELPERS\announcements.dm"

--- a/code/__DEFINES/directional.dm
+++ b/code/__DEFINES/directional.dm
@@ -19,7 +19,9 @@
 /obj/var/_reflection_is_directional = FALSE
 
 /// Create directional subtypes for a path to simplify mapping.
-#define MAPPING_DIRECTIONAL_HELPERS(path, offset)\
+#define MAPPING_DIRECTIONAL_HELPERS(path, offset) ##path/directional {\
+	abstract_type = ##path/directional; \
+} \
 ##path {\
 	_reflection_is_directional = TRUE;\
 } \

--- a/code/__DEFINES/role_preferences.dm
+++ b/code/__DEFINES/role_preferences.dm
@@ -264,8 +264,6 @@ GLOBAL_LIST_INIT(role_preference_entries, init_role_preference_entries())
 
 /proc/init_role_preference_entries()
 	var/list/output = list()
-	for (var/datum/role_preference/preference_type as anything in subtypesof(/datum/role_preference))
-		if (initial(preference_type.abstract_type) == preference_type)
-			continue
+	for (var/datum/role_preference/preference_type as anything in valid_subtypesof(/datum/role_preference))
 		output[preference_type] = new preference_type
 	return output

--- a/code/__HELPERS/abstract_types.dm
+++ b/code/__HELPERS/abstract_types.dm
@@ -1,0 +1,27 @@
+/// Returns a list of all abstract typepaths for all datums
+/proc/get_abstract_types()
+	var/static/list/abstracts
+	if(abstracts)
+		return abstracts
+	abstracts = list()
+	for(var/datum/sometype as anything in subtypesof(/datum))
+		if(sometype == sometype::abstract_type)
+			abstracts[sometype::abstract_type] = TRUE
+
+	return abstracts
+
+// The time complexity of these two procs is really bad, sitting at O(n * m).
+// And yet, the overhead is ridiculously small for some reason. We never figured out why.
+// So doing list subtraction instead of filtering is faster in all cases, at least for now.
+// If we ever breach like 3000-5000 abstract types, that will likely change.
+// As of right now we're at 272 or so, with subtraction being ~10x faster.
+// Curse this language, for you shall live in hell alongside me.
+
+/// Like subtypesof, but automatically excludes abstract typepaths
+/proc/valid_subtypesof(datum/sometype)
+	return subtypesof(sometype) - get_abstract_types()
+
+/// Like typesof, but automatically excludes abstract typepaths
+/proc/valid_typesof(datum/sometype)
+	return typesof(sometype) - get_abstract_types()
+

--- a/code/__HELPERS/global_lists.dm
+++ b/code/__HELPERS/global_lists.dm
@@ -82,9 +82,7 @@
 
 /// Inits crafting recipe lists
 /proc/init_crafting_recipes(list/crafting_recipes)
-	for(var/path in subtypesof(/datum/crafting_recipe))
-		if(ispath(path, /datum/crafting_recipe/stack))
-			continue
+	for(var/path in valid_subtypesof(/datum/crafting_recipe))
 		var/datum/crafting_recipe/recipe = new path()
 		var/is_cooking = (recipe.category in GLOB.crafting_category_food)
 		recipe.reqs = sort_list(recipe.reqs, GLOBAL_PROC_REF(cmp_crafting_req_priority))

--- a/code/_globalvars/lists/keybindings.dm
+++ b/code/_globalvars/lists/keybindings.dm
@@ -13,8 +13,7 @@
 	LAZYADD(GLOB.keybindings_by_name_to_key[instance.name], LAZYCOPY(instance.keys))
 
 /proc/init_emote_keybinds()
-	for(var/i in subtypesof(/datum/emote))
-		var/datum/emote/faketype = i
+	for(var/datum/emote/faketype as anything in valid_subtypesof(/datum/emote))
 		if(!initial(faketype.key))
 			continue
 		var/datum/keybinding/emote/emote_kb = new

--- a/code/_globalvars/lists/mobs.dm
+++ b/code/_globalvars/lists/mobs.dm
@@ -134,7 +134,7 @@ GLOBAL_LIST_INIT(blood_types, generate_blood_types())
 
 /proc/init_emote_list()
 	. = list()
-	for(var/path in subtypesof(/datum/emote))
+	for(var/path in valid_subtypesof(/datum/emote))
 		var/datum/emote/E = new path()
 		if(E.key)
 			if(!.[E.key])

--- a/code/controllers/configuration/config_entry.dm
+++ b/code/controllers/configuration/config_entry.dm
@@ -1,4 +1,6 @@
 /datum/config_entry
+	abstract_type = /datum/config_entry
+
 	var/name	//read-only, this is determined by the last portion of the derived entry type
 	var/config_entry_value
 	var/default	//read-only, just set value directly
@@ -9,7 +11,6 @@
 	var/deprecated_by	//the /datum/config_entry type that supercedes this one
 
 	var/protection = NONE
-	var/abstract_type = /datum/config_entry	//do not instantiate if type matches this
 
 	var/vv_VAS = TRUE		//Force validate and set on VV. VAS proccall guard will run regardless.
 

--- a/code/controllers/configuration/configuration.dm
+++ b/code/controllers/configuration/configuration.dm
@@ -84,10 +84,8 @@
 	var/list/_entries_by_type = list()
 	entries_by_type = _entries_by_type
 
-	for(var/I in typesof(/datum/config_entry))	//typesof is faster in this case
+	for(var/I in valid_subtypesof(/datum/config_entry))	//typesof is faster in this case
 		var/datum/config_entry/E = I
-		if(initial(E.abstract_type) == I)
-			continue
 		E = new I
 		var/esname = E.name
 		var/datum/config_entry/test = _entries[esname]

--- a/code/controllers/subsystem/assets.dm
+++ b/code/controllers/subsystem/assets.dm
@@ -25,10 +25,8 @@ SUBSYSTEM_DEF(assets)
 	transport.Load()
 
 /datum/controller/subsystem/assets/Initialize()
-	for(var/type in typesof(/datum/asset))
-		var/datum/asset/A = type
-		if (type != initial(A._abstract))
-			load_asset_datum(type)
+	for(var/datum/asset/asset_type as anything in valid_subtypesof(/datum/asset))
+		load_asset_datum(asset_type)
 
 	transport.Initialize(cache)
 

--- a/code/controllers/subsystem/dynamic/dynamic_rulesets.dm
+++ b/code/controllers/subsystem/dynamic/dynamic_rulesets.dm
@@ -1,4 +1,6 @@
 /datum/dynamic_ruleset
+	abstract_type = /datum/dynamic_ruleset
+
 	/**
 	 * Configurable Variables
 	 */
@@ -37,8 +39,6 @@
 	 * Backend Variables
 	 */
 
-	/// The base abstract path for this subtype.
-	var/abstract_type = /datum/dynamic_ruleset
 	/// List of possible mobs (or minds for roundstart rulesets) for this ruleset to draft.
 	var/list/candidates
 	/// A list of mobs (or minds for roundstart rulesets) chosen for this ruleset.

--- a/code/controllers/subsystem/dynamic/dynamic_rulesets_gamemode.dm
+++ b/code/controllers/subsystem/dynamic/dynamic_rulesets_gamemode.dm
@@ -1,8 +1,8 @@
 /datum/dynamic_ruleset/gamemode
+	abstract_type = /datum/dynamic_ruleset/gamemode
 	rule_category = DYNAMIC_CATEGORY_GAMEMODE
 	// Uses antag rep to pick candidates, as we choose from everyone available.
 	ruleset_flags = SHOULD_USE_ANTAG_REP
-	abstract_type = /datum/dynamic_ruleset/gamemode
 	// Sorry, but if you are going to be THE antagonist, you can't be leaving the station and making
 	// the round boring for everyone else.
 	protected_roles = list(JOB_NAME_SECURITYOFFICER, JOB_NAME_DETECTIVE, JOB_NAME_WARDEN, JOB_NAME_HEADOFSECURITY, JOB_NAME_CAPTAIN, JOB_NAME_PRISONER, JOB_NAME_SHAFTMINER, JOB_NAME_EXPLORATIONCREW)

--- a/code/controllers/subsystem/dynamic/dynamic_rulesets_midround.dm
+++ b/code/controllers/subsystem/dynamic/dynamic_rulesets_midround.dm
@@ -1,11 +1,7 @@
-/**
- * Do not directly inherit this!
- * Use either /datum/dynamic_ruleset/midround/living or /datum/dynamic_ruleset/midround/ghost
- */
 /datum/dynamic_ruleset/midround
+	abstract_type = /datum/dynamic_ruleset/midround
 	rule_category = DYNAMIC_CATEGORY_MIDROUND
 	restricted_roles = list(JOB_NAME_AI, JOB_NAME_CYBORG, JOB_NAME_POSIBRAIN)
-	abstract_type = /datum/dynamic_ruleset/midround
 	ruleset_flags = NO_TRANSFER_RULESET | REQUIRED_POP_ALLOW_UNREADY
 
 	/// How disruptive the ruleset is (DYNAMIC_MIDROUND_LIGHT, DYNAMIC_MIDROUND_MEDIUM, DYNAMIC_MIDROUND_HEAVY)

--- a/code/controllers/subsystem/dynamic/dynamic_rulesets_supplementary.dm
+++ b/code/controllers/subsystem/dynamic/dynamic_rulesets_supplementary.dm
@@ -1,7 +1,7 @@
 /datum/dynamic_ruleset/supplementary
+	abstract_type = /datum/dynamic_ruleset/supplementary
 	rule_category = DYNAMIC_CATEGORY_SUPPLEMENTARY
 	ruleset_flags = SHOULD_USE_ANTAG_REP
-	abstract_type = /datum/dynamic_ruleset/supplementary
 	minimum_players_required = 3
 	/// The percentage (0 to 100) chance that this ruleset will be repicked
 	/// when selected, assuming there are cost points available.

--- a/code/controllers/subsystem/early_assets.dm
+++ b/code/controllers/subsystem/early_assets.dm
@@ -16,10 +16,7 @@ SUBSYSTEM_DEF(early_assets)
 	flags = SS_NO_FIRE
 
 /datum/controller/subsystem/early_assets/Initialize()
-	for (var/datum/asset/asset_type as anything in subtypesof(/datum/asset))
-		if (asset_type::_abstract == asset_type)
-			continue
-
+	for (var/datum/asset/asset_type as anything in valid_subtypesof(/datum/asset))
 		if (!asset_type::early)
 			continue
 

--- a/code/controllers/subsystem/processing/instruments.dm
+++ b/code/controllers/subsystem/processing/instruments.dm
@@ -32,10 +32,8 @@ PROCESSING_SUBSYSTEM_DEF(instruments)
 	songs -= S
 
 /datum/controller/subsystem/processing/instruments/proc/initialize_instrument_data()
-	for(var/path in subtypesof(/datum/instrument))
+	for(var/path in valid_subtypesof(/datum/instrument))
 		var/datum/instrument/I = path
-		if(initial(I.abstract_type) == path)
-			continue
 		I = new path
 		I.Initialize()
 		if(!I.id)

--- a/code/controllers/subsystem/processing/station.dm
+++ b/code/controllers/subsystem/processing/station.dm
@@ -89,14 +89,10 @@ PROCESSING_SUBSYSTEM_DEF(station)
 		return
 
 	// Get list of possible traits
-	for (var/datum/station_trait/trait_typepath as anything in subtypesof(/datum/station_trait))
+	for (var/datum/station_trait/trait_typepath as anything in valid_subtypesof(/datum/station_trait))
 		// If forced, (probably debugging), just set it up now, keep it out of the pool.
 		if (initial(trait_typepath.force))
 			setup_trait(trait_typepath)
-			continue
-
-		// Don't add abstract traits
-		if (initial(trait_typepath.abstract_type) == trait_typepath)
 			continue
 
 		// we're on a planet but we can't do planet ;_;

--- a/code/datums/actions/action.dm
+++ b/code/datums/actions/action.dm
@@ -4,6 +4,7 @@
  * A simple base for an modular behavior attached to atom or datum.
  */
 /datum/action
+	abstract_type = /datum/action
 	/// The name of the action
 	var/name = "Generic Action"
 	/// The description of what the action does

--- a/code/datums/armor/_armor.dm
+++ b/code/datums/armor/_armor.dm
@@ -25,12 +25,7 @@ GLOBAL_LIST_INIT(armor_by_type, generate_armor_type_cache())
  * It also contains logic and helpers for calculating damage and effective damage
  */
 /datum/armor
-
-/**
- * The armor datum holds information about different types of armor that an atom can have.
- * It also contains logic and helpers for calculating damage and effective damage
- */
-/datum/armor
+	abstract_type = /datum/armor
 	VAR_PROTECTED/acid = 0
 	VAR_PROTECTED/bio = 0
 	VAR_PROTECTED/bleed = 0
@@ -42,7 +37,6 @@ GLOBAL_LIST_INIT(armor_by_type, generate_armor_type_cache())
 	VAR_PROTECTED/laser = 0
 	VAR_PROTECTED/melee = 0
 	VAR_PROTECTED/stamina = 0
-	//VAR_PROTECTED/wound = 0
 
 /// A version of armor with no protections
 /datum/armor/none

--- a/code/datums/blood_type.dm
+++ b/code/datums/blood_type.dm
@@ -1,4 +1,5 @@
 /datum/blood_type
+	abstract_type = /datum/blood_type
 	/// Displayed name of the blood type.
 	var/name = "?"
 	/// Shown color of the blood type.

--- a/code/datums/brain_damage/brain_trauma.dm
+++ b/code/datums/brain_damage/brain_trauma.dm
@@ -4,6 +4,7 @@
 // of the trauma.
 
 /datum/brain_trauma
+	abstract_type = /datum/emote
 	var/name = "Brain Trauma"
 	var/desc = "A trauma caused by brain damage, which causes issues to the patient."
 	var/scan_desc = "generic brain trauma" //description when detected by a health scanner

--- a/code/datums/brain_damage/brain_trauma.dm
+++ b/code/datums/brain_damage/brain_trauma.dm
@@ -4,7 +4,7 @@
 // of the trauma.
 
 /datum/brain_trauma
-	abstract_type = /datum/emote
+	abstract_type = /datum/brain_trauma
 	var/name = "Brain Trauma"
 	var/desc = "A trauma caused by brain damage, which causes issues to the patient."
 	var/scan_desc = "generic brain trauma" //description when detected by a health scanner

--- a/code/datums/brain_damage/magic.dm
+++ b/code/datums/brain_damage/magic.dm
@@ -3,6 +3,7 @@
 //Unlike regular traumas this can affect the victim's body and surroundings
 
 /datum/brain_trauma/magic
+	abstract_type = /datum/brain_trauma/magic
 	resilience = TRAUMA_RESILIENCE_LOBOTOMY
 
 /datum/brain_trauma/magic/lumiphobia

--- a/code/datums/brain_damage/mild.dm
+++ b/code/datums/brain_damage/mild.dm
@@ -3,6 +3,7 @@
 //Most of the old brain damage effects have been transferred to the dumbness trauma.
 
 /datum/brain_trauma/mild
+	abstract_type = /datum/brain_trauma/mild
 
 /datum/brain_trauma/mild/hallucinations
 	name = "Hallucinations"

--- a/code/datums/brain_damage/severe.dm
+++ b/code/datums/brain_damage/severe.dm
@@ -3,6 +3,7 @@
 //They cannot be cured with chemicals, and require brain recalibration to solve.
 
 /datum/brain_trauma/severe
+	abstract_type = /datum/brain_trauma/severe
 	resilience = TRAUMA_RESILIENCE_SURGERY
 
 /datum/brain_trauma/severe/mute

--- a/code/datums/brain_damage/special.dm
+++ b/code/datums/brain_damage/special.dm
@@ -2,6 +2,7 @@
 //they are the easiest to cure, which means that if you want
 //to keep them, you can't cure your other traumas
 /datum/brain_trauma/special
+	abstract_type = /datum/brain_trauma/special
 
 /datum/brain_trauma/special/godwoken
 	name = "Godwoken Syndrome"

--- a/code/datums/components/crafting/_recipes.dm
+++ b/code/datums/components/crafting/_recipes.dm
@@ -1,5 +1,7 @@
 
 /datum/crafting_recipe
+	abstract_type = /datum/crafting_recipe
+
 	///in-game display name
 	/// in-game display name
 	/// Optional, if not set uses result name
@@ -56,6 +58,9 @@
 		tool_behaviors = string_list(tool_behaviors)
 	if(tool_paths)
 		tool_paths = string_list(tool_paths)
+
+/datum/crafting_recipe/stack
+	abstract_type = /datum/crafting_recipe/stack
 
 /datum/crafting_recipe/stack/New(obj/item/stack/material, datum/stack_recipe/stack_recipe)
 	if(!material || !stack_recipe || !stack_recipe.result_type)

--- a/code/datums/components/crafting/guncrafting.dm
+++ b/code/datums/components/crafting/guncrafting.dm
@@ -1,6 +1,8 @@
 //Gun crafting parts til they can be moved elsewhere
 
 // PARTS //
+/obj/item/weaponcrafting
+	abstract_type = /obj/item/weaponcrafting
 
 /obj/item/weaponcrafting/receiver
 	name = "modular receiver"

--- a/code/datums/datum.dm
+++ b/code/datums/datum.dm
@@ -74,6 +74,18 @@
 	///The layout pref we take from the player looking at this datum's UI to know what layout to give.
 	var/datum/preference/choiced/layout_prefs_used = /datum/preference/choiced/tgui_layout
 
+	/**
+	 * Parent types.
+	 *
+	 * Abstract-ness is a meta-property of a class that is used to indicate
+	 * that the class is intended to be used as a base class for others, and
+	 * should not (or cannot) be instantiated.
+	 * We have no such language concept in DM, and so we provide a datum member
+	 * that can be used to hint at abstractness for circumstances where we would
+	 * like that to be the case, such as base behavior providers.
+	 */
+	var/abstract_type = /datum
+
 /**
  * Called when a href for this datum is clicked
  *

--- a/code/datums/diseases/advance/symptoms/heal.dm
+++ b/code/datums/diseases/advance/symptoms/heal.dm
@@ -1,6 +1,7 @@
 #define TELEPORT_COOLDOWN 60 SECONDS
 
 /datum/symptom/heal
+	abstract_type = /datum/symptom/heal
 	name = "Basic Healing (does nothing)" //warning for adminspawn viruses
 	desc = "You should not be seeing this."
 	stealth = 0

--- a/code/datums/diseases/transformation.dm
+++ b/code/datums/diseases/transformation.dm
@@ -1,4 +1,5 @@
 /datum/disease/transformation
+	abstract_type = /datum/disease/transformation
 	name = "Transformation"
 	max_stages = 5
 	spread_text = "Acute"

--- a/code/datums/emotes.dm
+++ b/code/datums/emotes.dm
@@ -10,11 +10,14 @@
  *
  */
 /datum/emote
+	abstract_type = /datum/emote
+
 	/// What calls the emote.
 	var/key = ""
 	/// This will also call the emote.
 	var/key_third_person = ""
-	var/name = "" // Needed for more user-friendly emote names, so emotes with keys like "aflap" will show as "flap angry". Defaulted to key.
+	/// Needed for more user-friendly emote names, so emotes with keys like "aflap" will show as "flap angry". Defaulted to key.
+	var/name = ""
 	/// Message displayed when emote is used.
 	var/message = ""
 	/// Message displayed if the user is a mime.

--- a/code/datums/materials/_material.dm
+++ b/code/datums/materials/_material.dm
@@ -6,6 +6,7 @@ Simple datum which is instanced once per type and is used for every object of sa
 
 
 /datum/material
+	abstract_type = /datum/material
 	var/name = "material"
 	var/desc = "its..stuff."
 	///Base color of the material, is used for greyscale. Item isn't changed in color if this is null.

--- a/code/datums/materials/alloys.dm
+++ b/code/datums/materials/alloys.dm
@@ -1,6 +1,7 @@
 /** Materials made from other materials.
   */
 /datum/material/alloy
+	abstract_type = /datum/material/alloy
 	name = "alloy"
 	desc = "A material composed of two or more other materials."
 	init_flags = NONE

--- a/code/datums/outfit.dm
+++ b/code/datums/outfit.dm
@@ -14,6 +14,8 @@
   * that can be restored at a later date
   */
 /datum/outfit
+	abstract_type = /datum/outfit
+
 	///Name of the outfit (shows up in the equip admin verb)
 	var/name = "Naked"
 

--- a/code/datums/station_traits/_station_trait.dm
+++ b/code/datums/station_traits/_station_trait.dm
@@ -1,5 +1,7 @@
 ///Base class of station traits. These are used to influence rounds in one way or the other by influencing the levers of the station.
 /datum/station_trait
+	abstract_type = /datum/station_trait
+
 	/// Name of the trait
 	var/name = "unnamed station trait"
 	/// The type of this trait. Used to classify how this trait influences the station
@@ -26,8 +28,6 @@
 	var/list/possible_announcements
 	/// Whether or not this trait can be reverted by an admin
 	var/can_revert = TRUE
-	/// Trait should not be instantiated in a round if its type matches this type
-	var/abstract_type = /datum/station_trait
 
 /datum/station_trait/New()
 	. = ..()

--- a/code/datums/station_traits/exclusive_traits.dm
+++ b/code/datums/station_traits/exclusive_traits.dm
@@ -6,12 +6,12 @@
 */
 
 /datum/station_trait/job
+	abstract_type = /datum/station_trait/job
 	name = "Special Job"
 	trait_type = STATION_TRAIT_EXCLUSIVE
 	weight = 0
 	show_in_report = TRUE
 	report_message = "We opened a slot for a special job. We expect their duty can fit the station."
-	abstract_type = /datum/station_trait/job
 
 	var/datum/job/job_to_add
 

--- a/code/datums/traits/_quirk.dm
+++ b/code/datums/traits/_quirk.dm
@@ -1,6 +1,7 @@
 //every quirk in this folder should be coded around being applied on spawn
 //these are NOT "mob quirks" like GOTTAGOFAST, but exist as a medium to apply them and other different effects
 /datum/quirk
+	abstract_type = /datum/quirk
 	var/name = "Test Quirk"
 	var/desc = "This is a test quirk."
 	/// The icon to show in the preferences menu.
@@ -19,7 +20,6 @@
 	var/process = FALSE // Does this quirk use on_process()?
 	var/datum/mind/quirk_holder // The mind that contains this quirk
 	var/mob/living/quirk_target // The mob that will be affected by this quirk
-	var/abstract_parent_type = /datum/quirk
 
 /datum/quirk/New(datum/mind/quirk_mind, mob/living/quirk_mob, spawn_effects)
 	..()

--- a/code/datums/weather/weather.dm
+++ b/code/datums/weather/weather.dm
@@ -1,6 +1,7 @@
 //The effects of weather occur across an entire z-level. For instance, lavaland has periodic ash storms that scorch most unprotected creatures.
 
 /datum/weather
+	abstract_type = /datum/weather
 	var/name = "space wind"
 	var/desc = "Heavy gusts of wind blanket the area, periodically knocking down anyone caught in the open."
 

--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -4,6 +4,7 @@
   * A grouping of tiles into a logical space, mostly used by map editors
   */
 /area
+	abstract_type = /area
 	name = "Space"
 	var/navigation_area_name /// when multiple areas should have the same name, set this. get_area_navigation_name() proc will use name variable if this is null
 	icon = 'icons/area/areas_misc.dmi'

--- a/code/game/area/areas/station.dm
+++ b/code/game/area/areas/station.dm
@@ -1,6 +1,7 @@
 // Station areas and shuttles
 
 /area/station
+	abstract_type = /area/station
 	name = "Station Areas"
 	icon = 'icons/area/areas_station.dmi'
 	icon_state = "station"
@@ -9,6 +10,7 @@
 //Maintenance
 
 /area/station/maintenance
+	abstract_type = /area/station/maintenance
 	name = "Generic Maintenance"
 	ambience_index = AMBIENCE_MAINT
 	ambient_buzz = 'sound/ambience/source_corridor2.ogg'
@@ -265,6 +267,7 @@
 //Hallway
 
 /area/station/hallway
+	abstract_type = /area/station/hallway
 	icon_state = "hall"
 	sound_environment = SOUND_AREA_STANDARD_STATION
 	lights_always_start_on = TRUE
@@ -369,6 +372,7 @@
 //Command
 
 /area/station/command
+	abstract_type = /area/station/command
 	name = "Command"
 	icon_state = "command"
 	ambientsounds = list('sound/ambience/signal.ogg')
@@ -458,6 +462,7 @@
 //Commons
 
 /area/station/commons
+	abstract_type = /area/station/commons
 	name = "\improper Crew Facilities"
 	area_flags = HIDDEN_STASH_LOCATION | BLOBS_ALLOWED | UNIQUE_AREA | CULT_PERMITTED
 	lighting_colour_tube = "#ffce99"
@@ -631,6 +636,7 @@
 //Service
 
 /area/station/service
+	abstract_type = /area/station/service
 	airlock_hack_difficulty = AIRLOCK_WIRE_SECURITY_NONE
 
 /area/station/service/cafeteria
@@ -843,6 +849,7 @@
 //Engineering
 
 /area/station/engineering
+	abstract_type = /area/station/engineering
 	icon_state = "engie"
 	ambience_index = AMBIENCE_ENGI
 	sound_environment = SOUND_AREA_LARGE_ENCLOSED
@@ -997,6 +1004,7 @@
 //Solars
 
 /area/station/solars
+	abstract_type = /area/station/solars
 	requires_power = FALSE
 	//always_unpowered = TRUE
 	area_flags = UNIQUE_AREA | NO_GRAVITY
@@ -1086,6 +1094,7 @@
 //MedBay
 
 /area/station/medical
+	abstract_type = /area/station/medical
 	name = "Medical"
 	icon_state = "medbay"
 	area_flags = HIDDEN_STASH_LOCATION | VALID_TERRITORY | BLOBS_ALLOWED | UNIQUE_AREA | CULT_PERMITTED
@@ -1242,6 +1251,7 @@
 ///When adding a new area to the security areas, make sure to add it to /datum/bounty/item/security/paperwork as well!
 
 /area/station/security
+	abstract_type = /area/station/security
 	name = "Security"
 	icon_state = "security"
 	ambience_index = AMBIENCE_DANGER
@@ -1495,6 +1505,7 @@
 //Cargo
 
 /area/station/cargo
+	abstract_type = /area/station/cargo
 	name = "Quartermasters"
 	icon_state = "quart"
 	lighting_colour_tube = "#ffe3cc"
@@ -1576,6 +1587,7 @@
 //Science
 
 /area/station/science
+	abstract_type = /area/station/science
 	name = "\improper Science Division"
 	icon_state = "science"
 	lighting_colour_tube = "#f0fbff"
@@ -1701,6 +1713,7 @@
 // Telecommunications Satellite
 
 /area/station/tcommsat
+	abstract_type = /area/station/tcommsat
 	icon_state = "tcomsatcham"
 	ambientsounds = list(
 		'sound/ambience/ambisin2.ogg',

--- a/code/game/atom/_atom.dm
+++ b/code/game/atom/_atom.dm
@@ -6,6 +6,7 @@
  * as much as possible to the components/elements system
  */
 /atom
+	abstract_type = /atom
 	layer = TURF_LAYER
 	plane = GAME_PLANE
 	appearance_flags = TILE_BOUND|LONG_GLIDE

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -1,4 +1,5 @@
 /atom/movable
+	abstract_type = /atom/movable
 	layer = OBJ_LAYER
 	glide_size = 8
 	appearance_flags = TILE_BOUND|PIXEL_SCALE|LONG_GLIDE

--- a/code/game/gamemodes/objectives/_objective.dm
+++ b/code/game/gamemodes/objectives/_objective.dm
@@ -1,6 +1,8 @@
 GLOBAL_LIST(admin_objective_list) //Prefilled admin assignable objective list
 
 /datum/objective
+	abstract_type = /datum/objective
+
 	/// The primary owner of the objective. !!SOMEWHAT DEPRECATED!! Prefer using 'team' for new code.
 	var/datum/mind/owner
 	/// An alternative to 'owner': a team. Use this when writing new code.

--- a/code/game/machinery/_machinery.dm
+++ b/code/game/machinery/_machinery.dm
@@ -86,6 +86,7 @@
  */
 
 /obj/machinery
+	abstract_type = /obj/machinery
 	name = "machinery"
 	icon = 'icons/obj/stationobjs.dmi'
 	desc = "Some kind of machine."

--- a/code/game/objects/effects/decals/cleanable.dm
+++ b/code/game/objects/effects/decals/cleanable.dm
@@ -1,4 +1,5 @@
 /obj/effect/decal/cleanable
+	abstract_type = /obj/effect/decal/cleanable
 	gender = PLURAL
 	layer = ABOVE_NORMAL_TURF_LAYER
 	var/list/random_icon_states = null

--- a/code/game/objects/effects/decals/decal.dm
+++ b/code/game/objects/effects/decals/decal.dm
@@ -1,4 +1,5 @@
 /obj/effect/decal
+	abstract_type = /obj/effect/decal
 	name = "decal"
 	plane = FLOOR_PLANE
 	anchored = TRUE

--- a/code/game/objects/effects/effect_system/effect_system.dm
+++ b/code/game/objects/effects/effect_system/effect_system.dm
@@ -25,6 +25,7 @@ would spawn and follow the beaker, even if it is carried or thrown.
 
 #define MAX_SPARKS 10 //max possible sparks
 /datum/effect_system
+	abstract_type = /datum/effect_system
 	var/number = 3
 	var/cardinals_only = FALSE
 	var/turf/location

--- a/code/game/objects/effects/effects.dm
+++ b/code/game/objects/effects/effects.dm
@@ -2,6 +2,7 @@
 //objects in /obj/effect should never be things that are attackable, use obj/structure instead.
 //Effects are mostly temporary visual effects like sparks, smoke, as well as decals, etc...
 /obj/effect
+	abstract_type = /obj/effect
 	icon = 'icons/effects/effects.dmi'
 	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | UNACIDABLE | ACID_PROOF | FREEZE_PROOF
 	move_resist = INFINITY

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -11,6 +11,7 @@ GLOBAL_VAR_INIT(rpg_loot_items, FALSE)
 // more... RPG-like.
 
 /obj/item
+	abstract_type = /obj/item
 	name = "item"
 	icon = 'icons/obj/items_and_weapons.dmi'
 	blocks_emissive = EMISSIVE_BLOCK_GENERIC

--- a/code/game/objects/items/RCD.dm
+++ b/code/game/objects/items/RCD.dm
@@ -10,6 +10,7 @@ RLD
 */
 
 /obj/item/construction
+	abstract_type = /obj/item/construction
 	name = "not for ingame use"
 	desc = "A device used to rapidly build and deconstruct. Reload with iron, plasteel, glass or compressed matter cartridges."
 	opacity = FALSE

--- a/code/game/objects/items/chromosome.dm
+++ b/code/game/objects/items/chromosome.dm
@@ -1,4 +1,5 @@
 /obj/item/chromosome
+	abstract_type = /obj/item/chromosome
 	name = "blank chromosome"
 	icon = 'icons/obj/chromosomes.dmi'
 	icon_state = ""

--- a/code/game/objects/items/circuitboards/circuitboard.dm
+++ b/code/game/objects/items/circuitboards/circuitboard.dm
@@ -4,6 +4,7 @@
 // Circuitboard
 
 /obj/item/circuitboard
+	abstract_type = /obj/item/circuitboard
 	name = "circuit board"
 	icon = 'icons/obj/module.dmi'
 	icon_state = "id_mod"
@@ -57,6 +58,7 @@ micro-manipulator, console screen, beaker, Microlaser, matter bin, power cells.
 */
 
 /obj/item/circuitboard/machine
+	abstract_type = /obj/item/circuitboard/machine
 	var/needs_anchored = TRUE // Whether this machine must be anchored to be constructed.
 	var/list/req_components // Components required by the machine.
 							// Example: list(/obj/item/stock_parts/matter_bin = 5)

--- a/code/game/objects/items/circuitboards/computer_circuitboards.dm
+++ b/code/game/objects/items/circuitboards/computer_circuitboards.dm
@@ -1,5 +1,7 @@
-//Command boards
+/obj/item/circuitboard/computer
+	abstract_type = /obj/item/circuitboard/computer
 
+//Command boards
 
 /obj/item/circuitboard/computer/aiupload
 	name = "AI upload (Computer Board)"

--- a/code/game/objects/items/debug_items.dm
+++ b/code/game/objects/items/debug_items.dm
@@ -1,4 +1,6 @@
 /* This file contains standalone items for debug purposes. */
+/obj/item/debug
+	abstract_type = /obj/item/debug
 
 /obj/item/debug/human_spawner
 	name = "human spawner"

--- a/code/game/objects/items/food/_food.dm
+++ b/code/game/objects/items/food/_food.dm
@@ -6,6 +6,7 @@
 
 ///Abstract class to allow us to easily create all the generic "normal" food without too much copy pasta of adding more components
 /obj/item/food
+	abstract_type = /obj/item/food
 	name = "food"
 	desc = "you eat this"
 	resistance_flags = FLAMMABLE

--- a/code/game/objects/items/food/bread.dm
+++ b/code/game/objects/items/food/bread.dm
@@ -1,5 +1,6 @@
 
 /obj/item/food/bread
+	abstract_type = /obj/item/food/bread
 	name = "bread?"
 	desc = "This shouldn't exist, report to codermonkeys"
 	icon = 'icons/obj/food/burgerbread.dmi'
@@ -24,6 +25,7 @@
 		AddElement(/datum/element/processable, TOOL_SAW, slice_type, yield, 4 SECONDS, table_required = TRUE, screentip_verb = "Slice")
 
 /obj/item/food/breadslice
+	abstract_type = /obj/item/food/breadslice
 	name = "breadslice?"
 	desc = "This shouldn't exist, report to codermonkeys"
 	icon = 'icons/obj/food/burgerbread.dmi'

--- a/code/game/objects/items/food/burgers.dm
+++ b/code/game/objects/items/food/burgers.dm
@@ -1,4 +1,5 @@
 /obj/item/food/burger
+	abstract_type = /obj/item/food/burger
 	icon = 'icons/obj/food/burgerbread.dmi'
 	icon_state = "hburger"
 	bite_consumption = 3

--- a/code/game/objects/items/food/cake.dm
+++ b/code/game/objects/items/food/cake.dm
@@ -1,4 +1,5 @@
 /obj/item/food/cake
+	abstract_type = /obj/item/food/cake
 	name = "Cake Parent"
 	desc = "You either spawned this erroneously, or a coder did. Either way, someone messed up."
 	icon = 'icons/obj/food/piecake.dmi'
@@ -26,6 +27,7 @@
 		AddElement(/datum/element/processable, TOOL_KNIFE, slice_type, yield, 3 SECONDS, table_required = TRUE, screentip_verb = "Slice")
 
 /obj/item/food/cakeslice
+	abstract_type = /obj/item/food/cakeslice
 	name = "Cakeslice Parent"
 	desc = "You either spawned this erroneously, or a coder did. Either way, someone messed up."
 	icon = 'icons/obj/food/piecake.dmi'

--- a/code/game/objects/items/food/cheese.dm
+++ b/code/game/objects/items/food/cheese.dm
@@ -1,4 +1,5 @@
 /obj/item/food/cheese
+	abstract_type = /obj/item/food/cheese
 	name = "the concept of cheese"
 	desc = "This probably shouldn't exist."
 	tastes = list("cheese" = 1)

--- a/code/game/objects/items/food/donuts.dm
+++ b/code/game/objects/items/food/donuts.dm
@@ -1,6 +1,7 @@
 #define DONUT_SPRINKLE_CHANCE 30
 
 /obj/item/food/donut
+	abstract_type = /obj/item/food/donut
 	name = "donut"
 	desc = "Goes great with robust coffee."
 	icon = 'icons/obj/food/donuts.dmi'

--- a/code/game/objects/items/food/meatdish.dm
+++ b/code/game/objects/items/food/meatdish.dm
@@ -566,6 +566,7 @@
 //////////////////////////////////////////// KEBABS AND OTHER SKEWERS ////////////////////////////////////////////
 
 /obj/item/food/kebab
+	abstract_type = /obj/item/food/kebab
 	trash_type = /obj/item/stack/rods
 	icon = 'icons/obj/food/meat.dmi'
 	icon_state = "kebab"

--- a/code/game/objects/items/food/meatslab.dm
+++ b/code/game/objects/items/food/meatslab.dm
@@ -1,4 +1,5 @@
 /obj/item/food/meat
+	abstract_type = /obj/item/food/meat
 	custom_materials = list(/datum/material/meat = MINERAL_MATERIAL_AMOUNT * 4)
 	w_class = WEIGHT_CLASS_SMALL
 	icon = 'icons/obj/food/meat.dmi'
@@ -49,6 +50,9 @@
 
 /obj/item/food/meat/slab/human/make_dryable()
 	AddElement(/datum/element/dryable, /obj/item/food/sosjerky/healthy/lean)
+
+/obj/item/food/meat/slab/human/mutant
+	abstract_type = /obj/item/food/meat/slab/human/mutant
 
 /obj/item/food/meat/slab/human/mutant/slime
 	icon_state = "slimemeat"

--- a/code/game/objects/items/food/pizza.dm
+++ b/code/game/objects/items/food/pizza.dm
@@ -1,6 +1,7 @@
 
 // Pizza (Whole)
 /obj/item/food/pizza
+	abstract_type = /obj/item/food/pizza
 	icon = 'icons/obj/food/pizza.dmi'
 	w_class = WEIGHT_CLASS_NORMAL
 	max_volume = 80
@@ -34,6 +35,7 @@
 
 // Pizza Slice
 /obj/item/food/pizzaslice
+	abstract_type = /obj/item/food/pizzaslice
 	icon = 'icons/obj/food/pizza.dmi'
 	food_reagents = list(/datum/reagent/consumable/nutriment = 5)
 	foodtypes = GRAIN | DAIRY | VEGETABLES

--- a/code/game/objects/items/food/salad.dm
+++ b/code/game/objects/items/food/salad.dm
@@ -1,6 +1,7 @@
 //this category is very little but I think that it has great potential to grow
 ////////////////////////////////////////////SALAD////////////////////////////////////////////
 /obj/item/food/salad
+	abstract_type = /obj/item/food/salad
 	icon = 'icons/obj/food/soupsalad.dmi'
 	trash_type = /obj/item/reagent_containers/cup/bowl
 	bite_consumption = 3

--- a/code/game/objects/items/food/soup.dm
+++ b/code/game/objects/items/food/soup.dm
@@ -1,4 +1,5 @@
 /obj/item/food/soup
+	abstract_type = /obj/item/food/soup
 	w_class = WEIGHT_CLASS_NORMAL
 	icon = 'icons/obj/food/soupsalad.dmi'
 	trash_type = /obj/item/reagent_containers/cup/bowl

--- a/code/game/objects/items/food/spaghetti.dm
+++ b/code/game/objects/items/food/spaghetti.dm
@@ -1,4 +1,5 @@
 /obj/item/food/spaghetti
+	abstract_type = /obj/item/food/spaghetti
 	name = "Spaghetti Parent"
 	desc = "You either spawned this erroneously, or a coder did. Either way, someone messed up."
 	icon = 'icons/obj/food/spaghetti.dmi'

--- a/code/game/objects/items/food/sushi.dm
+++ b/code/game/objects/items/food/sushi.dm
@@ -1,4 +1,5 @@
 /obj/item/food/sushi_roll
+	abstract_type = /obj/item/food/sushi_roll
 	name = "Sushi Parent"
 	desc = "You either spawned this erroneously, or a coder did. Either way, someone messed up."
 	icon = 'icons/obj/food/sushi.dmi'
@@ -17,6 +18,7 @@
 		AddElement(/datum/element/processable, TOOL_KNIFE, slice_type, yield, 3 SECONDS, table_required = TRUE, screentip_verb = "Slice")
 
 /obj/item/food/sushi_slice
+	abstract_type = /obj/item/food/sushi_slice
 	name = "Sushi Slice Parent"
 	desc = "You either spawned this erroneously, or a coder did. Either way, someone messed up."
 	icon = 'icons/obj/food/sushi.dmi'

--- a/code/game/objects/items/handcuffs.dm
+++ b/code/game/objects/items/handcuffs.dm
@@ -1,4 +1,5 @@
 /obj/item/restraints
+	abstract_type = /obj/item/restraints
 	breakouttime = 1 MINUTES
 	item_flags = ISWEAPON
 

--- a/code/game/objects/items/kitchen.dm
+++ b/code/game/objects/items/kitchen.dm
@@ -10,6 +10,7 @@
  */
 
 /obj/item/kitchen
+	abstract_type = /obj/item/kitchen
 	icon = 'icons/obj/service/kitchen.dmi'
 	lefthand_file = 'icons/mob/inhands/equipment/kitchen_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/kitchen_righthand.dmi'

--- a/code/game/objects/items/melee/energy.dm
+++ b/code/game/objects/items/melee/energy.dm
@@ -1,4 +1,5 @@
 /obj/item/melee/energy
+	abstract_type = /obj/item/melee/energy
 	icon = 'icons/obj/transforming_energy.dmi'
 	max_integrity = 200
 	armor_type = /datum/armor/transforming_energy

--- a/code/game/objects/items/melee/misc.dm
+++ b/code/game/objects/items/melee/misc.dm
@@ -1,4 +1,5 @@
 /obj/item/melee
+	abstract_type = /obj/item/melee
 	item_flags = NEEDS_PERMIT | ISWEAPON
 
 /obj/item/melee/proc/check_martial_counter(mob/living/carbon/human/target, mob/living/carbon/human/user)

--- a/code/game/objects/items/robot/robot_items.dm
+++ b/code/game/objects/items/robot/robot_items.dm
@@ -2,8 +2,8 @@
 						Cyborg Spec Items
 ***********************************************************************/
 /obj/item/borg
+	abstract_type = /obj/item/borg
 	icon = 'icons/mob/robot_items.dmi'
-
 
 /obj/item/borg/stun
 	name = "electrically-charged arm"

--- a/code/game/objects/items/shields.dm
+++ b/code/game/objects/items/shields.dm
@@ -1,4 +1,5 @@
 /obj/item/shield
+	abstract_type = /obj/item/shield
 	name = "shield"
 	icon = 'icons/obj/shields.dmi'
 	canblock = TRUE

--- a/code/game/objects/items/stacks/sheets/mineral/materials.dm
+++ b/code/game/objects/items/stacks/sheets/mineral/materials.dm
@@ -17,6 +17,9 @@ Mineral Sheets
 
 /* Sandstone */
 
+/obj/item/stack/sheet/mineral
+	abstract_type = /obj/item/stack/sheet/mineral
+
 /obj/item/stack/sheet/mineral/sandstone
 	name = "sandstone brick"
 	desc = "This appears to be a combination of both sand and stone."

--- a/code/game/objects/items/stacks/sheets/organic/hides.dm
+++ b/code/game/objects/items/stacks/sheets/organic/hides.dm
@@ -1,6 +1,7 @@
 /* Null hide */
 
 /obj/item/stack/sheet/animalhide
+	abstract_type = /obj/item/stack/sheet/animalhide
 	name = "hide"
 	desc = "Something went wrong."
 	icon_state = "sheet-hide"

--- a/code/game/objects/items/stacks/sheets/sheets.dm
+++ b/code/game/objects/items/stacks/sheets/sheets.dm
@@ -1,4 +1,5 @@
 /obj/item/stack/sheet
+	abstract_type = /obj/item/stack/sheet
 	name = "sheet"
 	lefthand_file = 'icons/mob/inhands/misc/sheets_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/misc/sheets_righthand.dmi'

--- a/code/game/objects/items/stacks/stack.dm
+++ b/code/game/objects/items/stacks/stack.dm
@@ -10,6 +10,7 @@
  */
 
 /obj/item/stack
+	abstract_type = /obj/item/stack
 	icon = 'icons/obj/stacks/minerals.dmi'
 	gender = PLURAL
 	material_modifier = 0.05 //5%, so that a 50 sheet stack has the effect of 5k materials instead of 100k.

--- a/code/game/objects/items/storage/bags.dm
+++ b/code/game/objects/items/storage/bags.dm
@@ -20,6 +20,7 @@
 
 //  Generic non-item
 /obj/item/storage/bag
+	abstract_type = /obj/item/storage/bag
 	slot_flags = ITEM_SLOT_BELT
 
 /obj/item/storage/bag/Initialize(mapload)

--- a/code/game/objects/items/storage/belt.dm
+++ b/code/game/objects/items/storage/belt.dm
@@ -1,4 +1,5 @@
 /obj/item/storage/belt
+	abstract_type = /obj/item/storage/belt
 	name = "belt"
 	desc = "Can hold various things."
 	icon = 'icons/obj/clothing/belts.dmi'

--- a/code/game/objects/items/storage/fancy.dm
+++ b/code/game/objects/items/storage/fancy.dm
@@ -12,6 +12,7 @@
  */
 
 /obj/item/storage/fancy
+	abstract_type = /obj/item/storage/fancy
 	icon = 'icons/obj/food/containers.dmi'
 	resistance_flags = FLAMMABLE
 	//custom_materials = list(/datum/material/cardboard = 2000)

--- a/code/game/objects/items/storage/storage.dm
+++ b/code/game/objects/items/storage/storage.dm
@@ -1,4 +1,5 @@
 /obj/item/storage
+	abstract_type = /obj/item/storage
 	name = "storage"
 	icon = 'icons/obj/storage/storage.dmi'
 	w_class = WEIGHT_CLASS_NORMAL

--- a/code/game/objects/items/toys.dm
+++ b/code/game/objects/items/toys.dm
@@ -28,6 +28,7 @@
 
 
 /obj/item/toy
+	abstract_type = /obj/item/toy
 	throwforce = 0
 	throw_speed = 3
 	throw_range = 7
@@ -268,6 +269,9 @@
 	user.visible_message(span_danger("[user] fires [src] at [target]!"), \
 						span_danger("You fire [src] at [target]!"), \
 						span_italics("You hear a gunshot!"))
+
+/obj/item/toy/ammo
+	abstract_type = /obj/item/toy/ammo
 
 /obj/item/toy/ammo/gun
 	name = "capgun ammo"

--- a/code/game/objects/items/trash.dm
+++ b/code/game/objects/items/trash.dm
@@ -1,5 +1,6 @@
 //Added by Jack Rost
 /obj/item/trash
+	abstract_type = /obj/item/trash
 	icon = 'icons/obj/janitor.dmi'
 	lefthand_file = 'icons/mob/inhands/misc/food_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/misc/food_righthand.dmi'

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -1,6 +1,7 @@
 CREATION_TEST_IGNORE_SELF(/obj)
 
 /obj
+	abstract_type = /obj
 	animate_movement = SLIDE_STEPS
 	speech_span = SPAN_ROBOT
 	var/obj_flags = CAN_BE_HIT

--- a/code/game/objects/structures.dm
+++ b/code/game/objects/structures.dm
@@ -1,5 +1,6 @@
 /// Inert structures, such as girders, machine frames, and crates/lockers.
 /obj/structure
+	abstract_type = /obj/structure
 	icon = 'icons/obj/structures.dmi'
 	pressure_resistance = 8
 	max_integrity = 300

--- a/code/game/objects/structures/statues.dm
+++ b/code/game/objects/structures/statues.dm
@@ -1,5 +1,6 @@
 
 /obj/structure/statue
+	abstract_type = /obj/structure/statue
 	name = "statue"
 	desc = "Placeholder. Yell at Qwerty if you SOMEHOW see this."
 	icon = 'icons/obj/statue.dmi'

--- a/code/game/turfs/closed/_closed.dm
+++ b/code/game/turfs/closed/_closed.dm
@@ -1,6 +1,7 @@
 CREATION_TEST_IGNORE_SELF(/turf/closed)
 
 /turf/closed
+	abstract_type = /turf/closed
 	layer = CLOSED_TURF_LAYER
 	opacity = TRUE
 	density = TRUE

--- a/code/game/turfs/closed/wall/mineral_walls.dm
+++ b/code/game/turfs/closed/wall/mineral_walls.dm
@@ -1,4 +1,5 @@
 /turf/closed/wall/mineral
+	abstract_type = /turf/closed/wall/mineral
 	name = "mineral wall"
 	desc = "This shouldn't exist"
 	icon_state = "wall-0"

--- a/code/game/turfs/open/_open.dm
+++ b/code/game/turfs/open/_open.dm
@@ -1,6 +1,7 @@
 CREATION_TEST_IGNORE_SELF(/turf/open)
 
 /turf/open
+	abstract_type = /turf/open
 	plane = FLOOR_PLANE
 	can_hit = FALSE
 	FASTDMM_PROP(\

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -4,6 +4,7 @@ GLOBAL_LIST_EMPTY(created_baseturf_lists)
 CREATION_TEST_IGNORE_SELF(/turf)
 
 /turf
+	abstract_type = /turf
 	icon = 'icons/turf/floors.dmi'
 	vis_flags = VIS_INHERIT_ID|VIS_INHERIT_PLANE // Important for interaction with and visualization of openspace.
 	uses_integrity = TRUE

--- a/code/modules/admin/verbs/debug.dm
+++ b/code/modules/admin/verbs/debug.dm
@@ -1176,10 +1176,8 @@ But you can call procs that are of type /mob/living/carbon/human/proc/ for that 
 		to_chat(usr, span_warning("Asset caching is disabled in the config!"))
 		return
 	var/regenerated = 0
-	for(var/datum/asset/target_spritesheet as anything in subtypesof(/datum/asset))
+	for(var/datum/asset/target_spritesheet as anything in valid_subtypesof(/datum/asset))
 		if(!initial(target_spritesheet.cross_round_cachable))
-			continue
-		if(target_spritesheet == initial(target_spritesheet._abstract))
 			continue
 		var/datum/asset/asset_datum = GLOB.asset_datums[target_spritesheet]
 		asset_datum.regenerate()
@@ -1194,9 +1192,7 @@ But you can call procs that are of type /mob/living/carbon/human/proc/ for that 
 		to_chat(usr, span_warning("Smart asset caching is disabled in the config!"))
 		return
 	var/cleared = 0
-	for(var/datum/asset/spritesheet_batched/target_spritesheet as anything in subtypesof(/datum/asset/spritesheet_batched))
-		if(target_spritesheet == initial(target_spritesheet._abstract))
-			continue
+	for(var/datum/asset/spritesheet_batched/target_spritesheet as anything in valid_subtypesof(/datum/asset/spritesheet_batched))
 		fdel("[ASSET_CROSS_ROUND_SMART_CACHE_DIRECTORY]/spritesheet_cache.[initial(target_spritesheet.name)].json")
 		cleared++
 	to_chat(usr, span_notice("Cleared [cleared] asset\s."))

--- a/code/modules/antagonists/_common/antag_datum.dm
+++ b/code/modules/antagonists/_common/antag_datum.dm
@@ -2,6 +2,7 @@ GLOBAL_LIST_EMPTY(active_antagonists)
 GLOBAL_LIST(admin_antag_list)
 
 /datum/antagonist
+	abstract_type = /datum/antagonist
 	var/tips
 	var/name = "Antagonist"
 	var/roundend_category = "other antagonists"				//Section of roundend report, datums with same category will be displayed together, also default header for the section

--- a/code/modules/antagonists/_common/antag_spawner.dm
+++ b/code/modules/antagonists/_common/antag_spawner.dm
@@ -1,4 +1,5 @@
 /obj/item/antag_spawner
+	abstract_type = /obj/item/antag_spawner
 	throw_speed = 1
 	throw_range = 5
 	w_class = WEIGHT_CLASS_TINY

--- a/code/modules/antagonists/abductor/equipment/abduction_gear.dm
+++ b/code/modules/antagonists/abductor/equipment/abduction_gear.dm
@@ -173,6 +173,7 @@
 	atom_storage.max_total_storage = 30
 
 /obj/item/abductor
+	abstract_type = /obj/item/abductor
 	icon = 'icons/obj/abductor.dmi'
 	lefthand_file = 'icons/mob/inhands/antag/abductor_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/antag/abductor_righthand.dmi'

--- a/code/modules/antagonists/changeling/changeling_power.dm
+++ b/code/modules/antagonists/changeling/changeling_power.dm
@@ -3,6 +3,7 @@
  */
 
 /datum/action/changeling
+	abstract_type = /datum/action/changeling
 	name = "Prototype Sting - Debug button, ahelp this"
 	background_icon_state = "bg_changeling"
 	button_icon = 'icons/hud/actions/actions_changeling.dmi'

--- a/code/modules/antagonists/changeling/powers/mutations.dm
+++ b/code/modules/antagonists/changeling/powers/mutations.dm
@@ -11,6 +11,7 @@
 
 //Parent to shields and blades because muh copypasted code.
 /datum/action/changeling/weapon
+	abstract_type = /datum/action/changeling/weapon
 	name = "Organic Weapon"
 	desc = "Go tell a coder if you see this"
 	helptext = "Yell at Miauw and/or Perakp"
@@ -67,6 +68,7 @@
 
 //Parent to space suits and armor.
 /datum/action/changeling/suit
+	abstract_type = /datum/action/changeling/suit
 	name = "Organic Suit"
 	desc = "Go tell a coder if you see this"
 	helptext = "Yell at Miauw and/or Perakp"

--- a/code/modules/antagonists/heretic/heretic_knowledge.dm
+++ b/code/modules/antagonists/heretic/heretic_knowledge.dm
@@ -9,14 +9,13 @@
  *
  */
 /datum/heretic_knowledge
+	abstract_type = /datum/heretic_knowledge
 	/// Name of the knowledge, shown to the heretic.
 	var/name = "Basic knowledge"
 	/// Description of the knowledge, shown to the heretic. Describes what it unlocks / does.
 	var/desc = "Basic knowledge of forbidden arts."
 	/// What's shown to the heretic when the knowledge is aquired
 	var/gain_text
-	/// The abstract parent type of the knowledge, used in determine mutual exclusivity in some cases
-	var/datum/heretic_knowledge/abstract_parent_type = /datum/heretic_knowledge
 	/// The knowledge this unlocks next after learning.
 	var/list/next_knowledge = list()
 	/// What knowledge is incompatible with this. Knowledge in this list cannot be researched with this current knowledge.
@@ -157,7 +156,7 @@
  * A knowledge subtype that grants the heretic a certain spell.
  */
 /datum/heretic_knowledge/spell
-	abstract_parent_type = /datum/heretic_knowledge/spell
+	abstract_type = /datum/heretic_knowledge/spell
 	/// Spell path we add to the heretic. Type-path.
 	var/datum/action/spell/spell_to_add
 	/// The spell we actually created.
@@ -185,6 +184,7 @@
  * created at once.
  */
 /datum/heretic_knowledge/limited_amount
+	abstract_type = /datum/heretic_knowledge/limited_amount
 	/// The limit to how many items we can create at once.
 	var/limit = 1
 	/// A list of weakrefs to all items we've created.
@@ -232,6 +232,7 @@
  * A knowledge subtype lets the heretic curse someone with a ritual.
  */
 /datum/heretic_knowledge/curse
+	abstract_type = /datum/heretic_knowledge/curse
 	/// The duration of the curse
 	var/duration = 5 MINUTES
 	/// Cache list of fingerprints (actual fingerprint strings) we have from our current ritual
@@ -295,6 +296,7 @@
  * A knowledge subtype lets the heretic summon a monster with the ritual.
  */
 /datum/heretic_knowledge/summon
+	abstract_type = /datum/heretic_knowledge/summon
 	/// Typepath of a mob to summon when we finish the recipe.
 	var/mob/living/mob_to_summon
 
@@ -437,6 +439,7 @@
  * The special final tier of knowledges that unlocks ASCENSION.
  */
 /datum/heretic_knowledge/final
+	abstract_type = /datum/heretic_knowledge/final
 	cost = 2
 	priority = MAX_KNOWLEDGE_PRIORITY + 1 // Yes, the final ritual should be ABOVE the max priority.
 	required_atoms = list(/mob/living/carbon/human = 3)

--- a/code/modules/antagonists/heretic/knowledge/starting_lore.dm
+++ b/code/modules/antagonists/heretic/knowledge/starting_lore.dm
@@ -9,7 +9,7 @@ GLOBAL_LIST_INIT(heretic_start_knowledge, initialize_starting_knowledge())
  */
 /proc/initialize_starting_knowledge()
 	. = list()
-	for(var/datum/heretic_knowledge/knowledge as anything in subtypesof(/datum/heretic_knowledge))
+	for(var/datum/heretic_knowledge/knowledge as anything in valid_subtypesof(/datum/heretic_knowledge))
 		if(initial(knowledge.route) == HERETIC_PATH_START)
 			. += knowledge
 

--- a/code/modules/antagonists/pirate/pirate_threat.dm
+++ b/code/modules/antagonists/pirate/pirate_threat.dm
@@ -402,6 +402,7 @@ DEFINE_BUFFER_HANDLER(/obj/machinery/computer/piratepad_control)
 
 /// This only serves to be a parent type to all pirate exports for purposes of find_loot
 /datum/export/pirate
+	abstract_type = /datum/export/pirate
 
 /datum/export/pirate/proc/find_loot()
 	return

--- a/code/modules/antagonists/role_preference/_role_preference.dm
+++ b/code/modules/antagonists/role_preference/_role_preference.dm
@@ -1,11 +1,11 @@
 /datum/role_preference
+	abstract_type = /datum/role_preference
+
 	var/name
 	/// A brief description of this role, to display in the preferences menu.
 	var/description
 	/// What heading to display this entry under in the preferences menu. Use ROLE_PREFERENCE_CATEGORY defines.
 	var/category
-	/// The base abstract path for this subtype.
-	var/abstract_type = /datum/role_preference
 	/// The Antagonist datum typepath for this entry, if there is one. Used to get data about the role for display (bans etc)
 	var/datum/antagonist/antag_datum
 	/// If this preference can vary between characters.
@@ -55,21 +55,21 @@
 
 /// Includes roundstart antagonists
 /datum/role_preference/roundstart
-	category = ROLE_PREFERENCE_CATEGORY_ROUNDSTART
 	abstract_type = /datum/role_preference/roundstart
+	category = ROLE_PREFERENCE_CATEGORY_ROUNDSTART
 	per_character = TRUE
 	default_enabled = TRUE
 
 /// Includes living dynamic midround assignments (does not apply to conversion antags).
 /datum/role_preference/midround
-	category = ROLE_PREFERENCE_CATEGORY_MIDROUND
 	abstract_type = /datum/role_preference/midround
+	category = ROLE_PREFERENCE_CATEGORY_MIDROUND
 	per_character = TRUE
 	default_enabled = TRUE
 
 /// Includes roundstart antagonists
 /datum/role_preference/supplementary
-	category = ROLE_PREFERENCE_CATEGORY_SUPPLEMENTARY
 	abstract_type = /datum/role_preference/supplementary
+	category = ROLE_PREFERENCE_CATEGORY_SUPPLEMENTARY
 	per_character = TRUE
 	default_enabled = TRUE

--- a/code/modules/antagonists/vampire/datum_vampire.dm
+++ b/code/modules/antagonists/vampire/datum_vampire.dm
@@ -100,7 +100,7 @@
 	var/obj/effect/abstract/vampire_tracker_holder/tracker
 
 	/// Static typecache of all vampire powers.
-	var/static/list/all_vampire_powers = typecacheof(/datum/action/vampire, ignore_root_path = TRUE)
+	var/static/list/all_vampire_powers = valid_subtypesof(/datum/action/vampire)
 	/// Antagonists that cannot be vassalized no matter what
 	var/static/list/vassal_banned_antags = list(
 		/datum/antagonist/vampire,

--- a/code/modules/antagonists/vampire/powers/_power.dm
+++ b/code/modules/antagonists/vampire/powers/_power.dm
@@ -1,4 +1,5 @@
 /datum/action/vampire
+	abstract_type = /datum/action/vampire
 	name = "Vampiric Gift"
 	desc = "A vampiric gift."
 	background_icon = 'icons/vampires/actions_vampire.dmi'

--- a/code/modules/antagonists/vampire/powers/_shapeshift.dm
+++ b/code/modules/antagonists/vampire/powers/_shapeshift.dm
@@ -1,4 +1,5 @@
 /datum/action/vampire/shapeshift
+	abstract_type = /datum/action/vampire/shapeshift
 	power_flags = BP_AM_TOGGLE
 	check_flags = BP_CANT_USE_IN_TORPOR | BP_CANT_USE_WHILE_STAKED | BP_CANT_USE_IN_FRENZY | BP_CANT_USE_WHILE_INCAPACITATED | BP_CANT_USE_WHILE_UNCONSCIOUS
 

--- a/code/modules/antagonists/vampire/powers/_targeted.dm
+++ b/code/modules/antagonists/vampire/powers/_targeted.dm
@@ -1,5 +1,6 @@
 // NOTE: All Targeted spells are Toggles! We just don't bother checking here.
 /datum/action/vampire/targeted
+	abstract_type = /datum/action/vampire/targeted
 	power_flags = BP_AM_TOGGLE
 
 	///If set, how far the target has to be for the power to work.

--- a/code/modules/asset_cache/asset_list.dm
+++ b/code/modules/asset_cache/asset_list.dm
@@ -14,7 +14,7 @@ GLOBAL_LIST_EMPTY(asset_datums)
 	return loaded_asset.ensure_ready()
 
 /datum/asset
-	var/_abstract = /datum/asset
+	abstract_type = /datum/asset
 	var/cached_serialized_url_mappings
 	var/cached_serialized_url_mappings_transport_type
 
@@ -74,7 +74,7 @@ GLOBAL_LIST_EMPTY(asset_datums)
 
 /// If you don't need anything complicated.
 /datum/asset/simple
-	_abstract = /datum/asset/simple
+	abstract_type = /datum/asset/simple
 	/// list of assets for this datum in the form of:
 	/// asset_filename = asset_file. At runtime the asset_file will be
 	/// converted into a asset_cache datum.
@@ -111,7 +111,7 @@ GLOBAL_LIST_EMPTY(asset_datums)
 
 // For registering or sending multiple others at once
 /datum/asset/group
-	_abstract = /datum/asset/group
+	abstract_type = /datum/asset/group
 	var/list/children
 
 /datum/asset/group/register()
@@ -135,7 +135,7 @@ GLOBAL_LIST_EMPTY(asset_datums)
 		A.unregister()
 
 /datum/asset/changelog_item
-	_abstract = /datum/asset/changelog_item
+	abstract_type = /datum/asset/changelog_item
 	var/item_filename
 
 /datum/asset/changelog_item/New(date)
@@ -154,7 +154,7 @@ GLOBAL_LIST_EMPTY(asset_datums)
 
 //Generates assets based on iconstates of a single icon
 /datum/asset/simple/icon_states
-	_abstract = /datum/asset/simple/icon_states
+	abstract_type = /datum/asset/simple/icon_states
 	var/icon
 	var/list/directions = list(SOUTH)
 	var/frame = 1
@@ -178,7 +178,7 @@ GLOBAL_LIST_EMPTY(asset_datums)
 			SSassets.transport.register_asset(asset_name, asset)
 
 /datum/asset/simple/icon_states/multiple_icons
-	_abstract = /datum/asset/simple/icon_states/multiple_icons
+	abstract_type = /datum/asset/simple/icon_states/multiple_icons
 	var/list/icons
 
 /datum/asset/simple/icon_states/multiple_icons/register()
@@ -191,7 +191,7 @@ GLOBAL_LIST_EMPTY(asset_datums)
 /// For example `blah.css` with asset `blah.png` will get loaded as `namespaces/a3d..14f/f12..d3c.css` and `namespaces/a3d..14f/blah.png`. allowing the css file to load `blah.png` by a relative url rather then compute the generated url with get_url_mappings().
 /// The namespace folder's name will change if any of the assets change. (excluding parent assets)
 /datum/asset/simple/namespaced
-	_abstract = /datum/asset/simple/namespaced
+	abstract_type = /datum/asset/simple/namespaced
 	/// parents - list of the parent asset or assets (in name = file assoicated format) for this namespace.
 	/// parent assets must be referenced by their generated url, but if an update changes a parent asset, it won't change the namespace's identity.
 	var/list/parents = list()
@@ -236,7 +236,7 @@ GLOBAL_LIST_EMPTY(asset_datums)
 
 /// A subtype to generate a JSON file from a list
 /datum/asset/json
-	_abstract = /datum/asset/json
+	abstract_type = /datum/asset/json
 	/// The filename, will be suffixed with ".json"
 	var/name
 

--- a/code/modules/asset_cache/spritesheet/batched/batched_spritesheet.dm
+++ b/code/modules/asset_cache/spritesheet/batched/batched_spritesheet.dm
@@ -7,7 +7,7 @@
 #define SPRITESHEET_SYSTEM_VERSION 1
 
 /datum/asset/spritesheet_batched
-	_abstract = /datum/asset/spritesheet_batched
+	abstract_type = /datum/asset/spritesheet_batched
 	var/name
 	/// list("32x32")
 	var/list/sizes = list()

--- a/code/modules/asset_cache/spritesheet/legacy/legacy_spritesheet.dm
+++ b/code/modules/asset_cache/spritesheet/legacy/legacy_spritesheet.dm
@@ -10,7 +10,7 @@
 
 /// Deprecated: Use /datum/asset/spritesheet_batched where possible
 /datum/asset/spritesheet
-	_abstract = /datum/asset/spritesheet
+	abstract_type = /datum/asset/spritesheet
 	cross_round_cachable = TRUE
 	var/name
 	/// List of arguments to pass into queuedInsert
@@ -383,7 +383,7 @@
 /// Spritesheet that only uses simple PNGs and CSS keys. See `assets` variable.
 /// Deprecated: Use /datum/asset/spritesheet_batched where possible
 /datum/asset/spritesheet/simple
-	_abstract = /datum/asset/spritesheet/simple
+	abstract_type = /datum/asset/spritesheet/simple
 	/// Associative list of icon keys (CSS class names) -> PNG filepaths (single quote!)
 	/// File paths MUST be PNGs
 	var/list/assets

--- a/code/modules/atmospherics/gasmixtures/gas_types.dm
+++ b/code/modules/atmospherics/gasmixtures/gas_types.dm
@@ -47,6 +47,7 @@ GLOBAL_LIST_INIT(hardcoded_gases, list(/datum/gas/oxygen, /datum/gas/nitrogen, /
 \*||||||||||||||||||||||||||||||||||||||||*/
 
 /datum/gas
+	abstract_type = /datum/gas
 	var/id = ""
 	var/specific_heat = 0
 	var/name = ""

--- a/code/modules/cargo/bounties/assistant.dm
+++ b/code/modules/cargo/bounties/assistant.dm
@@ -1,3 +1,6 @@
+/datum/bounty/item/assistant
+	abstract_type = /datum/bounty/item/assistant
+
 /datum/bounty/item/assistant/scooter
 	name = "Scooter"
 	description = "Nanotrasen has determined walking to be wasteful. Ship a scooter to CentCom to speed operations up."

--- a/code/modules/cargo/bounties/botany.dm
+++ b/code/modules/cargo/bounties/botany.dm
@@ -1,4 +1,7 @@
 /datum/bounty/item/botany
+	abstract_type = /datum/bounty/item/botany
+
+/datum/bounty/item/botany
 	reward = 5000
 	var/datum/bounty/item/botany/multiplier = 0 //adds bonus reward money; increased for higher tier or rare mutations
 	var/datum/bounty/item/botany/bonus_desc //for adding extra flavor text to bounty descriptions

--- a/code/modules/cargo/bounties/chef.dm
+++ b/code/modules/cargo/bounties/chef.dm
@@ -1,3 +1,6 @@
+/datum/bounty/item/chef
+	abstract_type = /datum/bounty/item/chef
+
 /datum/bounty/item/chef/birthday_cake
 	name = "Birthday Cake"
 	description = "Nanotrasen's birthday is coming up! Ship them a birthday cake to celebrate!"

--- a/code/modules/cargo/bounties/core.dm
+++ b/code/modules/cargo/bounties/core.dm
@@ -1,3 +1,6 @@
+/datum/bounty/item/core
+	abstract_type = /datum/bounty/item/core
+
 /datum/bounty/item/core/New()
 	..()
 	description = "The admiral heard that a [name] could help you grow your beard, fetch a [name] immediately! Ship it to receive a large payment."

--- a/code/modules/cargo/bounties/engineering.dm
+++ b/code/modules/cargo/bounties/engineering.dm
@@ -1,3 +1,6 @@
+/datum/bounty/item/engineering
+	abstract_type = /datum/bounty/item/engineering
+
 /datum/bounty/item/engineering/gas
 	name = "Full Tank of Pluoxium"
 	description = "CentCom RnD is researching extra compact internals. Ship us a tank full of Pluoxium and you'll be compensated."

--- a/code/modules/cargo/bounties/genetics.dm
+++ b/code/modules/cargo/bounties/genetics.dm
@@ -1,4 +1,7 @@
 /datum/bounty/genetics
+	abstract_type = /datum/bounty/genetics
+
+/datum/bounty/genetics
 	reward = 1000
 	var/shipped = FALSE
 	var/datum/mutation/bounty_mutation

--- a/code/modules/cargo/bounties/item.dm
+++ b/code/modules/cargo/bounties/item.dm
@@ -1,4 +1,5 @@
 /datum/bounty/item
+	abstract_type = /datum/bounty/item
 	/// How many items have to be shipped to complete the bounty
 	var/required_count = 1
 	/// How many items have been shipped for the bounty so far

--- a/code/modules/cargo/bounties/mech.dm
+++ b/code/modules/cargo/bounties/mech.dm
@@ -1,3 +1,6 @@
+/datum/bounty/item/mech
+	abstract_type = /datum/bounty/item/mech
+
 /datum/bounty/item/mech/New()
 	..()
 	description = "Upper management has requested one [name] mech be sent as soon as possible. Ship it to receive a large payment."

--- a/code/modules/cargo/bounties/medical.dm
+++ b/code/modules/cargo/bounties/medical.dm
@@ -1,3 +1,6 @@
+/datum/bounty/item/medical
+	abstract_type = /datum/bounty/item/medical
+
 /datum/bounty/item/medical/heart
 	name = "Heart"
 	description = "Commander Johnson is in critical condition after suffering yet another heart attack. Doctors say he needs a new heart fast. Ship one, pronto!"

--- a/code/modules/cargo/bounties/mining.dm
+++ b/code/modules/cargo/bounties/mining.dm
@@ -1,3 +1,6 @@
+/datum/bounty/item/mining
+	abstract_type = /datum/bounty/item/mining
+
 /datum/bounty/item/mining/goliath_steaks
 	name = "Lava-Cooked Goliath Steaks"
 	description = "Admiral Pavlov has gone on hunger strike ever since the canteen started serving only monkey and monkey byproducts. She is demanding lava-cooked Goliath steaks."

--- a/code/modules/cargo/bounties/reagent.dm
+++ b/code/modules/cargo/bounties/reagent.dm
@@ -1,4 +1,7 @@
 /datum/bounty/reagent
+	abstract_type = /datum/bounty/reagent
+
+/datum/bounty/reagent
 	var/required_volume = 10
 	var/shipped_volume = 0
 	var/datum/reagent/wanted_reagent

--- a/code/modules/cargo/bounties/science.dm
+++ b/code/modules/cargo/bounties/science.dm
@@ -1,3 +1,6 @@
+/datum/bounty/item/science
+	abstract_type = /datum/bounty/item/science
+
 /datum/bounty/item/science/boh
 	name = "Bag of Holding"
 	description = "Nanotrasen would make good use of high-capacity backpacks. If you have any, please ship them."

--- a/code/modules/cargo/bounties/security.dm
+++ b/code/modules/cargo/bounties/security.dm
@@ -1,3 +1,6 @@
+/datum/bounty/item/security
+	abstract_type = /datum/bounty/item/security
+
 /datum/bounty/item/security/riotshotgun
 	name = "Riot Shotguns"
 	description = "Hooligans have boarded CentCom! Ship riot shotguns quick, or things are going to get dirty."

--- a/code/modules/cargo/bounties/slime.dm
+++ b/code/modules/cargo/bounties/slime.dm
@@ -1,4 +1,5 @@
 /datum/bounty/item/slime
+	abstract_type = /datum/bounty/item/slime
 	reward = 3000
 
 /datum/bounty/item/slime/New()

--- a/code/modules/cargo/bounties/virus.dm
+++ b/code/modules/cargo/bounties/virus.dm
@@ -1,4 +1,5 @@
 /datum/bounty/virus
+	abstract_type = /datum/bounty/virus
 	reward = 5000
 	var/shipped = FALSE
 	var/stat_value = 0

--- a/code/modules/cargo/bounty.dm
+++ b/code/modules/cargo/bounty.dm
@@ -1,6 +1,7 @@
 GLOBAL_LIST_EMPTY(bounties_list)
 
 /datum/bounty
+	abstract_type = /datum/bounty
 	var/name
 	var/description
 	var/reward = 1000 // In credits. Modified by a bunch of outside variables, so this is not the real amount of credits awarded.
@@ -128,8 +129,7 @@ GLOBAL_LIST_EMPTY(bounties_list)
 			var/subtype = pick(subtypesof(/datum/bounty/manuscript))
 			return new subtype
 		if(15)
-			var/subtype = pick(subtypesof(/datum/bounty/genetics))
-			return new subtype
+			return new /datum/bounty/genetics()
 
 // Called lazily at startup to populate GLOB.bounties_list with random bounties.
 /proc/setup_bounties()

--- a/code/modules/cargo/exports.dm
+++ b/code/modules/cargo/exports.dm
@@ -97,6 +97,8 @@ then the player gets the profit from selling his own wasted time.
 	return report
 
 /datum/export
+	abstract_type = /datum/export
+
 	/// Unit name. Only used in "Received [total_amount] [name]s [message]."
 	var/unit_name = ""
 	/// Message appended to the sale report

--- a/code/modules/cargo/exports/large_objects.dm
+++ b/code/modules/cargo/exports/large_objects.dm
@@ -1,4 +1,8 @@
+/datum/export/large
+	abstract_type = /datum/export/large
+
 /datum/export/large/reagent_dispenser
+	abstract_type = /datum/export/large/reagent_dispenser
 	cost = 100 // +0-400 depending on amount of reagents left
 	var/contents_cost = 400
 

--- a/code/modules/cargo/exports/sheets.dm
+++ b/code/modules/cargo/exports/sheets.dm
@@ -1,4 +1,5 @@
 /datum/export/stack
+	abstract_type = /datum/export/stack
 	unit_name = "sheet"
 
 /datum/export/stack/get_amount(obj/O)

--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -1,4 +1,5 @@
 /datum/supply_pack
+	abstract_type = /datum/supply_pack
 	var/name = "Crate"
 	var/group = ""
 	var/hidden = FALSE
@@ -70,6 +71,7 @@
 //////////////////////////////////////////////////////////////////////////////
 
 /datum/supply_pack/emergency
+	abstract_type = /datum/supply_pack/emergency
 	group = "Emergency"
 
 /datum/supply_pack/emergency/vehicle
@@ -385,6 +387,7 @@
 //////////////////////////////////////////////////////////////////////////////
 
 /datum/supply_pack/security
+	abstract_type = /datum/supply_pack/security
 	group = "Security"
 	access = ACCESS_SECURITY
 	access_budget = ACCESS_SECURITY
@@ -1032,6 +1035,7 @@
 //////////////////////////////////////////////////////////////////////////////
 
 /datum/supply_pack/engineering
+	abstract_type = /datum/supply_pack/engineering
 	group = "Engineering"
 	crate_type = /obj/structure/closet/crate/engineering
 	access_budget = ACCESS_ENGINE
@@ -1379,6 +1383,7 @@
 //////////////////////////////////////////////////////////////////////////////
 
 /datum/supply_pack/engine
+	abstract_type = /datum/supply_pack/engine
 	group = "Engine Construction"
 	crate_type = /obj/structure/closet/crate/engineering
 	access_budget = ACCESS_ENGINE
@@ -1545,6 +1550,7 @@
 //////////////////////////////////////////////////////////////////////////////
 
 /datum/supply_pack/materials
+	abstract_type = /datum/supply_pack/materials
 	group = "Canisters & Materials"
 
 /datum/supply_pack/materials/cardboard50
@@ -1753,6 +1759,7 @@
 //////////////////////////////////////////////////////////////////////////////
 
 /datum/supply_pack/medical
+	abstract_type = /datum/supply_pack/medical
 	group = "Medical"
 	access_budget = ACCESS_MEDICAL
 	crate_type = /obj/structure/closet/crate/medical
@@ -2040,6 +2047,7 @@
 //////////////////////////////////////////////////////////////////////////////
 
 /datum/supply_pack/science
+	abstract_type = /datum/supply_pack/science
 	group = "Science"
 	access_budget = ACCESS_RESEARCH
 	crate_type = /obj/structure/closet/crate/science
@@ -2209,6 +2217,7 @@
 //////////////////////////////////////////////////////////////////////////////
 
 /datum/supply_pack/service
+	abstract_type = /datum/supply_pack/service
 	group = "Service"
 
 /datum/supply_pack/service/cargo_supples
@@ -2482,6 +2491,7 @@
 //////////////////////////////////////////////////////////////////////////////
 
 /datum/supply_pack/organic
+	abstract_type = /datum/supply_pack/organic
 	group = "Food & Hydroponics"
 	crate_type = /obj/structure/closet/crate/freezer
 
@@ -2830,6 +2840,7 @@
 //////////////////////////////////////////////////////////////////////////////
 
 /datum/supply_pack/critter
+	abstract_type = /datum/supply_pack/critter
 	group = "Livestock"
 	crate_type = /obj/structure/closet/crate/critter
 	max_supply = 4
@@ -3038,6 +3049,7 @@
 //////////////////////////////////////////////////////////////////////////////
 
 /datum/supply_pack/costumes_toys
+	abstract_type = /datum/supply_pack/costumes_toys
 	group = "Costumes & Toys"
 
 /datum/supply_pack/costumes_toys/randomised
@@ -3494,6 +3506,7 @@
 //////////////////////////////////////////////////////////////////////////////
 
 /datum/supply_pack/misc
+	abstract_type = /datum/supply_pack/misc
 	group = "Miscellaneous Supplies"
 
 /datum/supply_pack/misc/artsupply

--- a/code/modules/client/preferences/preference_entry.dm
+++ b/code/modules/client/preferences/preference_entry.dm
@@ -6,17 +6,13 @@ GLOBAL_LIST_INIT(preference_entries_by_key, init_preference_entries_by_key())
 
 /proc/init_preference_entries()
 	var/list/output = list()
-	for (var/datum/preference/preference_type as anything in subtypesof(/datum/preference))
-		if (initial(preference_type.abstract_type) == preference_type)
-			continue
+	for (var/datum/preference/preference_type as anything in valid_subtypesof(/datum/preference))
 		output[preference_type] = new preference_type
 	return output
 
 /proc/init_preference_entries_by_key()
 	var/list/output = list()
-	for (var/datum/preference/preference_type as anything in subtypesof(/datum/preference))
-		if (initial(preference_type.abstract_type) == preference_type)
-			continue
+	for (var/datum/preference/preference_type as anything in valid_subtypesof(/datum/preference))
 		output[initial(preference_type.db_key)] = GLOB.preference_entries[preference_type]
 	return output
 
@@ -35,6 +31,8 @@ GLOBAL_LIST_INIT(preference_entries_by_key, init_preference_entries_by_key())
 
 /// Represents an individual preference.
 /datum/preference
+	abstract_type = /datum/preference
+
 	/// The key inside the database to use.
 	/// This is also sent to the UI.
 	/// Once you pick this, don't change it.
@@ -44,9 +42,6 @@ GLOBAL_LIST_INIT(preference_entries_by_key, init_preference_entries_by_key())
 	/// This isn't used for anything other than as a key for UI data.
 	/// It is up to the PreferencesMenu UI itself to interpret it.
 	var/category = "misc"
-
-	/// Do not instantiate if type matches this.
-	var/abstract_type = /datum/preference
 
 	/// What location should this preference be read from?
 	/// Valid values are PREFERENCE_CHARACTER and PREFERENCE_PLAYER.

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -7,6 +7,7 @@
 #define MOTH_EATING_CLOTHING_DAMAGE 15
 
 /obj/item/clothing
+	abstract_type = /obj/item/clothing
 	name = "clothing"
 	resistance_flags = FLAMMABLE
 	max_integrity = 200

--- a/code/modules/clothing/ears/_ears.dm
+++ b/code/modules/clothing/ears/_ears.dm
@@ -1,6 +1,7 @@
 
 //Ears: currently only used for headsets and earmuffs
 /obj/item/clothing/ears
+	abstract_type = /obj/item/clothing/ears
 	name = "ears"
 	w_class = WEIGHT_CLASS_TINY
 	throwforce = 0

--- a/code/modules/clothing/glasses/_glasses.dm
+++ b/code/modules/clothing/glasses/_glasses.dm
@@ -1,5 +1,6 @@
 //Glasses
 /obj/item/clothing/glasses
+	abstract_type = /obj/item/clothing/glasses
 	name = "glasses"
 	icon = 'icons/obj/clothing/glasses.dmi'
 	w_class = WEIGHT_CLASS_SMALL

--- a/code/modules/clothing/glasses/hud.dm
+++ b/code/modules/clothing/glasses/hud.dm
@@ -1,4 +1,5 @@
 /obj/item/clothing/glasses/hud
+	abstract_type = /obj/item/clothing/glasses/hud
 	name = "HUD"
 	desc = "A heads-up display that provides important info in (almost) real time."
 	flags_1 = null //doesn't protect eyes because it's a monocle, duh

--- a/code/modules/clothing/gloves/_gloves.dm
+++ b/code/modules/clothing/gloves/_gloves.dm
@@ -1,4 +1,5 @@
 /obj/item/clothing/gloves
+	abstract_type = /obj/item/clothing/gloves
 	name = "gloves"
 	gender = PLURAL //Carn: for grammarically correct text-parsing
 	w_class = WEIGHT_CLASS_SMALL

--- a/code/modules/clothing/gloves/color.dm
+++ b/code/modules/clothing/gloves/color.dm
@@ -1,4 +1,5 @@
 /obj/item/clothing/gloves/color
+	abstract_type = /obj/item/clothing/gloves/color
 
 /obj/item/clothing/gloves/color/yellow
 	desc = "These gloves provide protection against electric shock."

--- a/code/modules/clothing/head/_head.dm
+++ b/code/modules/clothing/head/_head.dm
@@ -1,4 +1,5 @@
 /obj/item/clothing/head
+	abstract_type = /obj/item/clothing/head
 	name = BODY_ZONE_HEAD
 	icon = 'icons/obj/clothing/head/default.dmi'
 	worn_icon = 'icons/mob/clothing/head/default.dmi'

--- a/code/modules/clothing/head/collectable.dm
+++ b/code/modules/clothing/head/collectable.dm
@@ -30,6 +30,7 @@
 */
 
 /obj/item/clothing/head/collectable
+	abstract_type = /obj/item/clothing/head/collectable
 	name = "collectable hat"
 	desc = "A rare collectable hat."
 	icon = 'icons/obj/clothing/head/costume.dmi'

--- a/code/modules/clothing/head/costume.dm
+++ b/code/modules/clothing/head/costume.dm
@@ -1,4 +1,5 @@
 /obj/item/clothing/head/costume
+	abstract_type = /obj/item/clothing/head/costume
 	icon = 'icons/obj/clothing/head/costume.dmi'
 	worn_icon = 'icons/mob/clothing/head/costume.dmi'
 

--- a/code/modules/clothing/head/crown.dm
+++ b/code/modules/clothing/head/crown.dm
@@ -6,7 +6,6 @@
 	resistance_flags = FIRE_PROOF
 	dynamic_hair_suffix = ""
 
-
 /datum/armor/costume_crown
 	melee = 15
 	energy = 15

--- a/code/modules/clothing/head/hat.dm
+++ b/code/modules/clothing/head/hat.dm
@@ -1,4 +1,5 @@
 /obj/item/clothing/head/hats
+	abstract_type = /obj/item/clothing/head/hats
 	icon = 'icons/obj/clothing/head/hats.dmi'
 	worn_icon = 'icons/mob/clothing/head/hats.dmi'
 

--- a/code/modules/clothing/masks/_masks.dm
+++ b/code/modules/clothing/masks/_masks.dm
@@ -1,4 +1,5 @@
 /obj/item/clothing/mask
+	abstract_type = /obj/item/clothing/mask
 	name = "mask"
 	icon = 'icons/obj/clothing/masks.dmi'
 	body_parts_covered = HEAD

--- a/code/modules/clothing/neck/_neck.dm
+++ b/code/modules/clothing/neck/_neck.dm
@@ -1,4 +1,5 @@
 /obj/item/clothing/neck
+	abstract_type = /obj/item/clothing/neck
 	name = "necklace"
 	icon = 'icons/obj/clothing/neck.dmi'
 	body_parts_covered = NECK

--- a/code/modules/clothing/shoes/_shoes.dm
+++ b/code/modules/clothing/shoes/_shoes.dm
@@ -1,4 +1,5 @@
 /obj/item/clothing/shoes
+	abstract_type = /obj/item/clothing/shoes
 	name = "shoes"
 	icon = 'icons/obj/clothing/shoes.dmi'
 	desc = "Comfortable-looking shoes."

--- a/code/modules/clothing/suits/_suits.dm
+++ b/code/modules/clothing/suits/_suits.dm
@@ -1,6 +1,7 @@
 #define FOOTSTEP_COOLDOWN 3	//3 deci-seconds
 
 /obj/item/clothing/suit
+	abstract_type = /obj/item/clothing/suit
 	name = "suit"
 	icon = 'icons/obj/clothing/suits/default.dmi'
 	var/fire_resist = T0C+100

--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -1,4 +1,5 @@
 /obj/item/clothing/suit/armor
+	abstract_type = /obj/item/clothing/suit/armor
 	icon = 'icons/obj/clothing/suits/armor.dmi'
 	worn_icon = 'icons/mob/clothing/suits/armor.dmi'
 	allowed = null

--- a/code/modules/clothing/suits/chaplainsuits.dm
+++ b/code/modules/clothing/suits/chaplainsuits.dm
@@ -177,6 +177,7 @@
 
 //Prophet helmet
 /obj/item/clothing/head/helmet/plate/crusader/prophet
+	abstract_type = /obj/item/clothing/head/helmet/plate/crusader/prophet
 	name = "Prophet's Hat"
 	desc = "A religious-looking hat."
 	icon_state = null

--- a/code/modules/clothing/suits/costume.dm
+++ b/code/modules/clothing/suits/costume.dm
@@ -1,4 +1,5 @@
 /obj/item/clothing/suit/costume
+	abstract_type = /obj/item/clothing/suit/costume
 	icon = 'icons/obj/clothing/suits/costume.dmi'
 	worn_icon = 'icons/mob/clothing/suits/costume.dmi'
 

--- a/code/modules/clothing/suits/jacket.dm
+++ b/code/modules/clothing/suits/jacket.dm
@@ -1,4 +1,5 @@
 /obj/item/clothing/suit/jacket
+	abstract_type = /obj/item/clothing/suit/jacket
 	icon = 'icons/obj/clothing/suits/jacket.dmi'
 	worn_icon = 'icons/mob/clothing/suits/jacket.dmi'
 	allowed = list(

--- a/code/modules/clothing/suits/toggles.dm
+++ b/code/modules/clothing/suits/toggles.dm
@@ -110,6 +110,7 @@
 // Pretty much just a holder for `/datum/component/toggle_icon`.
 
 /obj/item/clothing/suit/toggle
+	abstract_type = /obj/item/clothing/suit/toggle
 	/// The noun that is displayed to the user on toggle. EX: "Toggles the suit's [buttons]".
 	var/toggle_noun = "buttons"
 

--- a/code/modules/clothing/under/_under.dm
+++ b/code/modules/clothing/under/_under.dm
@@ -1,4 +1,5 @@
 /obj/item/clothing/under
+	abstract_type = /obj/item/clothing/under
 	name = "under"
 	icon = 'icons/obj/clothing/under/default.dmi'
 	worn_icon = 'icons/mob/clothing/under/default.dmi'
@@ -391,6 +392,7 @@
 	return adjusted
 
 /obj/item/clothing/under/rank
+	abstract_type = /obj/item/clothing/under/rank
 	dying_key = DYE_REGISTRY_UNDER
 
 /obj/item/clothing/under/compile_monkey_icon()

--- a/code/modules/clothing/under/costume.dm
+++ b/code/modules/clothing/under/costume.dm
@@ -1,4 +1,5 @@
 /obj/item/clothing/under/costume
+	abstract_type = /obj/item/clothing/under/costume
 	icon = 'icons/obj/clothing/under/costume.dmi'
 	worn_icon = 'icons/mob/clothing/under/costume.dmi'
 

--- a/code/modules/clothing/under/jobs/cargo.dm
+++ b/code/modules/clothing/under/jobs/cargo.dm
@@ -1,4 +1,5 @@
 /obj/item/clothing/under/rank/cargo
+	abstract_type = /obj/item/clothing/under/rank/cargo
 	icon = 'icons/obj/clothing/under/cargo.dmi'
 	worn_icon = 'icons/mob/clothing/under/cargo.dmi'
 

--- a/code/modules/clothing/under/jobs/civilian/civilian.dm
+++ b/code/modules/clothing/under/jobs/civilian/civilian.dm
@@ -1,6 +1,7 @@
 //Alphabetical order of civilian jobs.
 
 /obj/item/clothing/under/rank/civilian
+	abstract_type = /obj/item/clothing/under/rank/civilian
 	icon = 'icons/obj/clothing/under/civilian.dmi'
 	worn_icon = 'icons/mob/clothing/under/civilian.dmi'
 

--- a/code/modules/clothing/under/jobs/engineering.dm
+++ b/code/modules/clothing/under/jobs/engineering.dm
@@ -1,6 +1,7 @@
 //Contains: Engineering department jumpsuits
 
 /obj/item/clothing/under/rank/engineering
+	abstract_type = /obj/item/clothing/under/rank/engineering
 	icon = 'icons/obj/clothing/under/engineering.dmi'
 	worn_icon = 'icons/mob/clothing/under/engineering.dmi'
 	armor_type = /datum/armor/rank_engineering

--- a/code/modules/clothing/under/jobs/medical.dm
+++ b/code/modules/clothing/under/jobs/medical.dm
@@ -1,4 +1,5 @@
 /obj/item/clothing/under/rank/medical
+	abstract_type = /obj/item/clothing/under/rank/medical
 	icon = 'icons/obj/clothing/under/medical.dmi'
 	worn_icon = 'icons/mob/clothing/under/medical.dmi'
 	armor_type = /datum/armor/rank_medical

--- a/code/modules/clothing/under/jobs/rnd.dm
+++ b/code/modules/clothing/under/jobs/rnd.dm
@@ -1,4 +1,5 @@
 /obj/item/clothing/under/rank/rnd
+	abstract_type = /obj/item/clothing/under/rank/rnd
 	icon = 'icons/obj/clothing/under/rnd.dmi'
 	worn_icon = 'icons/mob/clothing/under/rnd.dmi'
 

--- a/code/modules/clothing/under/jobs/security.dm
+++ b/code/modules/clothing/under/jobs/security.dm
@@ -10,6 +10,7 @@
  */
 
 /obj/item/clothing/under/rank/security
+	abstract_type = /obj/item/clothing/under/rank/security
 	icon = 'icons/obj/clothing/under/security.dmi'
 	worn_icon = 'icons/mob/clothing/under/security.dmi'
 	armor_type = /datum/armor/rank_security

--- a/code/modules/clothing/under/miscellaneous.dm
+++ b/code/modules/clothing/under/miscellaneous.dm
@@ -1,4 +1,5 @@
 /obj/item/clothing/under/misc
+	abstract_type = /obj/item/clothing/under/misc
 	icon = 'icons/obj/clothing/under/misc.dmi'
 	worn_icon = 'icons/mob/clothing/under/misc.dmi'
 

--- a/code/modules/clothing/under/pants.dm
+++ b/code/modules/clothing/under/pants.dm
@@ -1,4 +1,5 @@
 /obj/item/clothing/under/pants
+	abstract_type = /obj/item/clothing/under/pants
 	gender = PLURAL
 	body_parts_covered = GROIN|LEGS
 	female_sprite_flags = NO_FEMALE_UNIFORM

--- a/code/modules/clothing/under/shorts.dm
+++ b/code/modules/clothing/under/shorts.dm
@@ -1,4 +1,5 @@
 /obj/item/clothing/under/shorts
+	abstract_type = /obj/item/clothing/under/shorts
 	name = "athletic shorts"
 	desc = "95% Polyester, 5% Spandex!"
 	icon = 'icons/obj/clothing/under/shorts_pants_shirts.dmi'

--- a/code/modules/clothing/under/skirt_dress.dm
+++ b/code/modules/clothing/under/skirt_dress.dm
@@ -1,4 +1,5 @@
 /obj/item/clothing/under/dress
+	abstract_type = /obj/item/clothing/under/dress
 	female_sprite_flags = FEMALE_UNIFORM_TOP_ONLY
 	can_adjust = FALSE
 	body_parts_covered = CHEST|GROIN

--- a/code/modules/crew_objectives/_crew_objectives.dm
+++ b/code/modules/crew_objectives/_crew_objectives.dm
@@ -30,6 +30,7 @@
 		to_chat(src, "<B>Your objective:</B> [newObjective.explanation_text]")
 
 /datum/objective/crew
+	abstract_type = /datum/objective/crew
 	// Used for showing the roundend report again, instead of checking complete every time it's opened.
 	var/declared_complete = FALSE
 	// List or string of JOB_NAME defines that this applies to.

--- a/code/modules/events/_event.dm
+++ b/code/modules/events/_event.dm
@@ -2,6 +2,7 @@
 
 //this singleton datum is used by the events controller to dictate how it selects events
 /datum/round_event_control
+	abstract_type = /datum/round_event_control
 	var/name //The human-readable name of the event
 	//var/category //The category of the event
 	//var/description //The description of the event
@@ -115,6 +116,7 @@
 	return
 
 /datum/round_event	//NOTE: Times are measured in master controller ticks!
+	abstract_type = /datum/round_event
 	var/processing = TRUE
 	var/datum/round_event_control/control
 

--- a/code/modules/food_and_drinks/kitchen_machinery/processor.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/processor.dm
@@ -44,7 +44,7 @@
 
 /obj/machinery/processor/proc/select_recipe(input_item)
 	var/most_specific_type = /atom
-	for (var/datum/food_processor_process/recipe as anything in subtypesof(/datum/food_processor_process) - /datum/food_processor_process/mob)
+	for (var/datum/food_processor_process/recipe as anything in valid_subtypesof(/datum/food_processor_process))
 		var/recipe_input = initial(recipe.input)
 		if (istype(src, initial(recipe.required_machine)) && istype(input_item, recipe_input) && ispath(recipe_input, most_specific_type))
 			most_specific_type = recipe_input

--- a/code/modules/food_and_drinks/recipes/processor_recipes.dm
+++ b/code/modules/food_and_drinks/recipes/processor_recipes.dm
@@ -1,4 +1,5 @@
 /datum/food_processor_process
+	abstract_type = /datum/food_processor_process
 	var/input
 	var/output
 	var/time = 40
@@ -92,6 +93,9 @@
 /datum/food_processor_process/parsnip
 	input = /obj/item/food/grown/parsnip
 	output = /obj/item/food/roastparsnip
+
+/datum/food_processor_process/mob
+	abstract_type = /datum/food_processor_process/mob
 
 /datum/food_processor_process/mob/slime
 	input = /mob/living/simple_animal/slime

--- a/code/modules/holiday/holidays.dm
+++ b/code/modules/holiday/holidays.dm
@@ -1,4 +1,5 @@
 /datum/holiday
+	abstract_type = /datum/holiday
 	var/name = "Bugsgiving"
 
 	var/begin_day = 1

--- a/code/modules/hydroponics/grown.dm
+++ b/code/modules/hydroponics/grown.dm
@@ -7,6 +7,7 @@ CREATION_TEST_IGNORE_SELF(/obj/item/food/grown)
 
 // Base type. Subtypes are found in /grown dir. Lavaland-based subtypes can be found in mining/ash_flora.dm
 /obj/item/food/grown
+	abstract_type = /obj/item/food/grown
 	icon = 'icons/obj/hydroponics/harvest.dmi'
 	icon_state = "berrypile"
 	worn_icon = 'icons/mob/clothing/head/hydroponics.dmi'

--- a/code/modules/hydroponics/grown/citrus.dm
+++ b/code/modules/hydroponics/grown/citrus.dm
@@ -1,5 +1,6 @@
 // Citrus - base type
 /obj/item/food/grown/citrus
+	abstract_type = /obj/item/food/grown/citrus
 	seed = /obj/item/seeds/lime
 	name = "citrus"
 	desc = "It's so sour, your face will twist."

--- a/code/modules/hydroponics/growninedible.dm
+++ b/code/modules/hydroponics/growninedible.dm
@@ -3,6 +3,7 @@
 // **********************
 
 /obj/item/grown // Grown weapons
+	abstract_type = /obj/item/grown
 	name = "grown_weapon"
 	icon = 'icons/obj/hydroponics/harvest.dmi'
 	worn_icon = 'icons/mob/clothing/head/hydroponics.dmi'

--- a/code/modules/hydroponics/plant_genes.dm
+++ b/code/modules/hydroponics/plant_genes.dm
@@ -1,4 +1,5 @@
 /datum/plant_gene
+	abstract_type = /datum/plant_gene
 	var/name
 	var/mutability_flags = PLANT_GENE_EXTRACTABLE | PLANT_GENE_REMOVABLE ///These flags tells the genemodder if we want the gene to be extractable, only removable or neither.
 
@@ -27,6 +28,7 @@
 
 // Core plant genes store 5 main variables: lifespan, endurance, production, yield, potency
 /datum/plant_gene/core
+	abstract_type = /datum/plant_gene/core
 	var/value
 
 /datum/plant_gene/core/get_name()

--- a/code/modules/hydroponics/seeds.dm
+++ b/code/modules/hydroponics/seeds.dm
@@ -3,6 +3,7 @@
 // ********************************************************
 
 /obj/item/seeds
+	abstract_type = /obj/item/seeds
 	name = "seed"
 	icon = 'icons/obj/hydroponics/seeds.dmi'
 	icon_state = "seed" // Unknown plant seed - these shouldn't exist in-game.

--- a/code/modules/instruments/instrument_data/_instrument_data.dm
+++ b/code/modules/instruments/instrument_data/_instrument_data.dm
@@ -17,6 +17,8 @@
   * Since songs cache them while playing, there isn't realistic issues regarding performance from accessing.
   */
 /datum/instrument
+	abstract_type = /datum/instrument
+
 	/// Name of the instrument
 	var/name = "Generic instrument"
 	/// Uniquely identifies this instrument so runtime changes are possible as opposed to paths. If this is unset, things will use path instead.
@@ -24,7 +26,6 @@
 	/// Category
 	var/category = "Unsorted"
 	/// Used for categorization subtypes
-	var/abstract_type = /datum/instrument
 	/// Write here however many samples, follow this syntax: "%note num%"='%sample file%' eg. "27"='synthesizer/e2.ogg'. Key must never be lower than 0 and higher than 127
 	var/list/real_samples
 	/// assoc list key = /datum/instrument_key. do not fill this yourself!

--- a/code/modules/language/language.dm
+++ b/code/modules/language/language.dm
@@ -3,6 +3,8 @@
 
 /// Datum based languages. Easily editable and modular.
 /datum/language
+	abstract_type = /datum/language
+
 	/// Fluff name of language if any.
 	var/name = "an unknown language"
 	/// Short description for 'Check Languages'.

--- a/code/modules/language/language_holder.dm
+++ b/code/modules/language/language_holder.dm
@@ -36,6 +36,8 @@ Key procs
 */
 
 /datum/language_holder
+	abstract_type = /datum/language_holder
+
 	/// Lazyassoclist of all understood languages
 	var/list/understood_languages
 	/// Lazyassoclist of languages that can be spoken.

--- a/code/modules/mob/dead/dead.dm
+++ b/code/modules/mob/dead/dead.dm
@@ -3,6 +3,7 @@
 INITIALIZE_IMMEDIATE(/mob/dead)
 
 /mob/dead
+	abstract_type = /mob/dead
 	sight = SEE_TURFS | SEE_MOBS | SEE_OBJS | SEE_SELF
 	move_resist = INFINITY
 	throwforce = 0

--- a/code/modules/mob/living/basic/basic.dm
+++ b/code/modules/mob/living/basic/basic.dm
@@ -1,5 +1,6 @@
 ///Simple animals 2.0, This time, let's really try to keep it simple. This basetype should purely be used as a base-level for implementing simplified behaviours for things such as damage and attacks. Everything else should be in components or AI behaviours.
 /mob/living/basic
+	abstract_type = /mob/living/basic
 	name = "basic mob"
 	icon = 'icons/mob/animal.dmi'
 	health = 20

--- a/code/modules/mob/living/brain/emote.dm
+++ b/code/modules/mob/living/brain/emote.dm
@@ -1,4 +1,5 @@
 /datum/emote/brain
+	abstract_type = /datum/emote/brain
 	mob_type_allowed_typecache = list(/mob/living/brain)
 	mob_type_blacklist_typecache = list()
 	emote_type = EMOTE_AUDIBLE

--- a/code/modules/mob/living/carbon/alien/alien.dm
+++ b/code/modules/mob/living/carbon/alien/alien.dm
@@ -1,4 +1,5 @@
 /mob/living/carbon/alien
+	abstract_type = /mob/living/carbon/alien
 	name = "alien"
 	icon = 'icons/mob/alien.dmi'
 	gender = FEMALE //All xenos are girls!!

--- a/code/modules/mob/living/carbon/alien/emote.dm
+++ b/code/modules/mob/living/carbon/alien/emote.dm
@@ -1,4 +1,5 @@
 /datum/emote/living/alien
+	abstract_type = /datum/emote/living/alien
 	mob_type_allowed_typecache = list(/mob/living/carbon/alien)
 
 /datum/emote/living/alien/gnarl

--- a/code/modules/mob/living/carbon/alien/humanoid/humanoid.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/humanoid.dm
@@ -1,4 +1,5 @@
 /mob/living/carbon/alien/humanoid
+	abstract_type = /mob/living/carbon/alien/humanoid
 	name = "alien"
 	icon_state = "alien"
 	pass_flags = PASSTABLE

--- a/code/modules/mob/living/carbon/carbon_defines.dm
+++ b/code/modules/mob/living/carbon/carbon_defines.dm
@@ -1,4 +1,5 @@
 /mob/living/carbon
+	abstract_type = /mob/living/carbon
 	gender = MALE
 	pressure_resistance = 15
 	hud_possible = list(HEALTH_HUD,STATUS_HUD,ANTAG_HUD,GLAND_HUD,NANITE_HUD,DIAG_NANITE_FULL_HUD)

--- a/code/modules/mob/living/carbon/emote.dm
+++ b/code/modules/mob/living/carbon/emote.dm
@@ -1,4 +1,5 @@
 /datum/emote/living/carbon
+	abstract_type = /datum/emote/living/carbon
 	mob_type_allowed_typecache = list(/mob/living/carbon)
 
 /datum/emote/living/carbon/airguitar

--- a/code/modules/mob/living/carbon/human/emote.dm
+++ b/code/modules/mob/living/carbon/human/emote.dm
@@ -1,4 +1,5 @@
 /datum/emote/living/carbon/human
+	abstract_type = /datum/emote/living/carbon/human
 	mob_type_allowed_typecache = list(/mob/living/carbon/human)
 
 /// The time it takes for the crying visual to be removed

--- a/code/modules/mob/living/emote.dm
+++ b/code/modules/mob/living/emote.dm
@@ -1,6 +1,7 @@
 
 /* EMOTE DATUMS */
 /datum/emote/living
+	abstract_type = /datum/emote/living
 	mob_type_allowed_typecache = /mob/living
 	mob_type_blacklist_typecache = list(/mob/living/brain)
 

--- a/code/modules/mob/living/living_defines.dm
+++ b/code/modules/mob/living/living_defines.dm
@@ -1,4 +1,5 @@
 /mob/living
+	abstract_type = /mob/living
 	see_invisible = SEE_INVISIBLE_LIVING
 	sight = 0
 	see_in_dark = 2

--- a/code/modules/mob/living/silicon/ai/emote.dm
+++ b/code/modules/mob/living/silicon/ai/emote.dm
@@ -1,4 +1,5 @@
 /datum/emote/ai
+	abstract_type = /datum/emote/ai
 	mob_type_allowed_typecache = /mob/living/silicon/ai
 	mob_type_blacklist_typecache = list()
 

--- a/code/modules/mob/living/silicon/robot/emote.dm
+++ b/code/modules/mob/living/silicon/robot/emote.dm
@@ -1,4 +1,5 @@
 /datum/emote/silicon
+	abstract_type = /datum/emote/silicon
 	mob_type_allowed_typecache = list(/mob/living/brain, /mob/living/silicon, /mob/living/simple_animal/hostile/mining_drone)
 	emote_type = EMOTE_AUDIBLE
 

--- a/code/modules/mob/living/silicon/silicon.dm
+++ b/code/modules/mob/living/silicon/silicon.dm
@@ -1,6 +1,7 @@
 /mob/living/silicon
+	abstract_type = /mob/living/silicon
 	gender = NEUTER
-	has_unlimited_silicon_privilege = 1
+	has_unlimited_silicon_privilege = TRUE
 	verb_say = "states"
 	verb_ask = "queries"
 	verb_exclaim = "declares"

--- a/code/modules/mob/living/simple_animal/hostile/gorilla/emotes.dm
+++ b/code/modules/mob/living/simple_animal/hostile/gorilla/emotes.dm
@@ -1,4 +1,5 @@
 /datum/emote/gorilla
+	abstract_type = /datum/emote/gorilla
 	mob_type_allowed_typecache = /mob/living/simple_animal/hostile/gorilla
 	mob_type_blacklist_typecache = list()
 

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -1,4 +1,5 @@
 /mob/living/simple_animal
+	abstract_type = /mob/living/simple_animal
 	name = "animal"
 	icon = 'icons/mob/animal.dmi'
 	health = 20

--- a/code/modules/mob/living/simple_animal/slime/emote.dm
+++ b/code/modules/mob/living/simple_animal/slime/emote.dm
@@ -1,4 +1,5 @@
 /datum/emote/slime
+	abstract_type = /datum/emote/slime
 	mob_type_allowed_typecache = /mob/living/simple_animal/slime
 	mob_type_blacklist_typecache = list()
 

--- a/code/modules/mob/mob_defines.dm
+++ b/code/modules/mob/mob_defines.dm
@@ -9,6 +9,7 @@ CREATION_TEST_IGNORE_SELF(/mob)
   * Has a lot of the creature game world logic, such as health etc
   */
 /mob
+	abstract_type = /mob
 	density = TRUE
 	layer = MOB_LAYER
 	animate_movement = SLIDE_STEPS

--- a/code/modules/mod/mod_control.dm
+++ b/code/modules/mod/mod_control.dm
@@ -1,5 +1,6 @@
 /// MODsuits, trade-off between armor and utility
 /obj/item/mod
+	abstract_type = /obj/item/mod
 	name = "Base MOD"
 	desc = "You should not see this, yell at a coder!"
 	icon = 'icons/obj/clothing/modsuit/mod_clothing.dmi'

--- a/code/modules/power/power.dm
+++ b/code/modules/power/power.dm
@@ -7,6 +7,7 @@
 /////////////////////////////
 
 /obj/machinery/power
+	abstract_type = /obj/machinery/power
 	name = null
 	icon = 'icons/obj/power.dmi'
 	anchored = TRUE

--- a/code/modules/power/supermatter/supermatter_gas.dm
+++ b/code/modules/power/supermatter/supermatter_gas.dm
@@ -64,6 +64,7 @@ GLOBAL_LIST_INIT(sm_gas_behavior, init_sm_gas())
 /// If the gas has no effects you do not need to add another sm_gas subtype,
 /// We already guard for nulls in [/obj/machinery/power/supermatter_crystal/proc/calculate_gases]
 /datum/sm_gas
+	abstract_type = /datum/sm_gas
 	/// Path of the [/datum/gas] involved with this interaction.
 	var/gas_path
 	/// Influences zap power without interfering with the crystal's own energy. Gets scaled by [BASE_POWER_TRANSMISSION_RATE].

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -2,6 +2,7 @@
 #define FIRING_PIN_REMOVAL_DELAY 50
 
 /obj/item/gun
+	abstract_type = /obj/item/gun
 	name = "gun"
 	desc = "It's a gun. It's pretty terrible, though."
 	icon = 'icons/obj/guns/projectile.dmi'

--- a/code/modules/projectiles/guns/ballistic.dm
+++ b/code/modules/projectiles/guns/ballistic.dm
@@ -1,4 +1,5 @@
 /obj/item/gun/ballistic
+	abstract_type = /obj/item/gun/ballistic
 	desc = "Now comes in flavors like GUN. Uses 10mm ammo, for some reason."
 	name = "projectile gun"
 	icon_state = "pistol"

--- a/code/modules/projectiles/guns/energy.dm
+++ b/code/modules/projectiles/guns/energy.dm
@@ -1,4 +1,5 @@
 /obj/item/gun/energy
+	abstract_type = /obj/item/gun/energy
 	icon_state = "energy"
 	name = "energy gun"
 	desc = "A basic energy-based gun."

--- a/code/modules/projectiles/guns/magic.dm
+++ b/code/modules/projectiles/guns/magic.dm
@@ -1,4 +1,5 @@
 /obj/item/gun/magic
+	abstract_type = /obj/item/gun/magic
 	name = "staff of nothing"
 	desc = "This staff is boring to watch because even though it came first you've seen everything it can do in other staves for years."
 	icon = 'icons/obj/guns/magic.dmi'

--- a/code/modules/reagents/chemistry/reagents.dm
+++ b/code/modules/reagents/chemistry/reagents.dm
@@ -22,6 +22,8 @@ GLOBAL_LIST_INIT(name2reagent, build_name2reagent())
 
 /// A single reagent
 /datum/reagent
+	abstract_type = /datum/reagent
+
 	/// datums don't have names by default
 	var/name = "Reagent"
 	/// nor do they have descriptions

--- a/code/modules/reagents/chemistry/reagents/drug_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drug_reagents.dm
@@ -1,4 +1,5 @@
 /datum/reagent/drug
+	abstract_type = /datum/reagent/drug
 	name = "Drug"
 	chemical_flags = CHEMICAL_NOT_DEFINED
 	metabolization_rate = 0.5 * REAGENTS_METABOLISM

--- a/code/modules/reagents/chemistry/reagents/food_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/food_reagents.dm
@@ -8,6 +8,7 @@
 
 
 /datum/reagent/consumable
+	abstract_type = /datum/reagent/consumable
 	name = "Consumable"
 	chemical_flags = CHEMICAL_NOT_DEFINED
 	taste_description = "generic food"

--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -6,6 +6,7 @@
 // where all the reagents related to medicine go.
 
 /datum/reagent/medicine
+	abstract_type = /datum/reagent/medicine
 	name = "Medicine"
 	chemical_flags = CHEMICAL_NOT_DEFINED
 	taste_description = "bitterness"

--- a/code/modules/reagents/chemistry/reagents/metabolites.dm
+++ b/code/modules/reagents/chemistry/reagents/metabolites.dm
@@ -13,6 +13,7 @@
 */
 
 /datum/reagent/metabolite
+	abstract_type = /datum/reagent/metabolite
 	name = "Metabolites"
 	color = "#FAFF00"
 	description = "You should never see this. Contact an administrator or coder"
@@ -24,6 +25,7 @@
 		volume = MAX_METABOLITES
 
 /datum/reagent/metabolite/medicine
+	abstract_type = /datum/reagent/metabolite/medicine
 	name = "Medicinal Metabolites"
 	metabolization_rate = REAGENTS_METABOLISM * 0.025
 

--- a/code/modules/reagents/reagent_containers.dm
+++ b/code/modules/reagents/reagent_containers.dm
@@ -1,4 +1,5 @@
 /obj/item/reagent_containers
+	abstract_type = /obj/item/reagent_containers
 	name = "Container"
 	desc = "..."
 	icon = 'icons/obj/chemical.dmi'

--- a/code/modules/reagents/reagent_containers/cups/_cup.dm
+++ b/code/modules/reagents/reagent_containers/cups/_cup.dm
@@ -1,4 +1,5 @@
 /obj/item/reagent_containers/cup
+	abstract_type = /obj/item/reagent_containers/cup
 	name = "glass"
 	amount_per_transfer_from_this = 10
 	possible_transfer_amounts = list(5, 10, 15, 20, 25, 30, 50)

--- a/code/modules/reagents/reagent_containers/cups/drinks.dm
+++ b/code/modules/reagents/reagent_containers/cups/drinks.dm
@@ -2,6 +2,7 @@
 /// Drinks.
 ////////////////////////////////////////////////////////////////////////////////
 /obj/item/reagent_containers/cup/glass
+	abstract_type = /obj/item/reagent_containers/cup/glass
 	name = "drink"
 	desc = "yummy"
 	icon = 'icons/obj/drinks/drinks.dmi'

--- a/code/modules/reagents/reagent_containers/cups/soda.dm
+++ b/code/modules/reagents/reagent_containers/cups/soda.dm
@@ -7,6 +7,7 @@
 #define SODA_FIZZINESS_SHAKE 5
 
 /obj/item/reagent_containers/cup/soda_cans
+	abstract_type = /obj/item/reagent_containers/cup/soda_cans
 	name = "soda can"
 	icon = 'icons/obj/drinks/soda.dmi'
 	icon_state_preview = "cola"

--- a/code/modules/reagents/reagent_dispenser.dm
+++ b/code/modules/reagents/reagent_dispenser.dm
@@ -1,4 +1,5 @@
 /obj/structure/reagent_dispensers
+	abstract_type = /obj/structure/reagent_dispensers
 	name = "Dispenser"
 	desc = "..."
 	icon = 'icons/obj/objects.dmi'

--- a/code/modules/research/designs.dm
+++ b/code/modules/research/designs.dm
@@ -20,7 +20,9 @@ other types of metals and chemistry for reagents).
 //DESIGNS ARE GLOBAL. DO NOT CREATE OR DESTROY THEM AT RUNTIME OUTSIDE OF INIT, JUST REFERENCE THEM TO WHATEVER YOU'RE DOING! //why are you yelling?
 //DO NOT REFERENCE OUTSIDE OF SSRESEARCH. USE THE PROCS IN SSRESEARCH TO OBTAIN A REFERENCE.
 
-/datum/design						//Datum for object designs, used in construction
+/datum/design //Datum for object designs, used in construction
+	abstract_type = /datum/design
+
 	/// Name of the created object
 	var/name = "Name"
 	/// Description of the created object

--- a/code/modules/research/designs/medical_designs.dm
+++ b/code/modules/research/designs/medical_designs.dm
@@ -669,6 +669,7 @@
 ///Surgery Designs///
 /////////////////////
 /datum/design/surgery
+	abstract_type = /datum/design/surgery
 	name = "Surgery Design"
 	desc = "what"
 	id = "surgery_parent"

--- a/code/modules/research/stock_parts.dm
+++ b/code/modules/research/stock_parts.dm
@@ -219,6 +219,7 @@ If you create T5+ please take a pass at gene_modder.dm [L40]. Max_values MUST fi
 	return B.get_part_rating() - A.get_part_rating()
 
 /obj/item/stock_parts
+	abstract_type = /obj/item/stock_parts
 	name = "stock part"
 	desc = "What?"
 	icon = 'icons/obj/stock_parts.dmi'
@@ -385,6 +386,11 @@ If you create T5+ please take a pass at gene_modder.dm [L40]. Max_values MUST fi
 	custom_materials = list(/datum/material/iron=80)
 
 // Subspace stock parts
+
+/obj/item/stock_parts/subspace
+	abstract_type = /obj/item/stock_parts/subspace
+	name = "subspace stock part"
+	desc = "What?"
 
 /obj/item/stock_parts/subspace/ansible
 	name = "subspace ansible"

--- a/code/modules/research/techweb/_techweb_node.dm
+++ b/code/modules/research/techweb/_techweb_node.dm
@@ -3,6 +3,7 @@
 //USE SSRESEARCH PROCS TO OBTAIN REFERENCES. DO NOT REFERENCE OUTSIDE OF SSRESEARCH OR YOU WILL FUCK UP GC.
 
 /datum/techweb_node
+	abstract_type = /datum/techweb_node
 	var/id
 	var/tech_tier = 0
 	var/display_name = "Errored Node"

--- a/code/modules/research/xenobiology/crossbreeding/recurring.dm
+++ b/code/modules/research/xenobiology/crossbreeding/recurring.dm
@@ -7,6 +7,7 @@ Recurring extracts:
 CREATION_TEST_IGNORE_SELF(/obj/item/slimecross/recurring)
 
 /obj/item/slimecross/recurring
+	abstract_type = /obj/item/slimecross/recurring
 	name = "recurring extract"
 	desc = "A tiny, glowing core, wrapped in several layers of goo."
 	effect = "recurring"

--- a/code/modules/spells/spell.dm
+++ b/code/modules/spells/spell.dm
@@ -39,6 +39,7 @@
  * - [update_spell_name][/datum/action/spell/update_spell_name] updates the prefix of the spell name based on its level.
  */
 /datum/action/spell
+	abstract_type = /datum/action/spell
 	name = "Spell"
 	desc = "A wizard spell."
 	background_icon_state = "bg_spell"

--- a/code/modules/spells/spell_types/aoe_spell/_aoe_spell.dm
+++ b/code/modules/spells/spell_types/aoe_spell/_aoe_spell.dm
@@ -5,6 +5,7 @@
  * Calls cast_on_thing_in_aoe on all atoms returned by get_things_to_cast_on by default.
  */
 /datum/action/spell/aoe
+	abstract_type = /datum/action/spell/aoe
 	/// The max amount of targets we can affect via our AOE. 0 = unlimited
 	var/max_targets = 0
 	/// The radius of the aoe.

--- a/code/modules/spells/spell_types/jaunt/_jaunt.dm
+++ b/code/modules/spells/spell_types/jaunt/_jaunt.dm
@@ -12,6 +12,7 @@
  * Use enter_jaunt() and exit_jaunt() as wrappers.
  */
 /datum/action/spell/jaunt
+	abstract_type = /datum/action/spell/jaunt
 	school = SCHOOL_TRANSMUTATION
 
 	invocation_type = INVOCATION_NONE

--- a/code/modules/spells/spell_types/pointed/_pointed.dm
+++ b/code/modules/spells/spell_types/pointed/_pointed.dm
@@ -8,6 +8,7 @@
  * The cast_on atom is the person who was clicked on.
  */
 /datum/action/spell/pointed
+	abstract_type = /datum/action/spell/pointed
 	requires_target = TRUE
 
 	/// The base icon state of the spell's button icon, used for editing the icon "on" and "off"

--- a/code/modules/spells/spell_types/projectile/_basic_projectile.dm
+++ b/code/modules/spells/spell_types/projectile/_basic_projectile.dm
@@ -7,6 +7,7 @@
  * and aoe projectile spells in the future.
  */
 /datum/action/spell/basic_projectile
+	abstract_type = /datum/action/spell/basic_projectile
 	/// How far we try to fire the basic projectile. Blocked by dense objects.
 	var/projectile_range = 7
 	/// The projectile type fired at all people around us

--- a/code/modules/spells/spell_types/shapeshift/_shapeshift.dm
+++ b/code/modules/spells/spell_types/shapeshift/_shapeshift.dm
@@ -7,6 +7,7 @@
  * Allows the caster to transform to and from a different mob type.
  */
 /datum/action/spell/shapeshift
+	abstract_type = /datum/action/spell/shapeshift
 	name = "Shapeshift Base"
 	button_icon_state = "shapeshift"
 	school = SCHOOL_TRANSMUTATION

--- a/code/modules/spells/spell_types/teleport/_teleport.dm
+++ b/code/modules/spells/spell_types/teleport/_teleport.dm
@@ -4,6 +4,7 @@
  * Teleports the caster to a turf selected by get_destinations().
  */
 /datum/action/spell/teleport
+	abstract_type = /datum/action/spell/teleport
 	sound = 'sound/weapons/zapbang.ogg'
 
 	school = SCHOOL_TRANSLOCATION

--- a/code/modules/spells/spell_types/touch/_touch.dm
+++ b/code/modules/spells/spell_types/touch/_touch.dm
@@ -18,6 +18,7 @@
  * (generally) inadvisable unless you know what you're doing
  */
 /datum/action/spell/touch
+	abstract_type = /datum/action/spell/touch
 	check_flags = AB_CHECK_CONSCIOUS|AB_CHECK_HANDS_BLOCKED
 	sound = 'sound/items/welder.ogg'
 	invocation = "High Five!"

--- a/code/modules/surgery/bodyparts/parts.dm
+++ b/code/modules/surgery/bodyparts/parts.dm
@@ -70,6 +70,18 @@
 	bodytype = BODYTYPE_LARVA_PLACEHOLDER | BODYTYPE_ORGANIC
 	acceptable_bodytype = BODYTYPE_LARVA_PLACEHOLDER
 
+/obj/item/bodypart/arm
+	abstract_type = /obj/item/bodypart/arm
+	name = "arm"
+	desc = "Hey buddy give me a HAND and report this to the github because you shouldn't be seeing this."
+	attack_verb_continuous = list("slaps", "punches")
+	attack_verb_simple = list("slap", "punch")
+	max_damage = 40
+	max_stamina_damage = 50
+	aux_layer = BODYPARTS_HIGH_LAYER
+	body_damage_coeff = 0.75
+	can_be_disabled = TRUE
+
 /obj/item/bodypart/arm/left
 	name = "left arm"
 	desc = "Did you know that the word 'sinister' stems originally from the \
@@ -77,20 +89,13 @@
 		be possessed by the devil? This arm appears to be possessed by no \
 		one though."
 	icon_state = "default_human_l_arm"
-	attack_verb_continuous = list("slaps", "punches")
-	attack_verb_simple = list("slap", "punch")
-	max_damage = 40
-	max_stamina_damage = 50
 	body_zone = BODY_ZONE_L_ARM
 	body_part = ARM_LEFT
 	plaintext_zone = "left arm"
 	aux_zone = BODY_ZONE_PRECISE_L_HAND
-	aux_layer = BODYPARTS_HIGH_LAYER
-	body_damage_coeff = 0.75
 	held_index = 1
 	px_x = -6
 	px_y = 0
-	can_be_disabled = TRUE
 
 
 /obj/item/bodypart/arm/left/set_owner(new_owner)
@@ -181,21 +186,13 @@
 	desc = "Over 87% of humans are right handed. That figure is much lower \
 		among humans missing their right arm."
 	icon_state = "default_human_r_arm"
-	attack_verb_continuous = list("slaps", "punches")
-	attack_verb_simple = list("slap", "punch")
-	max_damage = 40
-	max_stamina_damage = 50
 	body_zone = BODY_ZONE_R_ARM
 	body_part = ARM_RIGHT
 	plaintext_zone = "right arm"
 	aux_zone = BODY_ZONE_PRECISE_R_HAND
-	aux_layer = BODYPARTS_HIGH_LAYER
-	body_damage_coeff = 0.75
 	held_index = 2
 	px_x = 6
 	px_y = 0
-	can_be_disabled = TRUE
-
 
 /obj/item/bodypart/arm/right/set_owner(new_owner)
 	. = ..()
@@ -281,23 +278,27 @@
 	max_damage = 100
 	should_draw_greyscale = FALSE
 
+/obj/item/bodypart/leg
+	abstract_type = /obj/item/bodypart/leg
+	name = "leg"
+	desc = "This item shouldn't exist. Talk about breaking a leg. Badum-Tss!"
+	attack_verb_continuous = list("kicks", "stomps")
+	attack_verb_simple = list("kick", "stomp")
+	max_damage = 40
+	body_damage_coeff = 0.75
+	max_stamina_damage = 50
+	can_be_disabled = TRUE
+
 /obj/item/bodypart/leg/left
 	name = "left leg"
 	desc = "Some athletes prefer to tie their left shoelaces first for good \
 		luck. In this instance, it probably would not have helped."
 	icon_state = "default_human_l_leg"
-	attack_verb_continuous = list("kicks", "stomps")
-	attack_verb_simple = list("kick", "stomp")
-	max_damage = 40
 	body_zone = BODY_ZONE_L_LEG
 	body_part = LEG_LEFT
 	plaintext_zone = "left leg"
-	body_damage_coeff = 0.75
 	px_x = -2
 	px_y = 12
-	max_stamina_damage = 50
-	can_be_disabled = TRUE
-
 
 /obj/item/bodypart/leg/left/set_owner(new_owner)
 	. = ..()
@@ -384,18 +385,11 @@
 		The hokey pokey has certainly changed a lot since space colonisation."
 	// alternative spellings of 'pokey' are available
 	icon_state = "default_human_r_leg"
-	attack_verb_continuous = list("kicks", "stomps")
-	attack_verb_simple = list("kick", "stomp")
-	max_damage = 40
 	body_zone = BODY_ZONE_R_LEG
 	body_part = LEG_RIGHT
 	plaintext_zone = "right leg"
-	body_damage_coeff = 0.75
 	px_x = 2
 	px_y = 12
-	max_stamina_damage = 50
-	can_be_disabled = TRUE
-
 
 /obj/item/bodypart/leg/right/set_owner(new_owner)
 	. = ..()

--- a/code/modules/surgery/organs/_organ.dm
+++ b/code/modules/surgery/organs/_organ.dm
@@ -1,4 +1,5 @@
 /obj/item/organ
+	abstract_type = /obj/item/organ
 	name = "organ"
 	icon = 'icons/obj/surgery.dmi'
 	w_class = WEIGHT_CLASS_SMALL

--- a/code/modules/surgery/organs/augments_arms.dm
+++ b/code/modules/surgery/organs/augments_arms.dm
@@ -1,4 +1,5 @@
 /obj/item/organ/cyberimp/arm
+	abstract_type = /obj/item/organ/cyberimp/arm
 	name = "arm-mounted implant"
 	desc = "You shouldn't see this! Adminhelp and report this as an issue on github!"
 	zone = BODY_ZONE_R_ARM

--- a/code/modules/surgery/organs/augments_chest.dm
+++ b/code/modules/surgery/organs/augments_chest.dm
@@ -1,4 +1,5 @@
 /obj/item/organ/cyberimp/chest
+	abstract_type = /obj/item/organ/cyberimp/chest
 	name = "cybernetic torso implant"
 	desc = "Implants for the organs in your torso."
 	icon_state = "chest_implant"

--- a/code/modules/surgery/organs/augments_eyes.dm
+++ b/code/modules/surgery/organs/augments_eyes.dm
@@ -1,3 +1,6 @@
+/obj/item/organ/cyberimp/eyes
+	abstract_type = /obj/item/organ/cyberimp/eyes
+
 /obj/item/organ/cyberimp/eyes/emp_act(severity)
 	if(prob(30/severity)) //They same effect as having cybernetic eyes
 		to_chat(owner, span_warning("Static obfuscates your vision!"))

--- a/code/modules/surgery/organs/augments_internal.dm
+++ b/code/modules/surgery/organs/augments_internal.dm
@@ -1,5 +1,6 @@
 
 /obj/item/organ/cyberimp
+	abstract_type = /obj/item/organ/cyberimp
 	name = "cybernetic implant"
 	desc = "A state-of-the-art implant that improves a baseline's functionality."
 	visual = FALSE

--- a/code/modules/surgery/organs/wings.dm
+++ b/code/modules/surgery/organs/wings.dm
@@ -1,4 +1,5 @@
 /obj/item/organ/wings
+	abstract_type = /obj/item/organ/wings
 	name = "Pair of wings"
 	desc = "A pair of wings. They look skinny and useless"
 	icon_state = "angelwings"

--- a/code/modules/surgery/surgery.dm
+++ b/code/modules/surgery/surgery.dm
@@ -1,4 +1,5 @@
 /datum/surgery
+	abstract_type = /datum/surgery
 	var/name = "surgery"
 	var/desc = "surgery description"
 	var/status = 1

--- a/code/modules/unit_tests/asset_smart_cache.dm
+++ b/code/modules/unit_tests/asset_smart_cache.dm
@@ -3,7 +3,7 @@
 	load_immediately = TRUE
 	force_cache = TRUE
 	// Don't let the asset subsystem load this. This is how we trick it.
-	_abstract = /datum/asset/spritesheet_batched/test
+	abstract_type = /datum/asset/spritesheet_batched/test
 	var/static/list/items = list(/obj/item/binoculars, /obj/item/camera, /obj/item/clothing/under/color/blue, /obj/item/clothing/under/color/black)
 
 /datum/asset/spritesheet_batched/test/create_spritesheets()

--- a/code/modules/unit_tests/dynamic_ruleset_sanity.dm
+++ b/code/modules/unit_tests/dynamic_ruleset_sanity.dm
@@ -3,10 +3,7 @@
 
 /datum/unit_test/dynamic_roundstart_ruleset_sanity/Run()
 	// Gamemode
-	for(var/datum/dynamic_ruleset/gamemode/ruleset as anything in subtypesof(/datum/dynamic_ruleset/gamemode))
-		if(ruleset == initial(ruleset.abstract_type))
-			continue
-
+	for(var/datum/dynamic_ruleset/gamemode/ruleset as anything in valid_subtypesof(/datum/dynamic_ruleset/gamemode))
 		// Name
 		if(!initial(ruleset.name))
 			TEST_FAIL("[ruleset] has no name!")
@@ -23,10 +20,7 @@
 			TEST_FAIL("[ruleset] has no role preference!")
 
 	// Roundstart
-	for(var/datum/dynamic_ruleset/supplementary/ruleset as anything in subtypesof(/datum/dynamic_ruleset/supplementary))
-		if(ruleset == initial(ruleset.abstract_type))
-			continue
-
+	for(var/datum/dynamic_ruleset/supplementary/ruleset as anything in valid_subtypesof(/datum/dynamic_ruleset/supplementary))
 		// Name
 		if(!initial(ruleset.name))
 			TEST_FAIL("[ruleset] has no name!")
@@ -43,10 +37,7 @@
 			TEST_FAIL("[ruleset] has no role preference!")
 
 	// Midround
-	for(var/datum/dynamic_ruleset/midround/ruleset as anything in subtypesof(/datum/dynamic_ruleset/midround))
-		if(ruleset == initial(ruleset.abstract_type))
-			continue
-
+	for(var/datum/dynamic_ruleset/midround/ruleset as anything in valid_subtypesof(/datum/dynamic_ruleset/midround))
 		// Name
 		if(!initial(ruleset.name))
 			TEST_FAIL("[ruleset] has no name!")

--- a/code/modules/unit_tests/janky_actions.dm
+++ b/code/modules/unit_tests/janky_actions.dm
@@ -2,7 +2,7 @@
 	priority = TEST_LONGER
 
 /datum/unit_test/test_janky_actions/Run()
-	for (var/obj/item/item_path as anything in subtypesof(/obj/item))
+	for (var/obj/item/item_path as anything in valid_subtypesof(/obj/item))
 		if (!item_path::icon || !item_path::icon_state || !item_path::name || (item_path in uncreatables) || (item_path.item_flags & ABSTRACT))
 			continue
 		var/mob/living/carbon/human/test_mob = allocate(/mob/living/carbon/human/consistent)

--- a/code/modules/unit_tests/limbsanity.dm
+++ b/code/modules/unit_tests/limbsanity.dm
@@ -1,12 +1,11 @@
 /datum/unit_test/limbsanity
 
 /datum/unit_test/limbsanity/Run()
-	for(var/path in subtypesof(/obj/item/bodypart) - list(/obj/item/bodypart/arm, /obj/item/bodypart/leg)) /// removes the abstract items.
-		var/obj/item/bodypart/part = path
+	for(var/obj/item/bodypart/part as anything in valid_subtypesof(/obj/item/bodypart))
 		if(part::is_dimorphic)
 			if(!icon_exists(UNLINT(part::should_draw_greyscale ? part::icon_greyscale : part::icon_static), "[part::limb_id]_[part::body_zone]_m"))
-				TEST_FAIL("[path] does not have a valid icon for male variants")
+				TEST_FAIL("[part] does not have a valid icon for male variants")
 			if(!icon_exists(UNLINT(part::should_draw_greyscale ? part::icon_greyscale : part::icon_static), "[part::limb_id]_[part::body_zone]_f"))
-				TEST_FAIL("[path] does not have a valid icon for female variants")
+				TEST_FAIL("[part] does not have a valid icon for female variants")
 		else if(!icon_exists(UNLINT(part::should_draw_greyscale ? part::icon_greyscale : part::icon_static), "[part::limb_id]_[part::body_zone]"))
-			TEST_FAIL("[path] does not have a valid icon")
+			TEST_FAIL("[part] does not have a valid icon")

--- a/code/modules/unit_tests/quirks.dm
+++ b/code/modules/unit_tests/quirks.dm
@@ -4,10 +4,7 @@
 /datum/unit_test/quirk_icons/Run()
 	var/list/used_icons = list()
 
-	for (var/datum/quirk/quirk_type as anything in subtypesof(/datum/quirk))
-		if (initial(quirk_type.abstract_parent_type) == quirk_type)
-			continue
-
+	for (var/datum/quirk/quirk_type as anything in valid_subtypesof(/datum/quirk))
 		var/icon = initial(quirk_type.icon)
 
 		if (isnull(icon))

--- a/code/modules/unit_tests/unit_test.dm
+++ b/code/modules/unit_tests/unit_test.dm
@@ -33,6 +33,8 @@ GLOBAL_VAR_INIT(focused_tests, focused_tests())
 	return focused_tests.len > 0 ? focused_tests : null
 
 /datum/unit_test
+	abstract_type = /datum/unit_test
+
 	//Bit of metadata for the future maybe
 	var/list/procs_tested
 
@@ -48,9 +50,6 @@ GLOBAL_VAR_INIT(focused_tests, focused_tests())
 	var/succeeded = TRUE
 	var/list/allocated
 	var/list/fail_reasons
-
-	/// Do not instantiate if type matches this
-	var/abstract_type = /datum/unit_test
 
 	/// List of atoms that we don't want to ever initialize in an agnostic context, like for Create and Destroy. Stored on the base datum for usability in other relevant tests that need this data.
 	var/static/list/uncreatables = null

--- a/code/modules/unit_tests/worn_icons.dm
+++ b/code/modules/unit_tests/worn_icons.dm
@@ -24,7 +24,7 @@
 	var/list/already_warned_icons = list()
 
 
-	for(var/obj/item/item_path as anything in subtypesof(/obj/item))// - typesof(/obj/item/mod)))
+	for(var/obj/item/item_path as anything in valid_subtypesof(/obj/item))
 		var/cached_slot_flags = initial(item_path.slot_flags)
 		if(!cached_slot_flags || (cached_slot_flags & ITEM_SLOT_LPOCKET) || (cached_slot_flags & ITEM_SLOT_RPOCKET) || initial(item_path.item_flags) & ABSTRACT)
 			continue

--- a/code/modules/vehicles/mecha/equipment/mecha_equipment.dm
+++ b/code/modules/vehicles/mecha/equipment/mecha_equipment.dm
@@ -3,6 +3,7 @@
  * All mech equippables are currently childs of this
  */
 /obj/item/mecha_parts/mecha_equipment
+	abstract_type = /obj/item/mecha_parts/mecha_equipment
 	name = "mecha equipment"
 	icon = 'icons/mecha/mecha_equipment.dmi'
 	icon_state = "mecha_equip"

--- a/code/modules/vehicles/mecha/equipment/weapons/weapons.dm
+++ b/code/modules/vehicles/mecha/equipment/weapons/weapons.dm
@@ -1,4 +1,5 @@
 /obj/item/mecha_parts/mecha_equipment/weapon
+	abstract_type = /obj/item/mecha_parts/mecha_equipment/weapon
 	name = "mecha weapon"
 	range = MECHA_RANGED
 	equipment_slot = MECHA_WEAPON

--- a/code/modules/vehicles/mecha/mecha_parts.dm
+++ b/code/modules/vehicles/mecha/mecha_parts.dm
@@ -3,6 +3,7 @@
 /////////////////////////
 
 /obj/item/mecha_parts
+	abstract_type = /obj/item/mecha_parts
 	name = "mecha part"
 	icon = 'icons/mob/mech_construct.dmi'
 	icon_state = "blank"

--- a/code/modules/vending/_vending.dm
+++ b/code/modules/vending/_vending.dm
@@ -48,6 +48,7 @@
   * Captalism in the year 2525, everything in a vending machine, even love
   */
 /obj/machinery/vending
+	abstract_type = /obj/machinery/vending
 	name = "\improper Vendomat"
 	desc = "A generic vending machine."
 	icon = 'icons/obj/vending.dmi'

--- a/code/modules/xenoarchaeology/component/materials.dm
+++ b/code/modules/xenoarchaeology/component/materials.dm
@@ -3,6 +3,7 @@
 */
 
 /datum/xenoartifact_material
+	abstract_type = /datum/xenoartifact_material
 	var/name = "debugium"
 	///What color we associate with this material
 	var/material_color = "#ff4800"


### PR DESCRIPTION
## About The Pull Request

Adds the `abstract_type` var to datums and removes all other implementations of it across typepaths. `abstract_type` is primarily used to exclude typepaths in both the `valid_subtypesof()` and `valid_typesof()` procs, with a few manual exceptions here and there (unit-tests). Here are a few examples of abstract types:

- `/datum`
- `/datum/asset`
- `/obj`
- `/obj/item`
- `/mob`
- `/mob/living`

To those of you reviewing, you will probably have noticed this horribleness in `abstract_types.dm`

```dm
/// Returns a list of all abstract typepaths for all datums
/proc/get_abstract_types()
	var/static/list/abstracts
	if(abstracts)
		return abstracts
	abstracts = list()
	for(var/datum/sometype as anything in subtypesof(/datum))
		if(sometype == sometype::abstract_type)
			abstracts[sometype::abstract_type] = TRUE

	return abstracts

/// Like subtypesof, but automatically excludes abstract typepaths
/proc/valid_subtypesof(datum/sometype)
	return subtypesof(sometype) - get_abstract_types()

/// Like typesof, but automatically excludes abstract typepaths
/proc/valid_typesof(datum/sometype)
	return typesof(sometype) - get_abstract_types()
```

Now, I don't really understand why, and neither do the /tg/ coders, but caching a list of abstract types and then subtracting it from your `subtypesof()`/`typesof()` is faster- **a lot faster actually**, than just checking for `abstract_type` equivalence in a `subtypesof()`/`typesof()` loop... I'll copy and paste RikuTheKiller's words for a little more information (I assume they're his words anyway)

```dm
// The time complexity of these two procs is really bad, sitting at O(n * m).
// And yet, the overhead is ridiculously small for some reason. We never figured out why.
// So doing list subtraction instead of filtering is faster in all cases, at least for now.
// If we ever breach like 3000-5000 abstract types, that will likely change.
// As of right now we're at 272 or so, with subtraction being ~10x faster.
// Curse this language, for you shall live in hell alongside me.
```

Ports:

- https://github.com/tgstation/tgstation/pull/92909
- https://github.com/tgstation/tgstation/pull/93439
- https://github.com/tgstation/tgstation/pull/93541
- https://github.com/tgstation/tgstation/pull/94092
- https://github.com/tgstation/tgstation/pull/94857
- https://github.com/tgstation/tgstation/pull/95064
- https://github.com/tgstation/tgstation/pull/95756

## Why It's Good For The Game

Standardizes a useful variable across the codebase- it's generally a bad sign when multiple typepaths have an abstract_parent implementation...

## Testing Photographs and Procedure

Assets & role preferences were both moved to `valid_subtypesof()` (Regenerate Asset Cache was used when taking this testing evidence)

<img width="1182" height="908" alt="image" src="https://github.com/user-attachments/assets/9da85c3b-70bd-480e-bb27-84c51f4d29f8" />

<img width="466" height="670" alt="image" src="https://github.com/user-attachments/assets/3fdfb16e-4701-41c1-9377-f5e51f618bdc" />


`GLOB.emote_list`

<img width="427" height="570" alt="image" src="https://github.com/user-attachments/assets/7c27dc4f-bb5a-4649-8abe-0929e41f3219" />

## Changelog
:cl: mrmanlikesbt, FalloutFalcon
code: abstract_type is now implemented on the /datum level instead of being scattered across several typepaths
fix: fixed the genetics bounty not rolling
/:cl: