### PR TITLE
Blast Cannon Fix and Re-Addition to Traitor Uplink

### DIFF
--- a/code/game/objects/items/devices/transfer_valve.dm
+++ b/code/game/objects/items/devices/transfer_valve.dm
@@ -126,23 +126,27 @@
 			if(sensor.on && sensor.visible)
 				add_overlay("proxy_beam")
 
-/// Merge both gases into a single tank. Combine the volume by default. If target tank isn't specified default to tank_two
-/obj/item/transfer_valve/proc/merge_gases(obj/item/tank/target, change_volume = TRUE)
-	if(!target)
-		target = tank_two
-
-	if(!istype(target) || (target != tank_one && target != tank_two))
+/// Merge both gases into a single gas_mixture. Combine the volume by default. If target mixture isn't specified, tank_two's air contents are used
+/obj/item/transfer_valve/proc/merge_gases(datum/gas_mixture/target, change_volume = TRUE)
+	var/target_self = FALSE
+	if(!tank_one || !tank_two)
 		return FALSE
-
 	// Throw both tanks into processing queue
-	var/datum/gas_mixture/target_mix = target.return_air()
-	var/datum/gas_mixture/other_mix
-	other_mix = (target == tank_one ? tank_two : tank_one).return_air()
+	var/datum/gas_mixture/mix_one = tank_one.return_air()
+	var/datum/gas_mixture/mix_two = tank_two.return_air()
+	if(!target || target == mix_one)
+		target = mix_two
+	if(target == mix_two)
+		target_self = TRUE
 
 	if(change_volume)
-		target_mix.volume += other_mix.volume
+		if(!target_self)
+			target.volume += mix_two.volume
+		target.volume += mix_one.volume
 
-	target_mix.merge(other_mix.remove_ratio(1))
+	target.merge(mix_one.remove_ratio(1))
+	if(!target_self)
+		target.merge(mix_two.remove_ratio(1))
 	return TRUE
 
 /obj/item/transfer_valve/proc/split_gases()
@@ -162,7 +166,7 @@
 	it explodes properly when it gets a signal (and it does).
 	*/
 
-/obj/item/transfer_valve/proc/toggle_valve(obj/item/tank/target, change_volume = TRUE)
+/obj/item/transfer_valve/proc/toggle_valve(datum/gas_mixture/target, change_volume = TRUE)
 	if(!valve_open && tank_one && tank_two)
 		var/turf/bombturf = get_turf(src)
 

--- a/code/modules/projectiles/guns/misc/blastcannon.dm
+++ b/code/modules/projectiles/guns/misc/blastcannon.dm
@@ -73,7 +73,8 @@
 /obj/item/gun/blastcannon/proc/calculate_bomb()
 	if(!istype(bomb) || !bomb.ready())
 		return 0
-	var/datum/gas_mixture/temp = new(max(reaction_volume_mod, 0))
+	var/datum/gas_mixture/temp = new(1)
+	temp.volume = max(reaction_volume_mod, 0) // makes gas_mixture/New() stop screaming about zero volume.
 	bomb.merge_gases(temp)
 	if(prereaction)
 		temp.react(src)
@@ -143,7 +144,7 @@ CREATION_TEST_IGNORE_SUBTYPES(/obj/projectile/blastwave)
 	else if(lightr)
 		amount_destruction = EXPLODE_LIGHT
 		wallbreak_chance = 33
-	if(amount_destruction)
+	if(amount_destruction && loc)
 		if(hugbox)
 			loc.contents_explosion(EXPLODE_HEAVY, loc)
 			if(istype(loc, /turf/closed/wall))

--- a/code/modules/projectiles/guns/misc/blastcannon.dm
+++ b/code/modules/projectiles/guns/misc/blastcannon.dm
@@ -73,9 +73,8 @@
 /obj/item/gun/blastcannon/proc/calculate_bomb()
 	if(!istype(bomb) || !bomb.ready())
 		return 0
-	var/datum/gas_mixture/temp = new(1)
-	temp.volume = max(reaction_volume_mod, 0) // makes gas_mixture/New() stop screaming about zero volume.
-	bomb.merge_gases(temp)
+	var/datum/gas_mixture/temp = new(bomb.tank_one.air_contents.volume + bomb.tank_two.air_contents.volume + max(reaction_volume_mod, 0))
+	bomb.merge_gases(temp, FALSE)
 	if(prereaction)
 		temp.react(src)
 		var/prereaction_pressure = temp.return_pressure()

--- a/code/modules/projectiles/guns/misc/blastcannon.dm
+++ b/code/modules/projectiles/guns/misc/blastcannon.dm
@@ -10,7 +10,7 @@
 	item_flags = NONE
 	clumsy_check = FALSE
 
-	var/hugbox = TRUE
+	var/hugbox = FALSE
 	var/max_power = INFINITY
 	var/reaction_volume_mod = 0
 	var/reaction_cycles = 3				//How many times gases react() before calculation. Very finnicky value, do not mess with without good reason.

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -2186,7 +2186,6 @@ GLOBAL_LIST_INIT(illegal_tech_blacklist, typecacheof(list(
 	item = /obj/item/gun/blastcannon
 	cost = 14							//High cost because of the potential for extreme damage in the hands of a skilled scientist.
 	restricted_roles = list(JOB_NAME_RESEARCHDIRECTOR, JOB_NAME_SCIENTIST)
-	disabled = TRUE // ! #11288 - Reported as non-functional
 	reputation_required = REPUTATION_EXCELLENT
 
 /datum/uplink_item/role_restricted/crushmagboots


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Reworks transfer_valve/merge_gases() to work off of a target gas_mixture instead of a gas tank, and lets it merge into a gas mixture that is not in one of the two attached tanks. This allows the blast cannon's bomb strength calculation to work properly again, as it used a temporary gas_mixture to mix the tanks in to prevent the ttv from actually exploding. I also fixed two other runtime errors, ignoring the runtime when making a gas_mixture of zero volume which is intentional here, and making a check on the blast wave projectile to stop exploding null turfs when leaving the borders of the  Z-level. I also readded the blast cannon to the traitor uplink so it can be used again.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
The blast cannon is a really fun tool for a traitor scientist to use that let them use TTVs in more creative ways, as well as rewarding technical knowledge of atmos and toxins beyond the explosive maxcap and the doppler sensor array's maximum payout. It can be used to breach into restricted rooms, snipe targets from across the map, or just be a heavy single-shot weapon to secure a kill. Compared to just a TTV, It's less destructive to each individual location, so engineering can patch up holes faster, but also has more widespread devastation, having more impact on the round.  
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
I tested TTVs and the blast cannon with a mixture of 33% trit and 67% oxy at 43K in one tank and pure plasma over 75000K in the other.
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>TTV and Blast Cannon test</summary>
<img width="364" height="321" alt="dreamseeker_e1gLwqlgA0_compressed" src="https://github.com/user-attachments/assets/3c5d41d7-c61a-40c6-8429-b27957119c4b" />
</details>

## Changelog
:cl:
add: Readded the blast cannon to the traitor uplink
fix: Fixed the blast cannon being unable to compute bomb strength
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
