### PR TITLE
Fix depvend enlistment announcement and add gps component

### DIFF
--- a/code/modules/vending/deputy.dm
+++ b/code/modules/vending/deputy.dm
@@ -61,6 +61,7 @@
 
 /obj/machinery/vending/deputy/Initialize(mapload)
 	. = ..()
+	AddComponent(/datum/component/gps, "DepVend")
 	radio = new /obj/item/radio(src)
 	radio.set_listening(FALSE)
 	radio.set_frequency(FREQ_COMMON)
@@ -118,8 +119,9 @@
 
 		if(!..())
 			return FALSE
+
 		playsound(src, 'sound/effects/startup.ogg', 100, FALSE)
-		radio.talk_into(src, "[buyer], [get_area(src)], has just enlisted for Auri Private Security's volunteer deputy program! APS thanks you for your service, and reminds all crew members: **Unauthorized enforcement is strictly prohibited!** Remember; Compliance is a team effort!")
+		radio.talk_into(src, "[buyer] has just enlisted for Auri Private Security's volunteer deputy program! APS thanks you for your service, and reminds all crew members: **Unauthorized enforcement is strictly prohibited!** Remember; Compliance is a team effort!")
 		return TRUE
 
 	playsound(src, 'sound/machines/buzz-sigh.ogg', 50, FALSE)


### PR DESCRIPTION
## About The Pull Request

Fixed a bad text thing about the sign up wording on the vendor by removing area information.
To compensate, depvends now have a gpw

## Why It's Good For The Game

Fixes are good, and the oversight of being able to find it when required is maintained.

## Testing Photographs and Procedure
<details>
<summary>Screenshots&Videos</summary>

<img width="1011" height="82" alt="image" src="https://github.com/user-attachments/assets/465ee891-e057-4eba-9c3b-570cc9277e40" />

</details>

## Changelog
:cl:
add: Added gps signal to depvend
fix: fixed depvend message
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
