### PR TITLE
Implement a maximum cap for midround dynamic point accumulation

### DIFF
--- a/code/controllers/subsystem/dynamic/dynamic.dm
+++ b/code/controllers/subsystem/dynamic/dynamic.dm
@@ -192,6 +192,8 @@ SUBSYSTEM_DEF(dynamic)
 	var/midround_linear_delta = 0.7
 	/// This delta is applied no matter what
 	var/midround_linear_delta_forced = 0.25
+	/// The maximum positive delta that can be added per tick.
+	var/midround_max_positive_delta = INFINITY
 
 	/// How long dynamic will wait to execute another ruleset if it fails to execute the previous one
 	/// Used to mitigate spam and antag rolling
@@ -791,7 +793,8 @@ SUBSYSTEM_DEF(dynamic)
 			antag_delta += midround_points_per_antag["[antag_datum.type]"]
 
 	// Add points
-	midround_points += max(living_delta + observing_delta + dead_delta + dead_security_delta + antag_delta + midround_linear_delta, 0)
+	var/variable_delta = living_delta + observing_delta + dead_delta + dead_security_delta + antag_delta + midround_linear_delta
+	midround_points += clamp(variable_delta, 0, midround_max_positive_delta)
 	midround_points += midround_linear_delta_forced
 
 	// Log point sources


### PR DESCRIPTION
## About The Pull Request

Adds `midround_max_positive_delta` to the dynamic subsystem to allow for a configurable upper limit on points gained per tick from variable sources. This provides a mechanism to prevent runaway point generation during the midround phase.

## Why It's Good For The Game

Atomization of https://github.com/BeeStation/BeeStation-Hornet/pull/14331

I guess it's good to have it?

## Testing Photographs and Procedure
<details>
<summary>Screenshots&Videos</summary>

Not much to test...

</details>

## Changelog
:cl:
code: Add midround_max_positive_delta in ssdynamic
/:cl: