### PR TITLE
Emergency Mech Nerf

### DIFF
--- a/code/modules/vehicles/mecha/combat/durand.dm
+++ b/code/modules/vehicles/mecha/combat/durand.dm
@@ -90,6 +90,9 @@
 /obj/vehicle/sealed/mecha/durand/proc/prehit(obj/vehicle/sealed/mecha/durand/source, obj/projectile/projectile, list/signal_args)
 	SIGNAL_HANDLER
 
+	if(istype(projectile, /obj/projectile/ion)) // Ion projectiles dont get redirected, instead they bypass the shield
+		return
+
 	if(defense_check(get_step(src, angle2dir(projectile.Angle + 180))) && shield)
 		signal_args[2] = shield
 

--- a/code/modules/vehicles/mecha/mecha_defense.dm
+++ b/code/modules/vehicles/mecha/mecha_defense.dm
@@ -390,7 +390,7 @@
 	while(atom_integrity < max_integrity) // Check for welder and the fact it's on
 		if(!W.tool_start_check(user, amount=1))
 			break
-		if(!W.use_tool(src, user, 2 SECONDS, volume=30, amount=1)) // Time to wait two seconds per repair
+		if(!W.use_tool(src, user, 4 SECONDS, volume=30, amount=1)) // Time to wait four seconds per repair
 			break
 		user.visible_message(span_notice("[user] repairs some damage to [name]."), span_notice("You repair some damage to [src]."))
 		atom_integrity = min(max_integrity, atom_integrity + 10)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Nerfs Mechs even further and fixes one issue

Time to repair is now 4 seconds per step

Durand shields no longer completely eat ion projectiles

## Why It's Good For The Game

Mechs continue to be ass

One singular durand shouldn't be able to destroy a 4-5 security team due to the fact the shield was completely eating the ion projectiles

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

https://github.com/user-attachments/assets/f722ad2b-9e72-4a6f-af5d-abaf95cc8a33

</details>

## Changelog
:cl: Isaac
balance: Mechs now require 4 seconds per repair step instead of 2 
fix: Durand shield will no longer eat ion projectiles

/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
