### PR TITLE
Fixes assistants not being crew members & bank account IDs not showing up in notes

### DIFF
--- a/code/__DEFINES/jobs.dm
+++ b/code/__DEFINES/jobs.dm
@@ -338,6 +338,8 @@
 #define JOB_CANNOT_OPEN_SLOTS (1<<6)
 /// This job is a head of staff.
 #define JOB_HEAD_OF_STAFF (1<<7)
+/// This job gets a paycheck when they spawn in
+#define JOB_GETS_STARTING_PAYCHECK (1<<8)
 
 DEFINE_BITFIELD(job_flags, list(
 	"JOB_ANNOUNCE_ARRIVAL" = JOB_ANNOUNCE_ARRIVAL,
@@ -351,7 +353,7 @@ DEFINE_BITFIELD(job_flags, list(
 ))
 
 /// Combination flag for jobs which are considered regular crew members of the station.
-#define STATION_JOB_FLAGS (JOB_ANNOUNCE_ARRIVAL|JOB_CREW_MANIFEST|JOB_EQUIP_RANK|JOB_CREW_MEMBER|JOB_NEW_PLAYER_JOINABLE|JOB_ASSIGN_QUIRKS)
+#define STATION_JOB_FLAGS (JOB_ANNOUNCE_ARRIVAL|JOB_CREW_MANIFEST|JOB_EQUIP_RANK|JOB_CREW_MEMBER|JOB_NEW_PLAYER_JOINABLE|JOB_ASSIGN_QUIRKS|JOB_GETS_STARTING_PAYCHECK)
 /// Combination flag for jobs which are considered heads of staff.
 #define HEAD_OF_STAFF_JOB_FLAGS (JOB_CANNOT_OPEN_SLOTS|JOB_HEAD_OF_STAFF)
 

--- a/code/controllers/subsystem/job.dm
+++ b/code/controllers/subsystem/job.dm
@@ -615,7 +615,8 @@ SUBSYSTEM_DEF(job)
 /mob/living/carbon/human/on_job_equipping(datum/job/equipping, joined_late, client/player_client)
 	if(equipping.bank_account_department)
 		var/datum/bank_account/bank_account = new(real_name, equipping)
-		bank_account.payday(STARTING_PAYCHECKS, TRUE)
+		if(equipping.job_flags & JOB_GETS_STARTING_PAYCHECK)
+			bank_account.payday(STARTING_PAYCHECKS, TRUE)
 		mind?.account_id = bank_account.account_id
 		player_client.mob.add_memory("Your account ID is [mind?.account_id].")
 

--- a/code/controllers/subsystem/job.dm
+++ b/code/controllers/subsystem/job.dm
@@ -617,8 +617,9 @@ SUBSYSTEM_DEF(job)
 		var/datum/bank_account/bank_account = new(real_name, equipping)
 		if(equipping.job_flags & JOB_GETS_STARTING_PAYCHECK)
 			bank_account.payday(STARTING_PAYCHECKS, TRUE)
-		mind?.account_id = bank_account.account_id
-		player_client.mob.add_memory("Your account ID is [mind?.account_id].")
+		if(mind)
+			mind.account_id = bank_account.account_id
+			mind.current.add_memory("Your account ID is [mind.account_id].")
 
 	. = dress_up_as_job(job = equipping, visual_only = FALSE, player_client = player_client, joined_late = joined_late)
 

--- a/code/modules/jobs/job_types/assistant.dm
+++ b/code/modules/jobs/job_types/assistant.dm
@@ -16,12 +16,12 @@ Assistant
 	base_access = list()	//See /datum/job/assistant/get_access()
 
 	departments = DEPT_BITFLAG_CIV
-	bank_account_department = NONE // nothing is free for them
+	bank_account_department = ACCOUNT_CIV_BITFLAG
 	payment_per_department = list(ACCOUNT_CIV_ID = PAYCHECK_ASSISTANT) // Get a job. Job reassignment changes your paycheck now. Get over it.
 
 	display_order = JOB_DISPLAY_ORDER_ASSISTANT
 
-	job_flags = STATION_JOB_FLAGS
+	job_flags = STATION_JOB_FLAGS & ~JOB_GETS_STARTING_PAYCHECK // nothing is free for them
 	rpg_title = "Lout"
 
 	species_outfits = list(

--- a/code/modules/jobs/job_types/prisoner.dm
+++ b/code/modules/jobs/job_types/prisoner.dm
@@ -13,7 +13,9 @@
 
 	base_access = list()
 	departments = DEPT_BITFLAG_UNASSIGNED
-	bank_account_department = NONE
+
+	bank_account_department = ACCOUNT_CIV_BITFLAG
+	payment_per_department = list(ACCOUNT_CIV_ID = 0)
 
 	display_order = JOB_DISPLAY_ORDER_PRISONER
 

--- a/code/modules/mob/living/carbon/human/human_helpers.dm
+++ b/code/modules/mob/living/carbon/human/human_helpers.dm
@@ -243,14 +243,8 @@
 
 /mob/living/carbon/human/proc/get_bank_account()
 	RETURN_TYPE(/datum/bank_account)
-	var/datum/bank_account/account
 	var/obj/item/card/id/I = get_idcard()
-
-	if(I?.registered_account)
-		account = I.registered_account
-		return account
-
-	return FALSE
+	return I?.registered_account
 
 /mob/living/carbon/human/proc/get_job_id() //Used in secHUD icon generation (the new one)
 	var/obj/item/card/id/I = wear_id.GetID()


### PR DESCRIPTION
## About The Pull Request

Assistants weren't being assigned a bank account because their `bank_account_department` was set to `NONE`. Before @Tsar-Salat's refactor this meant they didn't spawn with a starting paycheck, but after his rework was merged it broke bank account assignment. My solution was to give them the proper bank account department and to make a new job flag that doesn't give a starting paycheck.

Second issue: bank account IDs were not showing up in character notes. This happened because in the following code we call `add_memory()` on `player_client.mob`, which at this point, is still the authenticated new player. Because `SSticker.create_characters()` was called right before this code, all minds have been transferred to the new characters thus rendering `player_client.mob`'s `mind` var null. Simple solution, use `mind.current` instead.

```dm
/mob/living/carbon/human/on_job_equipping(datum/job/equipping, joined_late, client/player_client)
	if(equipping.bank_account_department)
		var/datum/bank_account/bank_account = new(real_name, equipping)
		bank_account.payday(STARTING_PAYCHECKS, TRUE)
		mind?.account_id = bank_account.account_id
		player_client.mob.add_memory("Your account ID is [mind?.account_id].")
	...
```

## Testing Photographs and Procedure

Roundstart:

<img width="832" height="505" alt="image" src="https://github.com/user-attachments/assets/46a57ab1-1af8-4f92-83f5-6f993f3651c4" />

Latejoin:

<img width="828" height="309" alt="image" src="https://github.com/user-attachments/assets/f3670b13-b6d0-4889-881f-643e8054a4d6" />

## Changelog
:cl:
fix: Fixed assistants not being assigned bank accounts or crew manifest entries
fix: Fixed bank account IDs not showing up in your character's notes when joining roundstart
/:cl:
