### PR TITLE
Fix Smoke

### DIFF
--- a/code/modules/particles/byond_particles/particle_holder.dm
+++ b/code/modules/particles/byond_particles/particle_holder.dm
@@ -22,13 +22,13 @@
 	///list of all particle emitters
 	var/list/emitters = list()
 
-/obj/effect/abstract/particle_holder/Initialize(mapload, particle_path = /particles/smoke)
+/obj/effect/abstract/particle_holder/Initialize(mapload, particle_path)
 	. = ..()
 	if(!loc)
 		stack_trace("particle holder was created with no loc!")
 		return INITIALIZE_HINT_QDEL
 
-	particles = new particle_path()
+	particles = particle_path ? new particle_path() : particles
 	if(ismovable(loc))
 		RegisterSignal(loc, COMSIG_MOVABLE_MOVED, PROC_REF(on_move))
 	RegisterSignal(loc, COMSIG_QDELETING, PROC_REF(on_qdel))


### PR DESCRIPTION
## About The Pull Request

A fire has broken out in lego city!
HEY!
Assemble the fire truck!
Douse the flames!

As far as I could see, nothing uses this default argument / behaviour. I can only imagine TG particle code is a little different to ours, either because we're 'behind' or use a modified approach. It don't matter, none of this matters.

## Why It's Good For The Game

Stops everything with particles smoking like chimney

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

<img width="474" height="222" alt="image" src="https://github.com/user-attachments/assets/06989aa0-fbd1-488e-a8d2-be62735bdd21" />
<img width="445" height="231" alt="image" src="https://github.com/user-attachments/assets/f0819547-8ae7-48c1-9c48-c142fd8ec8fb" />


</details>

## Changelog
:cl:
fix: Fix particles smoking
/:cl:
