### PR TITLE
Refactors air sensor & atmos monitor connecting and 2 atmos fixes

### DIFF
--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_syndicate_base1.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_syndicate_base1.dmm
@@ -4631,7 +4631,6 @@
 /area/ruin/unpowered/syndicate_lava_base/engineering)
 "Wc" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/monitored{
-	chamber_id = "syndie_lavaland_inc_in";
 	dir = 1
 	},
 /obj/structure/sign/warning/vacuum/external{

--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_syndicate_base2.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_syndicate_base2.dmm
@@ -2658,7 +2658,6 @@
 /area/ruin/unpowered/syndicate_lava_base/medbay)
 "CS" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/monitored{
-	chamber_id = "syndie_lavaland_inc_in";
 	dir = 1
 	},
 /obj/structure/sign/warning/vacuum/external{

--- a/_maps/RandomRuins/SpaceRuins/deepstorage.dmm
+++ b/_maps/RandomRuins/SpaceRuins/deepstorage.dmm
@@ -2293,12 +2293,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/deepstorage/power)
-"gd" = (
-/obj/machinery/atmospherics/components/unary/outlet_injector/monitored{
-	chamber_id = "n2_in_bunker"
-	},
-/turf/open/floor/plating/airless,
-/area/ruin/space/has_grav/deepstorage/power)
 "ge" = (
 /obj/machinery/door/airlock{
 	name = "Personal Dorm"
@@ -2521,9 +2515,7 @@
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/deepstorage/power)
 "gP" = (
-/obj/machinery/atmospherics/components/unary/outlet_injector/monitored{
-	chamber_id = "o2_in_bunker"
-	},
+/obj/machinery/atmospherics/components/unary/outlet_injector/monitored,
 /turf/open/floor/plating/airless,
 /area/ruin/space/has_grav/deepstorage/power)
 "gQ" = (
@@ -4636,7 +4628,7 @@ fb
 fp
 fC
 fL
-gd
+gP
 fp
 gv
 fL

--- a/_maps/map_files/CardinalStation/CardinalStation.dmm
+++ b/_maps/map_files/CardinalStation/CardinalStation.dmm
@@ -9689,8 +9689,7 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/components/unary/outlet_injector/monitored/toxins_burn_chamber_input{
-	dir = 8;
-	chamber_id = "toxinsburn2"
+	dir = 8
 	},
 /turf/open/floor/engine,
 /area/station/science/mixing/chamber)

--- a/_maps/map_files/EchoStation/EchoStation.dmm
+++ b/_maps/map_files/EchoStation/EchoStation.dmm
@@ -3468,7 +3468,6 @@
 "cuu" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/monitored/layer4{
 	dir = 4;
-	chamber_id = "n2o";
 	name = "Nitrous Oxide Chamber Injector"
 	},
 /turf/open/floor/engine/n2o,
@@ -6485,8 +6484,7 @@
 /area/station/maintenance/disposal/incinerator)
 "egM" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/monitored/layer4{
-	name = "Nitrogen Chamber Injector";
-	chamber_id = "n2"
+	name = "Nitrogen Chamber Injector"
 	},
 /turf/open/floor/engine/n2,
 /area/station/engineering/atmos)
@@ -8651,7 +8649,6 @@
 /area/station/service/library/abandoned)
 "fpJ" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/monitored/layer4{
-	chamber_id = "o2";
 	name = "Oxygen Chamber Injector"
 	},
 /turf/open/floor/engine/o2,
@@ -14424,7 +14421,6 @@
 "iSa" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/monitored/layer4{
 	dir = 4;
-	chamber_id = "plasma";
 	name = "Plasma Chamber Injector"
 	},
 /turf/open/floor/engine/plasma,
@@ -14808,7 +14804,6 @@
 /area/station/engineering/main)
 "jbq" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/monitored/layer2{
-	chamber_id = "air";
 	name = "Air Chamber Injector"
 	},
 /turf/open/floor/engine/air,
@@ -17804,7 +17799,6 @@
 /area/station/ai_monitored/turret_protected/aisat_interior)
 "kVz" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/monitored/layer4{
-	chamber_id = "co2";
 	name = "Carbon Dioxide Chamber Injector"
 	},
 /turf/open/floor/engine/co2,

--- a/code/__DEFINES/atmospherics/atmos_identifiers.dm
+++ b/code/__DEFINES/atmospherics/atmos_identifiers.dm
@@ -24,17 +24,6 @@
 #define ATMOS_GAS_MONITOR_WASTE "waste"
 #define ATMOS_GAS_MONITOR_ENGINE "engine"
 
-
-///maps a chamber id to its air sensor
-#define CHAMBER_SENSOR_FROM_ID(chamber_id) ((chamber_id) + "_sensor")
-///maps an air sensor's chamber id to its input valve[ i.e. outlet_injector] id
-#define CHAMBER_INPUT_FROM_ID(chamber_id) ((chamber_id) + "_in")
-///maps an air sensor's chamber id to its output valve[i.e. vent pump] id
-#define CHAMBER_OUTPUT_FROM_ID(chamber_id) ((chamber_id) + "_out")
-
-///list of all air sensor's created round start
-GLOBAL_LIST_EMPTY(map_loaded_sensors)
-
 // Human-readble names of these funny tags.
 GLOBAL_LIST_INIT(station_gas_chambers, list(
 	ATMOS_GAS_MONITOR_O2 = "Oxygen Supply",

--- a/code/game/machinery/computer/atmos_computers/_air_sensor.dm
+++ b/code/game/machinery/computer/atmos_computers/_air_sensor.dm
@@ -1,3 +1,8 @@
+///Indicator for inlet port
+#define INLET 1
+///Indicator for outlet port
+#define OUTLET 2
+
 /// Gas tank air sensor.
 /// These always hook to monitors, be mindful of them
 /obj/machinery/air_sensor
@@ -7,7 +12,6 @@
 	resistance_flags = FIRE_PROOF
 	power_channel = AREA_USAGE_ENVIRON
 	active_power_usage = 1
-	var/on = TRUE
 
 	/// The unique string that represents which atmos chamber to associate with.
 	var/chamber_id
@@ -17,21 +21,30 @@
 	var/outlet_id
 	/// The air alarm connected to this sensor
 	var/obj/machinery/airalarm/connected_airalarm
+	/// Is this sensor on
+	var/on = TRUE
 
 /obj/machinery/air_sensor/Initialize(mapload)
 	id_tag = assign_random_name()
-
-	//this global list of air sensors is available to all station monitering consoles round start and to new consoles made during the round
-	if(mapload)
-		GLOB.map_loaded_sensors[chamber_id] = id_tag
-		inlet_id = CHAMBER_INPUT_FROM_ID(chamber_id)
-		outlet_id = CHAMBER_OUTPUT_FROM_ID(chamber_id)
-
 	return ..()
+
+/obj/machinery/air_sensor/LateInitialize()
+	. = ..()
+
+	//auto connect to any inlet & outlet devices within a 4 diameter radius from this sensor
+	for(var/obj/machinery/atmospherics/components/unary/device in oview(4, src))
+		if(inlet_id && outlet_id)
+			break
+		configure(device)
 
 /obj/machinery/air_sensor/Destroy()
 	reset()
 	return ..()
+
+/obj/machinery/air_sensor/add_context_self(datum/screentip_context/context, mob/user)
+	context.use_cache()
+	context.add_left_click_tool_action("Link logged injectors/vents", TOOL_MULTITOOL)
+	context.add_right_click_tool_action("Reset all I/O ports", TOOL_MULTITOOL)
 
 /obj/machinery/air_sensor/return_air()
 	if(!on)
@@ -59,7 +72,7 @@
 	. = ..()
 
 	//switched off version of this air sensor but still anchored to the ground
-	var/obj/item/air_sensor/sensor = new(drop_location(), inlet_id, outlet_id)
+	var/obj/item/air_sensor/sensor = new(drop_location())
 	sensor.set_anchored(TRUE)
 	sensor.balloon_alert(user, "sensor turned off")
 
@@ -69,6 +82,47 @@
 /obj/machinery/air_sensor/update_icon_state()
 	icon_state = "gsensor[on]"
 	return ..()
+
+/**
+ * Connects an injector or an vent pump to this air sensor. Must be on the same z level as sensor
+ * return what type of port was configured or NONE for no op
+ *
+ * Arguments
+ * * obj/machinery/atmospherics/components/unary/port - the device we are trying to connect to this sensor
+ * * reconfigure - if TRUE it will override existing ports if they are already registered
+*/
+/obj/machinery/air_sensor/proc/configure(obj/machinery/atmospherics/components/unary/port, reconfigure = FALSE)
+	PRIVATE_PROC(TRUE)
+	if(!istype(port) || port.get_virtual_z_level() != get_virtual_z_level())
+		return NONE
+
+	if(istype(port, /obj/machinery/atmospherics/components/unary/outlet_injector))
+		if(!reconfigure && inlet_id)
+			return INLET
+		var/obj/machinery/atmospherics/components/unary/outlet_injector/input = port
+		//only configure non maploaded injectors cause they already have a preset config
+		if(input.type == /obj/machinery/atmospherics/components/unary/outlet_injector)
+			input.volume_rate = MAX_TRANSFER_RATE
+		inlet_id = input.id_tag
+		return INLET
+
+	else if(istype(port, /obj/machinery/atmospherics/components/unary/vent_pump))
+		if(!reconfigure && outlet_id)
+			return OUTLET
+		var/obj/machinery/atmospherics/components/unary/vent_pump/output = port
+		//only configure non maploaded vent pumps cause they already have a preset config
+		if(output.type == /obj/machinery/atmospherics/components/unary/vent_pump)
+			//so its no longer controlled by air alarm
+			output.disconnect_from_area()
+			//configuration copied from /obj/machinery/atmospherics/components/unary/vent_pump/siphon but with max pressure
+			output.pump_direction = ATMOS_DIRECTION_SIPHONING
+			output.pressure_checks = ATMOS_INTERNAL_BOUND
+			output.internal_pressure_bound = MAX_OUTPUT_PRESSURE
+			output.external_pressure_bound = 0
+		//finally assign it to this sensor
+		outlet_id = output.id_tag
+		return OUTLET
+	return NONE
 
 /obj/machinery/air_sensor/proc/reset()
 	inlet_id = null
@@ -82,34 +136,22 @@
 ///click with multi tool to disconnect everything
 /obj/machinery/air_sensor/screwdriver_act(mob/living/user, obj/item/tool)
 	. = ..()
-	balloon_alert(user, "reset ports")
 	reset()
+	balloon_alert(user, "ports reset")
 	return TRUE
 
 REGISTER_BUFFER_HANDLER(/obj/machinery/air_sensor)
 
 DEFINE_BUFFER_HANDLER(/obj/machinery/air_sensor)
-	if(istype(buffer, /obj/machinery/atmospherics/components/unary/outlet_injector))
-		var/obj/machinery/atmospherics/components/unary/outlet_injector/input = buffer
-		inlet_id = input.id_tag
-		FLUSH_BUFFER(buffer)
-		balloon_alert(user, "connected to input")
-	else if(istype(buffer, /obj/machinery/atmospherics/components/unary/vent_pump))
-		var/obj/machinery/atmospherics/components/unary/vent_pump/output = buffer
-		output.disconnect_from_area()
-		output.pump_direction = ATMOS_DIRECTION_SIPHONING
-		output.pressure_checks = ATMOS_INTERNAL_BOUND
-		output.internal_pressure_bound = 4000
-		output.external_pressure_bound = 0
-		//finally assign it to this sensor
-		outlet_id = output.id_tag
-		FLUSH_BUFFER(buffer)
-		balloon_alert(user, "connected to output")
-	else if (TRY_STORE_IN_BUFFER(buffer_parent, src))
-		to_chat(user, span_notice("You register [src] in [buffer_parent]'s buffer."))
-		balloon_alert(user, "added to multitool buffer")
-		return COMPONENT_BUFFER_RECEIVED
-	return NONE
+	var/type = configure(buffer, TRUE)
+	switch(type)
+		if(INLET, OUTLET)
+			var/port = "[type == INLET ? "input" : "output"] port"
+			user.balloon_alert(user, "[port] configured")
+			to_chat(user, span_notice("[src] has connected [buffer] to its [port]."))
+	to_chat(user, span_notice("[src] has been added to multitool buffer."))
+	TRY_STORE_IN_BUFFER(buffer_parent, src)
+	return COMPONENT_BUFFER_RECEIVED
 
 /**
  * A portable version of the /obj/machinery/air_sensor
@@ -123,15 +165,11 @@ DEFINE_BUFFER_HANDLER(/obj/machinery/air_sensor)
 	icon = 'icons/obj/stationobjs.dmi'
 	icon_state = "gsensor0"
 	custom_materials = list(/datum/material/iron = 100, /datum/material/glass = 100)
-	/// The injector linked with this sensor
-	var/input_id
-	/// The vent pump linked with this sensor
-	var/output_id
 
-/obj/item/air_sensor/Initialize(mapload, inlet, outlet)
-	. = ..()
-	input_id = inlet
-	output_id = outlet
+/obj/item/air_sensor/add_context_self(datum/screentip_context/context, mob/user)
+	context.add_left_click_tool_action(anchored ? "Unwrench" : "Wrench", TOOL_WRENCH)
+	if(anchored)
+		context.add_left_click_tool_action("Dismantle", TOOL_WELDER)
 
 /obj/item/air_sensor/examine(mob/user)
 	. = ..()
@@ -180,8 +218,6 @@ DEFINE_BUFFER_HANDLER(/obj/machinery/air_sensor)
 
 		//make real air sensor in its place
 		var/obj/machinery/air_sensor/new_sensor = new sensor(get_turf(src))
-		new_sensor.inlet_id = input_id
-		new_sensor.outlet_id = output_id
 		new_sensor.balloon_alert(user, "sensor turned on")
 		qdel(src)
 
@@ -206,4 +242,7 @@ DEFINE_BUFFER_HANDLER(/obj/machinery/air_sensor)
 /obj/item/air_sensor/deconstruct(disassembled)
 	. = ..()
 	new /obj/item/analyzer(loc)
-	new /obj/item/stack/sheet/iron(loc, 1)
+	new /obj/item/stack/sheet/iron(loc)
+
+#undef INLET
+#undef OUTLET

--- a/code/game/machinery/computer/atmos_computers/_atmos_control.dm
+++ b/code/game/machinery/computer/atmos_computers/_atmos_control.dm
@@ -12,49 +12,73 @@
 
 	/// Which sensors do we want to listen to.
 	/// Assoc of list[chamber_id] = readable_chamber_name
-	var/list/atmos_chambers
-
-	/// Used when control = FALSE to store the original atmos chambers so they dont get lost when reconnecting
-	var/list/always_displayed_chambers
+	var/list/atmos_chambers = list()
+	/// list of all sensors[key is chamber id, value is id of air sensor linked to this chamber] monitered by this computer
+	var/list/connected_sensors = list()
 
 	/// Whether we can actually adjust the chambers or not.
 	var/control = TRUE
 	/// Whether we are allowed to reconnect.
 	var/reconnecting = TRUE
+	/// Our last reconnected chamber
+	VAR_PRIVATE/last_chamber_id = ""
 
-	/// Was this computer multitooled before. If so copy the list connected_sensors as it now maintain's its own sensors independent of the map loaded one's
-	var/was_multi_tooled = FALSE
-
-	/// list of all sensors[key is chamber id, value is id of air sensor linked to this chamber] monitered by this computer
-	var/list/connected_sensors
-
-/obj/machinery/computer/atmos_control/Initialize(mapload)
+/obj/machinery/computer/atmos_control/LateInitialize()
 	. = ..()
-	AddComponent(/datum/component/buffer)
-
-	//all newly constructed/round start computers by default have access to this list
-	connected_sensors = GLOB.map_loaded_sensors
-
-	//special case for the station monitering console. We dont want to loose these chambers during reconnecting
-	if(!control && !isnull(atmos_chambers))
-		always_displayed_chambers = atmos_chambers.Copy()
+	scan()
 
 /obj/machinery/computer/atmos_control/examine(mob/user)
 	. = ..()
 	. += span_notice("Use a multitool to link a air sensor to this computer")
+
+///Scans the z level for new air sensors & monitors
+/obj/machinery/computer/atmos_control/proc/scan()
+	PRIVATE_PROC(TRUE)
+
+	//collect all sensors that are the closest to this computer
+	var/list/closest_sensors = list()
+	var/turf/comp_turf = get_turf(src)
+	for(var/obj/machinery/sensor in GLOB.machines)
+		if(!istype(sensor, /obj/machinery/air_sensor) && !istype(sensor, /obj/machinery/meter/monitored))
+			continue
+		//same z level
+		if(sensor.get_virtual_z_level() != get_virtual_z_level())
+			continue
+		//infer chamber id
+		var/chamber_id = ""
+		if(istype(sensor, /obj/machinery/air_sensor))
+			var/obj/machinery/air_sensor/air_sense = sensor
+			chamber_id = air_sense.chamber_id
+		else
+			var/obj/machinery/meter/monitored/meter = sensor
+			chamber_id = meter.chamber_id
+		//track & collect closest sensors
+		if(!closest_sensors[chamber_id])
+			closest_sensors[chamber_id] = sensor
+			continue
+		var/obj/machinery/target = closest_sensors[chamber_id]
+		if(get_dist(comp_turf, get_turf(sensor)) < get_dist(comp_turf, get_turf(target)))
+			closest_sensors[chamber_id] = sensor
+	//convert sensor list to id tags
+	connected_sensors.Cut()
+	for(var/chamber_id in closest_sensors)
+		var/obj/machinery/target = closest_sensors[chamber_id]
+		connected_sensors[chamber_id] = target.id_tag
 
 /// Reconnect only works for station based chambers.
 /obj/machinery/computer/atmos_control/proc/reconnect(mob/user)
 	if(!reconnecting)
 		return FALSE
 
+	scan()
+
 	// We only prompt the user with the sensors that are actually available.
 	var/available_devices = list()
-
 	for (var/chamber_identifier in connected_sensors)
 		//this sensor was destroyed at the time of reconnecting
 		var/obj/machinery/sensor = GLOB.objects_by_id_tag[connected_sensors[chamber_identifier]]
 		if(QDELETED(sensor))
+			connected_sensors -= chamber_identifier
 			continue
 
 		//non master computers don't have access to these station moniters. Only done to give master computer's special access to these chambers and make them feel special or something
@@ -73,32 +97,13 @@
 	if(isnull(new_id))
 		return FALSE
 
-	atmos_chambers = list()
-	//these are chambers we always want to display even after reconnecting
-	if(always_displayed_chambers)
-		for(var/chamber_id in always_displayed_chambers)
-			atmos_chambers[chamber_id] = always_displayed_chambers[chamber_id]
+	atmos_chambers -= last_chamber_id
 	atmos_chambers[new_id] = new_name
+	last_chamber_id = new_id
 
 	name = new_name + (control ? " Control" : " Monitor")
 
 	return TRUE
-
-REGISTER_BUFFER_HANDLER(/obj/machinery/computer/atmos_control)
-
-DEFINE_BUFFER_HANDLER(/obj/machinery/computer/atmos_control)
-	if (istype(buffer,/obj/machinery/air_sensor))
-		var/obj/machinery/air_sensor/sensor = buffer
-		to_chat(user, span_notice("You link [src] with [buffer] in [buffer_parent] buffer."))
-		if(!was_multi_tooled)
-			connected_sensors = connected_sensors.Copy()
-			was_multi_tooled = TRUE
-		//register the sensor's unique ID with its assositated chamber
-		connected_sensors[sensor.chamber_id] = sensor.id_tag
-		user.balloon_alert(user, "sensor connected to [src]")
-		return COMPONENT_BUFFER_RECEIVED
-	return NONE
-
 
 /obj/machinery/computer/atmos_control/ui_interact(mob/user, datum/tgui/ui)
 	ui = SStgui.try_update_ui(user, src, ui)
@@ -155,7 +160,6 @@ DEFINE_BUFFER_HANDLER(/obj/machinery/computer/atmos_control)
 		return
 
 	var/chamber = params["chamber"]
-
 	switch(action)
 		if("toggle_input")
 			if (!(chamber in atmos_chambers))
@@ -170,7 +174,9 @@ DEFINE_BUFFER_HANDLER(/obj/machinery/computer/atmos_control)
 				return TRUE
 
 			input.on = !input.on
-			input.update_icon()
+			input.update_appearance(UPDATE_ICON)
+			return TRUE
+
 		if("toggle_output")
 			if (!(chamber in atmos_chambers))
 				return TRUE
@@ -184,7 +190,9 @@ DEFINE_BUFFER_HANDLER(/obj/machinery/computer/atmos_control)
 				return TRUE
 
 			output.on = !output.on
-			output.update_icon()
+			output.update_appearance(UPDATE_ICON)
+			return TRUE
+
 		if("adjust_input")
 			if (!(chamber in atmos_chambers))
 				return TRUE
@@ -203,6 +211,8 @@ DEFINE_BUFFER_HANDLER(/obj/machinery/computer/atmos_control)
 			target = clamp(target, 0, MAX_TRANSFER_RATE)
 
 			input.volume_rate = clamp(target, 0, min(input.airs[1].volume, MAX_TRANSFER_RATE))
+			return TRUE
+
 		if("adjust_output")
 			if (!(chamber in atmos_chambers))
 				return TRUE
@@ -221,8 +231,11 @@ DEFINE_BUFFER_HANDLER(/obj/machinery/computer/atmos_control)
 			target = clamp(target, 0, ATMOS_PUMP_MAX_PRESSURE)
 
 			output.internal_pressure_bound = target
+			return TRUE
+
 		if("reconnect")
-			reconnect(usr)
+			reconnect(ui.user)
+			return TRUE
 
 	return TRUE
 

--- a/code/game/machinery/computer/atmos_computers/inlets.dm
+++ b/code/game/machinery/computer/atmos_computers/inlets.dm
@@ -1,12 +1,6 @@
 /obj/machinery/atmospherics/components/unary/outlet_injector/monitored
 	on = TRUE
 	volume_rate = MAX_TRANSFER_RATE
-	/// The air sensor type this injector is linked to
-	var/chamber_id
-
-/obj/machinery/atmospherics/components/unary/outlet_injector/monitored/Initialize(mapload)
-	id_tag = CHAMBER_INPUT_FROM_ID(chamber_id)
-	return ..()
 
 /obj/machinery/atmospherics/components/unary/outlet_injector/monitored/layer2
 	piping_layer = 2
@@ -18,64 +12,48 @@
 
 /obj/machinery/atmospherics/components/unary/outlet_injector/monitored/plasma_input
 	name = "plasma tank input injector"
-	chamber_id = ATMOS_GAS_MONITOR_PLAS
 
 /obj/machinery/atmospherics/components/unary/outlet_injector/monitored/oxygen_input
 	name = "oxygen tank input injector"
-	chamber_id = ATMOS_GAS_MONITOR_O2
 
 /obj/machinery/atmospherics/components/unary/outlet_injector/monitored/nitrogen_input
 	name = "nitrogen tank input injector"
-	chamber_id = ATMOS_GAS_MONITOR_N2
 
 /obj/machinery/atmospherics/components/unary/outlet_injector/monitored/mix_input
 	name = "mix tank input injector"
-	chamber_id = ATMOS_GAS_MONITOR_MIX
 
 /obj/machinery/atmospherics/components/unary/outlet_injector/monitored/nitrous_input
 	name = "nitrous oxide tank input injector"
-	chamber_id = ATMOS_GAS_MONITOR_N2O
 
 /obj/machinery/atmospherics/components/unary/outlet_injector/monitored/air_input
 	name = "air mix tank input injector"
-	chamber_id = ATMOS_GAS_MONITOR_AIR
 
 /obj/machinery/atmospherics/components/unary/outlet_injector/monitored/carbon_input
 	name = "carbon dioxide tank input injector"
-	chamber_id = ATMOS_GAS_MONITOR_CO2
 
 /obj/machinery/atmospherics/components/unary/outlet_injector/monitored/bz_input
 	name = "bz tank input injector"
-	chamber_id = ATMOS_GAS_MONITOR_BZ
 
 /obj/machinery/atmospherics/components/unary/outlet_injector/monitored/hypernoblium_input
 	name = "hypernoblium tank input injector"
-	chamber_id = ATMOS_GAS_MONITOR_HYPERNOBLIUM
 
 /obj/machinery/atmospherics/components/unary/outlet_injector/monitored/atmos/nitrium_input
 	name = "nitrium tank input injector"
-	chamber_id = ATMOS_GAS_MONITOR_NITRIUM
 
 /obj/machinery/atmospherics/components/unary/outlet_injector/monitored/pluoxium_input
 	name = "pluoxium tank input injector"
-	chamber_id = ATMOS_GAS_MONITOR_PLUOXIUM
 
 /obj/machinery/atmospherics/components/unary/outlet_injector/monitored/tritium_input
 	name = "tritium tank input injector"
-	chamber_id = ATMOS_GAS_MONITOR_TRITIUM
 
 /obj/machinery/atmospherics/components/unary/outlet_injector/monitored/water_vapor_input
 	name = "water vapor tank input injector"
-	chamber_id = ATMOS_GAS_MONITOR_H2O
 
 /obj/machinery/atmospherics/components/unary/outlet_injector/monitored/incinerator_input
 	name = "incinerator chamber input injector"
-	chamber_id = ATMOS_GAS_MONITOR_INCINERATOR
 
 /obj/machinery/atmospherics/components/unary/outlet_injector/monitored/toxins_burn_chamber_input
 	name = "toxins burn chamber input injector"
-	chamber_id = ATMOS_GAS_MONITOR_TOXINS_BURN
 
 /obj/machinery/atmospherics/components/unary/outlet_injector/monitored/toxins_freezer_chamber_input
 	name = "toxins freezer chamber input injector"
-	chamber_id = ATMOS_GAS_MONITOR_TOXINS_FREEZER

--- a/code/game/machinery/computer/atmos_computers/meters.dm
+++ b/code/game/machinery/computer/atmos_computers/meters.dm
@@ -4,9 +4,7 @@
 
 /obj/machinery/meter/monitored/Initialize(mapload, new_piping_layer)
 	id_tag = assign_random_name()
-	if(mapload)
-		GLOB.map_loaded_sensors[chamber_id] = id_tag
-	. = ..()
+	return ..()
 
 /obj/machinery/meter/monitored/layer2
 	target_layer = 2

--- a/code/game/machinery/computer/atmos_computers/outlets.dm
+++ b/code/game/machinery/computer/atmos_computers/outlets.dm
@@ -3,70 +3,54 @@
 	icon_state = "vent_map_siphon_on-3"
 
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/monitored/Initialize(mapload)
-	id_tag = CHAMBER_OUTPUT_FROM_ID(chamber_id)
 	. = ..()
 	//we dont want people messing with these special vents using the air alarm interface
 	disconnect_from_area()
 
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/monitored/plasma_output
 	name = "plasma tank output inlet"
-	chamber_id = ATMOS_GAS_MONITOR_PLAS
 
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/monitored/oxygen_output
 	name = "oxygen tank output inlet"
-	chamber_id = ATMOS_GAS_MONITOR_O2
 
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/monitored/nitrogen_output
 	name = "nitrogen tank output inlet"
-	chamber_id = ATMOS_GAS_MONITOR_N2
 
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/monitored/mix_output
 	name = "mix tank output inlet"
-	chamber_id = ATMOS_GAS_MONITOR_MIX
 
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/monitored/nitrous_output
 	name = "nitrous oxide tank output inlet"
-	chamber_id = ATMOS_GAS_MONITOR_N2O
 
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/monitored/carbon_output
 	name = "carbon dioxide tank output inlet"
-	chamber_id = ATMOS_GAS_MONITOR_CO2
 
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/monitored/bz_output
 	name = "bz tank output inlet"
-	chamber_id = ATMOS_GAS_MONITOR_BZ
 
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/monitored/hypernoblium_output
 	name = "hypernoblium tank output inlet"
-	chamber_id = ATMOS_GAS_MONITOR_HYPERNOBLIUM
 
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/monitored/nitrium_output
 	name = "nitrium tank output inlet"
-	chamber_id = ATMOS_GAS_MONITOR_NITRIUM
 
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/monitored/pluoxium_output
 	name = "pluoxium tank output inlet"
-	chamber_id = ATMOS_GAS_MONITOR_PLUOXIUM
 
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/monitored/tritium_output
 	name = "tritium tank output inlet"
-	chamber_id = ATMOS_GAS_MONITOR_TRITIUM
 
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/monitored/water_vapor_output
 	name = "water vapor tank output inlet"
-	chamber_id = ATMOS_GAS_MONITOR_H2O
 
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/monitored/incinerator_output
 	name = "incinerator chamber output inlet"
-	chamber_id = ATMOS_GAS_MONITOR_INCINERATOR
 
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/monitored/toxins_burn_chamber_output
 	name = "toxins burn chamber output inlet"
-	chamber_id = ATMOS_GAS_MONITOR_TOXINS_BURN
 
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/monitored/toxins_freezer_chamber_output
 	name = "toxins freezer chamber output inlet"
-	chamber_id = ATMOS_GAS_MONITOR_TOXINS_FREEZER
 
 /obj/machinery/atmospherics/components/unary/vent_pump/high_volume/siphon/monitored
 	on = TRUE
@@ -74,11 +58,9 @@
 
 // Same as the rest, but bigger volume.
 /obj/machinery/atmospherics/components/unary/vent_pump/high_volume/siphon/monitored/Initialize(mapload)
-	id_tag = CHAMBER_OUTPUT_FROM_ID(chamber_id)
 	. = ..()
 	//we dont want people messing with these special vents using the air alarm interface
 	disconnect_from_area()
 
 /obj/machinery/atmospherics/components/unary/vent_pump/high_volume/siphon/monitored/air_output
 	name = "air mix tank output inlet"
-	chamber_id = ATMOS_GAS_MONITOR_AIR

--- a/code/modules/atmospherics/machinery/air_alarm/_air_alarm.dm
+++ b/code/modules/atmospherics/machinery/air_alarm/_air_alarm.dm
@@ -752,7 +752,11 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/airalarm, 27)
 
 ///Used for air alarm link helper, which connects air alarm to a sensor with corresponding chamber_id
 /obj/machinery/airalarm/proc/setup_chamber_link()
-	var/obj/machinery/air_sensor/sensor = GLOB.objects_by_id_tag[GLOB.map_loaded_sensors[air_sensor_chamber_id]]
+	var/obj/machinery/air_sensor/sensor = null
+	for(var/obj/machinery/air_sensor/target in GLOB.machines)
+		if(target.get_virtual_z_level() == get_virtual_z_level() && target.chamber_id == air_sensor_chamber_id)
+			sensor = target
+			break
 	if(isnull(sensor))
 		log_mapping("[src] at [AREACOORD(src)] tried to connect to a sensor, but no sensor with chamber_id:[air_sensor_chamber_id] found!")
 		return

--- a/code/modules/atmospherics/machinery/components/unary_devices/passive_vent.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/passive_vent.dm
@@ -27,6 +27,9 @@
 	var/datum/gas_mixture/external = location.return_air()
 	var/datum/gas_mixture/internal = airs[1]
 
+	if(!internal.volume || !external.volume)
+		return
+
 	if(internal.equalize(external))
 		air_update_turf(FALSE, FALSE)
 		update_parents()

--- a/code/modules/atmospherics/machinery/datum_pipeline.dm
+++ b/code/modules/atmospherics/machinery/datum_pipeline.dm
@@ -297,9 +297,10 @@
 //--------------------
 // GAS VISUALS STUFF
 //
-// If I could have gotten layer filters to obey the RESET_COLOR appearance flag I would have used that here
-// so that only a single overlay object needs to exist for all pipelines per icon file. It shouldn't be too
-// hard to switch over to that if it becomes possible in the future or some other equivalent feature is added.
+// Gas visuals use direct color + alpha on the gas_visual object rather than
+// a color filter + KEEP_APART.
+// Color filters are expensive.
+// KEEP_APART forces a separate render.
 
 /**
  * Used to create and/or get the gas visual overlay created using the given icon file.
@@ -352,22 +353,11 @@
 		UpdateGasVisuals()
 
 /obj/effect/abstract/gas_visual
-	appearance_flags  = RESET_COLOR | KEEP_APART
+	appearance_flags = RESET_COLOR
 	vis_flags = VIS_INHERIT_ICON_STATE | VIS_INHERIT_LAYER | VIS_INHERIT_PLANE | VIS_INHERIT_ID
-	var/current_color
-	var/color_filter
-
-/obj/effect/abstract/gas_visual/Initialize(mapload)
-	. = ..()
-	color_filter = filter(type = "color", color = matrix())
-	filters += color_filter
-	color_filter = filters[filters.len]
-	if(current_color)
-		animate(color_filter, time = 0.5 SECONDS, color = current_color)
+	color = COLOR_BLACK
 
 /obj/effect/abstract/gas_visual/proc/change_color(new_color)
-	current_color = new_color
-	if(isnull(color_filter))
-		// Called before init
-		return
-	animate(color_filter, time = 0.5 SECONDS, color = new_color)
+	if(!new_color)
+		new_color = COLOR_BLACK
+	animate(src, color = new_color, time = 0.5 SECONDS)

--- a/tools/UpdatePaths/Scripts/tg_92849_atmos_monitor_sensor_connect.txt
+++ b/tools/UpdatePaths/Scripts/tg_92849_atmos_monitor_sensor_connect.txt
@@ -1,0 +1,2 @@
+/obj/machinery/atmospherics/components/unary/vent_pump/@SUBTYPES{chamber_id=@ANY} : /obj/machinery/atmospherics/components/unary/vent_pump/@SUBTYPES{@OLD;chamber_id=@SKIP}
+/obj/machinery/atmospherics/components/unary/outlet_injector/monitored/@SUBTYPES{chamber_id=@ANY} : /obj/machinery/atmospherics/components/unary/outlet_injector/monitored/@SUBTYPES{@OLD;chamber_id=@SKIP}


### PR DESCRIPTION
## About The Pull Request

The main bit of this PR is the air sensor connection refactor. I'll just copy and paste the original author's words because I'm LAZY

> **1. Qol**
> - Air sensors(maploaded & hand crafted) now auto connect to any input ports & output valves that are within a 4 tile radius from it meaning there is no need for these ports to have unique IDs attached to them & you don't need a multitool to link them together if you first placed those ports & then placed the air sensor close to them
> - Atmos control monitors now finds all air sensors that are closest to it within the same z level meaning you can have/place multiple air sensors of the same type on the same z level & the monitor will locate them correctly without any ambiguity

> **2. Refactor**
> - Removed var `chamber_id` from both injectors & vents meaning you don't need to have unique ids assigned to them. As long as mappers/players put them within 4 tile radius from the air sensor it will auto connect to them
> - Removed var `GLOB.map_loaded_sensors`

Attributions:
- https://github.com/tgstation/tgstation/pull/92849
- https://github.com/tgstation/tgstation/pull/95576
- https://github.com/tgstation/tgstation/pull/95794

## Why It's Good For The Game

Better & faster code (atomization of #14238)

## Testing Photographs and Procedure

https://github.com/user-attachments/assets/7eb146cb-bd42-41e4-9819-1c3753e6088e

## Changelog
:cl: mrmanlikesbt, SyncIt21, loganuk, vinylspiders
qol: hand crafted air sensors now auto connect to input & output ports if they are located within a 4 tile radius from it
qol: atmos control monitors now locate all air sensors nearest to in on that same z level meaning you can have multiple air sensors of the same type on the same map
refactor: refactored how air sensors & atmos monitors connect to each other. Please report any atmos computers that have missing input valves/output ports on their connected air sensors or those that don't list any air sensors at all on github
code: Atmos pipes should use less GPU to render their gas overlays now
fix: Fixed a division by zero error with passive vents
/:cl: