### PR TITLE
Cleans up join messages, splits up equiprank() more

### DIFF
--- a/code/__DEFINES/jobs.dm
+++ b/code/__DEFINES/jobs.dm
@@ -326,20 +326,23 @@
 #define JOB_ANNOUNCE_ARRIVAL (1<<0)
 /// Whether the mob is added to the crew manifest.
 #define JOB_CREW_MANIFEST (1<<1)
+/// Whether the mob is equipped through SSjob.equip_rank() on spawn.
+#define JOB_EQUIP_RANK (1<<2)
 /// Whether the job is considered a regular crew member of the station. Equipment such as AI and cyborgs not included.
-#define JOB_CREW_MEMBER (1<<2)
+#define JOB_CREW_MEMBER (1<<3)
 /// Whether this job can be joined through the new_player menu.
-#define JOB_NEW_PLAYER_JOINABLE (1<<3)
+#define JOB_NEW_PLAYER_JOINABLE (1<<4)
 /// If the player with this job can have quirks assigned to him or not. Relevant for new player joinable jobs and roundstart antags.
-#define JOB_ASSIGN_QUIRKS (1<<4)
+#define JOB_ASSIGN_QUIRKS (1<<5)
 /// This job cannot have more slots opened by the Head of Personnel (but admins or other random events can still do this).
-#define JOB_CANNOT_OPEN_SLOTS (1<<5)
+#define JOB_CANNOT_OPEN_SLOTS (1<<6)
 /// This job is a head of staff.
-#define JOB_HEAD_OF_STAFF (1<<6)
+#define JOB_HEAD_OF_STAFF (1<<7)
 
 DEFINE_BITFIELD(job_flags, list(
 	"JOB_ANNOUNCE_ARRIVAL" = JOB_ANNOUNCE_ARRIVAL,
 	"JOB_CREW_MANIFEST" = JOB_CREW_MANIFEST,
+	"JOB_EQUIP_RANK" = JOB_EQUIP_RANK,
 	"JOB_CREW_MEMBER" = JOB_CREW_MEMBER,
 	"JOB_NEW_PLAYER_JOINABLE" = JOB_NEW_PLAYER_JOINABLE,
 	"JOB_ASSIGN_QUIRKS" = JOB_ASSIGN_QUIRKS,
@@ -348,7 +351,7 @@ DEFINE_BITFIELD(job_flags, list(
 ))
 
 /// Combination flag for jobs which are considered regular crew members of the station.
-#define STATION_JOB_FLAGS (JOB_ANNOUNCE_ARRIVAL|JOB_CREW_MANIFEST|JOB_CREW_MEMBER|JOB_NEW_PLAYER_JOINABLE|JOB_ASSIGN_QUIRKS)
+#define STATION_JOB_FLAGS (JOB_ANNOUNCE_ARRIVAL|JOB_CREW_MANIFEST|JOB_EQUIP_RANK|JOB_CREW_MEMBER|JOB_NEW_PLAYER_JOINABLE|JOB_ASSIGN_QUIRKS)
 /// Combination flag for jobs which are considered heads of staff.
 #define HEAD_OF_STAFF_JOB_FLAGS (JOB_CANNOT_OPEN_SLOTS|JOB_HEAD_OF_STAFF)
 

--- a/code/__DEFINES/shuttles.dm
+++ b/code/__DEFINES/shuttles.dm
@@ -14,6 +14,7 @@
 #define EMERGENCY_IDLE_OR_RECALLED (SSshuttle.emergency && ((SSshuttle.emergency.mode == SHUTTLE_IDLE) || (SSshuttle.emergency.mode == SHUTTLE_RECALL)))
 #define EMERGENCY_ESCAPED_OR_ENDGAMED (SSshuttle.emergency && ((SSshuttle.emergency.mode == SHUTTLE_ESCAPE) || (SSshuttle.emergency.mode == SHUTTLE_ENDGAME)))
 #define EMERGENCY_AT_LEAST_DOCKED (SSshuttle.emergency && SSshuttle.emergency.mode != SHUTTLE_IDLE && SSshuttle.emergency.mode != SHUTTLE_RECALL && SSshuttle.emergency.mode != SHUTTLE_CALL)
+#define EMERGENCY_PAST_POINT_OF_NO_RETURN ((SSshuttle.emergency && SSshuttle.emergency.mode == SHUTTLE_CALL && !SSshuttle.canRecall()) || EMERGENCY_AT_LEAST_DOCKED)
 
 // Shuttle return values
 #define SHUTTLE_CAN_DOCK "can_dock"

--- a/code/controllers/subsystem/job.dm
+++ b/code/controllers/subsystem/job.dm
@@ -619,7 +619,7 @@ SUBSYSTEM_DEF(job)
 		mind?.account_id = bank_account.account_id
 		player_client.mob.add_memory("Your account ID is [mind?.account_id].")
 
-	return dress_up_as_job(job = equipping, visual_only = FALSE, player_client = player_client, joined_late = joined_late)
+	. = dress_up_as_job(job = equipping, visual_only = FALSE, player_client = player_client, joined_late = joined_late)
 
 	if(EMERGENCY_PAST_POINT_OF_NO_RETURN && prob(VERY_LATE_ARRIVAL_TOAST_PROB))
 		equip_to_slot_or_del(new /obj/item/food/griddle_toast(src), ITEM_SLOT_MASK)

--- a/code/controllers/subsystem/job.dm
+++ b/code/controllers/subsystem/job.dm
@@ -260,7 +260,7 @@ SUBSYSTEM_DEF(job)
 /datum/controller/subsystem/job/proc/ResetOccupations()
 	JobDebug("Occupations reset.")
 	for(var/mob/dead/new_player/authenticated/player in GLOB.auth_new_player_list)
-		if(!player?.mind)
+		if(!player.mind)
 			continue
 		player.mind.set_assigned_role(null)
 		player.mind.special_role = null

--- a/code/controllers/subsystem/job.dm
+++ b/code/controllers/subsystem/job.dm
@@ -259,11 +259,12 @@ SUBSYSTEM_DEF(job)
 
 /datum/controller/subsystem/job/proc/ResetOccupations()
 	JobDebug("Occupations reset.")
-	for(var/mob/dead/new_player/authenticated/player in GLOB.player_list)
-		if((player) && (player.mind))
-			player.mind.set_assigned_role(null)
-			player.mind.special_role = null
-			SSpersistence.antag_rep_change[player.ckey] = 0
+	for(var/mob/dead/new_player/authenticated/player in GLOB.auth_new_player_list)
+		if(!player?.mind)
+			continue
+		player.mind.set_assigned_role(null)
+		player.mind.special_role = null
+		SSpersistence.antag_rep_change[player.ckey] = 0
 	SetupOccupations()
 	unassigned = list()
 	set_overflow_role(overflow_role)
@@ -551,8 +552,7 @@ SUBSYSTEM_DEF(job)
 			DropLandAtRandomHallwayPoint(living_mob)
 			spawning_handled = TRUE
 		else if(HAS_TRAIT(SSstation, STATION_TRAIT_HANGOVER) && job.random_spawns_possible)
-			SpawnLandAtRandom(living_mob, (typesof(/area/station/hallway) | typesof(
-/area/station/service/bar) | typesof(/area/station/commons/dorms)))
+			SpawnLandAtRandom(living_mob, (typesof(/area/station/hallway) | typesof(/area/station/service/bar) | typesof(/area/station/commons/dorms)))
 			spawning_handled = TRUE
 		else if(length(GLOB.jobspawn_overrides[rank]))
 			S = pick(GLOB.jobspawn_overrides[rank])
@@ -574,10 +574,9 @@ SUBSYSTEM_DEF(job)
 
 
 	if(living_mob.mind)
-		living_mob.mind.set_assigned_role(rank, job)
-	to_chat(M, "<b>You are the [rank].</b>")
+		living_mob.mind.set_assigned_role_with_greeting(rank, job, M.client)
 	if(job)
-		var/new_mob = job.equip(living_mob, null, null, joined_late , null, M.client)
+		var/new_mob = living_mob.on_job_equipping(job, joined_late, M.client)
 		if(ismob(new_mob))
 			living_mob = new_mob
 			if(!joined_late)
@@ -599,19 +598,7 @@ SUBSYSTEM_DEF(job)
 				M.client.holder.auto_deadmin()
 			else
 				handle_auto_deadmin_roles(M.client, rank)
-		to_chat(M, "<b>As the [rank] you answer directly to [job.supervisors]. Special circumstances may change this.</b>")
-		job.radio_help_message(M)
-		if(job.req_admin_notify)
-			to_chat(M, "<b>You are playing a job that is important for Game Progression. If you have to disconnect, please notify the admins via adminhelp.</b>")
-		var/obj/item/id_card = living_mob?.get_idcard()
-		if (SSjob.initial_players_to_assign < job.min_pop && job.min_pop_redirect)
-			to_chat(M, span_noticebig("<b>Due to a lack of station personnel, you additionally have the responsibilities and access of \a [job.min_pop_redirect::title]!</b>"))
-		else if (id_card && length(id_card.GetAccess()) != length(job.base_access))
-			to_chat(M, span_notice("<B>You have been granted with additional access and responsibilities due to a lack of station personnel.</B>"))
-	if(ishuman(living_mob))
-		var/mob/living/carbon/human/wageslave = living_mob
-		if(wageslave.mind?.account_id)
-			living_mob.add_memory("Your account ID is [wageslave.mind.account_id].")
+
 	if(job && living_mob)
 		job.after_spawn(living_mob, M, joined_late, M.client) // note: this happens before the mob has a key! M will always have a client, living_mob might not.
 
@@ -619,6 +606,32 @@ SUBSYSTEM_DEF(job)
 		give_crew_objective(living_mob.mind, M)
 
 	return living_mob
+
+/mob/living/proc/on_job_equipping(datum/job/job, joined_late, client/player_client)
+	return
+
+#define VERY_LATE_ARRIVAL_TOAST_PROB 20
+
+/mob/living/carbon/human/on_job_equipping(datum/job/equipping, joined_late, client/player_client)
+	if(equipping.bank_account_department)
+		var/datum/bank_account/bank_account = new(real_name, equipping)
+		bank_account.payday(STARTING_PAYCHECKS, TRUE)
+		mind?.account_id = bank_account.account_id
+		player_client.mob.add_memory("Your account ID is [mind?.account_id].")
+
+	return dress_up_as_job(job = equipping, visual_only = FALSE, player_client = player_client, joined_late = joined_late)
+
+	if(EMERGENCY_PAST_POINT_OF_NO_RETURN && prob(VERY_LATE_ARRIVAL_TOAST_PROB))
+		equip_to_slot_or_del(new /obj/item/food/griddle_toast(src), ITEM_SLOT_MASK)
+
+#undef VERY_LATE_ARRIVAL_TOAST_PROB
+
+/mob/living/proc/dress_up_as_job(datum/job/job, visual_only = FALSE, client/player_client, joined_late = FALSE)
+	return
+
+/mob/living/carbon/human/dress_up_as_job(datum/job/job, visual_only = FALSE, client/player_client, joined_late = FALSE)
+	return job.equip(H = src, visuals_only = visual_only, announce = TRUE, latejoin = joined_late, outfit_override = null, preference_source = player_client)
+
 
 /datum/controller/subsystem/job/proc/handle_auto_deadmin_roles(client/C, rank)
 	if(!C?.holder)

--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -433,9 +433,9 @@ SUBSYSTEM_DEF(ticker)
 						highest_rank = spare_id_priority
 					else if(spare_id_priority == highest_rank)
 						spare_id_candidates += player
-		if(mind.assigned_role != mind.special_role)
-			SSjob.EquipRank(player, mind.assigned_role, FALSE)
 		var/datum/job/job = mind.assigned_role_datum
+		if(job?.job_flags & JOB_EQUIP_RANK)
+			SSjob.EquipRank(player, mind.assigned_role, FALSE)
 		if((job?.job_flags & JOB_ASSIGN_QUIRKS) && CONFIG_GET(flag/roundstart_traits))
 			SSquirks.AssignQuirks(mind, player.client, TRUE)
 		CHECK_TICK

--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -671,10 +671,6 @@
 			if(istype(O,objective_type))
 				return TRUE
 
-/mob/proc/sync_mind()
-	mind_initialize() //updates the mind (or creates and initializes one if one doesn't exist)
-	mind.active = TRUE //indicates that the mind is currently synced with a client
-
 /datum/mind/proc/has_martialart(string)
 	if(martial_art && martial_art.id == string)
 		return martial_art
@@ -705,6 +701,22 @@
 	//second argument was not filled, take string and find job datum. If there is no associated job-datum, it will be null anyway
 	else
 		assigned_role_datum = SSjob.GetJob(assigned_role)
+
+/// Sets us to the passed job datum, then greets them to their new job.
+/// Use this one for when you're assigning this mind to a new job for the first time,
+/// or for when someone's receiving a job they'd really want to be greeted to.
+/datum/mind/proc/set_assigned_role_with_greeting(role_title, datum/job/new_role, client/incoming_client)
+	. = set_assigned_role(role_title = role_title, job_datum = new_role)
+	if(assigned_role_datum != new_role)
+		return
+
+	var/intro_message = new_role.get_spawn_message()
+	if(incoming_client && intro_message)
+		to_chat(incoming_client, intro_message)
+
+/mob/proc/sync_mind()
+	mind_initialize() //updates the mind (or creates and initializes one if one doesn't exist)
+	mind.active = TRUE //indicates that the mind is currently synced with a client
 
 /mob/dead/new_player/sync_mind()
 	return

--- a/code/datums/outfit.dm
+++ b/code/datums/outfit.dm
@@ -189,8 +189,6 @@
 		EQUIP_OUTFIT_ITEM(back, ITEM_SLOT_BACK)
 	if(id)
 		EQUIP_OUTFIT_ITEM(id, ITEM_SLOT_ID)
-	if(suit_store)
-		EQUIP_OUTFIT_ITEM(suit_store, ITEM_SLOT_SUITSTORE)
 
 	if(!visuals_only && user.wear_id)
 		var/obj/item/card/id/id_card = user.wear_id
@@ -199,6 +197,9 @@
 
 		if(istype(id_card)) //Make sure that we actually found an ID to modify, otherwise this runtimes and cancels equipping the outfit
 			id_card.registered_age = user.age
+
+	if(suit_store)
+		EQUIP_OUTFIT_ITEM(suit_store, ITEM_SLOT_SUITSTORE)
 
 	if(accessory)
 		var/obj/item/clothing/under/U = user.w_uniform

--- a/code/game/objects/items/food/bread.dm
+++ b/code/game/objects/items/food/bread.dm
@@ -75,6 +75,9 @@
 	. = ..()
 	AddComponent(/datum/component/customizable_reagent_holder, null, CUSTOM_INGREDIENT_ICON_STACK)
 
+/obj/item/food/breadslice/plain/make_grillable()
+	AddComponent(/datum/component/grillable, /obj/item/food/griddle_toast, rand(15 SECONDS, 25 SECONDS), TRUE, TRUE)
+
 /obj/item/food/breadslice/moldy
 	name = "moldy 'bread' slice"
 	desc = "Entire stations have been ripped apart arguing whether this is still good to eat."

--- a/code/modules/jobs/job_types/_job.dm
+++ b/code/modules/jobs/job_types/_job.dm
@@ -423,9 +423,11 @@
 /proc/gear_priority_cmp(a, b)
 	return get_slot_priority(a) < get_slot_priority(b)
 
-/datum/job/proc/announce(mob/living/carbon/human/H)
+/// Announce that this job as joined the round to all crew members.
+/// Note the joining mob has no client at this point.
+/datum/job/proc/announce_job(mob/living/joining_mob)
 	if(head_announce)
-		announce_head(H, head_announce)
+		announce_head(joining_mob, head_announce)
 
 /datum/job/proc/override_latejoin_spawn(mob/living/carbon/human/H)		//Return TRUE to force latejoining to not automatically place the person in latejoin shuttle/whatever.
 	return FALSE
@@ -453,10 +455,6 @@
 		if(H.dna.species.id != SPECIES_HUMAN)
 			H.set_species(/datum/species/human)
 			H.apply_pref_name(/datum/preference/name/backup_human, preference_source)
-	if(!visuals_only)
-		var/datum/bank_account/bank_account = new(H.real_name, src)
-		bank_account.payday(STARTING_PAYCHECKS, TRUE)
-		H.mind?.account_id = bank_account.account_id
 
 	//Equip the rest of the gear
 	H.dna.species.before_equip_job(src, H, visuals_only)
@@ -472,7 +470,7 @@
 	H.dna.species.after_equip_job(src, H, visuals_only, preference_source)
 
 	if(!visuals_only && announce)
-		announce(H)
+		announce_job(H)
 	H.give_random_dormant_disease(biohazard, (title == JOB_NAME_CLOWN || title == JOB_NAME_MIME) ? 0 : 4)
 
 /datum/job/proc/get_access()
@@ -583,8 +581,34 @@
 	if(!(job_flags & JOB_NEW_PLAYER_JOINABLE))
 		return "Unavailable"
 
-/datum/job/proc/radio_help_message(mob/M)
-	to_chat(M, "<b>Prefix your message with :h to speak on your department's radio. To see other prefixes, look closely at your headset.</b>")
+/// Gets the message that shows up when spawning as this job
+/datum/job/proc/get_spawn_message()
+	SHOULD_NOT_OVERRIDE(TRUE)
+	return examine_block(span_infoplain(jointext(get_spawn_message_information(), "\n&bull; ")))
+
+/// Returns a list of strings that correspond to chat messages sent to this mob when they join the round.
+/datum/job/proc/get_spawn_message_information()
+	SHOULD_CALL_PARENT(TRUE)
+	var/list/info = list()
+	info += "<b>You are the [title].</b>\n"
+	var/radio_info = get_radio_information()
+	if(supervisors)
+		info += "As the [title] you answer directly to [supervisors]. Special circumstances may change this."
+	if(radio_info)
+		info += radio_info
+	if(req_admin_notify)
+		info += "<b>You are playing a job that is important for Game Progression. \
+			If you have to disconnect, please notify the admins via adminhelp.</b>"
+	if(SSjob.initial_players_to_assign < min_pop && min_pop_redirect)
+		info += span_noticebig("<b>Due to a lack of station personnel, you additionally have the responsibilities and access of \a [min_pop_redirect::title]!</b>")
+	if(length(get_access()) != length(base_access))
+		info += span_notice("<b>You have been granted with additional access and responsibilities due to a lack of station personnel.</b>")
+	return info
+
+/// Returns information pertaining to this job's radio.
+/datum/job/proc/get_radio_information()
+	if(job_flags & JOB_CREW_MEMBER)
+		return "<b>Prefix your message with :h to speak on your department's radio. To see other prefixes, look closely at your headset.</b>"
 
 /datum/outfit/job
 	name = "Standard Gear"

--- a/code/modules/jobs/job_types/ai.dm
+++ b/code/modules/jobs/job_types/ai.dm
@@ -55,7 +55,7 @@
 				R.TryConnectToAI()
 
 	if(latejoin)
-		announce(AI)
+		announce_job(AI)
 
 /datum/job/ai/override_latejoin_spawn()
 	return TRUE
@@ -70,10 +70,12 @@
 				return TRUE
 	return FALSE
 
-/datum/job/ai/announce(mob/living/silicon/ai/AI)
+/datum/job/ai/announce_job(mob/living/silicon/ai/AI)
 	. = ..()
 	SSticker.OnRoundstart(CALLBACK(GLOBAL_PROC, GLOBAL_PROC_REF(minor_announce), "[AI] has been downloaded to an empty bluespace-networked AI core at [AREACOORD(AI)]."))
 
 /datum/job/ai/config_check()
 	return CONFIG_GET(flag/allow_ai)
 
+/datum/job/ai/get_radio_information()
+	return "<b>Prefix your message with :b to speak with cyborgs and other AIs.</b>"

--- a/code/modules/jobs/job_types/ai.dm
+++ b/code/modules/jobs/job_types/ai.dm
@@ -17,7 +17,7 @@
 	random_spawns_possible = FALSE
 	allow_bureaucratic_error = FALSE
 
-	job_flags = JOB_NEW_PLAYER_JOINABLE | JOB_CANNOT_OPEN_SLOTS
+	job_flags = JOB_NEW_PLAYER_JOINABLE | JOB_EQUIP_RANK | JOB_CANNOT_OPEN_SLOTS
 	var/do_special_check = TRUE
 
 /datum/job/ai/get_access() // no point of calling parent proc

--- a/code/modules/jobs/job_types/captain.dm
+++ b/code/modules/jobs/job_types/captain.dm
@@ -54,9 +54,13 @@
 /datum/job/captain/get_access()
 	return get_all_accesses()
 
-/datum/job/captain/announce(mob/living/carbon/human/H)
+/datum/job/captain/announce_job(mob/living/carbon/human/H)
 	..()
 	SSticker.OnRoundstart(CALLBACK(GLOBAL_PROC, GLOBAL_PROC_REF(minor_announce), "Captain [H.real_name] on deck!"))
+
+/datum/job/captain/get_radio_information()
+	. = ..()
+	. += "\nYou have access to all radio channels, but they are not automatically tuned. Check your radio for more information."
 
 /datum/outfit/job/captain
 	name = JOB_NAME_CAPTAIN

--- a/code/modules/jobs/job_types/cyborg.dm
+++ b/code/modules/jobs/job_types/cyborg.dm
@@ -17,7 +17,7 @@
 	display_order = JOB_DISPLAY_ORDER_CYBORG
 	departments = DEPT_BITFLAG_SILICON
 
-	job_flags = JOB_NEW_PLAYER_JOINABLE | JOB_CANNOT_OPEN_SLOTS
+	job_flags = JOB_NEW_PLAYER_JOINABLE | JOB_EQUIP_RANK | JOB_CANNOT_OPEN_SLOTS
 
 /datum/job/cyborg/get_access() // no point of calling parent proc
 	return list()

--- a/code/modules/jobs/job_types/cyborg.dm
+++ b/code/modules/jobs/job_types/cyborg.dm
@@ -33,5 +33,5 @@
 	R.updatename(M.client)
 	R.gender = NEUTER
 
-/datum/job/cyborg/radio_help_message(mob/M)
-	to_chat(M, "<b>Prefix your message with :b to speak with other cyborgs and AI.</b>")
+/datum/job/cyborg/get_radio_information()
+	return "<b>Prefix your message with :b to speak with other cyborgs and AI.</b>"

--- a/code/modules/jobs/job_types/posibrain.dm
+++ b/code/modules/jobs/job_types/posibrain.dm
@@ -36,8 +36,8 @@ GLOBAL_LIST_EMPTY(on_station_posis)
 	qdel(H)
 	return P
 
-/datum/job/posibrain/radio_help_message(mob/M)
-	to_chat(M, "<b>Prefix your message with :b to speak with other cyborgs and AI.</b>")
+/datum/job/posibrain/get_radio_information()
+	return "<b>Prefix your message with :b to speak with other cyborgs and AI.</b>"
 
 /datum/job/posibrain/proc/check_add_posi_slot(obj/item/mmi/posibrain/pb)
 	var/turf/currentturf = get_turf(pb)

--- a/code/modules/jobs/job_types/prisoner.dm
+++ b/code/modules/jobs/job_types/prisoner.dm
@@ -35,7 +35,7 @@
 		JOB_NAME_ASSISTANT
 	)
 
-/datum/job/prisoner/announce(mob/living/carbon/human/H)
+/datum/job/prisoner/announce_job(mob/living/carbon/human/H)
 	var/deets = "<font size = 2><b>#Prisoner Transfer Documentation</font></b> \
 					<hr> \
 					<code> \
@@ -81,9 +81,12 @@
 	uniform = /obj/item/clothing/under/rank/prisoner/lowsec
 	shoes = /obj/item/clothing/shoes/sneakers/white
 
-/datum/job/prisoner/radio_help_message(mob/M)
+/datum/job/prisoner/get_spawn_message_information()
 	.=..()
-	to_chat(M,span_prisonermessage("<b>You have signed up as Low-Security Inmate, <i>This is primarily a roleplaying role.</i><hr>\
-									You are expected to create conflict using good role-play; in a way that is fun for others.<br>\
-									Good conflict escalation doesn't require spoiling the plan to a victim, but it is more interesting when you drop hints and attempt to get more players involved.<br>\
-									You are neutral to the station and are not expected to be on their side, but all conflicts must align with your character's motivations.<br></b>"))
+	var/list/info = list()
+	info += span_prisonermessage(
+		"<b>You have signed up as Low-Security Inmate, <i>This is primarily a roleplaying role.</i><hr>\
+		You are expected to create conflict using good role-play; in a way that is fun for others.<br>\
+		Good conflict escalation doesn't require spoiling the plan to a victim, but it is more interesting when you drop hints and attempt to get more players involved.<br>\
+		You are neutral to the station and are not expected to be on their side, but all conflicts must align with your character's motivations.<br></b>")
+	return info

--- a/code/modules/mob/living/carbon/human/human_update_icons.dm
+++ b/code/modules/mob/living/carbon/human/human_update_icons.dm
@@ -684,7 +684,7 @@ There are several things that need to be remembered:
 
 /mob/living/carbon/human/proc/update_hud_s_store(obj/item/worn_item)
 	worn_item.screen_loc = ui_sstore1
-	if((client && hud_used) && (hud_used.inventory_shown && hud_used.hud_shown))
+	if(client && hud_used?.hud_shown)
 		client.screen += worn_item
 	update_observer_view(worn_item,TRUE)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<img width="950" height="152" alt="image" src="https://github.com/user-attachments/assets/bcbd926d-7737-43f3-9673-38eb1b8a363d" />


Roundstart job messages are handled better.
Very latejoiners start with toast in their mouth.
Toast can now be created. Again.
jobequip() jobs use the flag for it

- https://github.com/tgstation/tgstation/pull/78647

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Better segmentation means less coders screwing up the chain, namely whatever put prisoner job information in their *radio*

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

See above

</details>

## Changelog
:cl: rkz, Rohesie
qol: roundstart / latejoin job greeting information is now in an examineblock
qol: Captain gets a little bit more information about how their radio works roundstart.
fix: Fixed roundstart players not getting radio information.
fix: fixed crappy cases where coders put job information in radio hints, rather than, y'know, JOB hints.
fix: fixes suit storage appearance bug
fix: you can make toast again
add: latelatejoiners spawn with toast
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
