### PR TITLE
Shuffles Psyphoza soul colour initialisation

### DIFF
--- a/code/_globalvars/soul_glimmer.dm
+++ b/code/_globalvars/soul_glimmer.dm
@@ -6,7 +6,7 @@
 */
 
 //ALL the psychic soul colours
-GLOBAL_LIST_INIT(soul_glimmer_colors, list(
+GLOBAL_LIST_INIT(soul_glimmer_colors, shuffle(list(
 	"Azure" = "#0091ff",
 	"Vermilion" = "#ff3a1c",
 	"Sage" = "#1fff5e",
@@ -16,7 +16,7 @@ GLOBAL_LIST_INIT(soul_glimmer_colors, list(
 	"Sunshine" = "#fff12c",
 	"Melancholia" = "#8100FF",
 	"Submarine" = "#1f1bff",
-	"Humour" = "#e876ff"))
+	"Humour" = "#e876ff")))
 
 /// TGUI chat colours
 GLOBAL_LIST_INIT(soul_glimmer_cfc_list, list(


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Shuffles Psyphoza soul colour initialisation

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

<img width="445" height="295" alt="image" src="https://github.com/user-attachments/assets/4cb060fc-197d-4d85-b8de-eee5985497ef" />

Azure / Vermilion / Sage have always been chosen first, but Psyphoza player says it's lame. By shuffles first colours, they will be able to see more colours at individual rounds. It doesn't mean the PR removes pop requirement.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

<img width="477" height="682" alt="image" src="https://github.com/user-attachments/assets/8f91165b-7cc8-42e8-953e-91d95007c4f4" />

</details>

## Changelog
:cl:
tweak: For Psyphoza soul colour, rather than 3 colours (Azure / Vermilion / Sage) are initialised first, 10 colours will be chosen. It doesn't mean low pop will have 10 colours presented at a round. This just lets you to see more colours tweaks rather than lame 3 colours.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
