### PR TITLE
Attempts to patch the examine() crashing issue

### DIFF
--- a/code/__HELPERS/icons.dm
+++ b/code/__HELPERS/icons.dm
@@ -998,10 +998,11 @@ GLOBAL_LIST_EMPTY(friendly_animal_types)
 				SSassets.transport.send_assets(thing2, name)
 			if(sourceonly)
 				return SSassets.transport.get_asset_url(name)
-			var/misc_url = SSassets.transport.get_asset_url(name)
-			if(!misc_url)
+			var/datum/asset_cache_item/misc_2 = SSassets.cache[name]
+			if(!misc_2)
+				stack_trace("icon2html(): asset '[name]' missing from cache after registration (thing=[thing], target=[target])")
 				return null
-			return "<img class='[extra_classes ? "[extra_classes] " : ""]icon icon-misc' src='[misc_url]'>"
+			return "<img class='[extra_classes ? "[extra_classes] " : ""]icon icon-misc' src='[SSassets.transport.get_asset_url(name, misc_2)]'>"
 
 		//its either an atom, image, or mutable_appearance, we want its icon var
 		icon2collapse = thing.icon
@@ -1041,10 +1042,11 @@ GLOBAL_LIST_EMPTY(friendly_animal_types)
 		SSassets.transport.send_assets(client_target, key)
 	if(sourceonly)
 		return SSassets.transport.get_asset_url(key)
-	var/icon_url = SSassets.transport.get_asset_url(key)
-	if(!icon_url)
+	var/datum/asset_cache_item/icon_2 = SSassets.cache[key]
+	if(!icon_2)
+		stack_trace("icon2html(): asset '[key]' missing from cache after registration (thing=[thing], target=[target])")
 		return null
-	return "<img class='[extra_classes ? "[extra_classes] " : ""]icon icon-[icon_state]' src='[icon_url]'>"
+	return "<img class='[extra_classes ? "[extra_classes] " : ""]icon icon-[icon_state]' src='[SSassets.transport.get_asset_url(key, icon_2)]'>"
 
 /proc/icon2base64html(thing)
 	if (!thing)

--- a/code/__HELPERS/icons.dm
+++ b/code/__HELPERS/icons.dm
@@ -998,7 +998,10 @@ GLOBAL_LIST_EMPTY(friendly_animal_types)
 				SSassets.transport.send_assets(thing2, name)
 			if(sourceonly)
 				return SSassets.transport.get_asset_url(name)
-			return "<img class='[extra_classes] icon icon-misc' src='[SSassets.transport.get_asset_url(name)]'>"
+			var/misc_url = SSassets.transport.get_asset_url(name)
+			if(!misc_url)
+				return null
+			return "<img class='[extra_classes ? "[extra_classes] " : ""]icon icon-misc' src='[misc_url]'>"
 
 		//its either an atom, image, or mutable_appearance, we want its icon var
 		icon2collapse = thing.icon
@@ -1028,7 +1031,7 @@ GLOBAL_LIST_EMPTY(friendly_animal_types)
 
 	var/list/name_and_ref = generate_and_hash_rsc_file(icon2collapse, icon_path)//pretend that tuples exist
 
-	var/rsc_ref = name_and_ref[1] //weird object thats not even readable to the debugger, represents a reference to the icons rsc entry
+	var/rsc_ref = name_and_ref[1] //weird object that's not even readable to the debugger, represents a reference to the icons rsc entry
 	var/file_hash = name_and_ref[2]
 	key = "[name_and_ref[3]].png"
 
@@ -1038,7 +1041,10 @@ GLOBAL_LIST_EMPTY(friendly_animal_types)
 		SSassets.transport.send_assets(client_target, key)
 	if(sourceonly)
 		return SSassets.transport.get_asset_url(key)
-	return "<img class='[extra_classes] icon icon-[icon_state]' src='[SSassets.transport.get_asset_url(key)]'>"
+	var/icon_url = SSassets.transport.get_asset_url(key)
+	if(!icon_url)
+		return null
+	return "<img class='[extra_classes ? "[extra_classes] " : ""]icon icon-[icon_state]' src='[icon_url]'>"
 
 /proc/icon2base64html(thing)
 	if (!thing)

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -1690,8 +1690,9 @@ GLOBAL_VAR_INIT(rpg_loot_items, FALSE)
 /// item in greater detail.
 /obj/item/proc/examine_worn_title(mob/living/wearer, mob/user, skip_examine_link = FALSE)
 	ASSERT(user, "Cannot generate worn examination title without a user, worn titles require the target which you are showing them to.")
-	ASSERT(user.client, "Attempting to generate worn title for a mob without a client, which is not allowed.")
 	var/examine_name = get_examine_name(user)
+	if(!user.client)
+		return examine_name
 
 	// Don't add examine link if this is the item being directly examined
 	if(skip_examine_link)
@@ -1702,12 +1703,8 @@ GLOBAL_VAR_INIT(rpg_loot_items, FALSE)
 /// This may be overriden to provice custom inspection commands, or may be called with a custom item name
 /// that differs from the returned examine name of the item.
 /obj/item/proc/examine_inspection_link(mob/user, examine_name)
-	var/whole_word = user.client.prefs?.read_player_preference(/datum/preference/toggle/whole_word_examine_links)
 	var/obj/item/card/id/ID = GetID()
 	if(ID)
 		return "[examine_name] <a href='byond://?src=\ref[ID];look_at_id=1'>\[Examine ID\]</a>"
 	else
-		if(whole_word)
-			return "<a href='byond://?src=\ref[src];examine=1'>[examine_name]</a>"
-		else
-			return "[examine_name] <a href='byond://?src=\ref[src];examine=1'>\[?\]</a>"
+		return "[examine_name] <a href='byond://?src=\ref[src];examine=1'>\[?\]</a>"

--- a/code/modules/client/preferences/entries/player/chat.dm
+++ b/code/modules/client/preferences/entries/player/chat.dm
@@ -85,9 +85,3 @@
 	category = PREFERENCE_CATEGORY_GAME_PREFERENCES
 	db_key = "examine_messages"
 	preference_type = PREFERENCE_PLAYER
-
-/datum/preference/toggle/whole_word_examine_links
-	category = PREFERENCE_CATEGORY_GAME_PREFERENCES
-	db_key = "whole_word_examine_links"
-	preference_type = PREFERENCE_PLAYER
-	default_value = TRUE

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/game_preferences/chat.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/game_preferences/chat.tsx
@@ -126,11 +126,3 @@ export const examine_messages: FeatureToggle = {
   description: "Receive 'player examined x' examine messages in chat.",
   component: CheckboxInput,
 };
-
-export const whole_word_examine_links: FeatureToggle = {
-  name: 'Whole Word Examine Links',
-  category: 'CHAT',
-  subcategory: 'IC',
-  description: 'Use whole word examine links instead of an appended [?].',
-  component: CheckboxInput,
-};


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This attempts a few methods of what we *think* is what is crashing people when they use examine verb on things. The way we pass images into the chatbox is a possible vulnerability.

In two cases, I've stored the value as a Lvar and just not let it proceed if its null. This should fix it if the asset system is sending null assets.

Basically, we are trying to prevent src='' being sent to the client at all.

Additionally, Ive removed the href preference that encases the whole line on examine. It was breaking the formatting and adjectives, and is tangentially related to the current issue, though I don't think it is causing the crashing. 
I intended it originally to be the alternate and not the default that it became, this just restores it.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

This is a rather juvenile attempt, but it should give good data.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

We shall see

</details>

## Changelog
:cl:
code: attempts a fix at the examine() crashes
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
