### PR TITLE
Dont run maplints if there are no map edits

### DIFF
--- a/.github/workflows/run_linters.yml
+++ b/.github/workflows/run_linters.yml
@@ -85,8 +85,17 @@ jobs:
       - name: Run OpenDream
         if: steps.linter-setup.conclusion == 'success' && !cancelled()
         run: ./DMCompiler_linux-x64/DMCompiler beestation.dme --suppress-unimplemented --define=CIBUILDING --version=515.1642 | bash tools/ci/annotate_od.sh
+      - name: Check for Map & Maplint File Edits
+        id: map-filter
+        uses: dorny/paths-filter@v4
+        with:
+          filters: |
+            run_maps:
+              - '**.dmm'
+              - 'tools/maplint/**'
+              - 'tools/mapmerge2/**'
       - name: Run Map Checks
-        if: steps.linter-setup.conclusion == 'success' && !cancelled()
+        if: steps.linter-setup.conclusion == 'success' && !cancelled() && steps.map-filter.outputs.run_maps == 'true'
         run: |
           tools/bootstrap/python -m mapmerge2.dmm_test
           tools/bootstrap/python -m tools.maplint.source

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -31482,7 +31482,6 @@
 /turf/open/floor/iron/dark,
 /area/station/service/bar/atrium)
 "lmh" = (
-/obj/effect/spawner/random/vending/colavend,
 /turf/open/floor/iron/dark,
 /area/station/hallway/secondary/command)
 "lmj" = (

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -31482,6 +31482,7 @@
 /turf/open/floor/iron/dark,
 /area/station/service/bar/atrium)
 "lmh" = (
+/obj/effect/spawner/random/vending/colavend,
 /turf/open/floor/iron/dark,
 /area/station/hallway/secondary/command)
 "lmj" = (


### PR DESCRIPTION
## About The Pull Request

Ports: 
- https://github.com/tgstation/tgstation/pull/95758

> This PR introduces a path-filtering step to `.github/workflows/run_linters.yml`. Currently, our map linters run on every single commit, regardless of whether a map was actually touched.

> I have added a check that only wakes up the Python map linter if:

> 1. A `.dmm` file is modified anywhere in the repository.
> 2. The linter tool itself (`tools/maplint/**`) is updated.
> 3. The mapmerge tool itself (`tools/mapmerge2/**`) is updated.

> To accomplish this, we use [dorny/paths-filter@v4](https://github.com/dorny/paths-filter) since GitHub’s built-in workflow path filters cannot be applied to specific jobs or steps within a shared CI job.

## Why It's Good For The Game

Marginally less CI time

## Testing Photographs and Procedure

With map-edits

<img width="515" height="332" alt="image" src="https://github.com/user-attachments/assets/e4fcdef1-56ea-46c8-8fa4-b6a21f49a1d4" />

Without map-edits

<img width="529" height="255" alt="image" src="https://github.com/user-attachments/assets/ca50f9b1-04e7-4e28-b3e4-8b9b24a3b2f5" />

## Changelog
:cl: timothymtorres
server: PRs that don't touch mapping no longer have maplints ran on them
/:cl:
