### PR TITLE
Brig Medbay access alteration + possible rad sci access alteration

### DIFF
--- a/_maps/_basemap.dm
+++ b/_maps/_basemap.dm
@@ -8,7 +8,7 @@
 // #define FORCE_MAP "deltastation"
 // #define FORCE_MAP "kilostation"
 // #define FORCE_MAP "flandstation"
-#define FORCE_MAP "radstation"
+// #define FORCE_MAP "radstation"
 // #define FORCE_MAP "echostation"
 // #define FORCE_MAP "runtimestation"
 // #define FORCE_MAP "multiz_debug"

--- a/_maps/_basemap.dm
+++ b/_maps/_basemap.dm
@@ -8,7 +8,7 @@
 // #define FORCE_MAP "deltastation"
 // #define FORCE_MAP "kilostation"
 // #define FORCE_MAP "flandstation"
-// #define FORCE_MAP "radstation"
+#define FORCE_MAP "radstation"
 // #define FORCE_MAP "echostation"
 // #define FORCE_MAP "runtimestation"
 // #define FORCE_MAP "multiz_debug"

--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -37718,10 +37718,12 @@
 /obj/machinery/door/airlock/security/glass{
 	name = "Brig Medical Outpost"
 	},
-/obj/effect/mapping_helpers/airlock/access/any/security/detective,
 /obj/effect/turf_decal/stripes/closeup,
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/yellow,
+/obj/effect/mapping_helpers/airlock/access/any/security/general,
+/obj/effect/mapping_helpers/airlock/access/any/security/detective,
+/obj/effect/mapping_helpers/airlock/access/any/security/brig_physician,
 /turf/open/floor/iron/dark,
 /area/station/security/brig)
 "pKd" = (

--- a/_maps/map_files/CardinalStation/CardinalStation.dmm
+++ b/_maps/map_files/CardinalStation/CardinalStation.dmm
@@ -6343,6 +6343,7 @@
 	id = "Prisongate";
 	name = "Prison Blast Door"
 	},
+/obj/effect/mapping_helpers/airlock/access/any/security/brig_physician,
 /turf/open/floor/iron/dark/textured_half,
 /area/station/security/medical)
 "bzt" = (
@@ -41587,6 +41588,7 @@
 /obj/structure/cable/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
+/obj/effect/mapping_helpers/airlock/access/any/security/brig_physician,
 /turf/open/floor/iron/dark/textured_half{
 	dir = 1
 	},

--- a/_maps/map_files/CardinalStation/CardinalStation.dmm
+++ b/_maps/map_files/CardinalStation/CardinalStation.dmm
@@ -63092,12 +63092,10 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
-/obj/structure/closet/toolcloset,
 /obj/structure/sign/warning/vacuum/external{
 	pixel_x = -32
 	},
 /obj/machinery/camera/directional/south,
-/obj/item/storage/belt/utility,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 1
 	},
@@ -81318,6 +81316,8 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 4
 	},
+/obj/structure/closet/toolcloset,
+/obj/item/storage/belt/utility,
 /turf/open/floor/iron/smooth,
 /area/station/maintenance/solars/port/fore)
 "teG" = (

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -64271,6 +64271,9 @@
 /obj/machinery/door/airlock/security/glass{
 	name = "Infirmary"
 	},
+/obj/effect/mapping_helpers/airlock/access/any/security/brig_physician,
+/obj/effect/mapping_helpers/airlock/access/any/security/detective,
+/obj/effect/mapping_helpers/airlock/access/any/security/general,
 /turf/open/floor/iron/dark,
 /area/station/security/brig)
 "wlo" = (

--- a/_maps/map_files/RadStation/RadStation.dmm
+++ b/_maps/map_files/RadStation/RadStation.dmm
@@ -20725,8 +20725,8 @@
 /obj/machinery/door/airlock/research/glass{
 	name = "Research Division"
 	},
-/obj/effect/mapping_helpers/airlock/access/any/science/ordnance,
 /obj/effect/mapping_helpers/airlock/access/any/science/robotics,
+/obj/effect/mapping_helpers/airlock/access/any/science/general,
 /turf/open/floor/iron/white,
 /area/station/science/research)
 "hXh" = (
@@ -25029,8 +25029,8 @@
 /obj/machinery/door/airlock/research/glass{
 	name = "Research Division"
 	},
-/obj/effect/mapping_helpers/airlock/access/any/science/ordnance,
 /obj/effect/mapping_helpers/airlock/access/any/science/robotics,
+/obj/effect/mapping_helpers/airlock/access/any/science/general,
 /turf/open/floor/iron/techmaint,
 /area/station/maintenance/department/science)
 "jEd" = (
@@ -29907,6 +29907,7 @@
 	dir = 1
 	},
 /obj/structure/cable/yellow,
+/obj/effect/mapping_helpers/airlock/access/any/security/brig_physician,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -43558,8 +43559,8 @@
 /obj/machinery/door/airlock/research/glass{
 	name = "Research Division"
 	},
-/obj/effect/mapping_helpers/airlock/access/any/science/ordnance,
 /obj/effect/mapping_helpers/airlock/access/any/science/robotics,
+/obj/effect/mapping_helpers/airlock/access/any/science/general,
 /turf/open/floor/iron/white,
 /area/station/science/research)
 "qvG" = (
@@ -46460,8 +46461,8 @@
 /obj/machinery/door/airlock/research/glass{
 	name = "Research Division"
 	},
-/obj/effect/mapping_helpers/airlock/access/any/science/ordnance,
 /obj/effect/mapping_helpers/airlock/access/any/science/robotics,
+/obj/effect/mapping_helpers/airlock/access/any/science/general,
 /turf/open/floor/iron/white,
 /area/station/science/research)
 "rzy" = (
@@ -50321,8 +50322,8 @@
 /obj/machinery/door/airlock/research/glass{
 	name = "Research Division"
 	},
-/obj/effect/mapping_helpers/airlock/access/any/science/ordnance,
 /obj/effect/mapping_helpers/airlock/access/any/science/robotics,
+/obj/effect/mapping_helpers/airlock/access/any/science/general,
 /turf/open/floor/iron/white,
 /area/station/science/research)
 "sXh" = (


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Brig Physicians were having trouble accessing the door to their own brig medbay. This should address the problem by adding their access to the airlocks (previously some of the maps were security + detective, or solely detective access).

Also possibly addressing a claim that scientists were having trouble accessing the entrance to science on Rad. I am not sure if this has changed anything as I couldn't replicate the problem but they should definitely have access now.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Brig Physicians were having trouble accessing their room so letting them access it is pretty good. 
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>

<img width="258" height="256" alt="BRIGPHYSACCESS" src="https://github.com/user-attachments/assets/a547cb6d-8d89-485d-991c-9921bd2973e4" />


Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>

## Changelog
:cl:
fix: Fixed Brig Physician's not being able to enter the brig medbay on some maps.
fix: Fixed overlapping locker/smes on Cardstation.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
