### PR TITLE
Empty SMESes can be mapped in again

### DIFF
--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -25139,10 +25139,8 @@
 	dir = 6
 	},
 /obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
-/obj/machinery/power/smes{
-	charge = 5e+006
-	},
 /obj/structure/cable,
+/obj/machinery/power/smes/engineering,
 /turf/open/floor/iron/dark,
 /area/station/engineering/gravity_generator)
 "kIT" = (
@@ -45448,10 +45446,8 @@
 /turf/open/floor/catwalk_floor,
 /area/station/cargo/exploration_dock)
 "sUf" = (
-/obj/machinery/power/smes{
-	charge = 5e+006
-	},
 /obj/structure/cable/yellow,
+/obj/machinery/power/smes/engineering,
 /turf/open/floor/circuit,
 /area/station/ai_monitored/turret_protected/ai)
 "sUz" = (
@@ -49185,13 +49181,11 @@
 /turf/open/floor/noslip/blue,
 /area/station/commons/dorms)
 "usu" = (
-/obj/machinery/power/smes{
-	charge = 5e+006
-	},
 /obj/machinery/light{
 	dir = 8
 	},
 /obj/structure/cable,
+/obj/machinery/power/smes/engineering,
 /turf/open/floor/circuit/telecomms,
 /area/station/tcommsat/server)
 "usy" = (

--- a/_maps/map_files/CardinalStation/CardinalStation.dmm
+++ b/_maps/map_files/CardinalStation/CardinalStation.dmm
@@ -25124,10 +25124,8 @@
 /turf/open/floor/plating,
 /area/station/medical/virology)
 "fUa" = (
-/obj/machinery/power/smes{
-	charge = 5e+006
-	},
 /obj/structure/cable,
+/obj/machinery/power/smes/engineering,
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/station/tcommsat/server)
 "fUg" = (
@@ -34999,10 +34997,8 @@
 /area/station/maintenance/department/chapel)
 "ikT" = (
 /obj/effect/turf_decal/siding/dark,
-/obj/machinery/power/smes{
-	charge = 5e+006
-	},
 /obj/structure/cable/pink,
+/obj/machinery/power/smes/engineering,
 /turf/open/floor/engine,
 /area/station/ai_monitored/turret_protected/ai)
 "ikV" = (
@@ -61328,14 +61324,12 @@
 /turf/open/floor/iron/dark,
 /area/station/science/robotics/lab)
 "orn" = (
-/obj/machinery/power/smes{
-	charge = 5e+006
-	},
 /obj/structure/cable/orange,
 /obj/machinery/atmospherics/pipe/smart/simple/general/hidden{
 	dir = 5
 	},
 /obj/machinery/airalarm/directional/west,
+/obj/machinery/power/smes/engineering,
 /turf/open/floor/plating,
 /area/station/ai_monitored/turret_protected/aisat/service)
 "oro" = (
@@ -103025,13 +103019,11 @@
 /turf/open/floor/iron/edge,
 /area/station/maintenance/disposal/incinerator)
 "ylr" = (
-/obj/machinery/power/smes{
-	charge = 5e+006
-	},
 /obj/structure/cable/orange,
 /obj/effect/turf_decal/trimline/yellow/warning{
 	dir = 5
 	},
+/obj/machinery/power/smes/engineering,
 /turf/open/floor/noslip/dark,
 /area/station/engineering/gravity_generator)
 "ylt" = (

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -3266,10 +3266,8 @@
 /area/station/maintenance/starboard)
 "bmN" = (
 /obj/structure/cable/yellow,
-/obj/machinery/power/smes{
-	charge = 2e+006
-	},
 /obj/machinery/incident_display/delam/directional/south,
+/obj/machinery/power/smes/engineering,
 /turf/open/floor/circuit/green,
 /area/station/engineering/atmospherics_engine)
 "bmT" = (
@@ -24999,13 +24997,11 @@
 /turf/open/floor/iron/dark,
 /area/station/security/courtroom)
 "iiG" = (
-/obj/machinery/power/smes{
-	charge = 5e+006
-	},
 /obj/effect/turf_decal/edges/borderfloor{
 	dir = 4
 	},
 /obj/structure/cable,
+/obj/machinery/power/smes/engineering,
 /turf/open/floor/iron/telecomms,
 /area/station/tcommsat/server)
 "iiI" = (
@@ -27381,9 +27377,6 @@
 /turf/open/floor/iron,
 /area/station/maintenance/port/fore)
 "iXj" = (
-/obj/machinery/power/smes{
-	charge = 5e+006
-	},
 /obj/structure/cable/yellow,
 /obj/machinery/light{
 	dir = 1
@@ -27394,6 +27387,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/obj/machinery/power/smes/engineering,
 /turf/open/floor/plating,
 /area/station/ai_monitored/turret_protected/aisat_interior)
 "iXk" = (
@@ -31392,9 +31386,6 @@
 /turf/open/floor/plating,
 /area/station/engineering/main)
 "keZ" = (
-/obj/machinery/power/smes{
-	charge = 5e+006
-	},
 /obj/structure/sign/warning/electric_shock{
 	pixel_y = 32
 	},
@@ -31404,6 +31395,7 @@
 	},
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/cable,
+/obj/machinery/power/smes/engineering,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/ai)
 "kfa" = (
@@ -42647,11 +42639,9 @@
 /obj/structure/sign/warning/no_smoking{
 	pixel_x = 32
 	},
-/obj/machinery/power/smes{
-	charge = 5e+006
-	},
 /obj/structure/cable/yellow,
 /obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
+/obj/machinery/power/smes/engineering,
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmospherics_engine)
 "nzL" = (
@@ -44825,9 +44815,6 @@
 "ofW" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/cobweb/cobweb2,
-/obj/machinery/power/smes{
-	charge = 5e+006
-	},
 /obj/structure/sign/nanotrasen{
 	pixel_y = 32
 	},
@@ -44836,6 +44823,7 @@
 	},
 /obj/structure/cable,
 /obj/effect/turf_decal/bot,
+/obj/machinery/power/smes/engineering,
 /turf/open/floor/iron,
 /area/station/engineering/gravity_generator)
 "ofX" = (

--- a/_maps/map_files/EchoStation/EchoStation.dmm
+++ b/_maps/map_files/EchoStation/EchoStation.dmm
@@ -19441,7 +19441,9 @@
 	pixel_y = 14
 	},
 /obj/structure/cable/yellow,
-/obj/machinery/power/smes/engineering,
+/obj/machinery/power/smes/engineering{
+	name = "ai power storage unit"
+	},
 /turf/open/floor/circuit/red,
 /area/station/ai_monitored/turret_protected/ai)
 "lVJ" = (

--- a/_maps/map_files/EchoStation/EchoStation.dmm
+++ b/_maps/map_files/EchoStation/EchoStation.dmm
@@ -19430,10 +19430,6 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/xenobiology)
 "lVz" = (
-/obj/machinery/power/smes{
-	charge = 5e+006;
-	name = "ai power storage unit"
-	},
 /obj/machinery/flasher{
 	id = "AI";
 	name = "Meatbag Pacifier";
@@ -19445,6 +19441,7 @@
 	pixel_y = 14
 	},
 /obj/structure/cable/yellow,
+/obj/machinery/power/smes/engineering,
 /turf/open/floor/circuit/red,
 /area/station/ai_monitored/turret_protected/ai)
 "lVJ" = (
@@ -30958,6 +30955,10 @@
 	dir = 4
 	},
 /area/station/hallway/primary/aft)
+"sPE" = (
+/obj/machinery/power/smes/engineering,
+/turf/closed/indestructible/rock/bedrock,
+/area/paradise)
 "sPX" = (
 /obj/machinery/door/morgue{
 	name = "Confession Booth"
@@ -38354,11 +38355,9 @@
 /turf/open/floor/iron,
 /area/station/science/research)
 "xgN" = (
-/obj/machinery/power/smes{
-	charge = 2e+007
-	},
 /obj/structure/cable,
 /obj/machinery/camera/directional/east,
+/obj/machinery/power/smes/engineering,
 /turf/open/floor/iron/dark/telecomms{
 	initial_gas_mix = "o2=22;n2=82;TEMP=293.15"
 	},
@@ -41109,7 +41108,7 @@ qdb
 qdb
 qdb
 qdb
-qdb
+sPE
 qdb
 mGR
 mGR

--- a/_maps/map_files/FlandStation/FlandStation.dmm
+++ b/_maps/map_files/FlandStation/FlandStation.dmm
@@ -16446,10 +16446,8 @@
 	dir = 4
 	},
 /obj/structure/lattice/catwalk/over,
-/obj/machinery/power/smes{
-	charge = 5e+006
-	},
 /obj/structure/cable/orange,
+/obj/machinery/power/smes/engineering,
 /turf/open/floor/plating/airless{
 	initial_gas_mix = "o2=14;n2=23;TEMP=300"
 	},
@@ -17509,10 +17507,8 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "fkF" = (
-/obj/machinery/power/smes{
-	charge = 5e+006
-	},
 /obj/structure/cable/orange,
+/obj/machinery/power/smes/engineering,
 /turf/open/floor/plating,
 /area/drydock)
 "fkG" = (
@@ -31301,10 +31297,8 @@
 /area/station/maintenance/department/medical)
 "jif" = (
 /obj/effect/turf_decal/stripes/full,
-/obj/machinery/power/smes{
-	charge = 5e+006
-	},
 /obj/structure/cable,
+/obj/machinery/power/smes/engineering,
 /turf/open/floor/iron/dark,
 /area/station/engineering/gravity_generator)
 "jik" = (
@@ -37570,12 +37564,10 @@
 /turf/closed/wall/r_wall,
 /area/station/command/heads_quarters/cmo)
 "kTr" = (
-/obj/machinery/power/smes{
-	charge = 5e+006
-	},
 /obj/effect/turf_decal/stripes/box,
 /obj/effect/turf_decal/stripes/red/box,
 /obj/structure/cable,
+/obj/machinery/power/smes/engineering,
 /turf/open/floor/iron/dark/telecomms,
 /area/station/tcommsat/server)
 "kTx" = (
@@ -37928,9 +37920,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/machinery/power/smes{
-	charge = 5e+006
-	},
+/obj/machinery/power/smes/engineering,
 /turf/open/floor/circuit/red,
 /area/station/ai_monitored/turret_protected/ai)
 "kYE" = (
@@ -55243,9 +55233,7 @@
 /obj/structure/sign/warning/electric_shock{
 	pixel_x = 32
 	},
-/obj/machinery/power/smes{
-	charge = 5e+006
-	},
+/obj/machinery/power/smes/engineering,
 /turf/open/floor/iron/tech/grid,
 /area/station/ai_monitored/turret_protected/ai_upload_foyer)
 "qic" = (
@@ -71526,10 +71514,8 @@
 /turf/open/floor/iron/techmaint,
 /area/station/service/chapel/office)
 "vch" = (
-/obj/machinery/power/smes{
-	charge = 5e+006
-	},
 /obj/structure/cable/orange,
+/obj/machinery/power/smes/engineering,
 /turf/open/floor/plating,
 /area/drydock/security)
 "vco" = (
@@ -80725,11 +80711,9 @@
 /turf/open/floor/iron/grid/steel,
 /area/station/science/research)
 "xNU" = (
-/obj/machinery/power/smes{
-	charge = 5e+006
-	},
 /obj/machinery/camera/directional/east,
 /obj/structure/cable/orange,
+/obj/machinery/power/smes/engineering,
 /turf/open/floor/engine{
 	initial_gas_mix = "o2=14;n2=23;TEMP=300"
 	},

--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -34106,10 +34106,7 @@
 	},
 /obj/effect/decal/cleanable/cobweb,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/power/smes{
-	charge = 5e+006;
-	name = "ai power storage unit"
-	},
+/obj/machinery/power/smes/engineering,
 /turf/open/floor/plating{
 	burnt = 1
 	},
@@ -35832,11 +35829,8 @@
 	},
 /area/station/maintenance/central)
 "mye" = (
-/obj/machinery/power/smes{
-	charge = 5e+006;
-	name = "ai power storage unit"
-	},
 /obj/structure/cable/yellow,
+/obj/machinery/power/smes/engineering,
 /turf/open/floor/circuit/red,
 /area/station/ai_monitored/turret_protected/ai)
 "myl" = (
@@ -57718,9 +57712,6 @@
 	},
 /area/station/cargo/warehouse)
 "tUZ" = (
-/obj/machinery/power/smes{
-	charge = 5e+006
-	},
 /obj/machinery/airalarm/directional/west{
 	pixel_x = -22
 	},
@@ -57730,6 +57721,7 @@
 /obj/effect/decal/cleanable/cobweb,
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/cable,
+/obj/machinery/power/smes/engineering,
 /turf/open/floor/circuit/green{
 	luminosity = 2
 	},
@@ -64110,9 +64102,6 @@
 /turf/open/floor/engine,
 /area/station/engineering/gravity_generator)
 "wga" = (
-/obj/machinery/power/smes{
-	charge = 5e+006
-	},
 /obj/machinery/light/small{
 	dir = 1
 	},
@@ -64120,6 +64109,7 @@
 	pixel_y = 32
 	},
 /obj/structure/cable,
+/obj/machinery/power/smes/engineering,
 /turf/open/floor/plating{
 	burnt = 1;
 	initial_gas_mix = "n2=100;TEMP=80"

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -25631,9 +25631,6 @@
 /turf/open/floor/plating,
 /area/station/maintenance/aft)
 "jqh" = (
-/obj/machinery/power/smes{
-	charge = 5e+006
-	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/flasher{
@@ -25642,6 +25639,7 @@
 	pixel_y = 28
 	},
 /obj/machinery/light/small/directional/north,
+/obj/machinery/power/smes/engineering,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/ai)
 "jqi" = (
@@ -32913,11 +32911,9 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
 "lOC" = (
-/obj/machinery/power/smes{
-	charge = 5e+006
-	},
 /obj/structure/cable,
 /obj/machinery/light/directional/south,
+/obj/machinery/power/smes/engineering,
 /turf/open/floor/iron,
 /area/station/engineering/gravity_generator)
 "lOE" = (
@@ -44839,11 +44835,9 @@
 /turf/open/floor/iron,
 /area/station/science/robotics/lab)
 "pKF" = (
-/obj/machinery/power/smes{
-	charge = 5e+006
-	},
 /obj/structure/cable/yellow,
 /obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
+/obj/machinery/power/smes/engineering,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/command/storage/satellite)
 "pKK" = (

--- a/_maps/map_files/Mining/Lavaland.dmm
+++ b/_maps/map_files/Mining/Lavaland.dmm
@@ -305,13 +305,11 @@
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "bJ" = (
-/obj/machinery/power/smes{
-	charge = 5e+006
-	},
 /obj/structure/cable/yellow,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/obj/machinery/power/smes/engineering,
 /turf/open/floor/iron/techmaint,
 /area/mine/production)
 "bL" = (

--- a/_maps/map_files/RadStation/RadStation.dmm
+++ b/_maps/map_files/RadStation/RadStation.dmm
@@ -6688,10 +6688,8 @@
 /area/station/science/robotics)
 "cvL" = (
 /obj/effect/turf_decal/stripes/line,
-/obj/machinery/power/smes{
-	charge = 2e+007
-	},
 /obj/structure/cable,
+/obj/machinery/power/smes/engineering,
 /turf/open/floor/circuit/telecomms/mainframe{
 	initial_gas_mix = "o2=22;n2=82;TEMP=293.15"
 	},
@@ -33191,10 +33189,8 @@
 /area/station/maintenance/department/security)
 "mAL" = (
 /obj/effect/turf_decal/bot,
-/obj/machinery/power/smes{
-	charge = 5e+006
-	},
 /obj/structure/cable/yellow,
+/obj/machinery/power/smes/engineering,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/ai_monitored/turret_protected/ai)
 "mAM" = (
@@ -49477,10 +49473,8 @@
 /obj/machinery/airalarm/directional/west{
 	pixel_x = -23
 	},
-/obj/machinery/power/smes{
-	charge = 2e+007
-	},
 /obj/structure/cable,
+/obj/machinery/power/smes/engineering,
 /turf/open/floor/iron/tech/grid,
 /area/station/engineering/gravity_generator)
 "sHt" = (
@@ -52742,9 +52736,7 @@
 /area/station/medical/genetics)
 "tNk" = (
 /obj/structure/cable/orange,
-/obj/machinery/power/smes{
-	charge = 5e+006
-	},
+/obj/machinery/power/smes/engineering,
 /turf/open/floor/plating,
 /area/station/ai_monitored/turret_protected/aisat/atmos)
 "tNz" = (

--- a/_maps/map_files/debug/multiz.dmm
+++ b/_maps/map_files/debug/multiz.dmm
@@ -77,9 +77,6 @@
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "as" = (
-/obj/machinery/power/smes{
-	charge = 5e+006
-	},
 /obj/machinery/airalarm/directional/north{
 	locked = 0;
 	pixel_y = 23
@@ -88,6 +85,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
+/obj/machinery/power/smes/engineering,
 /turf/open/floor/iron,
 /area/station/engineering/gravity_generator)
 "at" = (

--- a/_maps/map_files/debug/runtimestation.dmm
+++ b/_maps/map_files/debug/runtimestation.dmm
@@ -988,10 +988,8 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
-/obj/machinery/power/smes{
-	charge = 5e+006
-	},
 /obj/structure/cable,
+/obj/machinery/power/smes/engineering,
 /turf/open/floor/iron,
 /area/station/engineering/gravity_generator)
 "ij" = (

--- a/code/modules/power/smes.dm
+++ b/code/modules/power/smes.dm
@@ -53,8 +53,6 @@
 	if(!terminal)
 		atom_break()
 		return
-	if(mapload)
-		charge = capacity
 	terminal.master = src
 	update_appearance(UPDATE_OVERLAYS)
 
@@ -449,7 +447,7 @@
 	log_smes()
 
 /obj/machinery/power/smes/engineering
-	charge = 1.5e6 // Engineering starts with some charge for singulo
+	charge = 50 MEGAWATT // Engineering starts with some charge for singulo
 
 /obj/machinery/power/smes/magical
 	name = "magical power storage unit"


### PR DESCRIPTION
## About The Pull Request

#13066 introduced a very lazy solution when the station began running out of power and made empty maploaded SMESes impossible.

I looked at all `/obj/machinery/power/smes` instances on all maps and had to change a lot of them out. All SMESes have been changed to the `/obj/machinery/power/smes/engineering` typepath except solars, the atmos turbine, and a few other instances (stuff like the ruined lavaland science section)

## Why It's Good For The Game

#14238 needs maploaded empty SMESes

## Testing Photographs and Procedure

<img width="587" height="123" alt="image" src="https://github.com/user-attachments/assets/7d8c9e60-8688-4b1f-b00a-38871abd1abd" />

<img width="582" height="130" alt="image" src="https://github.com/user-attachments/assets/bf7b30ba-9638-4a81-bb3a-03a59034b885" />

## Changelog
:cl:
fix: Fixed it not being possible for maploaded SMESes to start empty
fix: Fixed several SMESes starting with power when they shouldn't have (disconnected part of the lavaland outpost)
/:cl: