### PR TITLE
We aren't /tg/

### DIFF
--- a/code/datums/helper_datums/getrev.dm
+++ b/code/datums/helper_datums/getrev.dm
@@ -23,7 +23,7 @@
 
 /datum/getrev/proc/get_log_message()
 	var/list/msg = list()
-	msg += "Running /tg/ revision: [date]"
+	msg += "Running BeeStation revision: [date]"
 	if(originmastercommit)
 		msg += "origin/master: [originmastercommit]"
 


### PR DESCRIPTION
## About The Pull Request

I guess this was never switched when we forked those many years ago

## Testing Photographs and Procedure

<img width="663" height="76" alt="image" src="https://github.com/user-attachments/assets/03087ef4-8537-40fd-a665-14ce12d0f4d1" />

## Changelog
:cl:
admin: The server revision log now displays BeeStation instead of /tg/
/:cl: