### PR TITLE
Refine acting captain selection and remove spare ID code requests

### DIFF
--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -407,11 +407,11 @@ SUBSYSTEM_DEF(ticker)
 
 /datum/controller/subsystem/ticker/proc/equip_characters()
 	var/captainless = TRUE
-
 	var/highest_rank = length(SSjob.chain_of_command) + 1
 	var/list/spare_id_candidates = list()
 	var/enforce_coc = CONFIG_GET(flag/spare_enforce_coc)
 
+	// Collect all eligible players
 	for(var/mob/dead/new_player/authenticated/player in GLOB.auth_new_player_list)
 		var/mob/living/carbon/human/new_character = player.new_character
 		if(!istype(new_character) || !new_character.mind?.assigned_role)
@@ -447,7 +447,41 @@ SUBSYSTEM_DEF(ticker)
 		else
 			SSjob.promote_to_captain(pick(spare_id_candidates), captainless)
 		CHECK_TICK
+	else
+		// No captain or head, panic.
+		var/list/eligible = list()
+		var/list/security = list(JOB_NAME_WARDEN, JOB_NAME_SECURITYOFFICER)
+		var/list/all_players = list()
 
+		// Collect all players
+		for(var/mob/dead/new_player/authenticated/player in GLOB.auth_new_player_list)
+
+			// Get our buddy for ease of use
+			var/mob/living/carbon/human/new_character = player.new_character
+
+			if(!istype(new_character) || !new_character.mind?.assigned_role)
+				continue
+
+			// NO ANTAGS!!
+			if(new_character.mind.has_antag_datum(/datum/antagonist))
+				continue
+
+			all_players += player
+
+			if(new_character.mind.assigned_role in security)
+				eligible += player	// All seccies are eligible first
+
+		if(!length(eligible))
+			eligible = all_players // No seccies? Damn. Gotta lower our standards.
+
+		if(length(eligible))
+			eligible = shuffle(eligible)
+			var/mob/dead/new_player/authenticated/winner = eligible[1]
+			SSjob.promote_to_captain(winner, TRUE) // Where is the party horn
+		else
+			// No one eligible, delete the spare ID safe
+			for(var/obj/item/storage/secure/safe/caps_spare/safe in world)
+				qdel(safe)
 
 /datum/controller/subsystem/ticker/proc/transfer_characters()
 	var/list/livings = list()

--- a/code/game/machinery/computer/communications.dm
+++ b/code/game/machinery/computer/communications.dm
@@ -345,31 +345,6 @@
 				log_game("[key_name(usr)] enabled emergency maintenance access.")
 				message_admins("[ADMIN_LOOKUPFLW(usr)] enabled emergency maintenance access.")
 				deadchat_broadcast(" enabled emergency maintenance access at [span_name("[get_area_name(usr, TRUE)]")].", span_name("[usr.real_name]"), usr, message_type = DEADCHAT_ANNOUNCEMENT)
-		// Request codes for the Captain's Spare ID safe.
-		if("requestSafeCodes")
-			if(SSjob.assigned_captain)
-				to_chat(usr, span_warning("There is already an assigned Captain or Acting Captain on deck!"))
-				return
-
-			if(SSjob.safe_code_timer_id)
-				to_chat(usr, span_warning("The safe code has already been requested and is being delivered to your station!"))
-				return
-
-			if(SSjob.safe_code_requested)
-				to_chat(usr, span_warning("The safe code has already been requested and delivered to your station!"))
-				return
-
-			if(!SSjob.spare_id_safe_code)
-				to_chat(usr, span_warning("There is no safe code to deliver to your station!"))
-				return
-
-			var/turf/pod_location = get_turf(src)
-
-			SSjob.safe_code_request_loc = pod_location
-			SSjob.safe_code_requested = TRUE
-			SSjob.safe_code_timer_id = addtimer(CALLBACK(SSjob, TYPE_PROC_REF(/datum/controller/subsystem/job, send_spare_id_safe_code), pod_location), 120 SECONDS, TIMER_UNIQUE | TIMER_STOPPABLE)
-			minor_announce("Due to staff shortages, your station has been approved for delivery of access codes to secure the Captain's Spare ID. Delivery via drop pod at [get_area(pod_location)]. ETA 120 seconds.")
-			. = TRUE
 
 /obj/machinery/computer/communications/ui_data(mob/user)
 	var/list/data = list(
@@ -381,18 +356,6 @@
 
 	var/has_connection = has_communication()
 	data["hasConnection"] = has_connection
-
-	if(!SSjob.assigned_captain && !SSjob.safe_code_requested && SSjob.spare_id_safe_code && has_connection)
-		data["canRequestSafeCode"] = TRUE
-		data["safeCodeDeliveryWait"] = 0
-	else
-		data["canRequestSafeCode"] = FALSE
-		if(SSjob.safe_code_timer_id && has_connection)
-			data["safeCodeDeliveryWait"] = timeleft(SSjob.safe_code_timer_id)
-			data["safeCodeDeliveryArea"] = get_area(SSjob.safe_code_request_loc)
-		else
-			data["safeCodeDeliveryWait"] = 0
-			data["safeCodeDeliveryArea"] = null
 
 	if (authenticated || issilicon(user))
 		data["authenticated"] = TRUE

--- a/tgui/packages/tgui/interfaces/CommunicationsConsole.jsx
+++ b/tgui/packages/tgui/interfaces/CommunicationsConsole.jsx
@@ -638,9 +638,6 @@ const ConditionalTooltip = (props) => {
 export const CommunicationsConsole = (props) => {
   const { act, data } = useBackend();
   const {
-    canRequestSafeCode,
-    safeCodeDeliveryWait,
-    safeCodeDeliveryArea,
     authenticated,
     authorizeName,
     canLogOut,
@@ -660,27 +657,6 @@ export const CommunicationsConsole = (props) => {
             flexDirection: 'column',
           }}
         >
-          {(canRequestSafeCode ? (
-            <Flex.Item>
-              <Section title="Emergency Safe Code">
-                <Button
-                  icon="key"
-                  content="Request Safe Code"
-                  color="good"
-                  onClick={() => act('requestSafeCodes')}
-                />
-              </Section>
-            </Flex.Item>
-          ) : null) ||
-            (safeCodeDeliveryWait ? (
-              <Flex.Item>
-                <Section title="Emergency Safe Code Delivery">
-                  {`Drop pod to ${safeCodeDeliveryArea} in \
-            ${Math.round(safeCodeDeliveryWait / 10)}s`}
-                </Section>
-              </Flex.Item>
-            ) : null)}
-
           {authenticated ? (
             <Flex.Item grow>
               <Stack fill>


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

### Central Command would like to ensure all personnel know the true story around these recent allegations: It is the official stance of NanoTrasen that, if you do not see a spare ID safe installed on your station, then it has simply never existed in the first place. Please wait for an authorized member of staff to join you.

Removes the ability to request Captain's Spare ID safe codes via the communications console.

Introduces an automated fallback mechanism in the ticker subsystem to ensure an acting captain is assigned if primary head of staff candidates are unavailable.

This fallback prioritizes security roles, then any non-antagonist player.

If no suitable player can be found, **a Nanotrasen  KP-500 "Basalt" turbo-plasmodynamic supersonic cruise missile is deployed upon the spare ID safe, annihilating it via particle-antiparticle detonation payload.**

## Why It's Good For The Game

The terror of lowpop antags will be reduced.

## Testing Photographs and Procedure
<details>
<summary>Screenshots&Videos</summary>

<img width="991" height="864" alt="image" src="https://github.com/user-attachments/assets/b575ab89-cfa2-4bbe-b549-1639d336d4b2" />

</details>

## Changelog
:cl:
del: Removed spare ID safe requisition
tweak: Acting captainship is now determined by CC panel vote(you are not on the panel)
/:cl:
