### PR TITLE
Adjusted Quadra-oxymix preset medicine

### DIFF
--- a/code/modules/reagents/reagent_containers/chem_bag.dm
+++ b/code/modules/reagents/reagent_containers/chem_bag.dm
@@ -27,13 +27,14 @@
 // this is specifically made as an example for a sleeper feature that uses a chem bag at roundstart.
 /obj/item/reagent_containers/chem_bag/oxy_mix
 	name = "Quadra-oxymix Medicines Bag"
-	desc = "a small note on it says: Perfluorodecalin 70u, Dexalin 10u, Dexalin Plus 10u, Salbutamol 10u."
+	desc = "a small note on it says: Perfluorodecalin 50u, Dexalin 20u, Dexalin Plus 20u, Salbutamol 20u, with 100u of Saline-Glucose Solution."
 	label_name = "Quadra-oxymix Medicines"
 	list_reagents = list(
-		/datum/reagent/medicine/perfluorodecalin = 70,
-		/datum/reagent/medicine/dexalin = 10,
-		/datum/reagent/medicine/dexalinp = 10,
-		/datum/reagent/medicine/salbutamol = 10
+		/datum/reagent/medicine/perfluorodecalin = 50,
+		/datum/reagent/medicine/dexalin = 20,
+		/datum/reagent/medicine/dexalinp = 20,
+		/datum/reagent/medicine/salbutamol = 20,
+		/datum/reagent/medicine/salglu_solution = 100,
 		) // you are welcome to change the chem contents here
 
 /obj/item/reagent_containers/chem_bag/epi


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adjusted Quadra-oxymix preset medicine
* Previously
  ```DM
	list_reagents = list(
		/datum/reagent/medicine/perfluorodecalin = 70,
		/datum/reagent/medicine/dexalin = 10,
		/datum/reagent/medicine/dexalinp = 10,
		/datum/reagent/medicine/salbutamol = 10
		)
* NEW: 
  ```DM
	list_reagents = list(
		/datum/reagent/medicine/perfluorodecalin = 50,
		/datum/reagent/medicine/dexalin = 20,
		/datum/reagent/medicine/dexalinp = 20,
		/datum/reagent/medicine/salbutamol = 20,
		/datum/reagent/medicine/salglu_solution = 100,
		)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
This preset medicine was made when the antitoxin was effectively curing people's toxin damage well. Since basic meds have some penalty, perflu has became a bit tedious to manage.
By adjusting chem values and adding saline glucose, perfluo is not quite superior in chem injection. Only 10u of antitoxin will be enough to manage for the patient aftercare.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

Patient full chem injection
-----------
<img width="310" height="520" alt="image" src="https://github.com/user-attachments/assets/7882256f-41b6-434e-b3b5-a695a9c9f7d5" />


After full metabolisation of perfluo
-------------
<img width="310" height="520" alt="image" src="https://github.com/user-attachments/assets/dfa6b29c-565f-49d8-b401-7d8894295543" />


After 5u of Antitoxin has been metabolised.
---------
<img width="310" height="520" alt="image" src="https://github.com/user-attachments/assets/8a9cc30b-ce76-4129-8cf9-74292d286b9a" />

</details>

## Changelog
:cl:
balance: Quadra-oxymix is now "Perfluorodecalin 50u, Dexalin 20u, Dexalin Plus 20u, Salbutamol 20u, with 100u of Saline-Glucose Solution". This change has been made in the late follow-up of the basic chem nerf. 5u of Antitoxin will be enough to manage the perfluo downside.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
