### PR TITLE
Fixes IPCs from developing a DNA and mutating.

### DIFF
--- a/code/datums/components/irradiated.dm
+++ b/code/datums/components/irradiated.dm
@@ -147,6 +147,8 @@
 
 /datum/component/irradiated/proc/mutate_human_parent(mob/living/carbon/human/human_parent)
 	COOLDOWN_START(src, irradiated_mutation, rand(45, 120) SECONDS)
+	if(!human_parent.can_mutate())
+		return
 	if(prob(75)) //usually a mutation, sometimes a total appearance change instead
 		human_parent.easy_random_mutate()
 	else

--- a/code/datums/dna.dm
+++ b/code/datums/dna.dm
@@ -569,7 +569,7 @@ GLOBAL_LIST_INIT(total_uf_len_by_block, populate_total_uf_len_by_block())
 	if(icon_update)
 		update_hair()
 
-/// Returns carbon's DNA object. For checking whether a mob can mutate - use can_mutate().
+
 /mob/proc/has_dna()
 	return
 
@@ -814,15 +814,11 @@ GLOBAL_LIST_INIT(total_uf_len_by_block, populate_total_uf_len_by_block())
 /mob/living/carbon/proc/random_mutate(list/candidates, difficulty = 2)
 	if(!has_dna())
 		return
-	if(!can_mutate())
-		return
 	var/mutation = pick(candidates)
 	. = dna.add_mutation(mutation)
 
 /mob/living/carbon/proc/easy_random_mutate(quality = POSITIVE + NEGATIVE + MINOR_NEGATIVE, scrambled = TRUE, sequence = TRUE, exclude_monkey = TRUE)
 	if(!has_dna())
-		return
-	if(!can_mutate())
 		return
 	var/list/mutations = list()
 	if(quality & POSITIVE)
@@ -849,8 +845,6 @@ GLOBAL_LIST_INIT(total_uf_len_by_block, populate_total_uf_len_by_block())
 /mob/living/carbon/proc/random_mutate_unique_identity()
 	if(!has_dna())
 		return
-	if(!can_mutate())
-		return
 	var/num = rand(1, DNA_UNI_IDENTITY_BLOCKS)
 	dna.set_uni_feature_block(num, random_string(GET_UI_BLOCK_LEN(num), GLOB.hex_characters))
 	updateappearance(mutations_overlay_update=1)
@@ -858,8 +852,6 @@ GLOBAL_LIST_INIT(total_uf_len_by_block, populate_total_uf_len_by_block())
 /mob/living/carbon/proc/random_mutate_unique_features()
 	if(!has_dna())
 		CRASH("[src] does not have DNA")
-	if(!can_mutate())
-		return
 	var/num = rand(1, DNA_FEATURE_BLOCKS)
 	dna.set_uni_feature_block(num, random_string(GET_UF_BLOCK_LEN(num), GLOB.hex_characters))
 	updateappearance(mutcolor_update = TRUE, mutations_overlay_update = TRUE)
@@ -875,8 +867,6 @@ GLOBAL_LIST_INIT(total_uf_len_by_block, populate_total_uf_len_by_block())
 
 /proc/scramble_dna(mob/living/carbon/M, ui=FALSE, se=FALSE, uf=FALSE, probability)
 	if(!M.has_dna())
-		return FALSE
-	if(!M.can_mutate())
 		return FALSE
 	if(se)
 		for(var/i=1, i<=DNA_MUTATION_BLOCKS, i++)

--- a/code/datums/dna.dm
+++ b/code/datums/dna.dm
@@ -569,7 +569,7 @@ GLOBAL_LIST_INIT(total_uf_len_by_block, populate_total_uf_len_by_block())
 	if(icon_update)
 		update_hair()
 
-
+/// Returns carbon's DNA object. For checking whether a mob can mutate - use can_mutate().
 /mob/proc/has_dna()
 	return
 
@@ -814,11 +814,15 @@ GLOBAL_LIST_INIT(total_uf_len_by_block, populate_total_uf_len_by_block())
 /mob/living/carbon/proc/random_mutate(list/candidates, difficulty = 2)
 	if(!has_dna())
 		return
+	if(!can_mutate())
+		return
 	var/mutation = pick(candidates)
 	. = dna.add_mutation(mutation)
 
 /mob/living/carbon/proc/easy_random_mutate(quality = POSITIVE + NEGATIVE + MINOR_NEGATIVE, scrambled = TRUE, sequence = TRUE, exclude_monkey = TRUE)
 	if(!has_dna())
+		return
+	if(!can_mutate())
 		return
 	var/list/mutations = list()
 	if(quality & POSITIVE)
@@ -845,6 +849,8 @@ GLOBAL_LIST_INIT(total_uf_len_by_block, populate_total_uf_len_by_block())
 /mob/living/carbon/proc/random_mutate_unique_identity()
 	if(!has_dna())
 		return
+	if(!can_mutate())
+		return
 	var/num = rand(1, DNA_UNI_IDENTITY_BLOCKS)
 	dna.set_uni_feature_block(num, random_string(GET_UI_BLOCK_LEN(num), GLOB.hex_characters))
 	updateappearance(mutations_overlay_update=1)
@@ -852,6 +858,8 @@ GLOBAL_LIST_INIT(total_uf_len_by_block, populate_total_uf_len_by_block())
 /mob/living/carbon/proc/random_mutate_unique_features()
 	if(!has_dna())
 		CRASH("[src] does not have DNA")
+	if(!can_mutate())
+		return
 	var/num = rand(1, DNA_FEATURE_BLOCKS)
 	dna.set_uni_feature_block(num, random_string(GET_UF_BLOCK_LEN(num), GLOB.hex_characters))
 	updateappearance(mutcolor_update = TRUE, mutations_overlay_update = TRUE)
@@ -867,6 +875,8 @@ GLOBAL_LIST_INIT(total_uf_len_by_block, populate_total_uf_len_by_block())
 
 /proc/scramble_dna(mob/living/carbon/M, ui=FALSE, se=FALSE, uf=FALSE, probability)
 	if(!M.has_dna())
+		return FALSE
+	if(!M.can_mutate())
 		return FALSE
 	if(se)
 		for(var/i=1, i<=DNA_MUTATION_BLOCKS, i++)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes #14337.
Adds a check in radiation mutation procs whether the victim should be able to mutate.

## Why It's Good For The Game

"Local robot gets irradiated, mutates so much he develops a DNA" is too sensationalistic.
IPCs getting incurable genetic mutations is bad.


## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

<img width="760" height="768" alt="зображення" src="https://github.com/user-attachments/assets/4a0042ec-5de2-4c03-bee4-5631107fa3fe" />
Robot develops no mutations from radiation.

</details>

## Changelog
:cl:
fix: IPCs no longer mutate from radiation.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
