### PR TITLE
Fixes brain mob speech

### DIFF
--- a/code/modules/mob/living/brain/brain_say.dm
+++ b/code/modules/mob/living/brain/brain_say.dm
@@ -29,8 +29,3 @@
 			return ITALICS | REDUCE_RANGE
 	else
 		return ..()
-
-/mob/living/brain/treat_message(message, capitalize_message = TRUE)
-	if(capitalize_message)
-		message = capitalize(message)
-	return treat_message_min(list(message))


### PR DESCRIPTION
## About The Pull Request

We were overriding `treat_message()` when we didn't need to and the override returned an unexpected value causing a runtime

## Why It's Good For The Game

closes #14344

## Testing Photographs and Procedure

<img width="134" height="128" alt="image" src="https://github.com/user-attachments/assets/05880857-9bc6-485a-9332-c85aa4f863d9" />

## Changelog
:cl:
fix: speech synthesizers have been reimplemented in positronic brains and MMIs
/:cl: