### PR TITLE
Berry Simple Null Check For Job Accounts

### DIFF
--- a/code/datums/records/manifest.dm
+++ b/code/datums/records/manifest.dm
@@ -138,7 +138,7 @@
 		name = person.real_name,
 		rank = assignment,
 		species = record_dna.species,
-		active_department = bank_account.active_departments,
+		active_department = bank_account ? bank_account.active_departments : null,
 		// Crew specific
 		lock_ref = FAST_REF(lockfile),
 		major_disabilities = person.get_quirk_string(FALSE, CAT_QUIRK_MAJOR_DISABILITY, from_scan = TRUE),


### PR DESCRIPTION
## About The Pull Request

A recent-_ish_ change to code, caused overflow jobs to not register properly, their bank accounts wouldnt generate, and they wouldnt appear on med/sec records, and therefore not on manifest. Im pretty sure this was an issue caused by jobs without an assigned department, Prisoner/Assistant namely who werent account for in the code, causing a runtime and the previously mentioned issues...

This PR adds a check for a null department, which makes non-departmental jobs generate an account, and join as intended...<sub> hopefully </sub>

## Why It's Good For The Game

Dont get me wrong, i LOVE a stowaway, but i dont think the intent is for Prisoners, Assistants and whatever else to spawn without access to a bank account, without being on the manifest.  There's alot of unintended issues occurring, and potential for even more. A bug fix is good, and im not aware of another PR doing similar

---

<sub> i removed the photo section because what would i take a photo of? The runtime appearing, and then not appearing? I CAN do that, but like- _do i have to_, i promise that's what this 1 line code change does :)

## Changelog
:cl:
fix: fixed overflow jobs not having registered bank accounts and not appearing on manifest.
/:cl:
