### PR TITLE
Removes url-loader

### DIFF
--- a/tgui/.yarnrc.yml
+++ b/tgui/.yarnrc.yml
@@ -12,9 +12,6 @@ logFilters:
   - code: YN0002
     level: discard
     pattern: 'css-loader@*'
-  - code: YN0002
-    level: discard
-    pattern: 'url-loader@*'
 
 pnpEnableEsmLoader: false
 

--- a/tgui/package.json
+++ b/tgui/package.json
@@ -50,7 +50,6 @@
     "style-loader": "^4.0.0",
     "swc-loader": "^0.2.6",
     "typescript": "^5.6.3",
-    "url-loader": "^4.1.1",
     "webpack": "^5.97.1",
     "webpack-bundle-analyzer": "^4.10.2",
     "webpack-cli": "^6.0.1"

--- a/tgui/webpack.config.js
+++ b/tgui/webpack.config.js
@@ -94,9 +94,22 @@ module.exports = (env = {}, argv) => {
             },
           ],
         },
+
         {
-          test: /\.(png|jpg|svg)$/,
+          test: /\.(cur|png|jpg)$/,
           type: 'asset/resource',
+        },
+        {
+          test: /.svg$/,
+          oneOf: [
+            {
+              issuer: /\.(s)?css$/,
+              type: 'asset/inline',
+            },
+            {
+              type: 'asset/resource',
+            },
+          ],
         },
       ],
     },

--- a/tgui/webpack.config.js
+++ b/tgui/webpack.config.js
@@ -96,14 +96,7 @@ module.exports = (env = {}, argv) => {
         },
         {
           test: /\.(png|jpg|svg)$/,
-          use: [
-            {
-              loader: require.resolve('url-loader'),
-              options: {
-                esModule: false,
-              },
-            },
-          ],
+          type: 'asset/resource',
         },
       ],
     },

--- a/tgui/yarn.lock
+++ b/tgui/yarn.lock
@@ -8699,7 +8699,6 @@ __metadata:
     style-loader: "npm:^4.0.0"
     swc-loader: "npm:^0.2.6"
     typescript: "npm:^5.6.3"
-    url-loader: "npm:^4.1.1"
     webpack: "npm:^5.97.1"
     webpack-bundle-analyzer: "npm:^4.10.2"
     webpack-cli: "npm:^6.0.1"
@@ -9137,23 +9136,6 @@ __metadata:
   dependencies:
     punycode: "npm:^2.1.0"
   checksum: 10c0/4ef57b45aa820d7ac6496e9208559986c665e49447cb072744c13b66925a362d96dd5a46c4530a6b8e203e5db5fe849369444440cb22ecfc26c679359e5dfa3c
-  languageName: node
-  linkType: hard
-
-"url-loader@npm:^4.1.1":
-  version: 4.1.1
-  resolution: "url-loader@npm:4.1.1"
-  dependencies:
-    loader-utils: "npm:^2.0.0"
-    mime-types: "npm:^2.1.27"
-    schema-utils: "npm:^3.0.0"
-  peerDependencies:
-    file-loader: "*"
-    webpack: ^4.0.0 || ^5.0.0
-  peerDependenciesMeta:
-    file-loader:
-      optional: true
-  checksum: 10c0/71b6300e02ce26c70625eae1a2297c0737635038c62691bb3007ac33e85c0130efc74bfb444baf5c6b3bad5953491159d31d66498967d1417865d0c7e7cd1a64
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## About The Pull Request

Copy and pasting Mr. jlsnow's words:

> Url loader is deprecated as of webpack v5 as its functionality is included in both webpack and rspack 

Port of:
- https://github.com/tgstation/tgstation/pull/91329

## Why It's Good For The Game

Prep for the bun port

## Testing Photographs and Procedure

<img width="425" height="633" alt="image" src="https://github.com/user-attachments/assets/b549bf6e-ddbd-4328-b0c7-2fc7ac4aa06c" />

<img width="1193" height="761" alt="image" src="https://github.com/user-attachments/assets/463aede4-969a-4b39-8cd7-4b23f21d4469" />

## Changelog
:cl: mrmanlikesbt, jslnow301
del: url-loader has been removed from tgui dependencies as it comes included with webpack
/:cl: