### PR TITLE
Fixes smartwire bugs

### DIFF
--- a/code/modules/power/cable.dm
+++ b/code/modules/power/cable.dm
@@ -167,6 +167,9 @@ CREATION_TEST_IGNORE_SUBTYPES(/obj/structure/cable)
 
 		connected_cable.update_power_node()
 		connected_cable.update_appearance(UPDATE_ICON)
+
+	update_power_node()
+
 	down?.set_up(null)
 	up?.set_down(null)
 
@@ -196,6 +199,8 @@ CREATION_TEST_IGNORE_SUBTYPES(/obj/structure/cable)
 			adjacent_cable.update_power_node()
 			adjacent_cable.update_appearance(UPDATE_ICON)
 
+	update_power_node()
+
 	// Linkup with multi-z cables
 	if (multiz)
 		var/turf/current_location = get_turf(src)
@@ -217,7 +222,7 @@ CREATION_TEST_IGNORE_SUBTYPES(/obj/structure/cable)
 	has_power_node = FALSE
 
 	// If we have 0 or 1 connections, we get a free power node
-	if((linked_dirs & NORTH) + (linked_dirs & SOUTH) + (linked_dirs & WEST) + (linked_dirs & EAST) <= 1)
+	if(!!(linked_dirs & NORTH) + !!(linked_dirs & SOUTH) + !!(linked_dirs & WEST) + !!(linked_dirs & EAST) <= 1)
 		has_power_node = TRUE
 
 	if (previous_node_state != has_power_node)

--- a/code/modules/power/cable.dm
+++ b/code/modules/power/cable.dm
@@ -531,8 +531,8 @@ CREATION_TEST_IGNORE_SUBTYPES(/obj/structure/cable)
 		if(!power_machine.connect_to_network())
 			power_machine.disconnect_from_network()
 
-/obj/structure/cable/proc/disconnect_from_machines()
-	for(var/obj/machinery/power/power_machine in get_turf(src))
+/obj/structure/cable/proc/disconnect_from_machines(turf/turf_to_check)
+	for(var/obj/machinery/power/power_machine in turf_to_check)
 		if(!power_machine.connect_to_network()) //can't find a node cable on a the turf to connect to
 			power_machine.disconnect_from_network() //remove from current network
 
@@ -548,12 +548,9 @@ CREATION_TEST_IGNORE_SUBTYPES(/obj/structure/cable)
 		moveToNullspace()
 	powernet.remove_cable(src) //remove the cut cable from its powernet
 
-	if (!location)
-		return
-
 	// Disconnect machines connected to nodes
-	if(has_power_node) // if we cut a node (O-X) cable
-		disconnect_from_machines()
+	if(location && has_power_node) // if we cut a node (O-X) cable
+		disconnect_from_machines(location)
 
 /obj/structure/cable/beforeShuttleMove(turf/newT, rotation, move_mode, obj/docking_port/mobile/moving_dock)
 	. = ..()

--- a/code/modules/power/power.dm
+++ b/code/modules/power/power.dm
@@ -190,15 +190,14 @@ WANTS_POWER_NODE(/obj/machinery/power)
 
 // connect the machine to a powernet if a node cable is present on the turf
 /obj/machinery/power/proc/connect_to_network(turf/turf = loc)
-	var/turf/T = turf
-	if(!T || !istype(T))
+	if(!istype(turf))
 		return FALSE
 
-	var/obj/structure/cable/C = T.get_cable_node() //check if we have a node cable on the machine turf, the first found is picked
-	if(!C || !C.powernet)
+	var/obj/structure/cable/connected_cable = turf.get_cable_node() //check if we have a node cable on the machine turf, the first found is picked
+	if(!connected_cable?.powernet)
 		return FALSE
 
-	C.powernet.add_machine(src)
+	connected_cable.powernet.add_machine(src)
 	return TRUE
 
 // remove and disconnect the machine from its current powernet

--- a/code/modules/power/smes.dm
+++ b/code/modules/power/smes.dm
@@ -58,6 +58,10 @@
 	terminal.master = src
 	update_appearance(UPDATE_OVERLAYS)
 
+/obj/machinery/power/smes/on_construction(mob/user)
+	. = ..()
+	connect_to_network()
+
 /obj/machinery/power/smes/disconnect_terminal()
 	if(terminal)
 		terminal.master = null


### PR DESCRIPTION
## About The Pull Request

Three bugs here:
- `update_power_node()` was incorrectly checking dirs
-  `cut_cable_from_powernet()` would not properly disconnect the cable's linked machines because the cable is moved to nullspace at the start of the proc
- SMESs weren't auto-connecting to cable nodes below them when constructed

## Testing Photographs and Procedure

https://github.com/user-attachments/assets/8b3a8aa2-c889-4b41-a704-15193d028c70

https://github.com/user-attachments/assets/b6ea4d8f-8e46-47a1-bc93-d55bb1ffa4c7

## Changelog
:cl:
fix: Fixed SMESs not connecting to the cable below them when constructed
fix: Fixed cutting a cable sometimes not unlinking 6its connected machinery
fix: Fixed a cable sometimes not correctly updating its has_power_node var when update_power_node() was called
/:cl: