### PR TITLE
fix: do_cpr mask message uses target's gender pronoun

### DIFF
--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -534,7 +534,7 @@
 			return FALSE
 
 		if (target.is_mouth_covered())
-			to_chat(src, span_warning("Remove [p_their()] mask first!"))
+			to_chat(src, span_warning("Remove [target.p_their()] mask first!"))
 			return FALSE
 
 		if (!get_organ_slot(ORGAN_SLOT_LUNGS))


### PR DESCRIPTION
## About The Pull Request

When the rescuer attempts CPR on a target whose mouth is covered,
\`do_cpr\` was sending them a warning interpolated with \`p_their()\`
— **the rescuer's own** pronoun — instead of \`target.p_their()\`.

\`code/modules/mob/living/carbon/human/human.dm\`, line 537:

\`\`\`dm
- to_chat(src, span_warning(\"Remove [p_their()] mask first!\"))
+ to_chat(src, span_warning(\"Remove [target.p_their()] mask first!\"))
\`\`\`

The branch one up already handles the \"remove your *own* mask\" case
explicitly (\"Remove your mask first!\"), so the only natural reading
of this branch is \"the target's mask is in the way\".

Reported in #14341 by the issue author.

## Why It's Good For The Game

Tiny correctness fix. A rescuer who happens to be a different gender
than the patient currently sees their own pronoun in a sentence about
the patient, which reads like a bug to anyone who notices.

## Testing Photographs and Procedure

Single one-line code change; no asset/sprite/sound/map work and no
new behaviour. The interpolated string is the only thing that
changes, from \`p_their()\` (rescuer) to \`target.p_their()\` (patient).

<details>
<summary>Screenshots&Videos</summary>

N/A — text-only fix to an existing message.

</details>

## Changelog
:cl:
fix: CPR's \"remove their mask first\" message now uses the patient's gender pronoun instead of the rescuer's.
/:cl: