### PR TITLE
Fixes Lavaland Syndie base being unpowered

### DIFF
--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_syndicate_base1.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_syndicate_base1.dmm
@@ -10,27 +10,27 @@
 /area/lavaland/surface/outdoors)
 "ae" = (
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
-/area/ruin/lavaland/syndicate_lava_base/testlab)
+/area/ruin/syndicate_lava_base)
 "af" = (
 /obj/machinery/light/small{
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
-/area/ruin/lavaland/syndicate_lava_base/main)
+/area/ruin/syndicate_lava_base)
 "ak" = (
 /obj/machinery/vending/boozeomat/syndicate_access,
 /turf/open/floor/plating,
-/area/ruin/lavaland/syndicate_lava_base/bar)
+/area/ruin/syndicate_lava_base)
 "ap" = (
 /obj/machinery/light/small{
 	dir = 1
 	},
 /turf/open/floor/engine,
-/area/ruin/lavaland/syndicate_lava_base/testlab)
+/area/ruin/syndicate_lava_base)
 "aq" = (
 /turf/open/floor/engine,
-/area/ruin/lavaland/syndicate_lava_base/testlab)
+/area/ruin/syndicate_lava_base)
 "ar" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/red/line{
@@ -38,10 +38,7 @@
 	},
 /obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/main)
-"as" = (
-/turf/closed/wall/mineral/plastitanium/nodiagonal,
-/area/ruin/lavaland/syndicate_lava_base/chemistry)
+/area/ruin/syndicate_lava_base)
 "az" = (
 /obj/structure/table/reinforced,
 /obj/effect/decal/cleanable/dirt,
@@ -51,14 +48,14 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/testlab)
+/area/ruin/syndicate_lava_base)
 "aF" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/engine,
-/area/ruin/lavaland/syndicate_lava_base/testlab)
+/area/ruin/syndicate_lava_base)
 "aL" = (
 /turf/closed/wall/mineral/plastitanium/explosive,
-/area/ruin/lavaland/syndicate_lava_base/testlab)
+/area/ruin/syndicate_lava_base)
 "aM" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -67,7 +64,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/chem_dispenser/fullupgrade,
 /turf/open/floor/iron,
-/area/ruin/lavaland/syndicate_lava_base/chemistry)
+/area/ruin/syndicate_lava_base)
 "aP" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/cup/rag{
@@ -84,7 +81,7 @@
 	pixel_y = -2
 	},
 /turf/open/floor/wood,
-/area/ruin/lavaland/syndicate_lava_base/bar)
+/area/ruin/syndicate_lava_base)
 "bg" = (
 /obj/structure/table/reinforced,
 /obj/item/radio/intercom{
@@ -94,7 +91,7 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/telecomms)
+/area/ruin/syndicate_lava_base)
 "bs" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -103,15 +100,15 @@
 	dir = 8
 	},
 /turf/open/floor/iron/white/side,
-/area/ruin/lavaland/syndicate_lava_base/medbay)
+/area/ruin/syndicate_lava_base)
 "bv" = (
 /obj/machinery/air_sensor,
 /turf/open/floor/engine/o2,
-/area/ruin/lavaland/syndicate_lava_base/engineering)
+/area/ruin/syndicate_lava_base)
 "bA" = (
 /obj/effect/turf_decal/tile/red/half/contrasted,
 /turf/open/floor/iron,
-/area/ruin/lavaland/syndicate_lava_base/main)
+/area/ruin/syndicate_lava_base)
 "bE" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
 /obj/machinery/firealarm/directional/west,
@@ -120,18 +117,18 @@
 	pixel_y = -30
 	},
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/telecomms)
+/area/ruin/syndicate_lava_base)
 "bF" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/bar)
+/area/ruin/syndicate_lava_base)
 "bN" = (
 /obj/structure/cable/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/plating,
-/area/ruin/lavaland/syndicate_lava_base/main)
+/area/ruin/syndicate_lava_base)
 "bS" = (
 /obj/structure/closet/secure_closet/medical1{
 	req_access = null;
@@ -145,7 +142,7 @@
 /turf/open/floor/iron/white/side{
 	dir = 9
 	},
-/area/ruin/lavaland/syndicate_lava_base/medbay)
+/area/ruin/syndicate_lava_base)
 "cd" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/structure/cable/yellow,
@@ -153,14 +150,14 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/plating,
-/area/ruin/lavaland/syndicate_lava_base/dormitories)
+/area/ruin/syndicate_lava_base)
 "ch" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/ruin/lavaland/syndicate_lava_base/cargo)
+/area/ruin/syndicate_lava_base)
 "ci" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -169,7 +166,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/ruin/lavaland/syndicate_lava_base/main)
+/area/ruin/syndicate_lava_base)
 "cn" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -27;
@@ -181,21 +178,13 @@
 	dir = 1
 	},
 /turf/open/floor/iron,
-/area/ruin/lavaland/syndicate_lava_base/engineering)
-"cs" = (
-/obj/machinery/door/airlock/maintenance,
-/obj/structure/cable/yellow,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
-/turf/open/floor/plating,
-/area/ruin/lavaland/syndicate_lava_base/main)
+/area/ruin/syndicate_lava_base)
 "cu" = (
 /obj/structure/table/wood,
 /obj/item/ammo_box/magazine/m10mm,
 /obj/item/ammo_box/magazine/sniper_rounds,
 /turf/open/floor/carpet/grimy,
-/area/ruin/lavaland/syndicate_lava_base/dormitories)
+/area/ruin/syndicate_lava_base)
 "cw" = (
 /obj/structure/railing{
 	dir = 9
@@ -206,13 +195,13 @@
 /obj/structure/cable/yellow,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
-/area/ruin/lavaland/syndicate_lava_base/science)
+/area/ruin/syndicate_lava_base)
 "cz" = (
 /obj/effect/mob_spawn/human/lavaland_syndicate/comms{
 	dir = 8
 	},
 /turf/open/floor/carpet/grimy,
-/area/ruin/lavaland/syndicate_lava_base/dormitories)
+/area/ruin/syndicate_lava_base)
 "cA" = (
 /obj/structure/table/reinforced,
 /obj/item/book/manual/wiki/chemistry,
@@ -221,7 +210,7 @@
 /obj/item/clothing/glasses/science,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
-/area/ruin/lavaland/syndicate_lava_base/chemistry)
+/area/ruin/syndicate_lava_base)
 "cC" = (
 /obj/structure/cable/yellow,
 /obj/effect/decal/cleanable/dirt,
@@ -229,7 +218,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/plating,
-/area/ruin/lavaland/syndicate_lava_base/science)
+/area/ruin/syndicate_lava_base)
 "cG" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -238,14 +227,14 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
-/area/ruin/lavaland/syndicate_lava_base/chemistry)
+/area/ruin/syndicate_lava_base)
 "cH" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/brown/anticorner/contrasted{
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/ruin/lavaland/syndicate_lava_base/main)
+/area/ruin/syndicate_lava_base)
 "cI" = (
 /obj/effect/mapping_helpers/no_lava,
 /obj/structure/railing{
@@ -258,7 +247,7 @@
 	dir = 4
 	},
 /turf/open/floor/engine,
-/area/ruin/lavaland/syndicate_lava_base/testlab)
+/area/ruin/syndicate_lava_base)
 "cS" = (
 /obj/structure/bed/roller,
 /obj/machinery/iv_drip,
@@ -268,31 +257,31 @@
 	},
 /obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/testlab)
+/area/ruin/syndicate_lava_base)
 "db" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/bar)
+/area/ruin/syndicate_lava_base)
 "dc" = (
 /obj/machinery/light/small{
 	dir = 8
 	},
 /turf/open/floor/engine,
-/area/ruin/lavaland/syndicate_lava_base/testlab)
+/area/ruin/syndicate_lava_base)
 "de" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/engine,
-/area/ruin/lavaland/syndicate_lava_base/testlab)
+/area/ruin/syndicate_lava_base)
 "di" = (
 /obj/machinery/light/small{
 	dir = 4
 	},
 /turf/open/floor/engine,
-/area/ruin/lavaland/syndicate_lava_base/testlab)
+/area/ruin/syndicate_lava_base)
 "dm" = (
 /obj/machinery/door/airlock{
 	name = "Cabin 3"
@@ -302,7 +291,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/iron,
-/area/ruin/lavaland/syndicate_lava_base/dormitories)
+/area/ruin/syndicate_lava_base)
 "dv" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
@@ -310,7 +299,7 @@
 /obj/machinery/chem_heater,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
-/area/ruin/lavaland/syndicate_lava_base/chemistry)
+/area/ruin/syndicate_lava_base)
 "dw" = (
 /obj/structure/chair/office/light{
 	dir = 1
@@ -318,7 +307,7 @@
 /obj/effect/turf_decal/bot,
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron,
-/area/ruin/lavaland/syndicate_lava_base/chemistry)
+/area/ruin/syndicate_lava_base)
 "dx" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
@@ -326,10 +315,7 @@
 /obj/structure/closet/crate/bin,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
-/area/ruin/lavaland/syndicate_lava_base/chemistry)
-"dy" = (
-/turf/closed/wall/mineral/plastitanium/nodiagonal,
-/area/ruin/lavaland/syndicate_lava_base/cargo)
+/area/ruin/syndicate_lava_base)
 "dA" = (
 /obj/structure/cable/yellow,
 /obj/effect/decal/cleanable/dirt,
@@ -339,24 +325,24 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/plating,
-/area/ruin/lavaland/syndicate_lava_base/main)
+/area/ruin/syndicate_lava_base)
 "dB" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/ruin/lavaland/syndicate_lava_base/chemistry)
+/area/ruin/syndicate_lava_base)
 "dC" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
-/area/ruin/lavaland/syndicate_lava_base/chemistry)
+/area/ruin/syndicate_lava_base)
 "dD" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/plating,
-/area/ruin/lavaland/syndicate_lava_base/main)
+/area/ruin/syndicate_lava_base)
 "dF" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -369,7 +355,7 @@
 	dir = 4
 	},
 /turf/open/floor/engine,
-/area/ruin/lavaland/syndicate_lava_base/engineering)
+/area/ruin/syndicate_lava_base)
 "dK" = (
 /obj/effect/turf_decal/box/white/corners{
 	dir = 1
@@ -392,7 +378,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/cargo)
+/area/ruin/syndicate_lava_base)
 "dL" = (
 /obj/machinery/airalarm/directional/north,
 /obj/effect/mapping_helpers/airalarm/syndicate_access,
@@ -432,7 +418,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/cargo)
+/area/ruin/syndicate_lava_base)
 "dM" = (
 /obj/effect/turf_decal/box/white/corners{
 	dir = 4
@@ -450,24 +436,21 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/cargo)
-"dP" = (
-/turf/closed/wall/mineral/plastitanium/explosive,
-/area/ruin/lavaland/syndicate_lava_base/cargo)
+/area/ruin/syndicate_lava_base)
 "dQ" = (
 /obj/structure/sign/warning/secure_area,
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
-/area/ruin/lavaland/syndicate_lava_base/testlab)
+/area/ruin/syndicate_lava_base)
 "dV" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/bar)
+/area/ruin/syndicate_lava_base)
 "dY" = (
 /obj/structure/chair{
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/ruin/lavaland/syndicate_lava_base/chemistry)
+/area/ruin/syndicate_lava_base)
 "eb" = (
 /obj/structure/closet/crate,
 /obj/item/storage/toolbox/electrical{
@@ -475,10 +458,7 @@
 	},
 /obj/item/storage/toolbox/mechanical,
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/cargo)
-"eh" = (
-/turf/closed/wall/mineral/plastitanium/nodiagonal,
-/area/ruin/lavaland/syndicate_lava_base/science)
+/area/ruin/syndicate_lava_base)
 "el" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/railing{
@@ -498,7 +478,7 @@
 	},
 /obj/item/stack/tile/iron,
 /turf/open/floor/iron,
-/area/ruin/lavaland/syndicate_lava_base/science)
+/area/ruin/syndicate_lava_base)
 "en" = (
 /obj/effect/mapping_helpers/airlock/locked,
 /obj/machinery/door/airlock/vault{
@@ -510,7 +490,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/main)
+/area/ruin/syndicate_lava_base)
 "eo" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/neutral{
@@ -520,7 +500,7 @@
 /obj/machinery/airalarm/directional/north,
 /obj/effect/mapping_helpers/airalarm/syndicate_access,
 /turf/open/floor/iron,
-/area/ruin/lavaland/syndicate_lava_base/dormitories)
+/area/ruin/syndicate_lava_base)
 "eq" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
@@ -529,7 +509,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/iron,
-/area/ruin/lavaland/syndicate_lava_base/dormitories)
+/area/ruin/syndicate_lava_base)
 "es" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
@@ -537,13 +517,13 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/crate/bin,
 /turf/open/floor/iron,
-/area/ruin/lavaland/syndicate_lava_base/chemistry)
+/area/ruin/syndicate_lava_base)
 "et" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
 /turf/open/floor/iron,
-/area/ruin/lavaland/syndicate_lava_base/chemistry)
+/area/ruin/syndicate_lava_base)
 "eu" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
@@ -552,7 +532,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
-/area/ruin/lavaland/syndicate_lava_base/chemistry)
+/area/ruin/syndicate_lava_base)
 "eC" = (
 /obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/locked,
@@ -561,12 +541,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/engine,
-/area/ruin/lavaland/syndicate_lava_base/engineering)
+/area/ruin/syndicate_lava_base)
 "eD" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
-/area/ruin/lavaland/syndicate_lava_base/cargo)
+/area/ruin/syndicate_lava_base)
 "eE" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -576,16 +556,16 @@
 /obj/item/wrench,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/mineral/plastitanium,
-/area/ruin/lavaland/syndicate_lava_base/cargo)
+/area/ruin/syndicate_lava_base)
 "eP" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/iron,
-/area/ruin/lavaland/syndicate_lava_base/arrivals)
+/area/ruin/syndicate_lava_base)
 "eQ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /turf/open/floor/iron,
-/area/ruin/lavaland/syndicate_lava_base/chemistry)
+/area/ruin/syndicate_lava_base)
 "eS" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -593,13 +573,13 @@
 /obj/machinery/chem_master,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
-/area/ruin/lavaland/syndicate_lava_base/chemistry)
+/area/ruin/syndicate_lava_base)
 "eT" = (
 /obj/effect/turf_decal/bot,
 /obj/structure/chair/office/light,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
-/area/ruin/lavaland/syndicate_lava_base/chemistry)
+/area/ruin/syndicate_lava_base)
 "eU" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -608,7 +588,7 @@
 /obj/machinery/chem_dispenser/fullupgrade,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
-/area/ruin/lavaland/syndicate_lava_base/chemistry)
+/area/ruin/syndicate_lava_base)
 "eX" = (
 /obj/effect/turf_decal/box/white/corners{
 	dir = 1
@@ -624,7 +604,7 @@
 /obj/item/clothing/mask/gas,
 /obj/item/clothing/mask/gas,
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/cargo)
+/area/ruin/syndicate_lava_base)
 "eY" = (
 /obj/effect/turf_decal/box/white/corners{
 	dir = 4
@@ -644,7 +624,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/cargo)
+/area/ruin/syndicate_lava_base)
 "fb" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/crate/bin,
@@ -652,14 +632,14 @@
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/ruin/lavaland/syndicate_lava_base/cargo)
+/area/ruin/syndicate_lava_base)
 "fd" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
-/area/ruin/lavaland/syndicate_lava_base/cargo)
+/area/ruin/syndicate_lava_base)
 "fe" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -668,34 +648,34 @@
 /obj/machinery/cell_charger,
 /obj/item/stock_parts/cell/high/plus,
 /turf/open/floor/mineral/plastitanium,
-/area/ruin/lavaland/syndicate_lava_base/cargo)
+/area/ruin/syndicate_lava_base)
 "fi" = (
 /obj/effect/mapping_helpers/no_lava,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
 /turf/open/floor/plating,
-/area/ruin/lavaland/syndicate_lava_base/main)
+/area/ruin/syndicate_lava_base)
 "fk" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/iron,
-/area/ruin/lavaland/syndicate_lava_base/cargo)
+/area/ruin/syndicate_lava_base)
 "fl" = (
 /obj/machinery/light/small{
 	dir = 1
 	},
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/bar)
+/area/ruin/syndicate_lava_base)
 "fp" = (
 /obj/machinery/smartfridge/chemistry/preloaded,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
-/area/ruin/lavaland/syndicate_lava_base/chemistry)
+/area/ruin/syndicate_lava_base)
 "fr" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
@@ -707,7 +687,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/iron,
-/area/ruin/lavaland/syndicate_lava_base/engineering)
+/area/ruin/syndicate_lava_base)
 "fs" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -723,7 +703,7 @@
 /turf/open/floor/iron/white/side{
 	dir = 8
 	},
-/area/ruin/lavaland/syndicate_lava_base/medbay)
+/area/ruin/syndicate_lava_base)
 "ft" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
@@ -732,7 +712,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/iron,
-/area/ruin/lavaland/syndicate_lava_base/dormitories)
+/area/ruin/syndicate_lava_base)
 "fu" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 4
@@ -741,7 +721,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron,
-/area/ruin/lavaland/syndicate_lava_base/arrivals)
+/area/ruin/syndicate_lava_base)
 "fw" = (
 /obj/effect/turf_decal/stripes/corner,
 /obj/machinery/firealarm{
@@ -750,26 +730,22 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
-/area/ruin/lavaland/syndicate_lava_base/cargo)
-"fx" = (
-/obj/structure/sign/warning/secure_area,
-/turf/closed/wall/mineral/plastitanium/nodiagonal,
-/area/ruin/lavaland/syndicate_lava_base/cargo)
+/area/ruin/syndicate_lava_base)
 "fy" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/engine,
-/area/ruin/lavaland/syndicate_lava_base/testlab)
+/area/ruin/syndicate_lava_base)
 "fD" = (
 /obj/structure/sign/warning/biohazard,
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
-/area/ruin/lavaland/syndicate_lava_base/science)
+/area/ruin/syndicate_lava_base)
 "fL" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 1
 	},
 /turf/open/floor/iron,
-/area/ruin/lavaland/syndicate_lava_base/arrivals)
+/area/ruin/syndicate_lava_base)
 "fV" = (
 /obj/structure/table,
 /obj/effect/decal/cleanable/dirt,
@@ -788,16 +764,16 @@
 	dir = 8
 	},
 /turf/open/floor/iron/white/side,
-/area/ruin/lavaland/syndicate_lava_base/main)
+/area/ruin/syndicate_lava_base)
 "fW" = (
 /obj/structure/chair,
 /obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/bar)
+/area/ruin/syndicate_lava_base)
 "fX" = (
 /obj/structure/sink/directional/west,
 /turf/open/floor/iron/white,
-/area/ruin/lavaland/syndicate_lava_base/bar)
+/area/ruin/syndicate_lava_base)
 "ga" = (
 /obj/structure/table/wood,
 /obj/item/ammo_box/magazine/m10mm,
@@ -805,7 +781,7 @@
 /obj/machinery/airalarm/directional/north,
 /obj/effect/mapping_helpers/airalarm/syndicate_access,
 /turf/open/floor/carpet/grimy,
-/area/ruin/lavaland/syndicate_lava_base/dormitories)
+/area/ruin/syndicate_lava_base)
 "gb" = (
 /obj/structure/table,
 /obj/item/paper_bin,
@@ -815,7 +791,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron,
-/area/ruin/lavaland/syndicate_lava_base/cargo)
+/area/ruin/syndicate_lava_base)
 "gc" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -825,7 +801,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
-/area/ruin/lavaland/syndicate_lava_base/cargo)
+/area/ruin/syndicate_lava_base)
 "gd" = (
 /obj/machinery/door/airlock/external,
 /obj/effect/mapping_helpers/airlock/access/all/syndicate/general,
@@ -834,7 +810,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/ruin/lavaland/syndicate_lava_base/cargo)
+/area/ruin/syndicate_lava_base)
 "ge" = (
 /obj/structure/table/optable,
 /obj/item/surgical_drapes,
@@ -843,14 +819,14 @@
 /turf/open/floor/iron/white/side{
 	dir = 4
 	},
-/area/ruin/lavaland/syndicate_lava_base/medbay)
+/area/ruin/syndicate_lava_base)
 "gf" = (
 /obj/structure/sign/warning/vacuum{
 	pixel_y = -32
 	},
 /obj/machinery/light/small,
 /turf/open/floor/plating,
-/area/ruin/lavaland/syndicate_lava_base/cargo)
+/area/ruin/syndicate_lava_base)
 "gg" = (
 /obj/structure/sign/warning/fire{
 	pixel_y = 32
@@ -859,7 +835,7 @@
 	pixel_y = -32
 	},
 /turf/open/floor/plating,
-/area/ruin/lavaland/syndicate_lava_base/cargo)
+/area/ruin/syndicate_lava_base)
 "gh" = (
 /obj/structure/fans/tiny,
 /obj/machinery/door/airlock/external,
@@ -868,14 +844,14 @@
 	dir = 8
 	},
 /turf/open/floor/plating,
-/area/ruin/lavaland/syndicate_lava_base/cargo)
+/area/ruin/syndicate_lava_base)
 "gm" = (
 /obj/structure/cable/yellow,
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
 /turf/open/floor/iron,
-/area/ruin/lavaland/syndicate_lava_base/arrivals)
+/area/ruin/syndicate_lava_base)
 "gp" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -887,7 +863,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/iron,
-/area/ruin/lavaland/syndicate_lava_base/main)
+/area/ruin/syndicate_lava_base)
 "gA" = (
 /obj/effect/turf_decal/delivery,
 /obj/machinery/door/firedoor,
@@ -900,7 +876,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/iron,
-/area/ruin/lavaland/syndicate_lava_base/engineering)
+/area/ruin/syndicate_lava_base)
 "gN" = (
 /obj/effect/turf_decal/delivery,
 /obj/structure/frame/machine,
@@ -908,11 +884,11 @@
 	dir = 1
 	},
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/science)
+/area/ruin/syndicate_lava_base)
 "gO" = (
 /obj/structure/sign/departments/cargo,
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
-/area/ruin/lavaland/syndicate_lava_base/cargo)
+/area/ruin/syndicate_lava_base)
 "gP" = (
 /obj/machinery/photocopier,
 /obj/effect/decal/cleanable/dirt,
@@ -920,11 +896,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron,
-/area/ruin/lavaland/syndicate_lava_base/cargo)
-"gQ" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
-/area/ruin/lavaland/syndicate_lava_base/cargo)
+/area/ruin/syndicate_lava_base)
 "gS" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
@@ -939,7 +911,7 @@
 	req_access_txt = "150"
 	},
 /turf/open/floor/iron,
-/area/ruin/lavaland/syndicate_lava_base/cargo)
+/area/ruin/syndicate_lava_base)
 "gZ" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
@@ -949,10 +921,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
-/area/ruin/lavaland/syndicate_lava_base/main)
-"ha" = (
-/turf/closed/wall/mineral/plastitanium/nodiagonal,
-/area/ruin/lavaland/syndicate_lava_base/main)
+/area/ruin/syndicate_lava_base)
 "hb" = (
 /obj/structure/fans/tiny,
 /obj/machinery/door/airlock/external,
@@ -961,20 +930,20 @@
 	cycle_id = "syndi-outpost2"
 	},
 /turf/open/floor/plating,
-/area/ruin/lavaland/syndicate_lava_base/main)
+/area/ruin/syndicate_lava_base)
 "hd" = (
 /obj/effect/turf_decal/tile/red,
 /turf/open/floor/iron,
-/area/ruin/lavaland/syndicate_lava_base/main)
+/area/ruin/syndicate_lava_base)
 "hi" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/ruin/lavaland/syndicate_lava_base/main)
+/area/ruin/syndicate_lava_base)
 "hl" = (
 /turf/open/floor/iron,
-/area/ruin/lavaland/syndicate_lava_base/cargo)
+/area/ruin/syndicate_lava_base)
 "ho" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -991,13 +960,7 @@
 	shuttleId = "syndie_cargo"
 	},
 /turf/open/floor/mineral/plastitanium,
-/area/ruin/lavaland/syndicate_lava_base/cargo)
-"hz" = (
-/turf/closed/wall/mineral/plastitanium/nodiagonal,
-/area/ruin/lavaland/syndicate_lava_base/dormitories)
-"hA" = (
-/turf/closed/wall/mineral/plastitanium/explosive,
-/area/ruin/lavaland/syndicate_lava_base/engineering)
+/area/ruin/syndicate_lava_base)
 "hD" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -1006,65 +969,54 @@
 /obj/item/storage/belt/utility,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/mineral/plastitanium,
-/area/ruin/lavaland/syndicate_lava_base/cargo)
+/area/ruin/syndicate_lava_base)
 "hN" = (
 /obj/structure/cable/yellow,
 /turf/open/floor/iron/white,
-/area/ruin/lavaland/syndicate_lava_base/bar)
-"hO" = (
-/turf/closed/wall/mineral/plastitanium/explosive,
-/area/ruin/lavaland/syndicate_lava_base/dormitories)
+/area/ruin/syndicate_lava_base)
 "hQ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
 /obj/machinery/modular_fabricator/autolathe/hacked,
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/main)
+/area/ruin/syndicate_lava_base)
 "hR" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/brown{
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/ruin/lavaland/syndicate_lava_base/main)
+/area/ruin/syndicate_lava_base)
 "hW" = (
 /obj/machinery/porta_turret/syndicate{
 	dir = 10
 	},
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
-/area/ruin/lavaland/syndicate_lava_base/main)
+/area/ruin/syndicate_lava_base)
 "id" = (
 /obj/structure/cable/yellow,
 /obj/effect/turf_decal/tile/red/half/contrasted{
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/ruin/lavaland/syndicate_lava_base/arrivals)
-"if" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
-/area/ruin/lavaland/syndicate_lava_base/main)
+/area/ruin/syndicate_lava_base)
 "ik" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/ruin/lavaland/syndicate_lava_base/main)
+/area/ruin/syndicate_lava_base)
 "ip" = (
 /obj/effect/turf_decal/stripes/red/corner,
 /turf/open/floor/iron,
-/area/ruin/lavaland/syndicate_lava_base/main)
-"iq" = (
-/obj/structure/sign/warning/secure_area,
-/turf/closed/wall/mineral/plastitanium/nodiagonal,
-/area/ruin/lavaland/syndicate_lava_base/main)
+/area/ruin/syndicate_lava_base)
 "ir" = (
 /obj/machinery/door/poddoor{
 	id = "lavalandsyndi_cargo"
 	},
 /obj/effect/spawner/structure/window/reinforced/plasma/plastitanium,
 /turf/open/floor/plating,
-/area/ruin/lavaland/syndicate_lava_base/cargo)
+/area/ruin/syndicate_lava_base)
 "is" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -1081,23 +1033,19 @@
 	req_access_txt = "150"
 	},
 /turf/open/floor/circuit/red,
-/area/ruin/lavaland/syndicate_lava_base/main)
+/area/ruin/syndicate_lava_base)
 "iz" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/ruin/lavaland/syndicate_lava_base/dormitories)
+/area/ruin/syndicate_lava_base)
 "iA" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
 	},
 /turf/open/floor/wood,
-/area/ruin/lavaland/syndicate_lava_base/bar)
-"iC" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
-/area/ruin/lavaland/syndicate_lava_base/dormitories)
+/area/ruin/syndicate_lava_base)
 "iH" = (
 /obj/effect/turf_decal/stripes/red/line{
 	dir = 4
@@ -1106,19 +1054,16 @@
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/ruin/lavaland/syndicate_lava_base/main)
+/area/ruin/syndicate_lava_base)
 "iJ" = (
 /turf/open/floor/circuit/red,
-/area/ruin/lavaland/syndicate_lava_base/main)
+/area/ruin/syndicate_lava_base)
 "iK" = (
 /obj/machinery/syndicatebomb/self_destruct{
 	anchored = 1
 	},
 /turf/open/floor/circuit/red,
-/area/ruin/lavaland/syndicate_lava_base/main)
-"iN" = (
-/turf/closed/wall/mineral/plastitanium/explosive,
-/area/ruin/lavaland/syndicate_lava_base/main)
+/area/ruin/syndicate_lava_base)
 "iR" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/medical{
@@ -1130,7 +1075,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/iron/white,
-/area/ruin/lavaland/syndicate_lava_base/chemistry)
+/area/ruin/syndicate_lava_base)
 "ja" = (
 /obj/effect/turf_decal/stripes/red/corner{
 	dir = 4
@@ -1145,7 +1090,7 @@
 	specialfunctions = 4
 	},
 /turf/open/floor/iron,
-/area/ruin/lavaland/syndicate_lava_base/main)
+/area/ruin/syndicate_lava_base)
 "jb" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/medical/glass{
@@ -1155,14 +1100,11 @@
 	dir = 1
 	},
 /turf/open/floor/iron,
-/area/ruin/lavaland/syndicate_lava_base/medbay)
+/area/ruin/syndicate_lava_base)
 "jc" = (
 /obj/machinery/light/small,
 /turf/open/floor/circuit/red,
-/area/ruin/lavaland/syndicate_lava_base/main)
-"jj" = (
-/turf/open/floor/iron,
-/area/ruin/lavaland/syndicate_lava_base/main)
+/area/ruin/syndicate_lava_base)
 "jm" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
@@ -1171,30 +1113,24 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/testlab)
+/area/ruin/syndicate_lava_base)
 "jn" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/effect/mapping_helpers/airlock/access/all/syndicate/general,
 /obj/structure/cable/yellow,
 /turf/open/floor/plating,
-/area/ruin/lavaland/syndicate_lava_base/bar)
-"ju" = (
-/turf/closed/wall/mineral/plastitanium/nodiagonal,
-/area/ruin/lavaland/syndicate_lava_base/engineering)
-"jy" = (
-/turf/closed/wall/mineral/plastitanium/nodiagonal,
-/area/ruin/lavaland/syndicate_lava_base/bar)
+/area/ruin/syndicate_lava_base)
 "jz" = (
 /obj/structure/window/reinforced/spawner/directional/west,
 /obj/machinery/deepfryer,
 /turf/open/floor/iron/white,
-/area/ruin/lavaland/syndicate_lava_base/bar)
+/area/ruin/syndicate_lava_base)
 "jK" = (
 /obj/structure/cable/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/iron,
-/area/ruin/lavaland/syndicate_lava_base/chemistry)
+/area/ruin/syndicate_lava_base)
 "jO" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 25
@@ -1202,10 +1138,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/bar)
-"jP" = (
-/turf/closed/wall/mineral/plastitanium/explosive,
-/area/ruin/lavaland/syndicate_lava_base/bar)
+/area/ruin/syndicate_lava_base)
 "jR" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -1214,20 +1147,20 @@
 	dir = 1
 	},
 /turf/open/floor/iron,
-/area/ruin/lavaland/syndicate_lava_base/main)
+/area/ruin/syndicate_lava_base)
 "jU" = (
 /obj/structure/sign/departments/engineering,
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
-/area/ruin/lavaland/syndicate_lava_base/engineering)
+/area/ruin/syndicate_lava_base)
 "jY" = (
 /obj/structure/chair{
 	dir = 1
 	},
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/bar)
+/area/ruin/syndicate_lava_base)
 "jZ" = (
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/bar)
+/area/ruin/syndicate_lava_base)
 "kj" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 8
@@ -1236,20 +1169,20 @@
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/ruin/lavaland/syndicate_lava_base/main)
+/area/ruin/syndicate_lava_base)
 "kp" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 4
 	},
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/bar)
+/area/ruin/syndicate_lava_base)
 "ks" = (
 /obj/structure/reagent_dispensers/fueltank,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
-/area/ruin/lavaland/syndicate_lava_base/main)
+/area/ruin/syndicate_lava_base)
 "kt" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -1259,14 +1192,14 @@
 /obj/item/mop,
 /obj/item/reagent_containers/cup/bucket,
 /turf/open/floor/plating,
-/area/ruin/lavaland/syndicate_lava_base/main)
+/area/ruin/syndicate_lava_base)
 "ku" = (
 /obj/structure/cable/yellow,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/plating,
-/area/ruin/lavaland/syndicate_lava_base/main)
+/area/ruin/syndicate_lava_base)
 "kw" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/caution/stand_clear{
@@ -1276,7 +1209,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/iron,
-/area/ruin/lavaland/syndicate_lava_base/arrivals)
+/area/ruin/syndicate_lava_base)
 "kA" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -1291,13 +1224,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/iron,
-/area/ruin/lavaland/syndicate_lava_base/arrivals)
+/area/ruin/syndicate_lava_base)
 "kH" = (
 /obj/structure/chair{
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/bar)
+/area/ruin/syndicate_lava_base)
 "kJ" = (
 /obj/machinery/computer/security/telescreen/entertainment{
 	pixel_x = -30
@@ -1305,19 +1238,16 @@
 /obj/structure/bookcase/random,
 /obj/machinery/light/small,
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/bar)
+/area/ruin/syndicate_lava_base)
 "kL" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/yellow/half/contrasted,
 /turf/open/floor/iron,
-/area/ruin/lavaland/syndicate_lava_base/main)
-"kQ" = (
-/turf/closed/wall/mineral/plastitanium/nodiagonal,
-/area/ruin/lavaland/syndicate_lava_base/medbay)
+/area/ruin/syndicate_lava_base)
 "kT" = (
 /obj/structure/sign/departments/medbay/alt,
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
-/area/ruin/lavaland/syndicate_lava_base/medbay)
+/area/ruin/syndicate_lava_base)
 "kV" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -1330,7 +1260,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
-/area/ruin/lavaland/syndicate_lava_base/engineering)
+/area/ruin/syndicate_lava_base)
 "kW" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -1339,7 +1269,7 @@
 /obj/structure/cable/yellow,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
-/area/ruin/lavaland/syndicate_lava_base/engineering)
+/area/ruin/syndicate_lava_base)
 "lu" = (
 /obj/structure/cable/yellow,
 /obj/effect/decal/cleanable/dirt,
@@ -1350,7 +1280,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/iron,
-/area/ruin/lavaland/syndicate_lava_base/main)
+/area/ruin/syndicate_lava_base)
 "lx" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/line{
@@ -1360,12 +1290,12 @@
 	dir = 8
 	},
 /turf/open/floor/plating,
-/area/ruin/lavaland/syndicate_lava_base/main)
+/area/ruin/syndicate_lava_base)
 "ly" = (
 /obj/structure/chair/stool/bar/directional/east,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/bar)
+/area/ruin/syndicate_lava_base)
 "lD" = (
 /obj/effect/mob_spawn/human/lavaland_syndicate{
 	dir = 4
@@ -1373,11 +1303,11 @@
 /obj/machinery/airalarm/directional/north,
 /obj/effect/mapping_helpers/airalarm/syndicate_access,
 /turf/open/floor/carpet/grimy,
-/area/ruin/lavaland/syndicate_lava_base/dormitories)
+/area/ruin/syndicate_lava_base)
 "lE" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/bar)
+/area/ruin/syndicate_lava_base)
 "lF" = (
 /obj/machinery/door/firedoor,
 /obj/effect/decal/cleanable/dirt,
@@ -1392,14 +1322,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/cargo)
-"lI" = (
-/turf/open/floor/iron,
-/area/ruin/lavaland/syndicate_lava_base/medbay)
-"lJ" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
-/area/ruin/lavaland/syndicate_lava_base/medbay)
+/area/ruin/syndicate_lava_base)
 "lP" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table/reinforced,
@@ -1411,29 +1334,29 @@
 /turf/open/floor/iron/white/side{
 	dir = 1
 	},
-/area/ruin/lavaland/syndicate_lava_base/main)
+/area/ruin/syndicate_lava_base)
 "lU" = (
 /obj/effect/turf_decal/tile/red/half/contrasted{
 	dir = 8
 	},
 /obj/structure/chair,
 /turf/open/floor/iron,
-/area/ruin/lavaland/syndicate_lava_base/arrivals)
+/area/ruin/syndicate_lava_base)
 "lX" = (
 /obj/structure/cable/yellow,
 /turf/open/floor/wood,
-/area/ruin/lavaland/syndicate_lava_base/bar)
+/area/ruin/syndicate_lava_base)
 "me" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
 /turf/open/floor/iron,
-/area/ruin/lavaland/syndicate_lava_base/medbay)
+/area/ruin/syndicate_lava_base)
 "mf" = (
 /obj/structure/sink/directional/west,
 /obj/machinery/airalarm/directional/east,
 /obj/effect/mapping_helpers/airalarm/syndicate_access,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
-/area/ruin/lavaland/syndicate_lava_base/medbay)
+/area/ruin/syndicate_lava_base)
 "ml" = (
 /obj/structure/table/wood,
 /obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
@@ -1443,13 +1366,7 @@
 	pixel_y = 8
 	},
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/bar)
-"mn" = (
-/turf/closed/wall/mineral/plastitanium/nodiagonal,
-/area/ruin/lavaland/syndicate_lava_base/telecomms)
-"mo" = (
-/turf/closed/wall/mineral/plastitanium/explosive,
-/area/ruin/lavaland/syndicate_lava_base/telecomms)
+/area/ruin/syndicate_lava_base)
 "mu" = (
 /obj/item/kirbyplants{
 	icon_state = "plant-22"
@@ -1457,7 +1374,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/bar)
+/area/ruin/syndicate_lava_base)
 "mw" = (
 /obj/effect/turf_decal/tile/blue/half/contrasted,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
@@ -1465,48 +1382,41 @@
 /turf/open/floor/iron/white/side{
 	dir = 4
 	},
-/area/ruin/lavaland/syndicate_lava_base/arrivals)
+/area/ruin/syndicate_lava_base)
 "mM" = (
 /turf/open/floor/circuit/green,
-/area/ruin/lavaland/syndicate_lava_base/telecomms)
-"mN" = (
-/obj/structure/sign/warning/secure_area,
-/turf/closed/wall/mineral/plastitanium/nodiagonal,
-/area/ruin/lavaland/syndicate_lava_base/telecomms)
+/area/ruin/syndicate_lava_base)
 "mP" = (
 /obj/structure/filingcabinet/security,
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/telecomms)
+/area/ruin/syndicate_lava_base)
 "mS" = (
 /obj/machinery/porta_turret/syndicate{
 	dir = 6
 	},
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
-/area/ruin/lavaland/syndicate_lava_base/telecomms)
-"mT" = (
-/turf/closed/wall/mineral/plastitanium/nodiagonal,
-/area/ruin/lavaland/syndicate_lava_base/arrivals)
+/area/ruin/syndicate_lava_base)
 "nf" = (
 /obj/structure/sign/warning/fire,
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
-/area/ruin/lavaland/syndicate_lava_base/engineering)
+/area/ruin/syndicate_lava_base)
 "ni" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/bar)
+/area/ruin/syndicate_lava_base)
 "nl" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "lavalandsyndi_telecomms"
 	},
 /obj/effect/spawner/structure/window/reinforced/plasma/plastitanium,
 /turf/open/floor/plating,
-/area/ruin/lavaland/syndicate_lava_base/telecomms)
+/area/ruin/syndicate_lava_base)
 "nE" = (
 /obj/machinery/atmospherics/pipe/smart/simple/orange/visible,
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
-/area/ruin/lavaland/syndicate_lava_base/engineering)
+/area/ruin/syndicate_lava_base)
 "nU" = (
 /obj/structure/cable/yellow,
 /obj/effect/turf_decal/tile/purple/half/contrasted{
@@ -1515,10 +1425,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/iron,
-/area/ruin/lavaland/syndicate_lava_base/main)
-"nW" = (
-/turf/open/floor/iron,
-/area/ruin/lavaland/syndicate_lava_base/arrivals)
+/area/ruin/syndicate_lava_base)
 "od" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -1527,7 +1434,7 @@
 	dir = 4
 	},
 /turf/open/floor/engine,
-/area/ruin/lavaland/syndicate_lava_base/engineering)
+/area/ruin/syndicate_lava_base)
 "oj" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable/yellow,
@@ -1540,7 +1447,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/iron,
-/area/ruin/lavaland/syndicate_lava_base/medbay)
+/area/ruin/syndicate_lava_base)
 "ol" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -1554,7 +1461,7 @@
 /obj/item/mining_scanner,
 /obj/item/pickaxe,
 /turf/open/floor/mineral/plastitanium,
-/area/ruin/lavaland/syndicate_lava_base/arrivals)
+/area/ruin/syndicate_lava_base)
 "oq" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Bar"
@@ -1562,7 +1469,7 @@
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/stripes/closeup,
 /turf/open/floor/iron,
-/area/ruin/lavaland/syndicate_lava_base/bar)
+/area/ruin/syndicate_lava_base)
 "ot" = (
 /obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/locked,
@@ -1571,20 +1478,20 @@
 	dir = 1
 	},
 /turf/open/floor/engine,
-/area/ruin/lavaland/syndicate_lava_base/engineering)
+/area/ruin/syndicate_lava_base)
 "ou" = (
 /obj/machinery/computer/message_monitor{
 	dir = 1
 	},
 /obj/item/paper/monitorkey,
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/telecomms)
+/area/ruin/syndicate_lava_base)
 "ov" = (
 /obj/structure/table/reinforced,
 /obj/item/paper_bin,
 /obj/item/pen,
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/telecomms)
+/area/ruin/syndicate_lava_base)
 "oy" = (
 /obj/machinery/button/door{
 	id = "lavalandsyndi_arrivals";
@@ -1596,19 +1503,19 @@
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/ruin/lavaland/syndicate_lava_base/arrivals)
+/area/ruin/syndicate_lava_base)
 "oz" = (
 /turf/open/floor/engine/vacuum,
-/area/ruin/lavaland/syndicate_lava_base/engineering)
+/area/ruin/syndicate_lava_base)
 "oA" = (
 /obj/structure/cable,
 /obj/machinery/igniter/incinerator_syndicatelava,
 /turf/open/floor/engine/vacuum,
-/area/ruin/lavaland/syndicate_lava_base/engineering)
+/area/ruin/syndicate_lava_base)
 "oC" = (
 /obj/machinery/door/poddoor/incinerator_syndicatelava_aux,
 /turf/open/floor/engine/vacuum,
-/area/ruin/lavaland/syndicate_lava_base/engineering)
+/area/ruin/syndicate_lava_base)
 "oE" = (
 /obj/structure/cable,
 /obj/machinery/power/compressor{
@@ -1617,22 +1524,18 @@
 	luminosity = 2
 	},
 /turf/open/floor/engine/vacuum,
-/area/ruin/lavaland/syndicate_lava_base/engineering)
-"oF" = (
-/obj/structure/sign/warning/secure_area,
-/turf/closed/wall/mineral/plastitanium/nodiagonal,
-/area/ruin/lavaland/syndicate_lava_base/arrivals)
+/area/ruin/syndicate_lava_base)
 "oG" = (
 /obj/structure/cable,
 /obj/machinery/power/turbine/lavaland{
 	luminosity = 2
 	},
 /turf/open/floor/engine/vacuum,
-/area/ruin/lavaland/syndicate_lava_base/engineering)
+/area/ruin/syndicate_lava_base)
 "oH" = (
 /obj/machinery/door/poddoor/incinerator_syndicatelava_main,
 /turf/open/floor/engine/vacuum,
-/area/ruin/lavaland/syndicate_lava_base/engineering)
+/area/ruin/syndicate_lava_base)
 "oJ" = (
 /obj/effect/spawner/structure/window/reinforced/plasma/plastitanium,
 /obj/machinery/door/poddoor/preopen{
@@ -1640,7 +1543,7 @@
 	name = "Syndicate Research Experimentation Shutters"
 	},
 /turf/open/floor/plating,
-/area/ruin/lavaland/syndicate_lava_base/testlab)
+/area/ruin/syndicate_lava_base)
 "oO" = (
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
@@ -1650,15 +1553,11 @@
 	},
 /obj/effect/mapping_helpers/airlock/access/all/syndicate/general,
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/cargo)
+/area/ruin/syndicate_lava_base)
 "oP" = (
 /obj/structure/sign/departments/chemistry,
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
-/area/ruin/lavaland/syndicate_lava_base/testlab)
-"oR" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
-/turf/open/floor/iron,
-/area/ruin/lavaland/syndicate_lava_base/medbay)
+/area/ruin/syndicate_lava_base)
 "oY" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/smart/simple/orange/visible{
@@ -1670,13 +1569,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/ruin/lavaland/syndicate_lava_base/engineering)
-"pf" = (
-/obj/structure/cable/yellow,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
-/turf/open/floor/iron,
-/area/ruin/lavaland/syndicate_lava_base/cargo)
+/area/ruin/syndicate_lava_base)
 "ph" = (
 /obj/machinery/power/apc/syndicate{
 	name = "Experimentation Lab APC";
@@ -1686,35 +1579,35 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/testlab)
+/area/ruin/syndicate_lava_base)
 "pj" = (
 /obj/effect/turf_decal/delivery,
 /obj/structure/frame/machine,
 /obj/effect/decal/cleanable/cobweb,
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/science)
+/area/ruin/syndicate_lava_base)
 "pl" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "lavalandsyndi_bar"
 	},
 /obj/effect/spawner/structure/window/reinforced/plasma/plastitanium,
 /turf/open/floor/plating,
-/area/ruin/lavaland/syndicate_lava_base/bar)
+/area/ruin/syndicate_lava_base)
 "pq" = (
 /turf/open/floor/iron/white,
-/area/ruin/lavaland/syndicate_lava_base/bar)
+/area/ruin/syndicate_lava_base)
 "pw" = (
 /turf/open/floor/iron/stairs/left{
 	dir = 4
 	},
-/area/ruin/lavaland/syndicate_lava_base/science)
+/area/ruin/syndicate_lava_base)
 "pC" = (
 /mob/living/simple_animal/rabbit{
 	faction = list("Syndicate");
 	desc = "Just a mildly evil rabbit."
 	},
 /turf/open/floor/wood,
-/area/ruin/lavaland/syndicate_lava_base/bar)
+/area/ruin/syndicate_lava_base)
 "pD" = (
 /obj/item/storage/box/lights/bulbs,
 /obj/item/stack/rods{
@@ -1727,17 +1620,17 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/rack,
 /turf/open/floor/plating,
-/area/ruin/lavaland/syndicate_lava_base/main)
+/area/ruin/syndicate_lava_base)
 "pK" = (
 /obj/machinery/air_sensor,
 /turf/open/floor/engine/n2,
-/area/ruin/lavaland/syndicate_lava_base/engineering)
+/area/ruin/syndicate_lava_base)
 "pQ" = (
 /obj/structure/sign/warning/explosives/alt{
 	pixel_x = 32
 	},
 /turf/open/floor/circuit/red,
-/area/ruin/lavaland/syndicate_lava_base/main)
+/area/ruin/syndicate_lava_base)
 "pR" = (
 /obj/machinery/atmospherics/pipe/smart/simple/orange/visible{
 	dir = 6
@@ -1747,7 +1640,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron,
-/area/ruin/lavaland/syndicate_lava_base/engineering)
+/area/ruin/syndicate_lava_base)
 "pT" = (
 /obj/machinery/power/apc/syndicate{
 	dir = 8;
@@ -1758,12 +1651,12 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/iron,
-/area/ruin/lavaland/syndicate_lava_base/chemistry)
+/area/ruin/syndicate_lava_base)
 "pY" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/mapping_helpers/no_lava,
 /turf/open/floor/plating,
-/area/ruin/lavaland/syndicate_lava_base/arrivals)
+/area/ruin/syndicate_lava_base)
 "ql" = (
 /obj/effect/mapping_helpers/no_lava,
 /obj/effect/turf_decal/stripes/corner{
@@ -1773,18 +1666,18 @@
 	dir = 8
 	},
 /turf/open/floor/plating,
-/area/ruin/lavaland/syndicate_lava_base/main)
+/area/ruin/syndicate_lava_base)
 "qp" = (
 /turf/open/floor/iron/stairs/right{
 	dir = 4
 	},
-/area/ruin/lavaland/syndicate_lava_base/science)
+/area/ruin/syndicate_lava_base)
 "qG" = (
 /obj/structure/sign/warning/explosives/alt{
 	pixel_x = -32
 	},
 /turf/open/floor/engine,
-/area/ruin/lavaland/syndicate_lava_base/testlab)
+/area/ruin/syndicate_lava_base)
 "qK" = (
 /obj/structure/closet/radiation,
 /obj/structure/extinguisher_cabinet{
@@ -1792,13 +1685,13 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
-/area/ruin/lavaland/syndicate_lava_base/science)
+/area/ruin/syndicate_lava_base)
 "qR" = (
 /obj/effect/turf_decal/tile/red/half/contrasted{
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/ruin/lavaland/syndicate_lava_base/arrivals)
+/area/ruin/syndicate_lava_base)
 "qZ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/yellow/half/contrasted{
@@ -1807,16 +1700,16 @@
 /turf/open/floor/iron/white/side{
 	dir = 1
 	},
-/area/ruin/lavaland/syndicate_lava_base/main)
+/area/ruin/syndicate_lava_base)
 "rn" = (
 /obj/effect/turf_decal/tile/blue/half/contrasted{
 	dir = 8
 	},
 /turf/open/floor/iron/white/side,
-/area/ruin/lavaland/syndicate_lava_base/main)
+/area/ruin/syndicate_lava_base)
 "rw" = (
 /turf/open/floor/plating,
-/area/ruin/lavaland/syndicate_lava_base/science)
+/area/ruin/syndicate_lava_base)
 "rx" = (
 /obj/structure/table/wood,
 /obj/machinery/light/small,
@@ -1836,24 +1729,18 @@
 	dir = 10
 	},
 /turf/open/floor/wood,
-/area/ruin/lavaland/syndicate_lava_base/bar)
-"rO" = (
-/obj/structure/cable/yellow,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
-/turf/open/floor/iron,
-/area/ruin/lavaland/syndicate_lava_base/main)
+/area/ruin/syndicate_lava_base)
 "rQ" = (
 /obj/structure/cable/yellow,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/iron,
-/area/ruin/lavaland/syndicate_lava_base/main)
+/area/ruin/syndicate_lava_base)
 "rS" = (
 /obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/engine,
-/area/ruin/lavaland/syndicate_lava_base/testlab)
+/area/ruin/syndicate_lava_base)
 "rX" = (
 /obj/structure/toilet{
 	pixel_y = 18
@@ -1869,7 +1756,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/dormitories)
+/area/ruin/syndicate_lava_base)
 "rY" = (
 /obj/machinery/door/airlock{
 	name = "Cabin 2"
@@ -1879,7 +1766,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/iron,
-/area/ruin/lavaland/syndicate_lava_base/dormitories)
+/area/ruin/syndicate_lava_base)
 "sd" = (
 /obj/effect/turf_decal/stripes/corner,
 /obj/machinery/light/small,
@@ -1894,7 +1781,7 @@
 	target_pressure = 4500
 	},
 /turf/open/floor/iron,
-/area/ruin/lavaland/syndicate_lava_base/engineering)
+/area/ruin/syndicate_lava_base)
 "se" = (
 /obj/machinery/atmospherics/components/binary/pump/on{
 	dir = 8;
@@ -1903,7 +1790,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
-/area/ruin/lavaland/syndicate_lava_base/engineering)
+/area/ruin/syndicate_lava_base)
 "so" = (
 /obj/structure/cable/yellow,
 /obj/effect/decal/cleanable/dirt,
@@ -1913,13 +1800,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/iron,
-/area/ruin/lavaland/syndicate_lava_base/engineering)
+/area/ruin/syndicate_lava_base)
 "ss" = (
 /obj/machinery/vending/cigarette{
 	extended_inventory = 1
 	},
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/bar)
+/area/ruin/syndicate_lava_base)
 "sB" = (
 /obj/structure/table/reinforced,
 /obj/structure/cable/yellow,
@@ -1932,14 +1819,14 @@
 	pixel_x = 6
 	},
 /turf/open/floor/wood,
-/area/ruin/lavaland/syndicate_lava_base/bar)
+/area/ruin/syndicate_lava_base)
 "sC" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/red,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/iron,
-/area/ruin/lavaland/syndicate_lava_base/arrivals)
+/area/ruin/syndicate_lava_base)
 "sZ" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -1948,40 +1835,34 @@
 /obj/machinery/firealarm/directional/west,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/cargo)
+/area/ruin/syndicate_lava_base)
 "ta" = (
 /obj/effect/turf_decal/tile/red/anticorner/contrasted{
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/ruin/lavaland/syndicate_lava_base/arrivals)
+/area/ruin/syndicate_lava_base)
 "tg" = (
 /obj/structure/table/reinforced,
 /obj/machinery/light/small/broken{
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/science)
-"to" = (
-/obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
-/turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/cargo)
+/area/ruin/syndicate_lava_base)
 "tq" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/engine,
-/area/ruin/lavaland/syndicate_lava_base/science)
+/area/ruin/syndicate_lava_base)
 "tv" = (
 /obj/machinery/door/poddoor{
 	id = "lavalandsyndi_chemistry"
 	},
 /obj/effect/spawner/structure/window/reinforced/plasma/plastitanium,
 /turf/open/floor/plating,
-/area/ruin/lavaland/syndicate_lava_base/chemistry)
+/area/ruin/syndicate_lava_base)
 "tz" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -1991,19 +1872,19 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/bar)
+/area/ruin/syndicate_lava_base)
 "tE" = (
 /obj/structure/cable/yellow,
 /obj/machinery/firealarm/directional/west,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/iron,
-/area/ruin/lavaland/syndicate_lava_base/chemistry)
+/area/ruin/syndicate_lava_base)
 "tK" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/telecomms)
+/area/ruin/syndicate_lava_base)
 "tQ" = (
 /obj/structure/cable/yellow,
 /obj/effect/turf_decal/tile/red/half/contrasted{
@@ -2012,14 +1893,14 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/iron,
-/area/ruin/lavaland/syndicate_lava_base/arrivals)
+/area/ruin/syndicate_lava_base)
 "ub" = (
 /obj/structure/closet/secure_closet/freezer/kitchen/maintenance{
 	req_access = null
 	},
 /obj/structure/window/reinforced/spawner/directional/west,
 /turf/open/floor/iron/white,
-/area/ruin/lavaland/syndicate_lava_base/bar)
+/area/ruin/syndicate_lava_base)
 "uc" = (
 /obj/effect/mob_spawn/human/lavaland_syndicate{
 	dir = 8
@@ -2027,10 +1908,7 @@
 /obj/machinery/airalarm/directional/north,
 /obj/effect/mapping_helpers/airalarm/syndicate_access,
 /turf/open/floor/carpet/grimy,
-/area/ruin/lavaland/syndicate_lava_base/dormitories)
-"ue" = (
-/turf/open/floor/iron,
-/area/ruin/lavaland/syndicate_lava_base/engineering)
+/area/ruin/syndicate_lava_base)
 "ug" = (
 /obj/effect/turf_decal/bot,
 /obj/structure/closet/crate/science,
@@ -2038,7 +1916,7 @@
 /obj/item/xenoartifact,
 /obj/item/xenoartifact,
 /turf/open/floor/engine,
-/area/ruin/lavaland/syndicate_lava_base/science)
+/area/ruin/syndicate_lava_base)
 "ui" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/yellow/half/contrasted{
@@ -2047,7 +1925,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/iron,
-/area/ruin/lavaland/syndicate_lava_base/engineering)
+/area/ruin/syndicate_lava_base)
 "uk" = (
 /obj/structure/closet/emcloset,
 /obj/machinery/light/small{
@@ -2056,12 +1934,12 @@
 /obj/effect/turf_decal/tile/purple/half/contrasted,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
-/area/ruin/lavaland/syndicate_lava_base/science)
+/area/ruin/syndicate_lava_base)
 "ul" = (
 /obj/machinery/atmospherics/pipe/layer_manifold,
 /obj/effect/spawner/structure/window/reinforced/plasma/plastitanium,
 /turf/open/floor/plating,
-/area/ruin/lavaland/syndicate_lava_base/engineering)
+/area/ruin/syndicate_lava_base)
 "un" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/mining/glass{
@@ -2072,14 +1950,14 @@
 	dir = 1
 	},
 /turf/open/floor/iron,
-/area/ruin/lavaland/syndicate_lava_base/cargo)
+/area/ruin/syndicate_lava_base)
 "uo" = (
 /obj/machinery/airalarm/directional/south,
 /obj/effect/mapping_helpers/airalarm/syndicate_access,
 /obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/testlab)
+/area/ruin/syndicate_lava_base)
 "uy" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
@@ -2098,7 +1976,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron,
-/area/ruin/lavaland/syndicate_lava_base/engineering)
+/area/ruin/syndicate_lava_base)
 "uD" = (
 /obj/effect/mapping_helpers/no_lava,
 /obj/machinery/light/small{
@@ -2108,20 +1986,20 @@
 	dir = 1
 	},
 /turf/open/floor/plating,
-/area/ruin/lavaland/syndicate_lava_base/arrivals)
+/area/ruin/syndicate_lava_base)
 "uE" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/iron,
-/area/ruin/lavaland/syndicate_lava_base/engineering)
+/area/ruin/syndicate_lava_base)
 "uH" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/blue/half/contrasted,
 /obj/machinery/atmospherics/pipe/smart/manifold/cyan/visible,
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/open/floor/iron,
-/area/ruin/lavaland/syndicate_lava_base/engineering)
+/area/ruin/syndicate_lava_base)
 "uJ" = (
 /obj/machinery/door/airlock/external,
 /obj/effect/mapping_helpers/airlock/access/all/syndicate/general,
@@ -2129,11 +2007,11 @@
 	cycle_id = "syndi-outpost1"
 	},
 /turf/open/floor/plating,
-/area/ruin/lavaland/syndicate_lava_base/arrivals)
+/area/ruin/syndicate_lava_base)
 "uL" = (
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/engine,
-/area/ruin/lavaland/syndicate_lava_base/science)
+/area/ruin/syndicate_lava_base)
 "uQ" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/on/layer4{
 	dir = 8;
@@ -2143,7 +2021,7 @@
 	baseturfs = /turf/open/lava/smooth/lava_land_surface;
 	initial_gas_mix = "o2=14;n2=5;co2=13;TEMP=300"
 	},
-/area/ruin/lavaland/syndicate_lava_base/main)
+/area/ruin/syndicate_lava_base)
 "uZ" = (
 /obj/structure/cable/yellow,
 /obj/effect/decal/cleanable/dirt,
@@ -2154,7 +2032,7 @@
 /turf/open/floor/iron/white/side{
 	dir = 4
 	},
-/area/ruin/lavaland/syndicate_lava_base/arrivals)
+/area/ruin/syndicate_lava_base)
 "va" = (
 /obj/machinery/door/airlock/hatch{
 	name = "Telecommunications Control"
@@ -2165,25 +2043,13 @@
 	dir = 1
 	},
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/telecomms)
-"vb" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/ruin/lavaland/syndicate_lava_base/arrivals)
+/area/ruin/syndicate_lava_base)
 "vg" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
 	},
 /turf/open/floor/engine,
-/area/ruin/lavaland/syndicate_lava_base/testlab)
-"vp" = (
-/obj/effect/turf_decal/tile/red/half/contrasted{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/ruin/lavaland/syndicate_lava_base/main)
+/area/ruin/syndicate_lava_base)
 "vq" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -2193,25 +2059,25 @@
 	name = "syndicate shuttle dock terminal"
 	},
 /turf/open/floor/mineral/plastitanium,
-/area/ruin/lavaland/syndicate_lava_base/arrivals)
+/area/ruin/syndicate_lava_base)
 "vv" = (
 /obj/machinery/light/small{
 	dir = 1
 	},
 /obj/machinery/oven,
 /turf/open/floor/iron/white/airless,
-/area/ruin/lavaland/syndicate_lava_base/bar)
+/area/ruin/syndicate_lava_base)
 "vA" = (
 /obj/machinery/griddle,
 /turf/open/floor/iron/white/airless,
-/area/ruin/lavaland/syndicate_lava_base/bar)
+/area/ruin/syndicate_lava_base)
 "vF" = (
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/iron,
-/area/ruin/lavaland/syndicate_lava_base/engineering)
+/area/ruin/syndicate_lava_base)
 "vG" = (
 /obj/structure/table/wood,
 /obj/item/storage/fancy/cigarettes/cigpack_syndicate{
@@ -2223,7 +2089,7 @@
 	pixel_y = 6
 	},
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/bar)
+/area/ruin/syndicate_lava_base)
 "vJ" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -27;
@@ -2242,7 +2108,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron,
-/area/ruin/lavaland/syndicate_lava_base/cargo)
+/area/ruin/syndicate_lava_base)
 "vR" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
@@ -2255,14 +2121,14 @@
 /obj/item/crowbar,
 /obj/item/screwdriver,
 /turf/open/floor/iron,
-/area/ruin/lavaland/syndicate_lava_base/main)
+/area/ruin/syndicate_lava_base)
 "vT" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/red/half/contrasted,
 /turf/open/floor/iron,
-/area/ruin/lavaland/syndicate_lava_base/main)
+/area/ruin/syndicate_lava_base)
 "vY" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -2270,7 +2136,7 @@
 	extended_inventory = 1
 	},
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/bar)
+/area/ruin/syndicate_lava_base)
 "wc" = (
 /obj/structure/cable/yellow,
 /obj/effect/decal/cleanable/dirt,
@@ -2278,7 +2144,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/iron,
-/area/ruin/lavaland/syndicate_lava_base/arrivals)
+/area/ruin/syndicate_lava_base)
 "wn" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/mining/glass{
@@ -2288,7 +2154,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron,
-/area/ruin/lavaland/syndicate_lava_base/cargo)
+/area/ruin/syndicate_lava_base)
 "wB" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/red/line{
@@ -2296,11 +2162,11 @@
 	},
 /obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/main)
+/area/ruin/syndicate_lava_base)
 "wG" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/cargo)
+/area/ruin/syndicate_lava_base)
 "wL" = (
 /obj/machinery/sleeper/syndie{
 	dir = 4
@@ -2309,7 +2175,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/iron,
-/area/ruin/lavaland/syndicate_lava_base/medbay)
+/area/ruin/syndicate_lava_base)
 "wM" = (
 /obj/effect/turf_decal/tile/purple/anticorner/contrasted{
 	dir = 8
@@ -2322,7 +2188,7 @@
 /obj/effect/mapping_helpers/airalarm/syndicate_access,
 /obj/structure/floodlight_frame,
 /turf/open/floor/iron,
-/area/ruin/lavaland/syndicate_lava_base/science)
+/area/ruin/syndicate_lava_base)
 "xf" = (
 /obj/structure/chair{
 	dir = 1
@@ -2331,14 +2197,14 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/testlab)
+/area/ruin/syndicate_lava_base)
 "xl" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
 /obj/structure/chair{
 	dir = 1
 	},
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/bar)
+/area/ruin/syndicate_lava_base)
 "xn" = (
 /obj/machinery/light/small,
 /obj/structure/filingcabinet/chestdrawer,
@@ -2347,7 +2213,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/ruin/lavaland/syndicate_lava_base/cargo)
+/area/ruin/syndicate_lava_base)
 "xq" = (
 /obj/structure/table/reinforced,
 /obj/item/clothing/glasses/science{
@@ -2355,7 +2221,7 @@
 	pixel_x = 1
 	},
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/science)
+/area/ruin/syndicate_lava_base)
 "xC" = (
 /obj/effect/spawner/structure/window/reinforced/plasma/plastitanium,
 /obj/structure/disposalpipe/segment,
@@ -2364,7 +2230,7 @@
 	name = "Syndicate Research Experimentation Shutters"
 	},
 /turf/open/floor/plating,
-/area/ruin/lavaland/syndicate_lava_base/testlab)
+/area/ruin/syndicate_lava_base)
 "xH" = (
 /obj/structure/sign/warning/vacuum{
 	pixel_x = -32
@@ -2373,16 +2239,16 @@
 	dir = 1
 	},
 /turf/open/floor/plating,
-/area/ruin/lavaland/syndicate_lava_base/arrivals)
+/area/ruin/syndicate_lava_base)
 "xR" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
-/area/ruin/lavaland/syndicate_lava_base/science)
+/area/ruin/syndicate_lava_base)
 "xU" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/carpet/grimy,
-/area/ruin/lavaland/syndicate_lava_base/dormitories)
+/area/ruin/syndicate_lava_base)
 "ye" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
@@ -2390,7 +2256,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/iron,
-/area/ruin/lavaland/syndicate_lava_base/engineering)
+/area/ruin/syndicate_lava_base)
 "yg" = (
 /obj/machinery/sleeper/syndie{
 	dir = 4
@@ -2398,7 +2264,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/iron,
-/area/ruin/lavaland/syndicate_lava_base/medbay)
+/area/ruin/syndicate_lava_base)
 "yr" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
@@ -2407,21 +2273,18 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/portable_atmospherics/scrubber,
 /turf/open/floor/plating,
-/area/ruin/lavaland/syndicate_lava_base/engineering)
+/area/ruin/syndicate_lava_base)
 "yx" = (
 /obj/machinery/atmospherics/miner/nitrogen,
 /obj/machinery/light/small{
 	dir = 4
 	},
 /turf/open/floor/engine/n2,
-/area/ruin/lavaland/syndicate_lava_base/engineering)
+/area/ruin/syndicate_lava_base)
 "yA" = (
 /obj/machinery/air_sensor,
 /turf/open/floor/engine/plasma,
-/area/ruin/lavaland/syndicate_lava_base/engineering)
-"yG" = (
-/turf/open/floor/iron,
-/area/ruin/lavaland/syndicate_lava_base/chemistry)
+/area/ruin/syndicate_lava_base)
 "yK" = (
 /obj/effect/turf_decal/bot,
 /obj/effect/decal/cleanable/dirt,
@@ -2432,7 +2295,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/ruin/lavaland/syndicate_lava_base/main)
+/area/ruin/syndicate_lava_base)
 "yM" = (
 /obj/effect/turf_decal/tile/purple/half/contrasted{
 	dir = 8
@@ -2448,7 +2311,7 @@
 	pixel_x = 25
 	},
 /turf/open/floor/iron,
-/area/ruin/lavaland/syndicate_lava_base/science)
+/area/ruin/syndicate_lava_base)
 "yR" = (
 /obj/structure/table/reinforced,
 /obj/item/folder,
@@ -2462,7 +2325,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/ruin/lavaland/syndicate_lava_base/cargo)
+/area/ruin/syndicate_lava_base)
 "yW" = (
 /obj/effect/turf_decal/box/white/corners,
 /obj/structure/closet/crate,
@@ -2486,7 +2349,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/cargo)
+/area/ruin/syndicate_lava_base)
 "yY" = (
 /obj/structure/table,
 /obj/structure/bedsheetbin,
@@ -2495,20 +2358,20 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/dormitories)
+/area/ruin/syndicate_lava_base)
 "zd" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/brown/half/contrasted{
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/ruin/lavaland/syndicate_lava_base/main)
+/area/ruin/syndicate_lava_base)
 "ze" = (
 /turf/open/floor/engine/n2,
-/area/ruin/lavaland/syndicate_lava_base/engineering)
+/area/ruin/syndicate_lava_base)
 "zf" = (
 /turf/open/floor/engine/o2,
-/area/ruin/lavaland/syndicate_lava_base/engineering)
+/area/ruin/syndicate_lava_base)
 "zp" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table/wood,
@@ -2518,13 +2381,13 @@
 /turf/open/floor/wood{
 	broken = 1
 	},
-/area/ruin/lavaland/syndicate_lava_base/bar)
+/area/ruin/syndicate_lava_base)
 "zA" = (
 /obj/effect/turf_decal/tile/red/half/contrasted{
 	dir = 1
 	},
 /turf/open/floor/iron,
-/area/ruin/lavaland/syndicate_lava_base/main)
+/area/ruin/syndicate_lava_base)
 "zK" = (
 /obj/structure/cable/yellow,
 /obj/machinery/power/apc/syndicate{
@@ -2536,7 +2399,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron,
-/area/ruin/lavaland/syndicate_lava_base/main)
+/area/ruin/syndicate_lava_base)
 "zL" = (
 /obj/structure/table,
 /obj/machinery/cell_charger,
@@ -2551,7 +2414,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron,
-/area/ruin/lavaland/syndicate_lava_base/engineering)
+/area/ruin/syndicate_lava_base)
 "zM" = (
 /obj/structure/cable/yellow,
 /obj/effect/turf_decal/tile/red{
@@ -2560,7 +2423,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/iron,
-/area/ruin/lavaland/syndicate_lava_base/arrivals)
+/area/ruin/syndicate_lava_base)
 "zR" = (
 /obj/effect/turf_decal/tile/yellow/half/contrasted{
 	dir = 1
@@ -2568,7 +2431,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/iron,
-/area/ruin/lavaland/syndicate_lava_base/engineering)
+/area/ruin/syndicate_lava_base)
 "zS" = (
 /obj/structure/closet/emcloset/anchored,
 /obj/structure/cable/yellow,
@@ -2577,7 +2440,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron,
-/area/ruin/lavaland/syndicate_lava_base/arrivals)
+/area/ruin/syndicate_lava_base)
 "Ac" = (
 /obj/machinery/light/small,
 /obj/structure/table/reinforced,
@@ -2591,7 +2454,7 @@
 	},
 /obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/testlab)
+/area/ruin/syndicate_lava_base)
 "Ae" = (
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/stripes/closeup,
@@ -2601,14 +2464,14 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/iron,
-/area/ruin/lavaland/syndicate_lava_base/bar)
+/area/ruin/syndicate_lava_base)
 "Ak" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
 	},
 /obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/plating,
-/area/ruin/lavaland/syndicate_lava_base/arrivals)
+/area/ruin/syndicate_lava_base)
 "An" = (
 /obj/structure/table/glass,
 /obj/machinery/reagentgrinder{
@@ -2621,17 +2484,17 @@
 /turf/open/floor/iron/white/side{
 	dir = 5
 	},
-/area/ruin/lavaland/syndicate_lava_base/chemistry)
+/area/ruin/syndicate_lava_base)
 "Aq" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
 /turf/open/floor/plating,
-/area/ruin/lavaland/syndicate_lava_base/science)
+/area/ruin/syndicate_lava_base)
 "Au" = (
 /obj/machinery/washing_machine,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/dormitories)
+/area/ruin/syndicate_lava_base)
 "Ax" = (
 /obj/structure/cable/yellow,
 /obj/machinery/computer/monitor/secret,
@@ -2640,7 +2503,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/yellow/fourcorners/contrasted,
 /turf/open/floor/iron,
-/area/ruin/lavaland/syndicate_lava_base/engineering)
+/area/ruin/syndicate_lava_base)
 "Az" = (
 /obj/structure/table,
 /obj/item/storage/toolbox/emergency,
@@ -2650,13 +2513,13 @@
 	dir = 1
 	},
 /turf/open/floor/iron,
-/area/ruin/lavaland/syndicate_lava_base/main)
+/area/ruin/syndicate_lava_base)
 "AB" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/iron,
-/area/ruin/lavaland/syndicate_lava_base/medbay)
+/area/ruin/syndicate_lava_base)
 "AC" = (
 /obj/structure/cable/yellow,
 /obj/effect/turf_decal/tile/red{
@@ -2665,7 +2528,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/iron,
-/area/ruin/lavaland/syndicate_lava_base/main)
+/area/ruin/syndicate_lava_base)
 "AF" = (
 /obj/structure/table/reinforced,
 /obj/item/restraints/handcuffs,
@@ -2673,14 +2536,14 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/testlab)
+/area/ruin/syndicate_lava_base)
 "AK" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/blue/half/contrasted{
 	dir = 8
 	},
 /turf/open/floor/iron/white/side,
-/area/ruin/lavaland/syndicate_lava_base/main)
+/area/ruin/syndicate_lava_base)
 "AR" = (
 /obj/machinery/light/small,
 /obj/effect/decal/cleanable/dirt,
@@ -2688,12 +2551,12 @@
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/ruin/lavaland/syndicate_lava_base/main)
+/area/ruin/syndicate_lava_base)
 "AU" = (
 /obj/machinery/door/firedoor,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
-/area/ruin/lavaland/syndicate_lava_base/main)
+/area/ruin/syndicate_lava_base)
 "Bc" = (
 /obj/structure/cable/yellow,
 /obj/effect/turf_decal/tile/red/half/contrasted{
@@ -2703,7 +2566,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/iron,
-/area/ruin/lavaland/syndicate_lava_base/arrivals)
+/area/ruin/syndicate_lava_base)
 "Bi" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/red/half/contrasted{
@@ -2711,7 +2574,7 @@
 	},
 /obj/structure/closet/emcloset/anchored,
 /turf/open/floor/iron,
-/area/ruin/lavaland/syndicate_lava_base/main)
+/area/ruin/syndicate_lava_base)
 "Bm" = (
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
 	dir = 4
@@ -2719,7 +2582,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/iron,
-/area/ruin/lavaland/syndicate_lava_base/dormitories)
+/area/ruin/syndicate_lava_base)
 "Bp" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -2734,7 +2597,7 @@
 /turf/open/floor/iron/white/side{
 	dir = 5
 	},
-/area/ruin/lavaland/syndicate_lava_base/medbay)
+/area/ruin/syndicate_lava_base)
 "Bt" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -2751,7 +2614,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/ruin/lavaland/syndicate_lava_base/engineering)
+/area/ruin/syndicate_lava_base)
 "BA" = (
 /obj/structure/table/wood,
 /obj/effect/turf_decal/siding/wood{
@@ -2760,19 +2623,19 @@
 /turf/open/floor/wood{
 	broken = 1
 	},
-/area/ruin/lavaland/syndicate_lava_base/bar)
+/area/ruin/syndicate_lava_base)
 "BC" = (
 /obj/effect/turf_decal/tile/red/half/contrasted{
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/ruin/lavaland/syndicate_lava_base/arrivals)
+/area/ruin/syndicate_lava_base)
 "BN" = (
 /obj/structure/chair{
 	dir = 4
 	},
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/bar)
+/area/ruin/syndicate_lava_base)
 "BS" = (
 /obj/structure/table/wood,
 /obj/item/lighter{
@@ -2780,17 +2643,17 @@
 	pixel_y = 6
 	},
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/bar)
+/area/ruin/syndicate_lava_base)
 "BW" = (
 /obj/effect/turf_decal/tile/red/anticorner/contrasted,
 /turf/open/floor/iron,
-/area/ruin/lavaland/syndicate_lava_base/arrivals)
+/area/ruin/syndicate_lava_base)
 "Cc" = (
 /obj/machinery/porta_turret/syndicate{
 	dir = 10
 	},
 /turf/closed/wall/mineral/plastitanium,
-/area/ruin/lavaland/syndicate_lava_base/telecomms)
+/area/ruin/syndicate_lava_base)
 "Cf" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -2809,25 +2672,25 @@
 /turf/open/floor/iron/white/side{
 	dir = 1
 	},
-/area/ruin/lavaland/syndicate_lava_base/chemistry)
+/area/ruin/syndicate_lava_base)
 "Cn" = (
 /obj/structure/chair/office{
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/telecomms)
+/area/ruin/syndicate_lava_base)
 "Co" = (
 /obj/structure/closet/firecloset,
 /obj/effect/turf_decal/tile/purple/anticorner/contrasted,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
-/area/ruin/lavaland/syndicate_lava_base/science)
+/area/ruin/syndicate_lava_base)
 "Cp" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /turf/open/floor/iron,
-/area/ruin/lavaland/syndicate_lava_base/chemistry)
+/area/ruin/syndicate_lava_base)
 "Cq" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/railing/corner{
@@ -2847,14 +2710,14 @@
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/ruin/lavaland/syndicate_lava_base/arrivals)
+/area/ruin/syndicate_lava_base)
 "Cx" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /turf/open/floor/engine,
-/area/ruin/lavaland/syndicate_lava_base/testlab)
+/area/ruin/syndicate_lava_base)
 "CL" = (
 /obj/structure/reagent_dispensers/beerkeg,
 /obj/structure/window/reinforced/spawner/directional/north{
@@ -2866,16 +2729,16 @@
 /turf/open/floor/wood{
 	broken = 1
 	},
-/area/ruin/lavaland/syndicate_lava_base/bar)
+/area/ruin/syndicate_lava_base)
 "CP" = (
 /obj/effect/turf_decal/tile/brown/half/contrasted,
 /turf/open/floor/iron,
-/area/ruin/lavaland/syndicate_lava_base/main)
+/area/ruin/syndicate_lava_base)
 "CZ" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/bar)
+/area/ruin/syndicate_lava_base)
 "De" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/railing{
@@ -2883,15 +2746,11 @@
 	},
 /turf/open/lava/smooth/lava_land_surface,
 /area/lavaland/surface/outdoors)
-"Dh" = (
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/engine,
-/area/ruin/lavaland/syndicate_lava_base/testlab)
 "Dp" = (
 /obj/item/book/manual/wiki/xenoarchaeology,
 /obj/structure/table/reinforced,
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/science)
+/area/ruin/syndicate_lava_base)
 "Ds" = (
 /obj/effect/turf_decal/delivery,
 /obj/machinery/door/firedoor,
@@ -2906,36 +2765,28 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/iron,
-/area/ruin/lavaland/syndicate_lava_base/engineering)
-"DA" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
-/area/ruin/lavaland/syndicate_lava_base/engineering)
+/area/ruin/syndicate_lava_base)
 "DF" = (
 /obj/machinery/porta_turret/syndicate{
 	dir = 5
 	},
 /turf/closed/wall/mineral/plastitanium,
-/area/ruin/lavaland/syndicate_lava_base/cargo)
+/area/ruin/syndicate_lava_base)
 "DK" = (
 /obj/machinery/atmospherics/miner/plasma,
 /obj/machinery/light/small,
 /turf/open/floor/engine/plasma,
-/area/ruin/lavaland/syndicate_lava_base/engineering)
+/area/ruin/syndicate_lava_base)
 "DL" = (
 /obj/structure/sign/warning/explosives/alt{
 	pixel_x = 32
 	},
 /turf/open/floor/engine,
-/area/ruin/lavaland/syndicate_lava_base/testlab)
-"DM" = (
-/obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
-/turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/bar)
+/area/ruin/syndicate_lava_base)
 "DO" = (
 /obj/effect/spawner/structure/window/reinforced/plasma/plastitanium,
 /turf/open/floor/plating,
-/area/ruin/lavaland/syndicate_lava_base/chemistry)
+/area/ruin/syndicate_lava_base)
 "DQ" = (
 /obj/structure/table/reinforced,
 /obj/item/retractor,
@@ -2945,31 +2796,25 @@
 /turf/open/floor/iron/white/side{
 	dir = 6
 	},
-/area/ruin/lavaland/syndicate_lava_base/medbay)
+/area/ruin/syndicate_lava_base)
 "DS" = (
 /obj/structure/cable/yellow,
 /turf/open/floor/iron,
-/area/ruin/lavaland/syndicate_lava_base/medbay)
-"Ef" = (
-/obj/structure/cable/yellow,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
-/turf/open/floor/iron,
-/area/ruin/lavaland/syndicate_lava_base/medbay)
+/area/ruin/syndicate_lava_base)
 "En" = (
 /obj/structure/cable/yellow,
 /obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/telecomms)
+/area/ruin/syndicate_lava_base)
 "EA" = (
 /obj/machinery/light/small{
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/yellow/half/contrasted,
 /turf/open/floor/iron,
-/area/ruin/lavaland/syndicate_lava_base/main)
+/area/ruin/syndicate_lava_base)
 "EL" = (
 /obj/structure/table/wood,
 /obj/machinery/chem_dispenser/drinks/beer/fullupgrade{
@@ -2983,7 +2828,7 @@
 	dir = 10
 	},
 /turf/open/floor/wood,
-/area/ruin/lavaland/syndicate_lava_base/bar)
+/area/ruin/syndicate_lava_base)
 "EM" = (
 /obj/structure/cable/yellow,
 /obj/effect/decal/cleanable/dirt,
@@ -2993,26 +2838,26 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/iron,
-/area/ruin/lavaland/syndicate_lava_base/main)
+/area/ruin/syndicate_lava_base)
 "EO" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/bar)
+/area/ruin/syndicate_lava_base)
 "EP" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/vending/assist,
 /obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/cargo)
+/area/ruin/syndicate_lava_base)
 "EZ" = (
 /obj/machinery/door/airlock/external,
 /obj/effect/mapping_helpers/airlock/access/all/syndicate/general,
 /obj/structure/fans/tiny,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /turf/open/floor/plating,
-/area/ruin/lavaland/syndicate_lava_base/arrivals)
+/area/ruin/syndicate_lava_base)
 "Fb" = (
 /obj/machinery/light/small,
 /obj/structure/cable/yellow,
@@ -3022,11 +2867,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/iron,
-/area/ruin/lavaland/syndicate_lava_base/dormitories)
-"Fr" = (
-/obj/effect/spawner/structure/window/reinforced/plasma/plastitanium,
-/turf/open/floor/plating,
-/area/ruin/lavaland/syndicate_lava_base/bar)
+/area/ruin/syndicate_lava_base)
 "Fs" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/red/line{
@@ -3036,7 +2877,7 @@
 /obj/item/folder/syndicate/mining,
 /obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/main)
+/area/ruin/syndicate_lava_base)
 "FC" = (
 /obj/structure/cable/yellow,
 /obj/effect/turf_decal/tile/red{
@@ -3044,7 +2885,7 @@
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
 /turf/open/floor/iron,
-/area/ruin/lavaland/syndicate_lava_base/main)
+/area/ruin/syndicate_lava_base)
 "FG" = (
 /obj/machinery/button/door{
 	id = "lavalandsyndi_bar";
@@ -3053,13 +2894,13 @@
 	pixel_x = -25
 	},
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/bar)
+/area/ruin/syndicate_lava_base)
 "FK" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/bar)
+/area/ruin/syndicate_lava_base)
 "FO" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/hatch{
@@ -3072,7 +2913,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/testlab)
+/area/ruin/syndicate_lava_base)
 "FS" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "lavalandsyndi_virology"
@@ -3082,21 +2923,14 @@
 	id = "lavalandsyndi_science"
 	},
 /turf/open/floor/plating,
-/area/ruin/lavaland/syndicate_lava_base/science)
-"FV" = (
-/obj/structure/cable/yellow,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
-/turf/open/floor/iron,
-/area/ruin/lavaland/syndicate_lava_base/dormitories)
+/area/ruin/syndicate_lava_base)
 "FX" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
 /obj/structure/chair/stool/bar/directional/east,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/bar)
+/area/ruin/syndicate_lava_base)
 "Gh" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
@@ -3107,13 +2941,13 @@
 /obj/item/holosign_creator/atmos,
 /obj/item/storage/belt/utility/full,
 /turf/open/floor/iron,
-/area/ruin/lavaland/syndicate_lava_base/engineering)
+/area/ruin/syndicate_lava_base)
 "Gi" = (
 /obj/effect/mob_spawn/human/lavaland_syndicate{
 	dir = 4
 	},
 /turf/open/floor/carpet/grimy,
-/area/ruin/lavaland/syndicate_lava_base/dormitories)
+/area/ruin/syndicate_lava_base)
 "Gk" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -3122,7 +2956,7 @@
 	dir = 1
 	},
 /turf/open/floor/carpet/grimy,
-/area/ruin/lavaland/syndicate_lava_base/dormitories)
+/area/ruin/syndicate_lava_base)
 "Gp" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -3133,32 +2967,28 @@
 /obj/effect/turf_decal/tile/yellow/half/contrasted,
 /obj/machinery/portable_thermomachine/atmos,
 /turf/open/floor/iron,
-/area/ruin/lavaland/syndicate_lava_base/engineering)
+/area/ruin/syndicate_lava_base)
 "Gq" = (
 /obj/structure/cable/yellow,
 /obj/effect/turf_decal/tile/yellow/half/contrasted,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/iron,
-/area/ruin/lavaland/syndicate_lava_base/main)
-"GG" = (
-/obj/effect/spawner/structure/window/reinforced/plasma/plastitanium,
-/turf/open/floor/plating,
-/area/ruin/lavaland/syndicate_lava_base/cargo)
+/area/ruin/syndicate_lava_base)
 "GJ" = (
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/tile/red/half/contrasted{
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/ruin/lavaland/syndicate_lava_base/main)
+/area/ruin/syndicate_lava_base)
 "GT" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/red/half/contrasted{
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/ruin/lavaland/syndicate_lava_base/main)
+/area/ruin/syndicate_lava_base)
 "GY" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -27;
@@ -3169,7 +2999,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron,
-/area/ruin/lavaland/syndicate_lava_base/main)
+/area/ruin/syndicate_lava_base)
 "He" = (
 /obj/effect/turf_decal/box/white/corners,
 /obj/structure/closet/crate/medical,
@@ -3183,26 +3013,22 @@
 	pixel_y = -3
 	},
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/cargo)
+/area/ruin/syndicate_lava_base)
 "Hi" = (
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plating,
-/area/ruin/lavaland/syndicate_lava_base/arrivals)
-"Hj" = (
-/obj/effect/spawner/structure/window/reinforced/plasma/plastitanium,
-/turf/open/floor/plating,
-/area/ruin/lavaland/syndicate_lava_base/testlab)
+/area/ruin/syndicate_lava_base)
 "Hk" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 4
 	},
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/bar)
+/area/ruin/syndicate_lava_base)
 "Hl" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/bar)
+/area/ruin/syndicate_lava_base)
 "Ho" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small,
@@ -3212,7 +3038,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/iron,
-/area/ruin/lavaland/syndicate_lava_base/arrivals)
+/area/ruin/syndicate_lava_base)
 "HA" = (
 /obj/effect/turf_decal/box/white/corners{
 	dir = 8
@@ -3242,13 +3068,13 @@
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/cargo)
+/area/ruin/syndicate_lava_base)
 "HD" = (
 /obj/effect/turf_decal/tile/brown/half/contrasted{
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/ruin/lavaland/syndicate_lava_base/main)
+/area/ruin/syndicate_lava_base)
 "HE" = (
 /obj/effect/turf_decal/box/white/corners{
 	dir = 8
@@ -3264,20 +3090,14 @@
 /obj/item/circuitboard/machine/smoke_machine,
 /obj/item/storage/part_replacer/cargo,
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/cargo)
-"HH" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
-/turf/open/floor/iron,
-/area/ruin/lavaland/syndicate_lava_base/cargo)
+/area/ruin/syndicate_lava_base)
 "HX" = (
 /obj/machinery/light/small{
 	dir = 8
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
 /turf/open/floor/carpet/grimy,
-/area/ruin/lavaland/syndicate_lava_base/dormitories)
+/area/ruin/syndicate_lava_base)
 "If" = (
 /obj/structure/sign/warning/xeno_mining{
 	pixel_x = -32
@@ -3287,20 +3107,14 @@
 	},
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plating,
-/area/ruin/lavaland/syndicate_lava_base/arrivals)
+/area/ruin/syndicate_lava_base)
 "Ig" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/ruin/lavaland/syndicate_lava_base/engineering)
-"Il" = (
-/obj/structure/cable/yellow,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
-/turf/open/floor/iron,
-/area/ruin/lavaland/syndicate_lava_base/arrivals)
+/area/ruin/syndicate_lava_base)
 "In" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -3326,22 +3140,18 @@
 	dir = 1
 	},
 /turf/open/floor/iron,
-/area/ruin/lavaland/syndicate_lava_base/cargo)
-"It" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
-/area/ruin/lavaland/syndicate_lava_base/science)
+/area/ruin/syndicate_lava_base)
 "IA" = (
 /obj/structure/cable/yellow,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/item/stack/tile/iron,
 /turf/open/floor/plating,
-/area/ruin/lavaland/syndicate_lava_base/science)
+/area/ruin/syndicate_lava_base)
 "IH" = (
 /obj/structure/chair,
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/bar)
+/area/ruin/syndicate_lava_base)
 "IN" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
@@ -3354,7 +3164,7 @@
 /obj/item/clothing/head/utility/welding,
 /obj/item/weldingtool/largetank,
 /turf/open/floor/plating,
-/area/ruin/lavaland/syndicate_lava_base/engineering)
+/area/ruin/syndicate_lava_base)
 "IO" = (
 /obj/structure/chair{
 	dir = 8
@@ -3366,7 +3176,7 @@
 	},
 /obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/telecomms)
+/area/ruin/syndicate_lava_base)
 "IR" = (
 /obj/machinery/door/airlock{
 	name = "Unisex Restrooms"
@@ -3376,7 +3186,7 @@
 /obj/effect/turf_decal/stripes/closeup,
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/dormitories)
+/area/ruin/syndicate_lava_base)
 "IV" = (
 /obj/structure/filingcabinet/chestdrawer,
 /obj/effect/decal/cleanable/dirt,
@@ -3384,7 +3194,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/ruin/lavaland/syndicate_lava_base/cargo)
+/area/ruin/syndicate_lava_base)
 "Jm" = (
 /obj/machinery/computer/turbine_computer{
 	dir = 1;
@@ -3405,19 +3215,13 @@
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/ruin/lavaland/syndicate_lava_base/engineering)
+/area/ruin/syndicate_lava_base)
 "Js" = (
 /obj/machinery/porta_turret/syndicate{
 	dir = 9
 	},
 /turf/closed/wall/mineral/plastitanium,
-/area/ruin/lavaland/syndicate_lava_base/telecomms)
-"Ju" = (
-/obj/machinery/porta_turret/syndicate{
-	dir = 5
-	},
-/turf/closed/wall/mineral/plastitanium,
-/area/ruin/lavaland/syndicate_lava_base/chemistry)
+/area/ruin/syndicate_lava_base)
 "Jv" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/on{
 	dir = 8;
@@ -3425,19 +3229,19 @@
 	name = "nitrogen out"
 	},
 /turf/open/floor/engine/n2,
-/area/ruin/lavaland/syndicate_lava_base/engineering)
+/area/ruin/syndicate_lava_base)
 "Jz" = (
 /turf/open/floor/wood{
 	broken = 1
 	},
-/area/ruin/lavaland/syndicate_lava_base/bar)
+/area/ruin/syndicate_lava_base)
 "JA" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/ruin/lavaland/syndicate_lava_base/arrivals)
+/area/ruin/syndicate_lava_base)
 "JE" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/yellow,
@@ -3449,7 +3253,7 @@
 /turf/open/floor/iron/white/side{
 	dir = 1
 	},
-/area/ruin/lavaland/syndicate_lava_base/main)
+/area/ruin/syndicate_lava_base)
 "JF" = (
 /obj/structure/cable/yellow,
 /obj/effect/turf_decal/tile/red/half/contrasted{
@@ -3458,12 +3262,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/iron,
-/area/ruin/lavaland/syndicate_lava_base/main)
-"JM" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
-/turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/cargo)
+/area/ruin/syndicate_lava_base)
 "JN" = (
 /obj/machinery/telecomms/relay/preset/ruskie{
 	use_power = 0
@@ -3473,11 +3272,7 @@
 	},
 /obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/telecomms)
-"JW" = (
-/obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
-/turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/telecomms)
+/area/ruin/syndicate_lava_base)
 "Kc" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 4
@@ -3485,7 +3280,7 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
 /obj/machinery/firealarm/directional/south,
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/testlab)
+/area/ruin/syndicate_lava_base)
 "Kd" = (
 /obj/machinery/door/airlock/external,
 /obj/effect/mapping_helpers/airlock/access/all/syndicate/general,
@@ -3494,7 +3289,7 @@
 	cycle_id = "syndi-outpost2"
 	},
 /turf/open/floor/plating,
-/area/ruin/lavaland/syndicate_lava_base/main)
+/area/ruin/syndicate_lava_base)
 "Kh" = (
 /obj/structure/rack{
 	dir = 8
@@ -3509,17 +3304,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/white/side,
-/area/ruin/lavaland/syndicate_lava_base/medbay)
-"Ku" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
-/turf/open/floor/iron,
-/area/ruin/lavaland/syndicate_lava_base/engineering)
-"KA" = (
-/obj/machinery/porta_turret/syndicate{
-	dir = 5
-	},
-/turf/closed/wall/mineral/plastitanium,
-/area/ruin/lavaland/syndicate_lava_base/engineering)
+/area/ruin/syndicate_lava_base)
 "KB" = (
 /obj/machinery/button/door{
 	id = "lavalandsyndi_bar";
@@ -3529,7 +3314,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/bar)
+/area/ruin/syndicate_lava_base)
 "KN" = (
 /obj/machinery/power/apc/syndicate{
 	name = "Dormitories APC";
@@ -3540,18 +3325,18 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/iron,
-/area/ruin/lavaland/syndicate_lava_base/dormitories)
+/area/ruin/syndicate_lava_base)
 "KP" = (
 /obj/structure/table,
 /obj/machinery/microwave,
 /turf/open/floor/iron/white,
-/area/ruin/lavaland/syndicate_lava_base/bar)
+/area/ruin/syndicate_lava_base)
 "KU" = (
 /obj/machinery/computer/camera_advanced/syndie,
 /obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/telecomms)
+/area/ruin/syndicate_lava_base)
 "Lc" = (
 /obj/structure/sign/warning/vacuum{
 	pixel_x = -32
@@ -3563,17 +3348,17 @@
 	dir = 1
 	},
 /turf/open/floor/plating,
-/area/ruin/lavaland/syndicate_lava_base/arrivals)
+/area/ruin/syndicate_lava_base)
 "Lg" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 4
 	},
 /turf/open/floor/engine,
-/area/ruin/lavaland/syndicate_lava_base/testlab)
+/area/ruin/syndicate_lava_base)
 "Lj" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
-/area/ruin/lavaland/syndicate_lava_base/main)
+/area/ruin/syndicate_lava_base)
 "Ll" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -3582,7 +3367,7 @@
 	},
 /obj/structure/closet/firecloset,
 /turf/open/floor/iron,
-/area/ruin/lavaland/syndicate_lava_base/main)
+/area/ruin/syndicate_lava_base)
 "Lo" = (
 /obj/structure/closet/crate,
 /obj/item/vending_refill/snack{
@@ -3600,7 +3385,7 @@
 /obj/effect/spawner/random/food_or_drink/donkpockets,
 /obj/structure/grille/broken,
 /turf/open/floor/plating,
-/area/ruin/lavaland/syndicate_lava_base/main)
+/area/ruin/syndicate_lava_base)
 "Lq" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small{
@@ -3610,7 +3395,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/plating,
-/area/ruin/lavaland/syndicate_lava_base/main)
+/area/ruin/syndicate_lava_base)
 "Ls" = (
 /obj/machinery/door/firedoor,
 /obj/effect/decal/cleanable/dirt,
@@ -3619,13 +3404,7 @@
 	},
 /obj/effect/turf_decal/stripes/closeup,
 /turf/open/floor/iron,
-/area/ruin/lavaland/syndicate_lava_base/medbay)
-"Lt" = (
-/obj/machinery/porta_turret/syndicate{
-	dir = 10
-	},
-/turf/closed/wall/mineral/plastitanium,
-/area/ruin/lavaland/syndicate_lava_base/science)
+/area/ruin/syndicate_lava_base)
 "Lw" = (
 /obj/machinery/door/airlock{
 	name = "Cabin 1"
@@ -3636,7 +3415,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/iron,
-/area/ruin/lavaland/syndicate_lava_base/dormitories)
+/area/ruin/syndicate_lava_base)
 "LB" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
@@ -3645,7 +3424,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/iron,
-/area/ruin/lavaland/syndicate_lava_base/engineering)
+/area/ruin/syndicate_lava_base)
 "LL" = (
 /obj/machinery/firealarm{
 	dir = 8;
@@ -3656,28 +3435,28 @@
 	dir = 1
 	},
 /turf/open/floor/iron,
-/area/ruin/lavaland/syndicate_lava_base/main)
+/area/ruin/syndicate_lava_base)
 "LV" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
 /obj/item/clothing/gloves/artifact_pinchers,
 /turf/open/floor/engine,
-/area/ruin/lavaland/syndicate_lava_base/science)
+/area/ruin/syndicate_lava_base)
 "LW" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/layer_manifold{
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/ruin/lavaland/syndicate_lava_base/engineering)
+/area/ruin/syndicate_lava_base)
 "LZ" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/structure/cable/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/plating,
-/area/ruin/lavaland/syndicate_lava_base/main)
+/area/ruin/syndicate_lava_base)
 "Ml" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
@@ -3687,21 +3466,14 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/iron,
-/area/ruin/lavaland/syndicate_lava_base/arrivals)
-"Mo" = (
-/obj/machinery/door/airlock/maintenance,
-/obj/structure/cable/yellow,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
-/turf/open/floor/plating,
-/area/ruin/lavaland/syndicate_lava_base/cargo)
+/area/ruin/syndicate_lava_base)
 "Mr" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/engine,
-/area/ruin/lavaland/syndicate_lava_base/science)
+/area/ruin/syndicate_lava_base)
 "Mu" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -3719,7 +3491,7 @@
 	dir = 1
 	},
 /turf/open/floor/plating,
-/area/ruin/lavaland/syndicate_lava_base/main)
+/area/ruin/syndicate_lava_base)
 "ME" = (
 /obj/machinery/atmospherics/pipe/smart/simple/orange/visible,
 /obj/machinery/airlock_controller/incinerator_syndicatelava{
@@ -3736,7 +3508,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/yellow/anticorner/contrasted,
 /turf/open/floor/iron,
-/area/ruin/lavaland/syndicate_lava_base/engineering)
+/area/ruin/syndicate_lava_base)
 "ML" = (
 /obj/structure/table,
 /obj/item/paper_bin,
@@ -3750,13 +3522,13 @@
 	},
 /obj/item/flashlight,
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/cargo)
+/area/ruin/syndicate_lava_base)
 "MM" = (
 /obj/structure/cable/yellow,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /turf/open/floor/iron,
-/area/ruin/lavaland/syndicate_lava_base/science)
+/area/ruin/syndicate_lava_base)
 "MN" = (
 /obj/structure/closet/secure_closet/medical1{
 	req_access = null;
@@ -3771,14 +3543,7 @@
 /turf/open/floor/iron/white/side{
 	dir = 1
 	},
-/area/ruin/lavaland/syndicate_lava_base/chemistry)
-"MQ" = (
-/obj/machinery/door/airlock/maintenance,
-/obj/structure/cable/yellow,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
-/turf/open/floor/plating,
-/area/ruin/lavaland/syndicate_lava_base/engineering)
+/area/ruin/syndicate_lava_base)
 "MS" = (
 /obj/structure/closet/bombcloset,
 /obj/effect/turf_decal/tile/purple/anticorner/contrasted{
@@ -3786,7 +3551,7 @@
 	},
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
-/area/ruin/lavaland/syndicate_lava_base/science)
+/area/ruin/syndicate_lava_base)
 "MT" = (
 /obj/structure/cable/yellow,
 /obj/effect/decal/cleanable/dirt,
@@ -3795,7 +3560,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/iron,
-/area/ruin/lavaland/syndicate_lava_base/science)
+/area/ruin/syndicate_lava_base)
 "MX" = (
 /obj/effect/turf_decal/tile/yellow/half/contrasted{
 	dir = 4
@@ -3803,14 +3568,14 @@
 /turf/open/floor/iron/white/side{
 	dir = 1
 	},
-/area/ruin/lavaland/syndicate_lava_base/main)
+/area/ruin/syndicate_lava_base)
 "Nb" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/carpet/grimy,
-/area/ruin/lavaland/syndicate_lava_base/dormitories)
+/area/ruin/syndicate_lava_base)
 "Np" = (
 /obj/effect/turf_decal/tile/purple/half/contrasted{
 	dir = 8
@@ -3819,7 +3584,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron,
-/area/ruin/lavaland/syndicate_lava_base/science)
+/area/ruin/syndicate_lava_base)
 "Nv" = (
 /obj/effect/turf_decal/bot,
 /obj/effect/decal/cleanable/dirt,
@@ -3828,20 +3593,14 @@
 	dir = 1
 	},
 /turf/open/floor/iron,
-/area/ruin/lavaland/syndicate_lava_base/engineering)
-"Nz" = (
-/obj/machinery/porta_turret/syndicate{
-	dir = 10
-	},
-/turf/closed/wall/mineral/plastitanium,
-/area/ruin/lavaland/syndicate_lava_base/engineering)
+/area/ruin/syndicate_lava_base)
 "NF" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/red/half/contrasted{
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/ruin/lavaland/syndicate_lava_base/arrivals)
+/area/ruin/syndicate_lava_base)
 "NI" = (
 /obj/structure/sign/warning/vacuum{
 	pixel_x = -32
@@ -3851,7 +3610,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/ruin/lavaland/syndicate_lava_base/main)
+/area/ruin/syndicate_lava_base)
 "NS" = (
 /obj/structure/cable/yellow,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
@@ -3863,7 +3622,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
-/area/ruin/lavaland/syndicate_lava_base/science)
+/area/ruin/syndicate_lava_base)
 "Oa" = (
 /obj/structure/cable/yellow,
 /obj/effect/decal/cleanable/dirt,
@@ -3875,7 +3634,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/iron,
-/area/ruin/lavaland/syndicate_lava_base/main)
+/area/ruin/syndicate_lava_base)
 "Ob" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/poddoor/preopen{
@@ -3890,7 +3649,7 @@
 	},
 /obj/effect/mapping_helpers/airlock/access/all/syndicate/general,
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/testlab)
+/area/ruin/syndicate_lava_base)
 "Oc" = (
 /obj/structure/table,
 /obj/item/storage/firstaid/regular,
@@ -3899,7 +3658,7 @@
 /turf/open/floor/iron/white/side{
 	dir = 4
 	},
-/area/ruin/lavaland/syndicate_lava_base/medbay)
+/area/ruin/syndicate_lava_base)
 "Oq" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -3909,14 +3668,14 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/iron,
-/area/ruin/lavaland/syndicate_lava_base/main)
+/area/ruin/syndicate_lava_base)
 "Os" = (
 /obj/machinery/firealarm/directional/south,
 /obj/machinery/computer/arcade/orion_trail{
 	dir = 4
 	},
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/bar)
+/area/ruin/syndicate_lava_base)
 "Ou" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
@@ -3926,14 +3685,14 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/bar)
+/area/ruin/syndicate_lava_base)
 "Oy" = (
 /obj/machinery/atmospherics/pipe/layer_manifold{
 	dir = 4
 	},
 /obj/effect/spawner/structure/window/reinforced/plasma/plastitanium,
 /turf/open/floor/plating,
-/area/ruin/lavaland/syndicate_lava_base/engineering)
+/area/ruin/syndicate_lava_base)
 "OC" = (
 /obj/effect/turf_decal/bot,
 /obj/structure/railing{
@@ -3944,7 +3703,7 @@
 /obj/item/xenoartifact,
 /obj/item/xenoartifact,
 /turf/open/floor/engine,
-/area/ruin/lavaland/syndicate_lava_base/science)
+/area/ruin/syndicate_lava_base)
 "OF" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
@@ -3953,7 +3712,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/iron,
-/area/ruin/lavaland/syndicate_lava_base/engineering)
+/area/ruin/syndicate_lava_base)
 "OJ" = (
 /obj/machinery/light/small,
 /obj/structure/bed/roller,
@@ -3964,17 +3723,17 @@
 	},
 /obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/testlab)
+/area/ruin/syndicate_lava_base)
 "OV" = (
 /turf/open/floor/wood,
-/area/ruin/lavaland/syndicate_lava_base/bar)
+/area/ruin/syndicate_lava_base)
 "Pk" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},
 /obj/item/xenoarchaeology_labeler,
 /turf/open/floor/engine,
-/area/ruin/lavaland/syndicate_lava_base/science)
+/area/ruin/syndicate_lava_base)
 "Pv" = (
 /obj/machinery/computer/atmos_control{
 	dir = 8;
@@ -3986,7 +3745,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron,
-/area/ruin/lavaland/syndicate_lava_base/engineering)
+/area/ruin/syndicate_lava_base)
 "Pw" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -4002,7 +3761,7 @@
 	dir = 8
 	},
 /turf/open/floor/plating,
-/area/ruin/lavaland/syndicate_lava_base/arrivals)
+/area/ruin/syndicate_lava_base)
 "Py" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -4011,19 +3770,19 @@
 	dir = 1
 	},
 /turf/open/floor/carpet/grimy,
-/area/ruin/lavaland/syndicate_lava_base/dormitories)
+/area/ruin/syndicate_lava_base)
 "Pz" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/random/vending/snackvend,
 /obj/machinery/firealarm/directional/east,
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/bar)
+/area/ruin/syndicate_lava_base)
 "PC" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
 /obj/structure/chair/stool/bar/directional/east,
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/bar)
+/area/ruin/syndicate_lava_base)
 "PG" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/neutral{
@@ -4032,7 +3791,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/iron,
-/area/ruin/lavaland/syndicate_lava_base/dormitories)
+/area/ruin/syndicate_lava_base)
 "PK" = (
 /obj/structure/table/wood,
 /obj/item/book/manual/wiki/barman_recipes,
@@ -4040,16 +3799,16 @@
 	dir = 8
 	},
 /turf/open/floor/wood,
-/area/ruin/lavaland/syndicate_lava_base/bar)
+/area/ruin/syndicate_lava_base)
 "PW" = (
 /obj/machinery/door/window/westright{
 	name = "Kitchen"
 	},
 /turf/open/floor/iron/white,
-/area/ruin/lavaland/syndicate_lava_base/bar)
+/area/ruin/syndicate_lava_base)
 "PX" = (
 /turf/open/floor/engine/plasma,
-/area/ruin/lavaland/syndicate_lava_base/engineering)
+/area/ruin/syndicate_lava_base)
 "PZ" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
 /obj/machinery/computer/security/telescreen/entertainment{
@@ -4058,14 +3817,14 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/bar)
+/area/ruin/syndicate_lava_base)
 "Qa" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/red/anticorner/contrasted{
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/ruin/lavaland/syndicate_lava_base/arrivals)
+/area/ruin/syndicate_lava_base)
 "Qe" = (
 /obj/structure/cable/yellow,
 /obj/effect/turf_decal/tile/blue/half/contrasted,
@@ -4074,7 +3833,7 @@
 /turf/open/floor/iron/white/side{
 	dir = 4
 	},
-/area/ruin/lavaland/syndicate_lava_base/arrivals)
+/area/ruin/syndicate_lava_base)
 "Qf" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/on{
 	dir = 1;
@@ -4082,22 +3841,18 @@
 	name = "toxin out"
 	},
 /turf/open/floor/engine/plasma,
-/area/ruin/lavaland/syndicate_lava_base/engineering)
+/area/ruin/syndicate_lava_base)
 "Qi" = (
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/science)
+/area/ruin/syndicate_lava_base)
 "Qj" = (
 /obj/machinery/door/poddoor{
 	id = "lavalandsyndi_arrivals"
 	},
 /obj/effect/spawner/structure/window/reinforced/plasma/plastitanium,
 /turf/open/floor/plating,
-/area/ruin/lavaland/syndicate_lava_base/arrivals)
-"Qs" = (
-/obj/effect/spawner/structure/window/reinforced/plasma/plastitanium,
-/turf/open/floor/plating,
-/area/ruin/lavaland/syndicate_lava_base/engineering)
+/area/ruin/syndicate_lava_base)
 "QA" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -4105,16 +3860,7 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/telecomms)
-"QK" = (
-/obj/structure/cable/yellow,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
-/turf/open/floor/iron,
-/area/ruin/lavaland/syndicate_lava_base/arrivals)
+/area/ruin/syndicate_lava_base)
 "QM" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -4131,12 +3877,12 @@
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/ruin/lavaland/syndicate_lava_base/cargo)
+/area/ruin/syndicate_lava_base)
 "QO" = (
 /obj/structure/chair/office/light,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
-/area/ruin/lavaland/syndicate_lava_base/science)
+/area/ruin/syndicate_lava_base)
 "QP" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -4160,7 +3906,7 @@
 /turf/open/floor/iron/white/side{
 	dir = 4
 	},
-/area/ruin/lavaland/syndicate_lava_base/chemistry)
+/area/ruin/syndicate_lava_base)
 "QQ" = (
 /obj/structure/table/wood,
 /obj/machinery/chem_dispenser/drinks/fullupgrade{
@@ -4170,16 +3916,13 @@
 	dir = 6
 	},
 /turf/open/floor/wood,
-/area/ruin/lavaland/syndicate_lava_base/bar)
-"Ra" = (
-/turf/closed/wall/mineral/plastitanium/explosive,
-/area/ruin/lavaland/syndicate_lava_base/medbay)
+/area/ruin/syndicate_lava_base)
 "Rh" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/ruin/lavaland/syndicate_lava_base/chemistry)
+/area/ruin/syndicate_lava_base)
 "Rl" = (
 /obj/effect/turf_decal/tile/purple/half/contrasted{
 	dir = 8
@@ -4187,7 +3930,7 @@
 /obj/item/storage/firstaid/regular,
 /obj/structure/table_frame,
 /turf/open/floor/iron,
-/area/ruin/lavaland/syndicate_lava_base/science)
+/area/ruin/syndicate_lava_base)
 "Ru" = (
 /obj/structure/table/glass,
 /obj/item/stack/sheet/mineral/plasma{
@@ -4205,7 +3948,7 @@
 /turf/open/floor/iron/white/side{
 	dir = 1
 	},
-/area/ruin/lavaland/syndicate_lava_base/chemistry)
+/area/ruin/syndicate_lava_base)
 "Ry" = (
 /obj/structure/railing{
 	dir = 8
@@ -4220,26 +3963,11 @@
 	},
 /obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/testlab)
+/area/ruin/syndicate_lava_base)
 "RD" = (
 /obj/effect/mapping_helpers/no_lava,
 /turf/open/floor/plating,
-/area/ruin/lavaland/syndicate_lava_base/main)
-"RT" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
-/obj/structure/cable/yellow,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
-/turf/open/floor/iron,
-/area/ruin/lavaland/syndicate_lava_base/main)
-"RU" = (
-/obj/structure/chair{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/ruin/lavaland/syndicate_lava_base/cargo)
+/area/ruin/syndicate_lava_base)
 "RW" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/medical/glass{
@@ -4247,7 +3975,7 @@
 	},
 /obj/effect/turf_decal/stripes/closeup,
 /turf/open/floor/iron,
-/area/ruin/lavaland/syndicate_lava_base/medbay)
+/area/ruin/syndicate_lava_base)
 "RZ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
@@ -4256,7 +3984,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/random/vending/colavend,
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/bar)
+/area/ruin/syndicate_lava_base)
 "Sa" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/public/glass{
@@ -4270,37 +3998,31 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/iron,
-/area/ruin/lavaland/syndicate_lava_base/dormitories)
+/area/ruin/syndicate_lava_base)
 "Sc" = (
 /obj/item/healthanalyzer,
 /turf/open/floor/plating,
-/area/ruin/lavaland/syndicate_lava_base/science)
+/area/ruin/syndicate_lava_base)
 "Sd" = (
 /obj/item/reagent_containers/condiment/enzyme,
 /obj/item/food/chocolatebar,
 /obj/structure/closet/secure_closet/freezer/fridge/open,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/white,
-/area/ruin/lavaland/syndicate_lava_base/bar)
+/area/ruin/syndicate_lava_base)
 "Sk" = (
 /obj/effect/turf_decal/box,
 /obj/item/xenoartifact,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/engine,
-/area/ruin/lavaland/syndicate_lava_base/science)
-"Sl" = (
-/obj/machinery/porta_turret/syndicate{
-	dir = 10
-	},
-/turf/closed/wall/mineral/plastitanium/nodiagonal,
-/area/ruin/lavaland/syndicate_lava_base/science)
+/area/ruin/syndicate_lava_base)
 "So" = (
 /obj/structure/chair{
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/bar)
+/area/ruin/syndicate_lava_base)
 "Sr" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
 	cycle_id = "syndi-outpost1"
@@ -4309,7 +4031,7 @@
 /obj/effect/mapping_helpers/airlock/access/all/syndicate/general,
 /obj/structure/fans/tiny,
 /turf/open/floor/plating,
-/area/ruin/lavaland/syndicate_lava_base/arrivals)
+/area/ruin/syndicate_lava_base)
 "St" = (
 /obj/structure/fans/tiny,
 /obj/machinery/door/airlock/external,
@@ -4318,7 +4040,7 @@
 	dir = 1
 	},
 /turf/open/floor/plating,
-/area/ruin/lavaland/syndicate_lava_base/arrivals)
+/area/ruin/syndicate_lava_base)
 "Su" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -4347,7 +4069,7 @@
 	pixel_x = 6
 	},
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/testlab)
+/area/ruin/syndicate_lava_base)
 "Sx" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable/yellow,
@@ -4362,12 +4084,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /obj/structure/barricade/wooden/crude,
 /turf/open/floor/iron,
-/area/ruin/lavaland/syndicate_lava_base/science)
+/area/ruin/syndicate_lava_base)
 "SE" = (
 /obj/structure/chair/stool/bar,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/bar)
+/area/ruin/syndicate_lava_base)
 "SF" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/red/line{
@@ -4377,11 +4099,11 @@
 /obj/structure/closet/crate,
 /obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/main)
+/area/ruin/syndicate_lava_base)
 "SI" = (
 /obj/structure/closet/crate/bin,
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/bar)
+/area/ruin/syndicate_lava_base)
 "SJ" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
@@ -4390,11 +4112,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/portable_atmospherics/pump,
 /turf/open/floor/plating,
-/area/ruin/lavaland/syndicate_lava_base/engineering)
-"SN" = (
-/obj/effect/turf_decal/tile/red,
-/turf/open/floor/iron,
-/area/ruin/lavaland/syndicate_lava_base/arrivals)
+/area/ruin/syndicate_lava_base)
 "SW" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/stripes/line,
@@ -4405,7 +4123,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/iron,
-/area/ruin/lavaland/syndicate_lava_base/engineering)
+/area/ruin/syndicate_lava_base)
 "Tc" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/components/binary/dp_vent_pump/high_volume/incinerator_syndicatelava{
@@ -4414,7 +4132,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /turf/open/floor/engine,
-/area/ruin/lavaland/syndicate_lava_base/engineering)
+/area/ruin/syndicate_lava_base)
 "Ti" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/computer/atmos_control{
@@ -4430,10 +4148,10 @@
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/ruin/lavaland/syndicate_lava_base/engineering)
+/area/ruin/syndicate_lava_base)
 "Tk" = (
 /turf/closed/wall/mineral/plastitanium,
-/area/ruin/lavaland/syndicate_lava_base/main)
+/area/ruin/syndicate_lava_base)
 "Tq" = (
 /obj/effect/turf_decal/stripes/corner,
 /obj/structure/cable/yellow,
@@ -4441,7 +4159,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/iron,
-/area/ruin/lavaland/syndicate_lava_base/arrivals)
+/area/ruin/syndicate_lava_base)
 "Tz" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/cup/glass/bottle/beer{
@@ -4449,21 +4167,21 @@
 	pixel_x = 7
 	},
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/bar)
+/area/ruin/syndicate_lava_base)
 "TK" = (
 /obj/machinery/light/small{
 	dir = 4
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
 /turf/open/floor/carpet/grimy,
-/area/ruin/lavaland/syndicate_lava_base/dormitories)
+/area/ruin/syndicate_lava_base)
 "TL" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/cargo)
+/area/ruin/syndicate_lava_base)
 "TN" = (
 /obj/structure/cable/yellow,
 /obj/effect/decal/cleanable/dirt,
@@ -4472,14 +4190,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/ruin/lavaland/syndicate_lava_base/engineering)
-"TW" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/tile/red/half/contrasted{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/ruin/lavaland/syndicate_lava_base/arrivals)
+/area/ruin/syndicate_lava_base)
 "Uh" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/on{
 	dir = 8;
@@ -4487,20 +4198,14 @@
 	name = "oxygen out"
 	},
 /turf/open/floor/engine/o2,
-/area/ruin/lavaland/syndicate_lava_base/engineering)
+/area/ruin/syndicate_lava_base)
 "Ut" = (
 /obj/effect/mapping_helpers/no_lava,
 /obj/machinery/light/small{
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/ruin/lavaland/syndicate_lava_base/main)
-"Uw" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/ruin/lavaland/syndicate_lava_base/medbay)
+/area/ruin/syndicate_lava_base)
 "Uz" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "lavalandsyndiwindow";
@@ -4510,7 +4215,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/plating,
-/area/ruin/lavaland/syndicate_lava_base/testlab)
+/area/ruin/syndicate_lava_base)
 "UF" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
@@ -4520,14 +4225,11 @@
 	dir = 1
 	},
 /turf/open/floor/iron,
-/area/ruin/lavaland/syndicate_lava_base/main)
+/area/ruin/syndicate_lava_base)
 "UL" = (
 /obj/effect/turf_decal/siding/wood/corner,
 /turf/open/floor/wood,
-/area/ruin/lavaland/syndicate_lava_base/bar)
-"UP" = (
-/turf/closed/wall/mineral/plastitanium/explosive,
-/area/ruin/lavaland/syndicate_lava_base/science)
+/area/ruin/syndicate_lava_base)
 "UT" = (
 /obj/structure/table,
 /obj/item/storage/box/syringes,
@@ -4540,7 +4242,7 @@
 /turf/open/floor/iron/white/side{
 	dir = 9
 	},
-/area/ruin/lavaland/syndicate_lava_base/medbay)
+/area/ruin/syndicate_lava_base)
 "UW" = (
 /obj/machinery/door/airlock/hatch{
 	name = "Monkey Pen"
@@ -4553,7 +4255,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/testlab)
+/area/ruin/syndicate_lava_base)
 "Vf" = (
 /obj/structure/table/reinforced,
 /obj/item/radio/intercom{
@@ -4563,7 +4265,7 @@
 /obj/item/paper/fluff/ruins/syndicomms,
 /obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/telecomms)
+/area/ruin/syndicate_lava_base)
 "Vr" = (
 /obj/effect/turf_decal/bot,
 /obj/effect/decal/cleanable/dirt,
@@ -4572,13 +4274,13 @@
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/ruin/lavaland/syndicate_lava_base/engineering)
+/area/ruin/syndicate_lava_base)
 "Vw" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/window/reinforced/spawner/directional/north,
 /obj/machinery/processor,
 /turf/open/floor/plating,
-/area/ruin/lavaland/syndicate_lava_base/main)
+/area/ruin/syndicate_lava_base)
 "VH" = (
 /obj/structure/cable/yellow,
 /obj/effect/decal/cleanable/dirt,
@@ -4588,18 +4290,18 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/iron,
-/area/ruin/lavaland/syndicate_lava_base/dormitories)
+/area/ruin/syndicate_lava_base)
 "VN" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/purple/half/contrasted{
 	dir = 1
 	},
 /turf/open/floor/iron,
-/area/ruin/lavaland/syndicate_lava_base/main)
+/area/ruin/syndicate_lava_base)
 "VP" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /turf/open/floor/engine,
-/area/ruin/lavaland/syndicate_lava_base/testlab)
+/area/ruin/syndicate_lava_base)
 "VS" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -4611,7 +4313,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/ruin/lavaland/syndicate_lava_base/main)
+/area/ruin/syndicate_lava_base)
 "VV" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/yellow,
@@ -4619,7 +4321,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron,
-/area/ruin/lavaland/syndicate_lava_base/engineering)
+/area/ruin/syndicate_lava_base)
 "Wc" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/monitored{
 	dir = 1
@@ -4628,7 +4330,7 @@
 	pixel_y = -32
 	},
 /turf/open/floor/engine/vacuum,
-/area/ruin/lavaland/syndicate_lava_base/engineering)
+/area/ruin/syndicate_lava_base)
 "Wm" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Dormitories"
@@ -4638,14 +4340,14 @@
 	dir = 1
 	},
 /turf/open/floor/iron,
-/area/ruin/lavaland/syndicate_lava_base/dormitories)
+/area/ruin/syndicate_lava_base)
 "Wn" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
 /turf/open/floor/iron,
-/area/ruin/lavaland/syndicate_lava_base/arrivals)
+/area/ruin/syndicate_lava_base)
 "Wq" = (
 /obj/structure/rack{
 	dir = 8
@@ -4658,13 +4360,13 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/cargo)
+/area/ruin/syndicate_lava_base)
 "Ww" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/cargo)
+/area/ruin/syndicate_lava_base)
 "Wy" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/shower{
@@ -4672,7 +4374,7 @@
 	desc = "The HS-452. Installed recently by the DonkCo Hygiene Division."
 	},
 /turf/open/floor/noslip/standard,
-/area/ruin/lavaland/syndicate_lava_base/main)
+/area/ruin/syndicate_lava_base)
 "Wz" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 6
@@ -4683,14 +4385,14 @@
 	pixel_y = 6
 	},
 /turf/open/floor/wood,
-/area/ruin/lavaland/syndicate_lava_base/bar)
+/area/ruin/syndicate_lava_base)
 "WF" = (
 /obj/structure/disposaloutlet{
 	dir = 1
 	},
 /obj/structure/disposalpipe/trunk,
 /turf/open/floor/engine,
-/area/ruin/lavaland/syndicate_lava_base/testlab)
+/area/ruin/syndicate_lava_base)
 "WJ" = (
 /obj/machinery/airalarm/directional/west,
 /obj/effect/mapping_helpers/airalarm/syndicate_access,
@@ -4699,13 +4401,7 @@
 	},
 /obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/telecomms)
-"WS" = (
-/obj/machinery/porta_turret/syndicate{
-	dir = 5
-	},
-/turf/closed/wall/mineral/plastitanium,
-/area/ruin/lavaland/syndicate_lava_base/testlab)
+/area/ruin/syndicate_lava_base)
 "WU" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
@@ -4717,13 +4413,13 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/plating,
-/area/ruin/lavaland/syndicate_lava_base/engineering)
+/area/ruin/syndicate_lava_base)
 "WV" = (
 /obj/structure/table,
 /obj/item/storage/toolbox/syndicate,
 /obj/item/multitool,
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/telecomms)
+/area/ruin/syndicate_lava_base)
 "WY" = (
 /obj/structure/table/reinforced,
 /obj/item/surgicaldrill,
@@ -4734,7 +4430,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/white/side,
-/area/ruin/lavaland/syndicate_lava_base/medbay)
+/area/ruin/syndicate_lava_base)
 "Xc" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
 /obj/machinery/button/door{
@@ -4745,7 +4441,7 @@
 	pixel_y = 25
 	},
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/telecomms)
+/area/ruin/syndicate_lava_base)
 "Xd" = (
 /obj/machinery/airalarm/directional/west,
 /obj/effect/mapping_helpers/airalarm/syndicate_access,
@@ -4753,7 +4449,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron,
-/area/ruin/lavaland/syndicate_lava_base/main)
+/area/ruin/syndicate_lava_base)
 "Xr" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/toolbox/syndicate,
@@ -4768,7 +4464,7 @@
 	dir = 9
 	},
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/testlab)
+/area/ruin/syndicate_lava_base)
 "Xx" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable/yellow,
@@ -4782,7 +4478,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/iron,
-/area/ruin/lavaland/syndicate_lava_base/main)
+/area/ruin/syndicate_lava_base)
 "XA" = (
 /obj/machinery/vending/toyliberationstation{
 	req_access_txt = "150"
@@ -4791,7 +4487,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/ruin/lavaland/syndicate_lava_base/cargo)
+/area/ruin/syndicate_lava_base)
 "XH" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/yellow/half/contrasted{
@@ -4800,7 +4496,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/iron,
-/area/ruin/lavaland/syndicate_lava_base/engineering)
+/area/ruin/syndicate_lava_base)
 "XR" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -4813,7 +4509,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/iron,
-/area/ruin/lavaland/syndicate_lava_base/chemistry)
+/area/ruin/syndicate_lava_base)
 "XV" = (
 /obj/structure/table/reinforced,
 /obj/item/scalpel,
@@ -4829,7 +4525,7 @@
 /turf/open/floor/iron/white/side{
 	dir = 4
 	},
-/area/ruin/lavaland/syndicate_lava_base/medbay)
+/area/ruin/syndicate_lava_base)
 "XY" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/brown/half/contrasted{
@@ -4837,7 +4533,7 @@
 	},
 /obj/structure/closet/firecloset,
 /turf/open/floor/iron,
-/area/ruin/lavaland/syndicate_lava_base/cargo)
+/area/ruin/syndicate_lava_base)
 "Ye" = (
 /obj/machinery/computer/atmos_control{
 	dir = 8;
@@ -4846,21 +4542,21 @@
 /obj/effect/turf_decal/tile/blue/half/contrasted,
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
 /turf/open/floor/iron,
-/area/ruin/lavaland/syndicate_lava_base/engineering)
+/area/ruin/syndicate_lava_base)
 "Yx" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
 /obj/structure/chair/stool/bar,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/bar)
+/area/ruin/syndicate_lava_base)
 "Yz" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
 /obj/machinery/airalarm/directional/west,
 /obj/effect/mapping_helpers/airalarm/syndicate_access,
 /obj/structure/chair/stool,
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/bar)
+/area/ruin/syndicate_lava_base)
 "YD" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_y = -29
@@ -4873,7 +4569,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron,
-/area/ruin/lavaland/syndicate_lava_base/arrivals)
+/area/ruin/syndicate_lava_base)
 "YK" = (
 /obj/machinery/door/window/southleft{
 	base_state = "right";
@@ -4887,12 +4583,7 @@
 /turf/open/floor/wood{
 	broken = 1
 	},
-/area/ruin/lavaland/syndicate_lava_base/bar)
-"YL" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
-/turf/open/floor/iron,
-/area/ruin/lavaland/syndicate_lava_base/medbay)
+/area/ruin/syndicate_lava_base)
 "YO" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 25
@@ -4902,7 +4593,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/testlab)
+/area/ruin/syndicate_lava_base)
 "YQ" = (
 /obj/effect/turf_decal/tile/purple/anticorner/contrasted{
 	dir = 4
@@ -4914,7 +4605,7 @@
 	},
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /turf/open/floor/iron,
-/area/ruin/lavaland/syndicate_lava_base/science)
+/area/ruin/syndicate_lava_base)
 "YU" = (
 /obj/structure/chair{
 	dir = 4
@@ -4928,7 +4619,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron,
-/area/ruin/lavaland/syndicate_lava_base/main)
+/area/ruin/syndicate_lava_base)
 "YV" = (
 /obj/machinery/airalarm/directional/west,
 /obj/effect/mapping_helpers/airalarm/syndicate_access,
@@ -4952,7 +4643,7 @@
 /obj/item/circuitboard/machine/thermomachine,
 /obj/item/analyzer/ranged,
 /turf/open/floor/iron,
-/area/ruin/lavaland/syndicate_lava_base/engineering)
+/area/ruin/syndicate_lava_base)
 "Za" = (
 /obj/machinery/door/airlock{
 	name = "Cabin 4"
@@ -4962,7 +4653,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/iron,
-/area/ruin/lavaland/syndicate_lava_base/dormitories)
+/area/ruin/syndicate_lava_base)
 "Zc" = (
 /obj/machinery/door/firedoor,
 /obj/structure/table/reinforced,
@@ -4972,14 +4663,14 @@
 	req_access_txt = "150"
 	},
 /turf/open/floor/plating,
-/area/ruin/lavaland/syndicate_lava_base/chemistry)
+/area/ruin/syndicate_lava_base)
 "Zd" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/siding/wood/corner{
 	dir = 8
 	},
 /turf/open/floor/wood,
-/area/ruin/lavaland/syndicate_lava_base/bar)
+/area/ruin/syndicate_lava_base)
 "Zf" = (
 /obj/structure/table/wood,
 /obj/effect/decal/cleanable/dirt,
@@ -4988,14 +4679,14 @@
 	dir = 8
 	},
 /turf/open/floor/wood,
-/area/ruin/lavaland/syndicate_lava_base/bar)
+/area/ruin/syndicate_lava_base)
 "Zi" = (
 /obj/structure/table/wood,
 /obj/item/ammo_box/magazine/m10mm,
 /obj/machinery/airalarm/directional/north,
 /obj/effect/mapping_helpers/airalarm/syndicate_access,
 /turf/open/floor/carpet/grimy,
-/area/ruin/lavaland/syndicate_lava_base/dormitories)
+/area/ruin/syndicate_lava_base)
 "Zj" = (
 /obj/structure/rack{
 	dir = 8
@@ -5011,14 +4702,14 @@
 	dir = 1
 	},
 /turf/open/floor/iron,
-/area/ruin/lavaland/syndicate_lava_base/arrivals)
+/area/ruin/syndicate_lava_base)
 "Zo" = (
 /obj/machinery/atmospherics/miner/oxygen,
 /obj/machinery/light/small{
 	dir = 4
 	},
 /turf/open/floor/engine/o2,
-/area/ruin/lavaland/syndicate_lava_base/engineering)
+/area/ruin/syndicate_lava_base)
 "Zy" = (
 /obj/machinery/door/airlock/hatch{
 	name = "Telecommunications"
@@ -5032,7 +4723,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/telecomms)
+/area/ruin/syndicate_lava_base)
 "ZE" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -5043,12 +4734,12 @@
 	},
 /obj/machinery/firealarm/directional/north,
 /turf/open/floor/iron,
-/area/ruin/lavaland/syndicate_lava_base/dormitories)
+/area/ruin/syndicate_lava_base)
 "ZT" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/bar)
+/area/ruin/syndicate_lava_base)
 "ZX" = (
 /obj/machinery/light/small,
 /obj/structure/extinguisher_cabinet{
@@ -5062,7 +4753,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
-/area/ruin/lavaland/syndicate_lava_base/medbay)
+/area/ruin/syndicate_lava_base)
 "ZZ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/vending/syndichem,
@@ -5070,7 +4761,7 @@
 /turf/open/floor/iron/white/side{
 	dir = 4
 	},
-/area/ruin/lavaland/syndicate_lava_base/chemistry)
+/area/ruin/syndicate_lava_base)
 
 (1,1,1) = {"
 aa
@@ -5257,11 +4948,11 @@ ab
 ab
 ab
 Js
-mn
-mn
-mn
-mn
-mn
+ae
+ae
+ae
+ae
+ae
 Cc
 ab
 ab
@@ -5306,13 +4997,13 @@ ab
 ab
 ab
 ab
-mn
-mn
+ae
+ae
 mM
 JN
 mM
-mn
-mn
+ae
+ae
 ab
 ab
 ab
@@ -5356,13 +5047,13 @@ ab
 ab
 ab
 ab
-mn
+ae
 mM
 mM
-JW
+wG
 mM
 mM
-mn
+ae
 ab
 ab
 ab
@@ -5386,33 +5077,33 @@ ab
 ab
 ab
 ab
-eh
-eh
-eh
-eh
-eh
-Sl
-ab
-ab
-ab
-ab
-ab
-ab
-ha
+ae
+ae
+ae
+ae
+ae
 hW
-ha
+ab
+ab
+ab
+ab
+ab
+ab
+ae
+hW
+ae
 ac
 ab
 ab
 ab
 ac
-mn
-mn
-mN
+ae
+ae
+dQ
 va
-mn
-mn
-mn
+ae
+ae
+ae
 ab
 ab
 ab
@@ -5435,13 +5126,13 @@ ab
 ab
 ab
 ac
-eh
-eh
+ae
+ae
 Dp
 tg
 xq
-eh
-eh
+ae
+ae
 ab
 ab
 ab
@@ -5459,11 +5150,11 @@ ac
 ac
 nl
 mP
-JW
+wG
 WJ
 bE
-mn
-mn
+ae
+ae
 ab
 ab
 ab
@@ -5485,13 +5176,13 @@ ab
 ab
 ab
 ab
-eh
+ae
 pj
 xR
 LV
 tq
 ug
-eh
+ae
 ab
 ab
 ab
@@ -5513,7 +5204,7 @@ tK
 KU
 Cn
 ou
-mn
+ae
 ab
 ab
 ab
@@ -5535,13 +5226,13 @@ ab
 ab
 ab
 ac
-eh
+ae
 gN
 xR
 Sk
 uL
 ug
-eh
+ae
 ab
 ab
 ab
@@ -5563,7 +5254,7 @@ Xc
 bg
 Vf
 ov
-mn
+ae
 ab
 ab
 ab
@@ -5585,14 +5276,14 @@ ab
 ab
 ab
 ac
-eh
+ae
 Qi
 Pk
 xR
 Mr
 ug
-eh
-eh
+ae
+ae
 ab
 ab
 ab
@@ -5606,13 +5297,13 @@ ab
 ab
 cI
 Ry
-mT
-mT
-mT
+ae
+ae
+ae
 QA
 En
 IO
-mn
+ae
 mS
 ab
 ab
@@ -5635,14 +5326,14 @@ ab
 ab
 ab
 ab
-eh
-eh
+ae
+ae
 OC
 pw
 qp
 cw
 wM
-eh
+ae
 ab
 ab
 ab
@@ -5658,11 +5349,11 @@ uD
 pY
 Sr
 xH
-mT
-mo
+ae
+aL
 Zy
-mn
-mn
+ae
+ae
 ab
 ab
 ab
@@ -5686,9 +5377,9 @@ ab
 ab
 ab
 ac
-eh
+ae
 MS
-It
+dC
 IA
 NS
 Rl
@@ -5704,15 +5395,15 @@ Cq
 pl
 pl
 pl
-jy
-jy
-mT
+ae
+ae
+ae
 Ak
-mT
+ae
 JA
 wc
 ol
-mT
+ae
 ab
 ab
 ab
@@ -5736,7 +5427,7 @@ ab
 ab
 ab
 ac
-UP
+aL
 qK
 Sc
 MM
@@ -5756,13 +5447,13 @@ BN
 So
 FG
 kJ
-mT
+ae
 Hi
 uJ
 Wn
-Il
+jK
 ol
-mT
+ae
 ab
 ab
 ab
@@ -5786,7 +5477,7 @@ ab
 ab
 ab
 ac
-eh
+ae
 YQ
 Aq
 cC
@@ -5804,15 +5495,15 @@ pl
 ss
 ml
 Tz
-DM
+wG
 Os
-mT
+ae
 Pw
-mT
+ae
 fu
-Il
+jK
 vq
-mT
+ae
 ab
 ab
 ab
@@ -5833,7 +5524,7 @@ ab
 ac
 ab
 ac
-WS
+DF
 ae
 ae
 ae
@@ -5842,8 +5533,8 @@ em
 MT
 uk
 Co
-eh
-Lt
+ae
+Cc
 ab
 ab
 De
@@ -5856,15 +5547,15 @@ kH
 Ou
 lE
 tz
-mT
-mT
-mT
+ae
+ae
+ae
 NF
 Tq
-mT
-mT
-mT
-oF
+ae
+ae
+ae
+dQ
 ab
 ab
 ab
@@ -5890,10 +5581,10 @@ OJ
 ae
 fD
 Sx
-eh
-eh
-eh
-eh
+ae
+ae
+ae
+ae
 el
 el
 Cq
@@ -5904,11 +5595,11 @@ vG
 jY
 db
 jZ
-DM
+wG
 jZ
 Yz
 ZT
-Fr
+DO
 NF
 kw
 EZ
@@ -5935,25 +5626,25 @@ qG
 dc
 rS
 dQ
-Hj
+DO
 UW
 ae
 yK
 vR
 UF
-ha
+ae
 NI
 hb
 fi
 RD
-jy
-jy
+ae
+ae
 KB
 fW
 BS
 xl
 jZ
-DM
+wG
 jZ
 Hk
 jZ
@@ -5961,10 +5652,10 @@ db
 oq
 BC
 Ml
-mT
-mT
-mT
-oF
+ae
+ae
+ae
+dQ
 ab
 ab
 ab
@@ -5983,20 +5674,20 @@ aq
 cJ
 aq
 Lg
-Dh
+uL
 Ob
 RC
 Kc
 ae
 Wy
-RT
+OF
 gZ
 Kd
 lx
-ha
+ae
 ql
 Ut
-jy
+ae
 SI
 CZ
 jZ
@@ -6008,11 +5699,11 @@ FX
 ly
 PC
 mu
-Fr
+DO
 Qa
 zM
-TW
-mT
+GT
+ae
 ab
 ab
 ab
@@ -6040,16 +5731,16 @@ uo
 ae
 ae
 Xx
-ha
-ha
+ae
+ae
 Mu
-ha
-ha
-ha
-ha
-jy
+ae
+ae
+ae
+ae
+ae
 fl
-DM
+wG
 jZ
 kp
 SE
@@ -6058,11 +5749,11 @@ PK
 aP
 Zf
 rx
-jy
-jy
+ae
+ae
 Bc
 YD
-mT
+ae
 Qj
 ab
 ab
@@ -6091,16 +5782,16 @@ ph
 ae
 nU
 VN
-ha
-iN
-ha
+ae
+aL
+ae
 Az
 YU
 VS
 oq
-DM
+wG
 jZ
-DM
+wG
 Hl
 Yx
 BA
@@ -6109,9 +5800,9 @@ lX
 pC
 Zd
 EL
-jy
+ae
 tQ
-vb
+hi
 ta
 Qj
 ab
@@ -6140,7 +5831,7 @@ xf
 YO
 FO
 rQ
-rO
+jK
 Oa
 gp
 lu
@@ -6159,7 +5850,7 @@ lX
 UL
 iA
 QQ
-jP
+aL
 tQ
 fL
 qR
@@ -6195,12 +5886,12 @@ bA
 bA
 vT
 ik
-if
+dC
 EM
-hz
-hz
-hz
-hz
+ae
+ae
+ae
+ae
 Pz
 RZ
 CL
@@ -6208,10 +5899,10 @@ iA
 sB
 Wz
 ak
-jy
-jy
+ae
+ae
 kA
-nW
+hl
 lU
 Qj
 ab
@@ -6239,29 +5930,29 @@ ae
 ae
 oP
 qZ
-rO
-vp
-hz
-hz
-hz
-hz
+jK
+qR
+ae
+ae
+ae
+ae
 Wm
 Sa
-hz
+ae
 lD
 cu
-hz
-jy
-jy
+ae
+ae
+ae
 jz
 PW
 hN
 pq
 ub
-jy
+ae
 zS
-QK
-SN
+AC
+hd
 BW
 Qj
 ab
@@ -6280,8 +5971,8 @@ ab
 ab
 ab
 ac
-Ju
-as
+DF
+ae
 MN
 pT
 tE
@@ -6289,30 +5980,30 @@ XR
 jK
 iR
 JE
-rO
-vp
-hO
+jK
+qR
+aL
 ga
 Gi
-hz
+ae
 iz
 VH
 Lw
 Nb
 Gk
-hz
+ae
 pD
-jy
+ae
 vv
 pq
 hN
 pq
 Sd
-jy
+ae
 Cr
 eP
 oy
-mT
+ae
 Qj
 ab
 ab
@@ -6330,8 +6021,8 @@ ab
 ab
 ab
 ab
-as
-as
+ae
+ae
 Cf
 dB
 Cp
@@ -6339,30 +6030,30 @@ es
 eS
 DO
 MX
-jj
+hl
 GT
-hz
+ae
 TK
 xU
 rY
 eq
 Fb
-hz
-hz
-hz
-hz
+ae
+ae
+ae
+ae
 Lo
-jy
+ae
 vA
 fX
 hN
 KP
-jy
-jy
+ae
+ae
 id
 sC
 BW
-mT
+ae
 ab
 ab
 ab
@@ -6389,30 +6080,30 @@ et
 eT
 Zc
 MX
-jj
+hl
 AR
-hz
-hz
-hz
-hz
+ae
+ae
+ae
+ae
 eo
-FV
+rQ
 cd
 ku
 ku
 bN
 ku
-jy
-jy
-jy
+ae
+ae
+ae
 jn
-jy
-jy
+ae
+ae
 Zj
 gm
 Ho
-mT
-mT
+ae
+ae
 ab
 ab
 ab
@@ -6439,29 +6130,29 @@ eu
 eU
 fp
 qZ
-jj
-vp
+hl
+qR
 hQ
-hz
+ae
 rX
 IR
-iC
+dC
 KN
-hz
-hz
-hz
-hz
+ae
+ae
+ae
+ae
 dA
 bN
 bN
 bN
 bN
 ku
-cs
+cd
 uZ
 Qe
 mw
-mT
+ae
 ab
 ab
 ab
@@ -6485,34 +6176,34 @@ cG
 dx
 Ru
 dY
-yG
+hl
 dC
-as
+ae
 lP
-if
-vp
-hz
-hz
-hz
-hz
+dC
+qR
+ae
+ae
+ae
+ae
 ZE
 ft
 dm
 Nb
 Py
-hz
+ae
 bN
 ks
 Vw
-kQ
-kQ
-kQ
-Ra
+ae
+ae
+ae
+aL
 kT
 oj
 jb
-kQ
-kQ
+ae
+ae
 ab
 ab
 ab
@@ -6530,39 +6221,39 @@ ab
 ab
 ab
 ab
-as
-as
-as
+ae
+ae
+ae
 An
 QP
 ZZ
-as
-as
-as
+ae
+ae
+ae
 AU
 GJ
-hz
+ae
 HX
 xU
 Za
 Bm
 PG
-hz
+ae
 uc
 cu
-hz
+ae
 ku
 kt
-kQ
-kQ
+ae
+ae
 UT
 wL
 fs
 yg
-Ef
-lI
+jK
+hl
 Kh
-kQ
+ae
 ab
 ab
 ab
@@ -6581,38 +6272,38 @@ ab
 ab
 ab
 ab
-Ju
-as
-as
-as
-as
-as
+DF
+ae
+ae
+ae
+ae
+ae
 EP
-dy
+ae
 ci
-vp
-hz
+qR
+ae
 Zi
 cz
-hz
+ae
 Au
 yY
-hz
-hO
-hz
-hz
+ae
+aL
+ae
+ae
 LZ
-ha
-kQ
+ae
+ae
 bS
-lJ
+dC
 me
-YL
+eP
 AB
-Ef
-lJ
+jK
+dC
 bs
-kQ
+ae
 ac
 ab
 ab
@@ -6632,37 +6323,37 @@ ab
 ab
 ab
 ac
-dy
+ae
 dK
 HA
 sZ
 wG
-JM
+db
 oO
 HD
-vp
-hz
-hz
-hz
-hz
-hz
-hz
-hz
+qR
+ae
+ae
+ae
+ae
+ae
+ae
+ae
 Ll
 Bi
 jR
 rQ
 rn
 RW
-lI
-lI
-lI
-oR
-lI
+hl
+hl
+hl
+eQ
+hl
 DS
 ZX
-kQ
-kQ
+ae
+ae
 ac
 ab
 ab
@@ -6682,13 +6373,13 @@ ab
 ab
 ab
 ab
-dy
+ae
 dL
 eb
 Ww
 eX
 HE
-GG
+DO
 zd
 hi
 zA
@@ -6699,19 +6390,19 @@ LL
 GY
 zK
 FC
-rO
-rO
-rO
+jK
+jK
+jK
 AK
 Ls
-lI
-lJ
+hl
+dC
 mf
-Uw
-lI
+Rh
+hl
 WY
-kQ
-kQ
+ae
+ae
 ac
 ac
 ab
@@ -6732,13 +6423,13 @@ ab
 ab
 ab
 ab
-dy
+ae
 dM
 He
-to
+ni
 eY
 yW
-dP
+aL
 cH
 CP
 CP
@@ -6747,20 +6438,20 @@ af
 ip
 iH
 ja
-jj
-jj
+hl
+hl
 rQ
-if
+dC
 kj
 fV
 kT
 Bp
 Oc
-kQ
+ae
 XV
 ge
 DQ
-kQ
+ae
 ac
 ac
 ab
@@ -6782,39 +6473,39 @@ ab
 ab
 ab
 ab
-dy
-dy
+ae
+ae
 ML
 TL
 Wq
-dy
-dy
+ae
+ae
 gO
 un
 wn
-dP
-dy
-iq
+aL
+ae
+dQ
 en
-iq
-ha
+dQ
+ae
 EA
 Gq
 kL
-ju
-ju
-ju
-ju
-ju
-hA
-ju
-ju
-ju
-ju
-ju
-ju
-ju
-Nz
+ae
+ae
+ae
+ae
+ae
+aL
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+Cc
 ab
 ab
 ab
@@ -6833,25 +6524,25 @@ ab
 ab
 ab
 ac
-dy
-dy
+ae
+ae
 lF
-GG
-dy
+DO
+ae
 vJ
 gP
-gQ
+dC
 hl
 yR
-dy
+ae
 SF
 iJ
 wB
-ha
-ju
+ae
+ae
 Ds
 jU
-ju
+ae
 SJ
 kV
 WU
@@ -6859,12 +6550,12 @@ YV
 zL
 cn
 Jm
-ju
+ae
 od
-ju
+ae
 oz
-ju
-ju
+ae
+ae
 nf
 ab
 ab
@@ -6883,25 +6574,25 @@ ab
 ab
 ab
 ac
-dy
+ae
 XY
-HH
+AB
 fb
 In
 gb
 ch
 hl
-gQ
+dC
 XA
-dy
+ae
 is
 iK
 jc
-ha
+ae
 Nv
 LB
 uy
-ju
+ae
 yr
 kW
 IN
@@ -6933,21 +6624,21 @@ ab
 ab
 ab
 ab
-dy
+ae
 QM
 fk
-pf
-pf
-pf
+jK
+jK
+jK
 fk
 fk
-pf
+jK
 xn
-dy
+ae
 Fs
 pQ
 ar
-ha
+ae
 Gh
 OF
 fr
@@ -6963,8 +6654,8 @@ nE
 dF
 nE
 Wc
-ju
-ju
+ae
+ae
 nf
 ab
 ab
@@ -6983,35 +6674,35 @@ ab
 ab
 ab
 ab
-dy
-dy
+ae
+ae
 eD
 fd
 fw
 gc
 gS
-gQ
+dC
 fk
 IV
-dy
-ha
-ha
-ha
-ha
-ju
-MQ
-ju
-ju
+ae
+ae
+ae
+ae
+ae
+ae
+LZ
+ae
+ae
 Bt
-Ku
-ue
-DA
+eQ
+hl
+dC
 se
 sd
 nf
-ju
-ju
-ju
+ae
+ae
+ae
 oC
 nf
 ab
@@ -7034,34 +6725,34 @@ ab
 ab
 ab
 DF
-dy
+ae
 eE
 fe
-dy
+ae
 gd
-dy
-RU
+ae
+dY
 fk
 fk
-Mo
+LZ
 dD
 dD
 Lq
 bN
 dD
 dD
-ju
+ae
 Ax
 TN
 LW
-ue
-ue
+hl
+hl
 Ig
 oY
 ul
 Qf
 PX
-ju
+ae
 ab
 ab
 ab
@@ -7084,34 +6775,34 @@ ab
 ab
 ab
 ab
-dy
+ae
 ir
 ir
-dy
+ae
 gf
-dy
+ae
 ho
 hD
-dy
-dy
-ha
-ha
-ha
-ha
-ha
+ae
+ae
+ae
+ae
+ae
+ae
+ae
 Lj
-ju
-ju
+ae
+ae
 Pv
 Vr
 Gp
 Ye
 uH
 Ti
-Qs
+DO
 yA
 DK
-ju
+ae
 ab
 ab
 ab
@@ -7137,12 +6828,12 @@ ab
 ab
 ab
 ab
-dy
+ae
 gg
-dy
+ae
 ir
 ir
-dy
+ae
 DF
 ab
 ab
@@ -7150,18 +6841,18 @@ ab
 ab
 ab
 uQ
-KA
-ju
-Qs
+DF
+ae
+DO
 Oy
-ju
-Qs
+ae
+DO
 Oy
-ju
-ju
-ju
-ju
-ju
+ae
+ae
+ae
+ae
+ae
 ab
 ab
 ab
@@ -7187,9 +6878,9 @@ ab
 ab
 ab
 ab
-fx
+dQ
 gh
-dy
+ae
 ab
 ab
 ab
@@ -7201,14 +6892,14 @@ ab
 ab
 ab
 ab
-ju
+ae
 pK
 Jv
-ju
+ae
 bv
 Uh
-ju
-KA
+ae
+DF
 ab
 ab
 ab
@@ -7251,13 +6942,13 @@ ab
 ab
 ab
 ab
-ju
+ae
 yx
 ze
-ju
+ae
 Zo
 zf
-ju
+ae
 ab
 ab
 ab
@@ -7301,13 +6992,13 @@ ab
 ab
 ab
 ab
-ju
-ju
-ju
-ju
-ju
-ju
-ju
+ae
+ae
+ae
+ae
+ae
+ae
+ae
 ab
 ab
 ab

--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_syndicate_base1.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_syndicate_base1.dmm
@@ -10,27 +10,27 @@
 /area/lavaland/surface/outdoors)
 "ae" = (
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
-/area/ruin/unpowered/syndicate_lava_base/testlab)
+/area/ruin/lavaland/syndicate_lava_base/testlab)
 "af" = (
 /obj/machinery/light/small{
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/main)
+/area/ruin/lavaland/syndicate_lava_base/main)
 "ak" = (
 /obj/machinery/vending/boozeomat/syndicate_access,
 /turf/open/floor/plating,
-/area/ruin/unpowered/syndicate_lava_base/bar)
+/area/ruin/lavaland/syndicate_lava_base/bar)
 "ap" = (
 /obj/machinery/light/small{
 	dir = 1
 	},
 /turf/open/floor/engine,
-/area/ruin/unpowered/syndicate_lava_base/testlab)
+/area/ruin/lavaland/syndicate_lava_base/testlab)
 "aq" = (
 /turf/open/floor/engine,
-/area/ruin/unpowered/syndicate_lava_base/testlab)
+/area/ruin/lavaland/syndicate_lava_base/testlab)
 "ar" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/red/line{
@@ -38,10 +38,10 @@
 	},
 /obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/main)
+/area/ruin/lavaland/syndicate_lava_base/main)
 "as" = (
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
-/area/ruin/unpowered/syndicate_lava_base/chemistry)
+/area/ruin/lavaland/syndicate_lava_base/chemistry)
 "az" = (
 /obj/structure/table/reinforced,
 /obj/effect/decal/cleanable/dirt,
@@ -51,14 +51,14 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/testlab)
+/area/ruin/lavaland/syndicate_lava_base/testlab)
 "aF" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/engine,
-/area/ruin/unpowered/syndicate_lava_base/testlab)
+/area/ruin/lavaland/syndicate_lava_base/testlab)
 "aL" = (
 /turf/closed/wall/mineral/plastitanium/explosive,
-/area/ruin/unpowered/syndicate_lava_base/testlab)
+/area/ruin/lavaland/syndicate_lava_base/testlab)
 "aM" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -67,7 +67,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/chem_dispenser/fullupgrade,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/chemistry)
+/area/ruin/lavaland/syndicate_lava_base/chemistry)
 "aP" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/cup/rag{
@@ -84,7 +84,7 @@
 	pixel_y = -2
 	},
 /turf/open/floor/wood,
-/area/ruin/unpowered/syndicate_lava_base/bar)
+/area/ruin/lavaland/syndicate_lava_base/bar)
 "bg" = (
 /obj/structure/table/reinforced,
 /obj/item/radio/intercom{
@@ -94,7 +94,7 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/telecomms)
+/area/ruin/lavaland/syndicate_lava_base/telecomms)
 "bs" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -103,15 +103,15 @@
 	dir = 8
 	},
 /turf/open/floor/iron/white/side,
-/area/ruin/unpowered/syndicate_lava_base/medbay)
+/area/ruin/lavaland/syndicate_lava_base/medbay)
 "bv" = (
 /obj/machinery/air_sensor,
 /turf/open/floor/engine/o2,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/lavaland/syndicate_lava_base/engineering)
 "bA" = (
 /obj/effect/turf_decal/tile/red/half/contrasted,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/main)
+/area/ruin/lavaland/syndicate_lava_base/main)
 "bE" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
 /obj/machinery/firealarm/directional/west,
@@ -120,18 +120,18 @@
 	pixel_y = -30
 	},
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/telecomms)
+/area/ruin/lavaland/syndicate_lava_base/telecomms)
 "bF" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/bar)
+/area/ruin/lavaland/syndicate_lava_base/bar)
 "bN" = (
 /obj/structure/cable/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/plating,
-/area/ruin/unpowered/syndicate_lava_base/main)
+/area/ruin/lavaland/syndicate_lava_base/main)
 "bS" = (
 /obj/structure/closet/secure_closet/medical1{
 	req_access = null;
@@ -145,7 +145,7 @@
 /turf/open/floor/iron/white/side{
 	dir = 9
 	},
-/area/ruin/unpowered/syndicate_lava_base/medbay)
+/area/ruin/lavaland/syndicate_lava_base/medbay)
 "cd" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/structure/cable/yellow,
@@ -153,14 +153,14 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/plating,
-/area/ruin/unpowered/syndicate_lava_base/dormitories)
+/area/ruin/lavaland/syndicate_lava_base/dormitories)
 "ch" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
+/area/ruin/lavaland/syndicate_lava_base/cargo)
 "ci" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -169,7 +169,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/main)
+/area/ruin/lavaland/syndicate_lava_base/main)
 "cn" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -27;
@@ -181,7 +181,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/lavaland/syndicate_lava_base/engineering)
 "cs" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/structure/cable/yellow,
@@ -189,13 +189,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/plating,
-/area/ruin/unpowered/syndicate_lava_base/main)
+/area/ruin/lavaland/syndicate_lava_base/main)
 "cu" = (
 /obj/structure/table/wood,
 /obj/item/ammo_box/magazine/m10mm,
 /obj/item/ammo_box/magazine/sniper_rounds,
 /turf/open/floor/carpet/grimy,
-/area/ruin/unpowered/syndicate_lava_base/dormitories)
+/area/ruin/lavaland/syndicate_lava_base/dormitories)
 "cw" = (
 /obj/structure/railing{
 	dir = 9
@@ -206,13 +206,13 @@
 /obj/structure/cable/yellow,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/science)
+/area/ruin/lavaland/syndicate_lava_base/science)
 "cz" = (
 /obj/effect/mob_spawn/human/lavaland_syndicate/comms{
 	dir = 8
 	},
 /turf/open/floor/carpet/grimy,
-/area/ruin/unpowered/syndicate_lava_base/dormitories)
+/area/ruin/lavaland/syndicate_lava_base/dormitories)
 "cA" = (
 /obj/structure/table/reinforced,
 /obj/item/book/manual/wiki/chemistry,
@@ -221,7 +221,7 @@
 /obj/item/clothing/glasses/science,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/chemistry)
+/area/ruin/lavaland/syndicate_lava_base/chemistry)
 "cC" = (
 /obj/structure/cable/yellow,
 /obj/effect/decal/cleanable/dirt,
@@ -229,7 +229,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/plating,
-/area/ruin/unpowered/syndicate_lava_base/science)
+/area/ruin/lavaland/syndicate_lava_base/science)
 "cG" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -238,14 +238,14 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/chemistry)
+/area/ruin/lavaland/syndicate_lava_base/chemistry)
 "cH" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/brown/anticorner/contrasted{
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/main)
+/area/ruin/lavaland/syndicate_lava_base/main)
 "cI" = (
 /obj/effect/mapping_helpers/no_lava,
 /obj/structure/railing{
@@ -258,7 +258,7 @@
 	dir = 4
 	},
 /turf/open/floor/engine,
-/area/ruin/unpowered/syndicate_lava_base/testlab)
+/area/ruin/lavaland/syndicate_lava_base/testlab)
 "cS" = (
 /obj/structure/bed/roller,
 /obj/machinery/iv_drip,
@@ -268,31 +268,31 @@
 	},
 /obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/testlab)
+/area/ruin/lavaland/syndicate_lava_base/testlab)
 "db" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/bar)
+/area/ruin/lavaland/syndicate_lava_base/bar)
 "dc" = (
 /obj/machinery/light/small{
 	dir = 8
 	},
 /turf/open/floor/engine,
-/area/ruin/unpowered/syndicate_lava_base/testlab)
+/area/ruin/lavaland/syndicate_lava_base/testlab)
 "de" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/engine,
-/area/ruin/unpowered/syndicate_lava_base/testlab)
+/area/ruin/lavaland/syndicate_lava_base/testlab)
 "di" = (
 /obj/machinery/light/small{
 	dir = 4
 	},
 /turf/open/floor/engine,
-/area/ruin/unpowered/syndicate_lava_base/testlab)
+/area/ruin/lavaland/syndicate_lava_base/testlab)
 "dm" = (
 /obj/machinery/door/airlock{
 	name = "Cabin 3"
@@ -302,7 +302,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/dormitories)
+/area/ruin/lavaland/syndicate_lava_base/dormitories)
 "dv" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
@@ -310,7 +310,7 @@
 /obj/machinery/chem_heater,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/chemistry)
+/area/ruin/lavaland/syndicate_lava_base/chemistry)
 "dw" = (
 /obj/structure/chair/office/light{
 	dir = 1
@@ -318,7 +318,7 @@
 /obj/effect/turf_decal/bot,
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/chemistry)
+/area/ruin/lavaland/syndicate_lava_base/chemistry)
 "dx" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
@@ -326,10 +326,10 @@
 /obj/structure/closet/crate/bin,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/chemistry)
+/area/ruin/lavaland/syndicate_lava_base/chemistry)
 "dy" = (
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
+/area/ruin/lavaland/syndicate_lava_base/cargo)
 "dA" = (
 /obj/structure/cable/yellow,
 /obj/effect/decal/cleanable/dirt,
@@ -339,24 +339,24 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/plating,
-/area/ruin/unpowered/syndicate_lava_base/main)
+/area/ruin/lavaland/syndicate_lava_base/main)
 "dB" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/chemistry)
+/area/ruin/lavaland/syndicate_lava_base/chemistry)
 "dC" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/chemistry)
+/area/ruin/lavaland/syndicate_lava_base/chemistry)
 "dD" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/plating,
-/area/ruin/unpowered/syndicate_lava_base/main)
+/area/ruin/lavaland/syndicate_lava_base/main)
 "dF" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -369,7 +369,7 @@
 	dir = 4
 	},
 /turf/open/floor/engine,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/lavaland/syndicate_lava_base/engineering)
 "dK" = (
 /obj/effect/turf_decal/box/white/corners{
 	dir = 1
@@ -392,7 +392,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
+/area/ruin/lavaland/syndicate_lava_base/cargo)
 "dL" = (
 /obj/machinery/airalarm/directional/north,
 /obj/effect/mapping_helpers/airalarm/syndicate_access,
@@ -432,7 +432,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
+/area/ruin/lavaland/syndicate_lava_base/cargo)
 "dM" = (
 /obj/effect/turf_decal/box/white/corners{
 	dir = 4
@@ -450,24 +450,24 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
+/area/ruin/lavaland/syndicate_lava_base/cargo)
 "dP" = (
 /turf/closed/wall/mineral/plastitanium/explosive,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
+/area/ruin/lavaland/syndicate_lava_base/cargo)
 "dQ" = (
 /obj/structure/sign/warning/secure_area,
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
-/area/ruin/unpowered/syndicate_lava_base/testlab)
+/area/ruin/lavaland/syndicate_lava_base/testlab)
 "dV" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/bar)
+/area/ruin/lavaland/syndicate_lava_base/bar)
 "dY" = (
 /obj/structure/chair{
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/chemistry)
+/area/ruin/lavaland/syndicate_lava_base/chemistry)
 "eb" = (
 /obj/structure/closet/crate,
 /obj/item/storage/toolbox/electrical{
@@ -475,10 +475,10 @@
 	},
 /obj/item/storage/toolbox/mechanical,
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
+/area/ruin/lavaland/syndicate_lava_base/cargo)
 "eh" = (
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
-/area/ruin/unpowered/syndicate_lava_base/science)
+/area/ruin/lavaland/syndicate_lava_base/science)
 "el" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/railing{
@@ -498,7 +498,7 @@
 	},
 /obj/item/stack/tile/iron,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/science)
+/area/ruin/lavaland/syndicate_lava_base/science)
 "en" = (
 /obj/effect/mapping_helpers/airlock/locked,
 /obj/machinery/door/airlock/vault{
@@ -510,7 +510,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/main)
+/area/ruin/lavaland/syndicate_lava_base/main)
 "eo" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/neutral{
@@ -520,7 +520,7 @@
 /obj/machinery/airalarm/directional/north,
 /obj/effect/mapping_helpers/airalarm/syndicate_access,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/dormitories)
+/area/ruin/lavaland/syndicate_lava_base/dormitories)
 "eq" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
@@ -529,7 +529,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/dormitories)
+/area/ruin/lavaland/syndicate_lava_base/dormitories)
 "es" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
@@ -537,13 +537,13 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/crate/bin,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/chemistry)
+/area/ruin/lavaland/syndicate_lava_base/chemistry)
 "et" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/chemistry)
+/area/ruin/lavaland/syndicate_lava_base/chemistry)
 "eu" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
@@ -552,7 +552,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/chemistry)
+/area/ruin/lavaland/syndicate_lava_base/chemistry)
 "eC" = (
 /obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/locked,
@@ -561,12 +561,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/engine,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/lavaland/syndicate_lava_base/engineering)
 "eD" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
+/area/ruin/lavaland/syndicate_lava_base/cargo)
 "eE" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -576,16 +576,16 @@
 /obj/item/wrench,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/mineral/plastitanium,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
+/area/ruin/lavaland/syndicate_lava_base/cargo)
 "eP" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/arrivals)
+/area/ruin/lavaland/syndicate_lava_base/arrivals)
 "eQ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/chemistry)
+/area/ruin/lavaland/syndicate_lava_base/chemistry)
 "eS" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -593,13 +593,13 @@
 /obj/machinery/chem_master,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/chemistry)
+/area/ruin/lavaland/syndicate_lava_base/chemistry)
 "eT" = (
 /obj/effect/turf_decal/bot,
 /obj/structure/chair/office/light,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/chemistry)
+/area/ruin/lavaland/syndicate_lava_base/chemistry)
 "eU" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -608,7 +608,7 @@
 /obj/machinery/chem_dispenser/fullupgrade,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/chemistry)
+/area/ruin/lavaland/syndicate_lava_base/chemistry)
 "eX" = (
 /obj/effect/turf_decal/box/white/corners{
 	dir = 1
@@ -624,7 +624,7 @@
 /obj/item/clothing/mask/gas,
 /obj/item/clothing/mask/gas,
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
+/area/ruin/lavaland/syndicate_lava_base/cargo)
 "eY" = (
 /obj/effect/turf_decal/box/white/corners{
 	dir = 4
@@ -644,7 +644,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
+/area/ruin/lavaland/syndicate_lava_base/cargo)
 "fb" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/crate/bin,
@@ -652,14 +652,14 @@
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
+/area/ruin/lavaland/syndicate_lava_base/cargo)
 "fd" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
+/area/ruin/lavaland/syndicate_lava_base/cargo)
 "fe" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -668,34 +668,34 @@
 /obj/machinery/cell_charger,
 /obj/item/stock_parts/cell/high/plus,
 /turf/open/floor/mineral/plastitanium,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
+/area/ruin/lavaland/syndicate_lava_base/cargo)
 "fi" = (
 /obj/effect/mapping_helpers/no_lava,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
 /turf/open/floor/plating,
-/area/ruin/unpowered/syndicate_lava_base/main)
+/area/ruin/lavaland/syndicate_lava_base/main)
 "fk" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
+/area/ruin/lavaland/syndicate_lava_base/cargo)
 "fl" = (
 /obj/machinery/light/small{
 	dir = 1
 	},
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/bar)
+/area/ruin/lavaland/syndicate_lava_base/bar)
 "fp" = (
 /obj/machinery/smartfridge/chemistry/preloaded,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/chemistry)
+/area/ruin/lavaland/syndicate_lava_base/chemistry)
 "fr" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
@@ -707,7 +707,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/lavaland/syndicate_lava_base/engineering)
 "fs" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -723,7 +723,7 @@
 /turf/open/floor/iron/white/side{
 	dir = 8
 	},
-/area/ruin/unpowered/syndicate_lava_base/medbay)
+/area/ruin/lavaland/syndicate_lava_base/medbay)
 "ft" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
@@ -732,7 +732,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/dormitories)
+/area/ruin/lavaland/syndicate_lava_base/dormitories)
 "fu" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 4
@@ -741,7 +741,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/arrivals)
+/area/ruin/lavaland/syndicate_lava_base/arrivals)
 "fw" = (
 /obj/effect/turf_decal/stripes/corner,
 /obj/machinery/firealarm{
@@ -750,26 +750,26 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
+/area/ruin/lavaland/syndicate_lava_base/cargo)
 "fx" = (
 /obj/structure/sign/warning/secure_area,
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
+/area/ruin/lavaland/syndicate_lava_base/cargo)
 "fy" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/engine,
-/area/ruin/unpowered/syndicate_lava_base/testlab)
+/area/ruin/lavaland/syndicate_lava_base/testlab)
 "fD" = (
 /obj/structure/sign/warning/biohazard,
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
-/area/ruin/unpowered/syndicate_lava_base/science)
+/area/ruin/lavaland/syndicate_lava_base/science)
 "fL" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 1
 	},
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/arrivals)
+/area/ruin/lavaland/syndicate_lava_base/arrivals)
 "fV" = (
 /obj/structure/table,
 /obj/effect/decal/cleanable/dirt,
@@ -788,16 +788,16 @@
 	dir = 8
 	},
 /turf/open/floor/iron/white/side,
-/area/ruin/unpowered/syndicate_lava_base/main)
+/area/ruin/lavaland/syndicate_lava_base/main)
 "fW" = (
 /obj/structure/chair,
 /obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/bar)
+/area/ruin/lavaland/syndicate_lava_base/bar)
 "fX" = (
 /obj/structure/sink/directional/west,
 /turf/open/floor/iron/white,
-/area/ruin/unpowered/syndicate_lava_base/bar)
+/area/ruin/lavaland/syndicate_lava_base/bar)
 "ga" = (
 /obj/structure/table/wood,
 /obj/item/ammo_box/magazine/m10mm,
@@ -805,7 +805,7 @@
 /obj/machinery/airalarm/directional/north,
 /obj/effect/mapping_helpers/airalarm/syndicate_access,
 /turf/open/floor/carpet/grimy,
-/area/ruin/unpowered/syndicate_lava_base/dormitories)
+/area/ruin/lavaland/syndicate_lava_base/dormitories)
 "gb" = (
 /obj/structure/table,
 /obj/item/paper_bin,
@@ -815,7 +815,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
+/area/ruin/lavaland/syndicate_lava_base/cargo)
 "gc" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -825,7 +825,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
+/area/ruin/lavaland/syndicate_lava_base/cargo)
 "gd" = (
 /obj/machinery/door/airlock/external,
 /obj/effect/mapping_helpers/airlock/access/all/syndicate/general,
@@ -834,7 +834,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
+/area/ruin/lavaland/syndicate_lava_base/cargo)
 "ge" = (
 /obj/structure/table/optable,
 /obj/item/surgical_drapes,
@@ -843,14 +843,14 @@
 /turf/open/floor/iron/white/side{
 	dir = 4
 	},
-/area/ruin/unpowered/syndicate_lava_base/medbay)
+/area/ruin/lavaland/syndicate_lava_base/medbay)
 "gf" = (
 /obj/structure/sign/warning/vacuum{
 	pixel_y = -32
 	},
 /obj/machinery/light/small,
 /turf/open/floor/plating,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
+/area/ruin/lavaland/syndicate_lava_base/cargo)
 "gg" = (
 /obj/structure/sign/warning/fire{
 	pixel_y = 32
@@ -859,7 +859,7 @@
 	pixel_y = -32
 	},
 /turf/open/floor/plating,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
+/area/ruin/lavaland/syndicate_lava_base/cargo)
 "gh" = (
 /obj/structure/fans/tiny,
 /obj/machinery/door/airlock/external,
@@ -868,14 +868,14 @@
 	dir = 8
 	},
 /turf/open/floor/plating,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
+/area/ruin/lavaland/syndicate_lava_base/cargo)
 "gm" = (
 /obj/structure/cable/yellow,
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/arrivals)
+/area/ruin/lavaland/syndicate_lava_base/arrivals)
 "gp" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -887,7 +887,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/main)
+/area/ruin/lavaland/syndicate_lava_base/main)
 "gA" = (
 /obj/effect/turf_decal/delivery,
 /obj/machinery/door/firedoor,
@@ -900,7 +900,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/lavaland/syndicate_lava_base/engineering)
 "gN" = (
 /obj/effect/turf_decal/delivery,
 /obj/structure/frame/machine,
@@ -908,11 +908,11 @@
 	dir = 1
 	},
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/science)
+/area/ruin/lavaland/syndicate_lava_base/science)
 "gO" = (
 /obj/structure/sign/departments/cargo,
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
+/area/ruin/lavaland/syndicate_lava_base/cargo)
 "gP" = (
 /obj/machinery/photocopier,
 /obj/effect/decal/cleanable/dirt,
@@ -920,11 +920,11 @@
 	dir = 1
 	},
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
+/area/ruin/lavaland/syndicate_lava_base/cargo)
 "gQ" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
+/area/ruin/lavaland/syndicate_lava_base/cargo)
 "gS" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
@@ -939,7 +939,7 @@
 	req_access_txt = "150"
 	},
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
+/area/ruin/lavaland/syndicate_lava_base/cargo)
 "gZ" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
@@ -949,10 +949,10 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/main)
+/area/ruin/lavaland/syndicate_lava_base/main)
 "ha" = (
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
-/area/ruin/unpowered/syndicate_lava_base/main)
+/area/ruin/lavaland/syndicate_lava_base/main)
 "hb" = (
 /obj/structure/fans/tiny,
 /obj/machinery/door/airlock/external,
@@ -961,20 +961,20 @@
 	cycle_id = "syndi-outpost2"
 	},
 /turf/open/floor/plating,
-/area/ruin/unpowered/syndicate_lava_base/main)
+/area/ruin/lavaland/syndicate_lava_base/main)
 "hd" = (
 /obj/effect/turf_decal/tile/red,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/main)
+/area/ruin/lavaland/syndicate_lava_base/main)
 "hi" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/main)
+/area/ruin/lavaland/syndicate_lava_base/main)
 "hl" = (
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
+/area/ruin/lavaland/syndicate_lava_base/cargo)
 "ho" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -991,13 +991,13 @@
 	shuttleId = "syndie_cargo"
 	},
 /turf/open/floor/mineral/plastitanium,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
+/area/ruin/lavaland/syndicate_lava_base/cargo)
 "hz" = (
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
-/area/ruin/unpowered/syndicate_lava_base/dormitories)
+/area/ruin/lavaland/syndicate_lava_base/dormitories)
 "hA" = (
 /turf/closed/wall/mineral/plastitanium/explosive,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/lavaland/syndicate_lava_base/engineering)
 "hD" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -1006,65 +1006,65 @@
 /obj/item/storage/belt/utility,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/mineral/plastitanium,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
+/area/ruin/lavaland/syndicate_lava_base/cargo)
 "hN" = (
 /obj/structure/cable/yellow,
 /turf/open/floor/iron/white,
-/area/ruin/unpowered/syndicate_lava_base/bar)
+/area/ruin/lavaland/syndicate_lava_base/bar)
 "hO" = (
 /turf/closed/wall/mineral/plastitanium/explosive,
-/area/ruin/unpowered/syndicate_lava_base/dormitories)
+/area/ruin/lavaland/syndicate_lava_base/dormitories)
 "hQ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
 /obj/machinery/modular_fabricator/autolathe/hacked,
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/main)
+/area/ruin/lavaland/syndicate_lava_base/main)
 "hR" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/brown{
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/main)
+/area/ruin/lavaland/syndicate_lava_base/main)
 "hW" = (
 /obj/machinery/porta_turret/syndicate{
 	dir = 10
 	},
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
-/area/ruin/unpowered/syndicate_lava_base/main)
+/area/ruin/lavaland/syndicate_lava_base/main)
 "id" = (
 /obj/structure/cable/yellow,
 /obj/effect/turf_decal/tile/red/half/contrasted{
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/arrivals)
+/area/ruin/lavaland/syndicate_lava_base/arrivals)
 "if" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/main)
+/area/ruin/lavaland/syndicate_lava_base/main)
 "ik" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/main)
+/area/ruin/lavaland/syndicate_lava_base/main)
 "ip" = (
 /obj/effect/turf_decal/stripes/red/corner,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/main)
+/area/ruin/lavaland/syndicate_lava_base/main)
 "iq" = (
 /obj/structure/sign/warning/secure_area,
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
-/area/ruin/unpowered/syndicate_lava_base/main)
+/area/ruin/lavaland/syndicate_lava_base/main)
 "ir" = (
 /obj/machinery/door/poddoor{
 	id = "lavalandsyndi_cargo"
 	},
 /obj/effect/spawner/structure/window/reinforced/plasma/plastitanium,
 /turf/open/floor/plating,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
+/area/ruin/lavaland/syndicate_lava_base/cargo)
 "is" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -1081,23 +1081,23 @@
 	req_access_txt = "150"
 	},
 /turf/open/floor/circuit/red,
-/area/ruin/unpowered/syndicate_lava_base/main)
+/area/ruin/lavaland/syndicate_lava_base/main)
 "iz" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/dormitories)
+/area/ruin/lavaland/syndicate_lava_base/dormitories)
 "iA" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
 	},
 /turf/open/floor/wood,
-/area/ruin/unpowered/syndicate_lava_base/bar)
+/area/ruin/lavaland/syndicate_lava_base/bar)
 "iC" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/dormitories)
+/area/ruin/lavaland/syndicate_lava_base/dormitories)
 "iH" = (
 /obj/effect/turf_decal/stripes/red/line{
 	dir = 4
@@ -1106,19 +1106,19 @@
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/main)
+/area/ruin/lavaland/syndicate_lava_base/main)
 "iJ" = (
 /turf/open/floor/circuit/red,
-/area/ruin/unpowered/syndicate_lava_base/main)
+/area/ruin/lavaland/syndicate_lava_base/main)
 "iK" = (
 /obj/machinery/syndicatebomb/self_destruct{
 	anchored = 1
 	},
 /turf/open/floor/circuit/red,
-/area/ruin/unpowered/syndicate_lava_base/main)
+/area/ruin/lavaland/syndicate_lava_base/main)
 "iN" = (
 /turf/closed/wall/mineral/plastitanium/explosive,
-/area/ruin/unpowered/syndicate_lava_base/main)
+/area/ruin/lavaland/syndicate_lava_base/main)
 "iR" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/medical{
@@ -1130,7 +1130,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/iron/white,
-/area/ruin/unpowered/syndicate_lava_base/chemistry)
+/area/ruin/lavaland/syndicate_lava_base/chemistry)
 "ja" = (
 /obj/effect/turf_decal/stripes/red/corner{
 	dir = 4
@@ -1145,7 +1145,7 @@
 	specialfunctions = 4
 	},
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/main)
+/area/ruin/lavaland/syndicate_lava_base/main)
 "jb" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/medical/glass{
@@ -1155,14 +1155,14 @@
 	dir = 1
 	},
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/medbay)
+/area/ruin/lavaland/syndicate_lava_base/medbay)
 "jc" = (
 /obj/machinery/light/small,
 /turf/open/floor/circuit/red,
-/area/ruin/unpowered/syndicate_lava_base/main)
+/area/ruin/lavaland/syndicate_lava_base/main)
 "jj" = (
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/main)
+/area/ruin/lavaland/syndicate_lava_base/main)
 "jm" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
@@ -1171,30 +1171,30 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/testlab)
+/area/ruin/lavaland/syndicate_lava_base/testlab)
 "jn" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/effect/mapping_helpers/airlock/access/all/syndicate/general,
 /obj/structure/cable/yellow,
 /turf/open/floor/plating,
-/area/ruin/unpowered/syndicate_lava_base/bar)
+/area/ruin/lavaland/syndicate_lava_base/bar)
 "ju" = (
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/lavaland/syndicate_lava_base/engineering)
 "jy" = (
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
-/area/ruin/unpowered/syndicate_lava_base/bar)
+/area/ruin/lavaland/syndicate_lava_base/bar)
 "jz" = (
 /obj/structure/window/reinforced/spawner/directional/west,
 /obj/machinery/deepfryer,
 /turf/open/floor/iron/white,
-/area/ruin/unpowered/syndicate_lava_base/bar)
+/area/ruin/lavaland/syndicate_lava_base/bar)
 "jK" = (
 /obj/structure/cable/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/chemistry)
+/area/ruin/lavaland/syndicate_lava_base/chemistry)
 "jO" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 25
@@ -1202,10 +1202,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/bar)
+/area/ruin/lavaland/syndicate_lava_base/bar)
 "jP" = (
 /turf/closed/wall/mineral/plastitanium/explosive,
-/area/ruin/unpowered/syndicate_lava_base/bar)
+/area/ruin/lavaland/syndicate_lava_base/bar)
 "jR" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -1214,20 +1214,20 @@
 	dir = 1
 	},
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/main)
+/area/ruin/lavaland/syndicate_lava_base/main)
 "jU" = (
 /obj/structure/sign/departments/engineering,
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/lavaland/syndicate_lava_base/engineering)
 "jY" = (
 /obj/structure/chair{
 	dir = 1
 	},
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/bar)
+/area/ruin/lavaland/syndicate_lava_base/bar)
 "jZ" = (
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/bar)
+/area/ruin/lavaland/syndicate_lava_base/bar)
 "kj" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 8
@@ -1236,20 +1236,20 @@
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/main)
+/area/ruin/lavaland/syndicate_lava_base/main)
 "kp" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 4
 	},
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/bar)
+/area/ruin/lavaland/syndicate_lava_base/bar)
 "ks" = (
 /obj/structure/reagent_dispensers/fueltank,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
-/area/ruin/unpowered/syndicate_lava_base/main)
+/area/ruin/lavaland/syndicate_lava_base/main)
 "kt" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -1259,14 +1259,14 @@
 /obj/item/mop,
 /obj/item/reagent_containers/cup/bucket,
 /turf/open/floor/plating,
-/area/ruin/unpowered/syndicate_lava_base/main)
+/area/ruin/lavaland/syndicate_lava_base/main)
 "ku" = (
 /obj/structure/cable/yellow,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/plating,
-/area/ruin/unpowered/syndicate_lava_base/main)
+/area/ruin/lavaland/syndicate_lava_base/main)
 "kw" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/caution/stand_clear{
@@ -1276,7 +1276,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/arrivals)
+/area/ruin/lavaland/syndicate_lava_base/arrivals)
 "kA" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -1291,13 +1291,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/arrivals)
+/area/ruin/lavaland/syndicate_lava_base/arrivals)
 "kH" = (
 /obj/structure/chair{
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/bar)
+/area/ruin/lavaland/syndicate_lava_base/bar)
 "kJ" = (
 /obj/machinery/computer/security/telescreen/entertainment{
 	pixel_x = -30
@@ -1305,19 +1305,19 @@
 /obj/structure/bookcase/random,
 /obj/machinery/light/small,
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/bar)
+/area/ruin/lavaland/syndicate_lava_base/bar)
 "kL" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/yellow/half/contrasted,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/main)
+/area/ruin/lavaland/syndicate_lava_base/main)
 "kQ" = (
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
-/area/ruin/unpowered/syndicate_lava_base/medbay)
+/area/ruin/lavaland/syndicate_lava_base/medbay)
 "kT" = (
 /obj/structure/sign/departments/medbay/alt,
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
-/area/ruin/unpowered/syndicate_lava_base/medbay)
+/area/ruin/lavaland/syndicate_lava_base/medbay)
 "kV" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -1330,7 +1330,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/lavaland/syndicate_lava_base/engineering)
 "kW" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -1339,7 +1339,7 @@
 /obj/structure/cable/yellow,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/lavaland/syndicate_lava_base/engineering)
 "lu" = (
 /obj/structure/cable/yellow,
 /obj/effect/decal/cleanable/dirt,
@@ -1350,7 +1350,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/main)
+/area/ruin/lavaland/syndicate_lava_base/main)
 "lx" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/line{
@@ -1360,12 +1360,12 @@
 	dir = 8
 	},
 /turf/open/floor/plating,
-/area/ruin/unpowered/syndicate_lava_base/main)
+/area/ruin/lavaland/syndicate_lava_base/main)
 "ly" = (
 /obj/structure/chair/stool/bar/directional/east,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/bar)
+/area/ruin/lavaland/syndicate_lava_base/bar)
 "lD" = (
 /obj/effect/mob_spawn/human/lavaland_syndicate{
 	dir = 4
@@ -1373,11 +1373,11 @@
 /obj/machinery/airalarm/directional/north,
 /obj/effect/mapping_helpers/airalarm/syndicate_access,
 /turf/open/floor/carpet/grimy,
-/area/ruin/unpowered/syndicate_lava_base/dormitories)
+/area/ruin/lavaland/syndicate_lava_base/dormitories)
 "lE" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/bar)
+/area/ruin/lavaland/syndicate_lava_base/bar)
 "lF" = (
 /obj/machinery/door/firedoor,
 /obj/effect/decal/cleanable/dirt,
@@ -1392,14 +1392,14 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
+/area/ruin/lavaland/syndicate_lava_base/cargo)
 "lI" = (
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/medbay)
+/area/ruin/lavaland/syndicate_lava_base/medbay)
 "lJ" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/medbay)
+/area/ruin/lavaland/syndicate_lava_base/medbay)
 "lP" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table/reinforced,
@@ -1411,29 +1411,29 @@
 /turf/open/floor/iron/white/side{
 	dir = 1
 	},
-/area/ruin/unpowered/syndicate_lava_base/main)
+/area/ruin/lavaland/syndicate_lava_base/main)
 "lU" = (
 /obj/effect/turf_decal/tile/red/half/contrasted{
 	dir = 8
 	},
 /obj/structure/chair,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/arrivals)
+/area/ruin/lavaland/syndicate_lava_base/arrivals)
 "lX" = (
 /obj/structure/cable/yellow,
 /turf/open/floor/wood,
-/area/ruin/unpowered/syndicate_lava_base/bar)
+/area/ruin/lavaland/syndicate_lava_base/bar)
 "me" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/medbay)
+/area/ruin/lavaland/syndicate_lava_base/medbay)
 "mf" = (
 /obj/structure/sink/directional/west,
 /obj/machinery/airalarm/directional/east,
 /obj/effect/mapping_helpers/airalarm/syndicate_access,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/medbay)
+/area/ruin/lavaland/syndicate_lava_base/medbay)
 "ml" = (
 /obj/structure/table/wood,
 /obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
@@ -1443,13 +1443,13 @@
 	pixel_y = 8
 	},
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/bar)
+/area/ruin/lavaland/syndicate_lava_base/bar)
 "mn" = (
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
-/area/ruin/unpowered/syndicate_lava_base/telecomms)
+/area/ruin/lavaland/syndicate_lava_base/telecomms)
 "mo" = (
 /turf/closed/wall/mineral/plastitanium/explosive,
-/area/ruin/unpowered/syndicate_lava_base/telecomms)
+/area/ruin/lavaland/syndicate_lava_base/telecomms)
 "mu" = (
 /obj/item/kirbyplants{
 	icon_state = "plant-22"
@@ -1457,7 +1457,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/bar)
+/area/ruin/lavaland/syndicate_lava_base/bar)
 "mw" = (
 /obj/effect/turf_decal/tile/blue/half/contrasted,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
@@ -1465,48 +1465,48 @@
 /turf/open/floor/iron/white/side{
 	dir = 4
 	},
-/area/ruin/unpowered/syndicate_lava_base/arrivals)
+/area/ruin/lavaland/syndicate_lava_base/arrivals)
 "mM" = (
 /turf/open/floor/circuit/green,
-/area/ruin/unpowered/syndicate_lava_base/telecomms)
+/area/ruin/lavaland/syndicate_lava_base/telecomms)
 "mN" = (
 /obj/structure/sign/warning/secure_area,
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
-/area/ruin/unpowered/syndicate_lava_base/telecomms)
+/area/ruin/lavaland/syndicate_lava_base/telecomms)
 "mP" = (
 /obj/structure/filingcabinet/security,
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/telecomms)
+/area/ruin/lavaland/syndicate_lava_base/telecomms)
 "mS" = (
 /obj/machinery/porta_turret/syndicate{
 	dir = 6
 	},
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
-/area/ruin/unpowered/syndicate_lava_base/telecomms)
+/area/ruin/lavaland/syndicate_lava_base/telecomms)
 "mT" = (
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
-/area/ruin/unpowered/syndicate_lava_base/arrivals)
+/area/ruin/lavaland/syndicate_lava_base/arrivals)
 "nf" = (
 /obj/structure/sign/warning/fire,
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/lavaland/syndicate_lava_base/engineering)
 "ni" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/bar)
+/area/ruin/lavaland/syndicate_lava_base/bar)
 "nl" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "lavalandsyndi_telecomms"
 	},
 /obj/effect/spawner/structure/window/reinforced/plasma/plastitanium,
 /turf/open/floor/plating,
-/area/ruin/unpowered/syndicate_lava_base/telecomms)
+/area/ruin/lavaland/syndicate_lava_base/telecomms)
 "nE" = (
 /obj/machinery/atmospherics/pipe/smart/simple/orange/visible,
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/lavaland/syndicate_lava_base/engineering)
 "nU" = (
 /obj/structure/cable/yellow,
 /obj/effect/turf_decal/tile/purple/half/contrasted{
@@ -1515,10 +1515,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/main)
+/area/ruin/lavaland/syndicate_lava_base/main)
 "nW" = (
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/arrivals)
+/area/ruin/lavaland/syndicate_lava_base/arrivals)
 "od" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -1527,7 +1527,7 @@
 	dir = 4
 	},
 /turf/open/floor/engine,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/lavaland/syndicate_lava_base/engineering)
 "oj" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable/yellow,
@@ -1540,7 +1540,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/medbay)
+/area/ruin/lavaland/syndicate_lava_base/medbay)
 "ol" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -1554,7 +1554,7 @@
 /obj/item/mining_scanner,
 /obj/item/pickaxe,
 /turf/open/floor/mineral/plastitanium,
-/area/ruin/unpowered/syndicate_lava_base/arrivals)
+/area/ruin/lavaland/syndicate_lava_base/arrivals)
 "oq" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Bar"
@@ -1562,7 +1562,7 @@
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/stripes/closeup,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/bar)
+/area/ruin/lavaland/syndicate_lava_base/bar)
 "ot" = (
 /obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/locked,
@@ -1571,20 +1571,20 @@
 	dir = 1
 	},
 /turf/open/floor/engine,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/lavaland/syndicate_lava_base/engineering)
 "ou" = (
 /obj/machinery/computer/message_monitor{
 	dir = 1
 	},
 /obj/item/paper/monitorkey,
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/telecomms)
+/area/ruin/lavaland/syndicate_lava_base/telecomms)
 "ov" = (
 /obj/structure/table/reinforced,
 /obj/item/paper_bin,
 /obj/item/pen,
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/telecomms)
+/area/ruin/lavaland/syndicate_lava_base/telecomms)
 "oy" = (
 /obj/machinery/button/door{
 	id = "lavalandsyndi_arrivals";
@@ -1596,19 +1596,19 @@
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/arrivals)
+/area/ruin/lavaland/syndicate_lava_base/arrivals)
 "oz" = (
 /turf/open/floor/engine/vacuum,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/lavaland/syndicate_lava_base/engineering)
 "oA" = (
 /obj/structure/cable,
 /obj/machinery/igniter/incinerator_syndicatelava,
 /turf/open/floor/engine/vacuum,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/lavaland/syndicate_lava_base/engineering)
 "oC" = (
 /obj/machinery/door/poddoor/incinerator_syndicatelava_aux,
 /turf/open/floor/engine/vacuum,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/lavaland/syndicate_lava_base/engineering)
 "oE" = (
 /obj/structure/cable,
 /obj/machinery/power/compressor{
@@ -1617,22 +1617,22 @@
 	luminosity = 2
 	},
 /turf/open/floor/engine/vacuum,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/lavaland/syndicate_lava_base/engineering)
 "oF" = (
 /obj/structure/sign/warning/secure_area,
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
-/area/ruin/unpowered/syndicate_lava_base/arrivals)
+/area/ruin/lavaland/syndicate_lava_base/arrivals)
 "oG" = (
 /obj/structure/cable,
 /obj/machinery/power/turbine/lavaland{
 	luminosity = 2
 	},
 /turf/open/floor/engine/vacuum,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/lavaland/syndicate_lava_base/engineering)
 "oH" = (
 /obj/machinery/door/poddoor/incinerator_syndicatelava_main,
 /turf/open/floor/engine/vacuum,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/lavaland/syndicate_lava_base/engineering)
 "oJ" = (
 /obj/effect/spawner/structure/window/reinforced/plasma/plastitanium,
 /obj/machinery/door/poddoor/preopen{
@@ -1640,7 +1640,7 @@
 	name = "Syndicate Research Experimentation Shutters"
 	},
 /turf/open/floor/plating,
-/area/ruin/unpowered/syndicate_lava_base/testlab)
+/area/ruin/lavaland/syndicate_lava_base/testlab)
 "oO" = (
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
@@ -1650,15 +1650,15 @@
 	},
 /obj/effect/mapping_helpers/airlock/access/all/syndicate/general,
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
+/area/ruin/lavaland/syndicate_lava_base/cargo)
 "oP" = (
 /obj/structure/sign/departments/chemistry,
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
-/area/ruin/unpowered/syndicate_lava_base/testlab)
+/area/ruin/lavaland/syndicate_lava_base/testlab)
 "oR" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/medbay)
+/area/ruin/lavaland/syndicate_lava_base/medbay)
 "oY" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/smart/simple/orange/visible{
@@ -1670,13 +1670,13 @@
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/lavaland/syndicate_lava_base/engineering)
 "pf" = (
 /obj/structure/cable/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
+/area/ruin/lavaland/syndicate_lava_base/cargo)
 "ph" = (
 /obj/machinery/power/apc/syndicate{
 	name = "Experimentation Lab APC";
@@ -1686,35 +1686,35 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/testlab)
+/area/ruin/lavaland/syndicate_lava_base/testlab)
 "pj" = (
 /obj/effect/turf_decal/delivery,
 /obj/structure/frame/machine,
 /obj/effect/decal/cleanable/cobweb,
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/science)
+/area/ruin/lavaland/syndicate_lava_base/science)
 "pl" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "lavalandsyndi_bar"
 	},
 /obj/effect/spawner/structure/window/reinforced/plasma/plastitanium,
 /turf/open/floor/plating,
-/area/ruin/unpowered/syndicate_lava_base/bar)
+/area/ruin/lavaland/syndicate_lava_base/bar)
 "pq" = (
 /turf/open/floor/iron/white,
-/area/ruin/unpowered/syndicate_lava_base/bar)
+/area/ruin/lavaland/syndicate_lava_base/bar)
 "pw" = (
 /turf/open/floor/iron/stairs/left{
 	dir = 4
 	},
-/area/ruin/unpowered/syndicate_lava_base/science)
+/area/ruin/lavaland/syndicate_lava_base/science)
 "pC" = (
 /mob/living/simple_animal/rabbit{
 	faction = list("Syndicate");
 	desc = "Just a mildly evil rabbit."
 	},
 /turf/open/floor/wood,
-/area/ruin/unpowered/syndicate_lava_base/bar)
+/area/ruin/lavaland/syndicate_lava_base/bar)
 "pD" = (
 /obj/item/storage/box/lights/bulbs,
 /obj/item/stack/rods{
@@ -1727,17 +1727,17 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/rack,
 /turf/open/floor/plating,
-/area/ruin/unpowered/syndicate_lava_base/main)
+/area/ruin/lavaland/syndicate_lava_base/main)
 "pK" = (
 /obj/machinery/air_sensor,
 /turf/open/floor/engine/n2,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/lavaland/syndicate_lava_base/engineering)
 "pQ" = (
 /obj/structure/sign/warning/explosives/alt{
 	pixel_x = 32
 	},
 /turf/open/floor/circuit/red,
-/area/ruin/unpowered/syndicate_lava_base/main)
+/area/ruin/lavaland/syndicate_lava_base/main)
 "pR" = (
 /obj/machinery/atmospherics/pipe/smart/simple/orange/visible{
 	dir = 6
@@ -1747,7 +1747,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/lavaland/syndicate_lava_base/engineering)
 "pT" = (
 /obj/machinery/power/apc/syndicate{
 	dir = 8;
@@ -1758,12 +1758,12 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/chemistry)
+/area/ruin/lavaland/syndicate_lava_base/chemistry)
 "pY" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/mapping_helpers/no_lava,
 /turf/open/floor/plating,
-/area/ruin/unpowered/syndicate_lava_base/arrivals)
+/area/ruin/lavaland/syndicate_lava_base/arrivals)
 "ql" = (
 /obj/effect/mapping_helpers/no_lava,
 /obj/effect/turf_decal/stripes/corner{
@@ -1773,18 +1773,18 @@
 	dir = 8
 	},
 /turf/open/floor/plating,
-/area/ruin/unpowered/syndicate_lava_base/main)
+/area/ruin/lavaland/syndicate_lava_base/main)
 "qp" = (
 /turf/open/floor/iron/stairs/right{
 	dir = 4
 	},
-/area/ruin/unpowered/syndicate_lava_base/science)
+/area/ruin/lavaland/syndicate_lava_base/science)
 "qG" = (
 /obj/structure/sign/warning/explosives/alt{
 	pixel_x = -32
 	},
 /turf/open/floor/engine,
-/area/ruin/unpowered/syndicate_lava_base/testlab)
+/area/ruin/lavaland/syndicate_lava_base/testlab)
 "qK" = (
 /obj/structure/closet/radiation,
 /obj/structure/extinguisher_cabinet{
@@ -1792,13 +1792,13 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
-/area/ruin/unpowered/syndicate_lava_base/science)
+/area/ruin/lavaland/syndicate_lava_base/science)
 "qR" = (
 /obj/effect/turf_decal/tile/red/half/contrasted{
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/arrivals)
+/area/ruin/lavaland/syndicate_lava_base/arrivals)
 "qZ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/yellow/half/contrasted{
@@ -1807,16 +1807,16 @@
 /turf/open/floor/iron/white/side{
 	dir = 1
 	},
-/area/ruin/unpowered/syndicate_lava_base/main)
+/area/ruin/lavaland/syndicate_lava_base/main)
 "rn" = (
 /obj/effect/turf_decal/tile/blue/half/contrasted{
 	dir = 8
 	},
 /turf/open/floor/iron/white/side,
-/area/ruin/unpowered/syndicate_lava_base/main)
+/area/ruin/lavaland/syndicate_lava_base/main)
 "rw" = (
 /turf/open/floor/plating,
-/area/ruin/unpowered/syndicate_lava_base/science)
+/area/ruin/lavaland/syndicate_lava_base/science)
 "rx" = (
 /obj/structure/table/wood,
 /obj/machinery/light/small,
@@ -1836,24 +1836,24 @@
 	dir = 10
 	},
 /turf/open/floor/wood,
-/area/ruin/unpowered/syndicate_lava_base/bar)
+/area/ruin/lavaland/syndicate_lava_base/bar)
 "rO" = (
 /obj/structure/cable/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/main)
+/area/ruin/lavaland/syndicate_lava_base/main)
 "rQ" = (
 /obj/structure/cable/yellow,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/main)
+/area/ruin/lavaland/syndicate_lava_base/main)
 "rS" = (
 /obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/engine,
-/area/ruin/unpowered/syndicate_lava_base/testlab)
+/area/ruin/lavaland/syndicate_lava_base/testlab)
 "rX" = (
 /obj/structure/toilet{
 	pixel_y = 18
@@ -1869,7 +1869,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/dormitories)
+/area/ruin/lavaland/syndicate_lava_base/dormitories)
 "rY" = (
 /obj/machinery/door/airlock{
 	name = "Cabin 2"
@@ -1879,7 +1879,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/dormitories)
+/area/ruin/lavaland/syndicate_lava_base/dormitories)
 "sd" = (
 /obj/effect/turf_decal/stripes/corner,
 /obj/machinery/light/small,
@@ -1894,7 +1894,7 @@
 	target_pressure = 4500
 	},
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/lavaland/syndicate_lava_base/engineering)
 "se" = (
 /obj/machinery/atmospherics/components/binary/pump/on{
 	dir = 8;
@@ -1903,7 +1903,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/lavaland/syndicate_lava_base/engineering)
 "so" = (
 /obj/structure/cable/yellow,
 /obj/effect/decal/cleanable/dirt,
@@ -1913,13 +1913,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/lavaland/syndicate_lava_base/engineering)
 "ss" = (
 /obj/machinery/vending/cigarette{
 	extended_inventory = 1
 	},
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/bar)
+/area/ruin/lavaland/syndicate_lava_base/bar)
 "sB" = (
 /obj/structure/table/reinforced,
 /obj/structure/cable/yellow,
@@ -1932,14 +1932,14 @@
 	pixel_x = 6
 	},
 /turf/open/floor/wood,
-/area/ruin/unpowered/syndicate_lava_base/bar)
+/area/ruin/lavaland/syndicate_lava_base/bar)
 "sC" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/red,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/arrivals)
+/area/ruin/lavaland/syndicate_lava_base/arrivals)
 "sZ" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -1948,40 +1948,40 @@
 /obj/machinery/firealarm/directional/west,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
+/area/ruin/lavaland/syndicate_lava_base/cargo)
 "ta" = (
 /obj/effect/turf_decal/tile/red/anticorner/contrasted{
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/arrivals)
+/area/ruin/lavaland/syndicate_lava_base/arrivals)
 "tg" = (
 /obj/structure/table/reinforced,
 /obj/machinery/light/small/broken{
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/science)
+/area/ruin/lavaland/syndicate_lava_base/science)
 "to" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
+/area/ruin/lavaland/syndicate_lava_base/cargo)
 "tq" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/engine,
-/area/ruin/unpowered/syndicate_lava_base/science)
+/area/ruin/lavaland/syndicate_lava_base/science)
 "tv" = (
 /obj/machinery/door/poddoor{
 	id = "lavalandsyndi_chemistry"
 	},
 /obj/effect/spawner/structure/window/reinforced/plasma/plastitanium,
 /turf/open/floor/plating,
-/area/ruin/unpowered/syndicate_lava_base/chemistry)
+/area/ruin/lavaland/syndicate_lava_base/chemistry)
 "tz" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -1991,19 +1991,19 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/bar)
+/area/ruin/lavaland/syndicate_lava_base/bar)
 "tE" = (
 /obj/structure/cable/yellow,
 /obj/machinery/firealarm/directional/west,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/chemistry)
+/area/ruin/lavaland/syndicate_lava_base/chemistry)
 "tK" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/telecomms)
+/area/ruin/lavaland/syndicate_lava_base/telecomms)
 "tQ" = (
 /obj/structure/cable/yellow,
 /obj/effect/turf_decal/tile/red/half/contrasted{
@@ -2012,14 +2012,14 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/arrivals)
+/area/ruin/lavaland/syndicate_lava_base/arrivals)
 "ub" = (
 /obj/structure/closet/secure_closet/freezer/kitchen/maintenance{
 	req_access = null
 	},
 /obj/structure/window/reinforced/spawner/directional/west,
 /turf/open/floor/iron/white,
-/area/ruin/unpowered/syndicate_lava_base/bar)
+/area/ruin/lavaland/syndicate_lava_base/bar)
 "uc" = (
 /obj/effect/mob_spawn/human/lavaland_syndicate{
 	dir = 8
@@ -2027,10 +2027,10 @@
 /obj/machinery/airalarm/directional/north,
 /obj/effect/mapping_helpers/airalarm/syndicate_access,
 /turf/open/floor/carpet/grimy,
-/area/ruin/unpowered/syndicate_lava_base/dormitories)
+/area/ruin/lavaland/syndicate_lava_base/dormitories)
 "ue" = (
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/lavaland/syndicate_lava_base/engineering)
 "ug" = (
 /obj/effect/turf_decal/bot,
 /obj/structure/closet/crate/science,
@@ -2038,7 +2038,7 @@
 /obj/item/xenoartifact,
 /obj/item/xenoartifact,
 /turf/open/floor/engine,
-/area/ruin/unpowered/syndicate_lava_base/science)
+/area/ruin/lavaland/syndicate_lava_base/science)
 "ui" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/yellow/half/contrasted{
@@ -2047,7 +2047,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/lavaland/syndicate_lava_base/engineering)
 "uk" = (
 /obj/structure/closet/emcloset,
 /obj/machinery/light/small{
@@ -2056,12 +2056,12 @@
 /obj/effect/turf_decal/tile/purple/half/contrasted,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/science)
+/area/ruin/lavaland/syndicate_lava_base/science)
 "ul" = (
 /obj/machinery/atmospherics/pipe/layer_manifold,
 /obj/effect/spawner/structure/window/reinforced/plasma/plastitanium,
 /turf/open/floor/plating,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/lavaland/syndicate_lava_base/engineering)
 "un" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/mining/glass{
@@ -2072,14 +2072,14 @@
 	dir = 1
 	},
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
+/area/ruin/lavaland/syndicate_lava_base/cargo)
 "uo" = (
 /obj/machinery/airalarm/directional/south,
 /obj/effect/mapping_helpers/airalarm/syndicate_access,
 /obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/testlab)
+/area/ruin/lavaland/syndicate_lava_base/testlab)
 "uy" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
@@ -2098,7 +2098,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/lavaland/syndicate_lava_base/engineering)
 "uD" = (
 /obj/effect/mapping_helpers/no_lava,
 /obj/machinery/light/small{
@@ -2108,20 +2108,20 @@
 	dir = 1
 	},
 /turf/open/floor/plating,
-/area/ruin/unpowered/syndicate_lava_base/arrivals)
+/area/ruin/lavaland/syndicate_lava_base/arrivals)
 "uE" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/lavaland/syndicate_lava_base/engineering)
 "uH" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/blue/half/contrasted,
 /obj/machinery/atmospherics/pipe/smart/manifold/cyan/visible,
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/lavaland/syndicate_lava_base/engineering)
 "uJ" = (
 /obj/machinery/door/airlock/external,
 /obj/effect/mapping_helpers/airlock/access/all/syndicate/general,
@@ -2129,11 +2129,11 @@
 	cycle_id = "syndi-outpost1"
 	},
 /turf/open/floor/plating,
-/area/ruin/unpowered/syndicate_lava_base/arrivals)
+/area/ruin/lavaland/syndicate_lava_base/arrivals)
 "uL" = (
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/engine,
-/area/ruin/unpowered/syndicate_lava_base/science)
+/area/ruin/lavaland/syndicate_lava_base/science)
 "uQ" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/on/layer4{
 	dir = 8;
@@ -2143,7 +2143,7 @@
 	baseturfs = /turf/open/lava/smooth/lava_land_surface;
 	initial_gas_mix = "o2=14;n2=5;co2=13;TEMP=300"
 	},
-/area/ruin/unpowered/syndicate_lava_base/main)
+/area/ruin/lavaland/syndicate_lava_base/main)
 "uZ" = (
 /obj/structure/cable/yellow,
 /obj/effect/decal/cleanable/dirt,
@@ -2154,7 +2154,7 @@
 /turf/open/floor/iron/white/side{
 	dir = 4
 	},
-/area/ruin/unpowered/syndicate_lava_base/arrivals)
+/area/ruin/lavaland/syndicate_lava_base/arrivals)
 "va" = (
 /obj/machinery/door/airlock/hatch{
 	name = "Telecommunications Control"
@@ -2165,25 +2165,25 @@
 	dir = 1
 	},
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/telecomms)
+/area/ruin/lavaland/syndicate_lava_base/telecomms)
 "vb" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/arrivals)
+/area/ruin/lavaland/syndicate_lava_base/arrivals)
 "vg" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
 	},
 /turf/open/floor/engine,
-/area/ruin/unpowered/syndicate_lava_base/testlab)
+/area/ruin/lavaland/syndicate_lava_base/testlab)
 "vp" = (
 /obj/effect/turf_decal/tile/red/half/contrasted{
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/main)
+/area/ruin/lavaland/syndicate_lava_base/main)
 "vq" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -2193,25 +2193,25 @@
 	name = "syndicate shuttle dock terminal"
 	},
 /turf/open/floor/mineral/plastitanium,
-/area/ruin/unpowered/syndicate_lava_base/arrivals)
+/area/ruin/lavaland/syndicate_lava_base/arrivals)
 "vv" = (
 /obj/machinery/light/small{
 	dir = 1
 	},
 /obj/machinery/oven,
 /turf/open/floor/iron/white/airless,
-/area/ruin/unpowered/syndicate_lava_base/bar)
+/area/ruin/lavaland/syndicate_lava_base/bar)
 "vA" = (
 /obj/machinery/griddle,
 /turf/open/floor/iron/white/airless,
-/area/ruin/unpowered/syndicate_lava_base/bar)
+/area/ruin/lavaland/syndicate_lava_base/bar)
 "vF" = (
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/lavaland/syndicate_lava_base/engineering)
 "vG" = (
 /obj/structure/table/wood,
 /obj/item/storage/fancy/cigarettes/cigpack_syndicate{
@@ -2223,7 +2223,7 @@
 	pixel_y = 6
 	},
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/bar)
+/area/ruin/lavaland/syndicate_lava_base/bar)
 "vJ" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -27;
@@ -2242,7 +2242,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
+/area/ruin/lavaland/syndicate_lava_base/cargo)
 "vR" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
@@ -2255,14 +2255,14 @@
 /obj/item/crowbar,
 /obj/item/screwdriver,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/main)
+/area/ruin/lavaland/syndicate_lava_base/main)
 "vT" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/red/half/contrasted,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/main)
+/area/ruin/lavaland/syndicate_lava_base/main)
 "vY" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -2270,7 +2270,7 @@
 	extended_inventory = 1
 	},
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/bar)
+/area/ruin/lavaland/syndicate_lava_base/bar)
 "wc" = (
 /obj/structure/cable/yellow,
 /obj/effect/decal/cleanable/dirt,
@@ -2278,7 +2278,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/arrivals)
+/area/ruin/lavaland/syndicate_lava_base/arrivals)
 "wn" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/mining/glass{
@@ -2288,7 +2288,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
+/area/ruin/lavaland/syndicate_lava_base/cargo)
 "wB" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/red/line{
@@ -2296,11 +2296,11 @@
 	},
 /obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/main)
+/area/ruin/lavaland/syndicate_lava_base/main)
 "wG" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
+/area/ruin/lavaland/syndicate_lava_base/cargo)
 "wL" = (
 /obj/machinery/sleeper/syndie{
 	dir = 4
@@ -2309,7 +2309,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/medbay)
+/area/ruin/lavaland/syndicate_lava_base/medbay)
 "wM" = (
 /obj/effect/turf_decal/tile/purple/anticorner/contrasted{
 	dir = 8
@@ -2322,7 +2322,7 @@
 /obj/effect/mapping_helpers/airalarm/syndicate_access,
 /obj/structure/floodlight_frame,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/science)
+/area/ruin/lavaland/syndicate_lava_base/science)
 "xf" = (
 /obj/structure/chair{
 	dir = 1
@@ -2331,14 +2331,14 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/testlab)
+/area/ruin/lavaland/syndicate_lava_base/testlab)
 "xl" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
 /obj/structure/chair{
 	dir = 1
 	},
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/bar)
+/area/ruin/lavaland/syndicate_lava_base/bar)
 "xn" = (
 /obj/machinery/light/small,
 /obj/structure/filingcabinet/chestdrawer,
@@ -2347,7 +2347,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
+/area/ruin/lavaland/syndicate_lava_base/cargo)
 "xq" = (
 /obj/structure/table/reinforced,
 /obj/item/clothing/glasses/science{
@@ -2355,7 +2355,7 @@
 	pixel_x = 1
 	},
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/science)
+/area/ruin/lavaland/syndicate_lava_base/science)
 "xC" = (
 /obj/effect/spawner/structure/window/reinforced/plasma/plastitanium,
 /obj/structure/disposalpipe/segment,
@@ -2364,7 +2364,7 @@
 	name = "Syndicate Research Experimentation Shutters"
 	},
 /turf/open/floor/plating,
-/area/ruin/unpowered/syndicate_lava_base/testlab)
+/area/ruin/lavaland/syndicate_lava_base/testlab)
 "xH" = (
 /obj/structure/sign/warning/vacuum{
 	pixel_x = -32
@@ -2373,16 +2373,16 @@
 	dir = 1
 	},
 /turf/open/floor/plating,
-/area/ruin/unpowered/syndicate_lava_base/arrivals)
+/area/ruin/lavaland/syndicate_lava_base/arrivals)
 "xR" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
-/area/ruin/unpowered/syndicate_lava_base/science)
+/area/ruin/lavaland/syndicate_lava_base/science)
 "xU" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/carpet/grimy,
-/area/ruin/unpowered/syndicate_lava_base/dormitories)
+/area/ruin/lavaland/syndicate_lava_base/dormitories)
 "ye" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
@@ -2390,7 +2390,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/lavaland/syndicate_lava_base/engineering)
 "yg" = (
 /obj/machinery/sleeper/syndie{
 	dir = 4
@@ -2398,7 +2398,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/medbay)
+/area/ruin/lavaland/syndicate_lava_base/medbay)
 "yr" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
@@ -2407,21 +2407,21 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/portable_atmospherics/scrubber,
 /turf/open/floor/plating,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/lavaland/syndicate_lava_base/engineering)
 "yx" = (
 /obj/machinery/atmospherics/miner/nitrogen,
 /obj/machinery/light/small{
 	dir = 4
 	},
 /turf/open/floor/engine/n2,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/lavaland/syndicate_lava_base/engineering)
 "yA" = (
 /obj/machinery/air_sensor,
 /turf/open/floor/engine/plasma,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/lavaland/syndicate_lava_base/engineering)
 "yG" = (
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/chemistry)
+/area/ruin/lavaland/syndicate_lava_base/chemistry)
 "yK" = (
 /obj/effect/turf_decal/bot,
 /obj/effect/decal/cleanable/dirt,
@@ -2432,7 +2432,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/main)
+/area/ruin/lavaland/syndicate_lava_base/main)
 "yM" = (
 /obj/effect/turf_decal/tile/purple/half/contrasted{
 	dir = 8
@@ -2448,7 +2448,7 @@
 	pixel_x = 25
 	},
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/science)
+/area/ruin/lavaland/syndicate_lava_base/science)
 "yR" = (
 /obj/structure/table/reinforced,
 /obj/item/folder,
@@ -2462,7 +2462,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
+/area/ruin/lavaland/syndicate_lava_base/cargo)
 "yW" = (
 /obj/effect/turf_decal/box/white/corners,
 /obj/structure/closet/crate,
@@ -2486,7 +2486,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
+/area/ruin/lavaland/syndicate_lava_base/cargo)
 "yY" = (
 /obj/structure/table,
 /obj/structure/bedsheetbin,
@@ -2495,20 +2495,20 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/dormitories)
+/area/ruin/lavaland/syndicate_lava_base/dormitories)
 "zd" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/brown/half/contrasted{
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/main)
+/area/ruin/lavaland/syndicate_lava_base/main)
 "ze" = (
 /turf/open/floor/engine/n2,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/lavaland/syndicate_lava_base/engineering)
 "zf" = (
 /turf/open/floor/engine/o2,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/lavaland/syndicate_lava_base/engineering)
 "zp" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table/wood,
@@ -2518,13 +2518,13 @@
 /turf/open/floor/wood{
 	broken = 1
 	},
-/area/ruin/unpowered/syndicate_lava_base/bar)
+/area/ruin/lavaland/syndicate_lava_base/bar)
 "zA" = (
 /obj/effect/turf_decal/tile/red/half/contrasted{
 	dir = 1
 	},
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/main)
+/area/ruin/lavaland/syndicate_lava_base/main)
 "zK" = (
 /obj/structure/cable/yellow,
 /obj/machinery/power/apc/syndicate{
@@ -2536,7 +2536,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/main)
+/area/ruin/lavaland/syndicate_lava_base/main)
 "zL" = (
 /obj/structure/table,
 /obj/machinery/cell_charger,
@@ -2551,7 +2551,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/lavaland/syndicate_lava_base/engineering)
 "zM" = (
 /obj/structure/cable/yellow,
 /obj/effect/turf_decal/tile/red{
@@ -2560,7 +2560,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/arrivals)
+/area/ruin/lavaland/syndicate_lava_base/arrivals)
 "zR" = (
 /obj/effect/turf_decal/tile/yellow/half/contrasted{
 	dir = 1
@@ -2568,7 +2568,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/lavaland/syndicate_lava_base/engineering)
 "zS" = (
 /obj/structure/closet/emcloset/anchored,
 /obj/structure/cable/yellow,
@@ -2577,7 +2577,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/arrivals)
+/area/ruin/lavaland/syndicate_lava_base/arrivals)
 "Ac" = (
 /obj/machinery/light/small,
 /obj/structure/table/reinforced,
@@ -2591,7 +2591,7 @@
 	},
 /obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/testlab)
+/area/ruin/lavaland/syndicate_lava_base/testlab)
 "Ae" = (
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/stripes/closeup,
@@ -2601,14 +2601,14 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/bar)
+/area/ruin/lavaland/syndicate_lava_base/bar)
 "Ak" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
 	},
 /obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/plating,
-/area/ruin/unpowered/syndicate_lava_base/arrivals)
+/area/ruin/lavaland/syndicate_lava_base/arrivals)
 "An" = (
 /obj/structure/table/glass,
 /obj/machinery/reagentgrinder{
@@ -2621,17 +2621,17 @@
 /turf/open/floor/iron/white/side{
 	dir = 5
 	},
-/area/ruin/unpowered/syndicate_lava_base/chemistry)
+/area/ruin/lavaland/syndicate_lava_base/chemistry)
 "Aq" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
 /turf/open/floor/plating,
-/area/ruin/unpowered/syndicate_lava_base/science)
+/area/ruin/lavaland/syndicate_lava_base/science)
 "Au" = (
 /obj/machinery/washing_machine,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/dormitories)
+/area/ruin/lavaland/syndicate_lava_base/dormitories)
 "Ax" = (
 /obj/structure/cable/yellow,
 /obj/machinery/computer/monitor/secret,
@@ -2640,7 +2640,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/yellow/fourcorners/contrasted,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/lavaland/syndicate_lava_base/engineering)
 "Az" = (
 /obj/structure/table,
 /obj/item/storage/toolbox/emergency,
@@ -2650,13 +2650,13 @@
 	dir = 1
 	},
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/main)
+/area/ruin/lavaland/syndicate_lava_base/main)
 "AB" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/medbay)
+/area/ruin/lavaland/syndicate_lava_base/medbay)
 "AC" = (
 /obj/structure/cable/yellow,
 /obj/effect/turf_decal/tile/red{
@@ -2665,7 +2665,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/main)
+/area/ruin/lavaland/syndicate_lava_base/main)
 "AF" = (
 /obj/structure/table/reinforced,
 /obj/item/restraints/handcuffs,
@@ -2673,14 +2673,14 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/testlab)
+/area/ruin/lavaland/syndicate_lava_base/testlab)
 "AK" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/blue/half/contrasted{
 	dir = 8
 	},
 /turf/open/floor/iron/white/side,
-/area/ruin/unpowered/syndicate_lava_base/main)
+/area/ruin/lavaland/syndicate_lava_base/main)
 "AR" = (
 /obj/machinery/light/small,
 /obj/effect/decal/cleanable/dirt,
@@ -2688,12 +2688,12 @@
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/main)
+/area/ruin/lavaland/syndicate_lava_base/main)
 "AU" = (
 /obj/machinery/door/firedoor,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/main)
+/area/ruin/lavaland/syndicate_lava_base/main)
 "Bc" = (
 /obj/structure/cable/yellow,
 /obj/effect/turf_decal/tile/red/half/contrasted{
@@ -2703,7 +2703,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/arrivals)
+/area/ruin/lavaland/syndicate_lava_base/arrivals)
 "Bi" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/red/half/contrasted{
@@ -2711,7 +2711,7 @@
 	},
 /obj/structure/closet/emcloset/anchored,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/main)
+/area/ruin/lavaland/syndicate_lava_base/main)
 "Bm" = (
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
 	dir = 4
@@ -2719,7 +2719,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/dormitories)
+/area/ruin/lavaland/syndicate_lava_base/dormitories)
 "Bp" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -2734,7 +2734,7 @@
 /turf/open/floor/iron/white/side{
 	dir = 5
 	},
-/area/ruin/unpowered/syndicate_lava_base/medbay)
+/area/ruin/lavaland/syndicate_lava_base/medbay)
 "Bt" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -2751,7 +2751,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/lavaland/syndicate_lava_base/engineering)
 "BA" = (
 /obj/structure/table/wood,
 /obj/effect/turf_decal/siding/wood{
@@ -2760,19 +2760,19 @@
 /turf/open/floor/wood{
 	broken = 1
 	},
-/area/ruin/unpowered/syndicate_lava_base/bar)
+/area/ruin/lavaland/syndicate_lava_base/bar)
 "BC" = (
 /obj/effect/turf_decal/tile/red/half/contrasted{
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/arrivals)
+/area/ruin/lavaland/syndicate_lava_base/arrivals)
 "BN" = (
 /obj/structure/chair{
 	dir = 4
 	},
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/bar)
+/area/ruin/lavaland/syndicate_lava_base/bar)
 "BS" = (
 /obj/structure/table/wood,
 /obj/item/lighter{
@@ -2780,17 +2780,17 @@
 	pixel_y = 6
 	},
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/bar)
+/area/ruin/lavaland/syndicate_lava_base/bar)
 "BW" = (
 /obj/effect/turf_decal/tile/red/anticorner/contrasted,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/arrivals)
+/area/ruin/lavaland/syndicate_lava_base/arrivals)
 "Cc" = (
 /obj/machinery/porta_turret/syndicate{
 	dir = 10
 	},
 /turf/closed/wall/mineral/plastitanium,
-/area/ruin/unpowered/syndicate_lava_base/telecomms)
+/area/ruin/lavaland/syndicate_lava_base/telecomms)
 "Cf" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -2809,25 +2809,25 @@
 /turf/open/floor/iron/white/side{
 	dir = 1
 	},
-/area/ruin/unpowered/syndicate_lava_base/chemistry)
+/area/ruin/lavaland/syndicate_lava_base/chemistry)
 "Cn" = (
 /obj/structure/chair/office{
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/telecomms)
+/area/ruin/lavaland/syndicate_lava_base/telecomms)
 "Co" = (
 /obj/structure/closet/firecloset,
 /obj/effect/turf_decal/tile/purple/anticorner/contrasted,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/science)
+/area/ruin/lavaland/syndicate_lava_base/science)
 "Cp" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/chemistry)
+/area/ruin/lavaland/syndicate_lava_base/chemistry)
 "Cq" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/railing/corner{
@@ -2847,14 +2847,14 @@
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/arrivals)
+/area/ruin/lavaland/syndicate_lava_base/arrivals)
 "Cx" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /turf/open/floor/engine,
-/area/ruin/unpowered/syndicate_lava_base/testlab)
+/area/ruin/lavaland/syndicate_lava_base/testlab)
 "CL" = (
 /obj/structure/reagent_dispensers/beerkeg,
 /obj/structure/window/reinforced/spawner/directional/north{
@@ -2866,16 +2866,16 @@
 /turf/open/floor/wood{
 	broken = 1
 	},
-/area/ruin/unpowered/syndicate_lava_base/bar)
+/area/ruin/lavaland/syndicate_lava_base/bar)
 "CP" = (
 /obj/effect/turf_decal/tile/brown/half/contrasted,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/main)
+/area/ruin/lavaland/syndicate_lava_base/main)
 "CZ" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/bar)
+/area/ruin/lavaland/syndicate_lava_base/bar)
 "De" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/railing{
@@ -2886,12 +2886,12 @@
 "Dh" = (
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/engine,
-/area/ruin/unpowered/syndicate_lava_base/testlab)
+/area/ruin/lavaland/syndicate_lava_base/testlab)
 "Dp" = (
 /obj/item/book/manual/wiki/xenoarchaeology,
 /obj/structure/table/reinforced,
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/science)
+/area/ruin/lavaland/syndicate_lava_base/science)
 "Ds" = (
 /obj/effect/turf_decal/delivery,
 /obj/machinery/door/firedoor,
@@ -2906,36 +2906,36 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/lavaland/syndicate_lava_base/engineering)
 "DA" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/lavaland/syndicate_lava_base/engineering)
 "DF" = (
 /obj/machinery/porta_turret/syndicate{
 	dir = 5
 	},
 /turf/closed/wall/mineral/plastitanium,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
+/area/ruin/lavaland/syndicate_lava_base/cargo)
 "DK" = (
 /obj/machinery/atmospherics/miner/plasma,
 /obj/machinery/light/small,
 /turf/open/floor/engine/plasma,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/lavaland/syndicate_lava_base/engineering)
 "DL" = (
 /obj/structure/sign/warning/explosives/alt{
 	pixel_x = 32
 	},
 /turf/open/floor/engine,
-/area/ruin/unpowered/syndicate_lava_base/testlab)
+/area/ruin/lavaland/syndicate_lava_base/testlab)
 "DM" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/bar)
+/area/ruin/lavaland/syndicate_lava_base/bar)
 "DO" = (
 /obj/effect/spawner/structure/window/reinforced/plasma/plastitanium,
 /turf/open/floor/plating,
-/area/ruin/unpowered/syndicate_lava_base/chemistry)
+/area/ruin/lavaland/syndicate_lava_base/chemistry)
 "DQ" = (
 /obj/structure/table/reinforced,
 /obj/item/retractor,
@@ -2945,31 +2945,31 @@
 /turf/open/floor/iron/white/side{
 	dir = 6
 	},
-/area/ruin/unpowered/syndicate_lava_base/medbay)
+/area/ruin/lavaland/syndicate_lava_base/medbay)
 "DS" = (
 /obj/structure/cable/yellow,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/medbay)
+/area/ruin/lavaland/syndicate_lava_base/medbay)
 "Ef" = (
 /obj/structure/cable/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/medbay)
+/area/ruin/lavaland/syndicate_lava_base/medbay)
 "En" = (
 /obj/structure/cable/yellow,
 /obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/telecomms)
+/area/ruin/lavaland/syndicate_lava_base/telecomms)
 "EA" = (
 /obj/machinery/light/small{
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/yellow/half/contrasted,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/main)
+/area/ruin/lavaland/syndicate_lava_base/main)
 "EL" = (
 /obj/structure/table/wood,
 /obj/machinery/chem_dispenser/drinks/beer/fullupgrade{
@@ -2983,7 +2983,7 @@
 	dir = 10
 	},
 /turf/open/floor/wood,
-/area/ruin/unpowered/syndicate_lava_base/bar)
+/area/ruin/lavaland/syndicate_lava_base/bar)
 "EM" = (
 /obj/structure/cable/yellow,
 /obj/effect/decal/cleanable/dirt,
@@ -2993,26 +2993,26 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/main)
+/area/ruin/lavaland/syndicate_lava_base/main)
 "EO" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/bar)
+/area/ruin/lavaland/syndicate_lava_base/bar)
 "EP" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/vending/assist,
 /obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
+/area/ruin/lavaland/syndicate_lava_base/cargo)
 "EZ" = (
 /obj/machinery/door/airlock/external,
 /obj/effect/mapping_helpers/airlock/access/all/syndicate/general,
 /obj/structure/fans/tiny,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /turf/open/floor/plating,
-/area/ruin/unpowered/syndicate_lava_base/arrivals)
+/area/ruin/lavaland/syndicate_lava_base/arrivals)
 "Fb" = (
 /obj/machinery/light/small,
 /obj/structure/cable/yellow,
@@ -3022,11 +3022,11 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/dormitories)
+/area/ruin/lavaland/syndicate_lava_base/dormitories)
 "Fr" = (
 /obj/effect/spawner/structure/window/reinforced/plasma/plastitanium,
 /turf/open/floor/plating,
-/area/ruin/unpowered/syndicate_lava_base/bar)
+/area/ruin/lavaland/syndicate_lava_base/bar)
 "Fs" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/red/line{
@@ -3036,7 +3036,7 @@
 /obj/item/folder/syndicate/mining,
 /obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/main)
+/area/ruin/lavaland/syndicate_lava_base/main)
 "FC" = (
 /obj/structure/cable/yellow,
 /obj/effect/turf_decal/tile/red{
@@ -3044,7 +3044,7 @@
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/main)
+/area/ruin/lavaland/syndicate_lava_base/main)
 "FG" = (
 /obj/machinery/button/door{
 	id = "lavalandsyndi_bar";
@@ -3053,13 +3053,13 @@
 	pixel_x = -25
 	},
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/bar)
+/area/ruin/lavaland/syndicate_lava_base/bar)
 "FK" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/bar)
+/area/ruin/lavaland/syndicate_lava_base/bar)
 "FO" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/hatch{
@@ -3072,7 +3072,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/testlab)
+/area/ruin/lavaland/syndicate_lava_base/testlab)
 "FS" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "lavalandsyndi_virology"
@@ -3082,21 +3082,21 @@
 	id = "lavalandsyndi_science"
 	},
 /turf/open/floor/plating,
-/area/ruin/unpowered/syndicate_lava_base/science)
+/area/ruin/lavaland/syndicate_lava_base/science)
 "FV" = (
 /obj/structure/cable/yellow,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/dormitories)
+/area/ruin/lavaland/syndicate_lava_base/dormitories)
 "FX" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
 /obj/structure/chair/stool/bar/directional/east,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/bar)
+/area/ruin/lavaland/syndicate_lava_base/bar)
 "Gh" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
@@ -3107,13 +3107,13 @@
 /obj/item/holosign_creator/atmos,
 /obj/item/storage/belt/utility/full,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/lavaland/syndicate_lava_base/engineering)
 "Gi" = (
 /obj/effect/mob_spawn/human/lavaland_syndicate{
 	dir = 4
 	},
 /turf/open/floor/carpet/grimy,
-/area/ruin/unpowered/syndicate_lava_base/dormitories)
+/area/ruin/lavaland/syndicate_lava_base/dormitories)
 "Gk" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -3122,7 +3122,7 @@
 	dir = 1
 	},
 /turf/open/floor/carpet/grimy,
-/area/ruin/unpowered/syndicate_lava_base/dormitories)
+/area/ruin/lavaland/syndicate_lava_base/dormitories)
 "Gp" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -3133,32 +3133,32 @@
 /obj/effect/turf_decal/tile/yellow/half/contrasted,
 /obj/machinery/portable_thermomachine/atmos,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/lavaland/syndicate_lava_base/engineering)
 "Gq" = (
 /obj/structure/cable/yellow,
 /obj/effect/turf_decal/tile/yellow/half/contrasted,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/main)
+/area/ruin/lavaland/syndicate_lava_base/main)
 "GG" = (
 /obj/effect/spawner/structure/window/reinforced/plasma/plastitanium,
 /turf/open/floor/plating,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
+/area/ruin/lavaland/syndicate_lava_base/cargo)
 "GJ" = (
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/tile/red/half/contrasted{
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/main)
+/area/ruin/lavaland/syndicate_lava_base/main)
 "GT" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/red/half/contrasted{
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/main)
+/area/ruin/lavaland/syndicate_lava_base/main)
 "GY" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -27;
@@ -3169,7 +3169,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/main)
+/area/ruin/lavaland/syndicate_lava_base/main)
 "He" = (
 /obj/effect/turf_decal/box/white/corners,
 /obj/structure/closet/crate/medical,
@@ -3183,26 +3183,26 @@
 	pixel_y = -3
 	},
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
+/area/ruin/lavaland/syndicate_lava_base/cargo)
 "Hi" = (
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plating,
-/area/ruin/unpowered/syndicate_lava_base/arrivals)
+/area/ruin/lavaland/syndicate_lava_base/arrivals)
 "Hj" = (
 /obj/effect/spawner/structure/window/reinforced/plasma/plastitanium,
 /turf/open/floor/plating,
-/area/ruin/unpowered/syndicate_lava_base/testlab)
+/area/ruin/lavaland/syndicate_lava_base/testlab)
 "Hk" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 4
 	},
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/bar)
+/area/ruin/lavaland/syndicate_lava_base/bar)
 "Hl" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/bar)
+/area/ruin/lavaland/syndicate_lava_base/bar)
 "Ho" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small,
@@ -3212,7 +3212,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/arrivals)
+/area/ruin/lavaland/syndicate_lava_base/arrivals)
 "HA" = (
 /obj/effect/turf_decal/box/white/corners{
 	dir = 8
@@ -3242,13 +3242,13 @@
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
+/area/ruin/lavaland/syndicate_lava_base/cargo)
 "HD" = (
 /obj/effect/turf_decal/tile/brown/half/contrasted{
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/main)
+/area/ruin/lavaland/syndicate_lava_base/main)
 "HE" = (
 /obj/effect/turf_decal/box/white/corners{
 	dir = 8
@@ -3264,20 +3264,20 @@
 /obj/item/circuitboard/machine/smoke_machine,
 /obj/item/storage/part_replacer/cargo,
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
+/area/ruin/lavaland/syndicate_lava_base/cargo)
 "HH" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
+/area/ruin/lavaland/syndicate_lava_base/cargo)
 "HX" = (
 /obj/machinery/light/small{
 	dir = 8
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
 /turf/open/floor/carpet/grimy,
-/area/ruin/unpowered/syndicate_lava_base/dormitories)
+/area/ruin/lavaland/syndicate_lava_base/dormitories)
 "If" = (
 /obj/structure/sign/warning/xeno_mining{
 	pixel_x = -32
@@ -3287,20 +3287,20 @@
 	},
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plating,
-/area/ruin/unpowered/syndicate_lava_base/arrivals)
+/area/ruin/lavaland/syndicate_lava_base/arrivals)
 "Ig" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/lavaland/syndicate_lava_base/engineering)
 "Il" = (
 /obj/structure/cable/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/arrivals)
+/area/ruin/lavaland/syndicate_lava_base/arrivals)
 "In" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -3326,22 +3326,22 @@
 	dir = 1
 	},
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
+/area/ruin/lavaland/syndicate_lava_base/cargo)
 "It" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/science)
+/area/ruin/lavaland/syndicate_lava_base/science)
 "IA" = (
 /obj/structure/cable/yellow,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/item/stack/tile/iron,
 /turf/open/floor/plating,
-/area/ruin/unpowered/syndicate_lava_base/science)
+/area/ruin/lavaland/syndicate_lava_base/science)
 "IH" = (
 /obj/structure/chair,
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/bar)
+/area/ruin/lavaland/syndicate_lava_base/bar)
 "IN" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
@@ -3354,7 +3354,7 @@
 /obj/item/clothing/head/utility/welding,
 /obj/item/weldingtool/largetank,
 /turf/open/floor/plating,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/lavaland/syndicate_lava_base/engineering)
 "IO" = (
 /obj/structure/chair{
 	dir = 8
@@ -3366,7 +3366,7 @@
 	},
 /obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/telecomms)
+/area/ruin/lavaland/syndicate_lava_base/telecomms)
 "IR" = (
 /obj/machinery/door/airlock{
 	name = "Unisex Restrooms"
@@ -3376,7 +3376,7 @@
 /obj/effect/turf_decal/stripes/closeup,
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/dormitories)
+/area/ruin/lavaland/syndicate_lava_base/dormitories)
 "IV" = (
 /obj/structure/filingcabinet/chestdrawer,
 /obj/effect/decal/cleanable/dirt,
@@ -3384,7 +3384,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
+/area/ruin/lavaland/syndicate_lava_base/cargo)
 "Jm" = (
 /obj/machinery/computer/turbine_computer{
 	dir = 1;
@@ -3405,19 +3405,19 @@
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/lavaland/syndicate_lava_base/engineering)
 "Js" = (
 /obj/machinery/porta_turret/syndicate{
 	dir = 9
 	},
 /turf/closed/wall/mineral/plastitanium,
-/area/ruin/unpowered/syndicate_lava_base/telecomms)
+/area/ruin/lavaland/syndicate_lava_base/telecomms)
 "Ju" = (
 /obj/machinery/porta_turret/syndicate{
 	dir = 5
 	},
 /turf/closed/wall/mineral/plastitanium,
-/area/ruin/unpowered/syndicate_lava_base/chemistry)
+/area/ruin/lavaland/syndicate_lava_base/chemistry)
 "Jv" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/on{
 	dir = 8;
@@ -3425,19 +3425,19 @@
 	name = "nitrogen out"
 	},
 /turf/open/floor/engine/n2,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/lavaland/syndicate_lava_base/engineering)
 "Jz" = (
 /turf/open/floor/wood{
 	broken = 1
 	},
-/area/ruin/unpowered/syndicate_lava_base/bar)
+/area/ruin/lavaland/syndicate_lava_base/bar)
 "JA" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/arrivals)
+/area/ruin/lavaland/syndicate_lava_base/arrivals)
 "JE" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/yellow,
@@ -3449,7 +3449,7 @@
 /turf/open/floor/iron/white/side{
 	dir = 1
 	},
-/area/ruin/unpowered/syndicate_lava_base/main)
+/area/ruin/lavaland/syndicate_lava_base/main)
 "JF" = (
 /obj/structure/cable/yellow,
 /obj/effect/turf_decal/tile/red/half/contrasted{
@@ -3458,12 +3458,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/main)
+/area/ruin/lavaland/syndicate_lava_base/main)
 "JM" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
+/area/ruin/lavaland/syndicate_lava_base/cargo)
 "JN" = (
 /obj/machinery/telecomms/relay/preset/ruskie{
 	use_power = 0
@@ -3473,11 +3473,11 @@
 	},
 /obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/telecomms)
+/area/ruin/lavaland/syndicate_lava_base/telecomms)
 "JW" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/telecomms)
+/area/ruin/lavaland/syndicate_lava_base/telecomms)
 "Kc" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 4
@@ -3485,7 +3485,7 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
 /obj/machinery/firealarm/directional/south,
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/testlab)
+/area/ruin/lavaland/syndicate_lava_base/testlab)
 "Kd" = (
 /obj/machinery/door/airlock/external,
 /obj/effect/mapping_helpers/airlock/access/all/syndicate/general,
@@ -3494,7 +3494,7 @@
 	cycle_id = "syndi-outpost2"
 	},
 /turf/open/floor/plating,
-/area/ruin/unpowered/syndicate_lava_base/main)
+/area/ruin/lavaland/syndicate_lava_base/main)
 "Kh" = (
 /obj/structure/rack{
 	dir = 8
@@ -3509,17 +3509,17 @@
 	dir = 8
 	},
 /turf/open/floor/iron/white/side,
-/area/ruin/unpowered/syndicate_lava_base/medbay)
+/area/ruin/lavaland/syndicate_lava_base/medbay)
 "Ku" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/lavaland/syndicate_lava_base/engineering)
 "KA" = (
 /obj/machinery/porta_turret/syndicate{
 	dir = 5
 	},
 /turf/closed/wall/mineral/plastitanium,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/lavaland/syndicate_lava_base/engineering)
 "KB" = (
 /obj/machinery/button/door{
 	id = "lavalandsyndi_bar";
@@ -3529,7 +3529,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/bar)
+/area/ruin/lavaland/syndicate_lava_base/bar)
 "KN" = (
 /obj/machinery/power/apc/syndicate{
 	name = "Dormitories APC";
@@ -3540,18 +3540,18 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/dormitories)
+/area/ruin/lavaland/syndicate_lava_base/dormitories)
 "KP" = (
 /obj/structure/table,
 /obj/machinery/microwave,
 /turf/open/floor/iron/white,
-/area/ruin/unpowered/syndicate_lava_base/bar)
+/area/ruin/lavaland/syndicate_lava_base/bar)
 "KU" = (
 /obj/machinery/computer/camera_advanced/syndie,
 /obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/telecomms)
+/area/ruin/lavaland/syndicate_lava_base/telecomms)
 "Lc" = (
 /obj/structure/sign/warning/vacuum{
 	pixel_x = -32
@@ -3563,17 +3563,17 @@
 	dir = 1
 	},
 /turf/open/floor/plating,
-/area/ruin/unpowered/syndicate_lava_base/arrivals)
+/area/ruin/lavaland/syndicate_lava_base/arrivals)
 "Lg" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 4
 	},
 /turf/open/floor/engine,
-/area/ruin/unpowered/syndicate_lava_base/testlab)
+/area/ruin/lavaland/syndicate_lava_base/testlab)
 "Lj" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
-/area/ruin/unpowered/syndicate_lava_base/main)
+/area/ruin/lavaland/syndicate_lava_base/main)
 "Ll" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -3582,7 +3582,7 @@
 	},
 /obj/structure/closet/firecloset,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/main)
+/area/ruin/lavaland/syndicate_lava_base/main)
 "Lo" = (
 /obj/structure/closet/crate,
 /obj/item/vending_refill/snack{
@@ -3600,7 +3600,7 @@
 /obj/effect/spawner/random/food_or_drink/donkpockets,
 /obj/structure/grille/broken,
 /turf/open/floor/plating,
-/area/ruin/unpowered/syndicate_lava_base/main)
+/area/ruin/lavaland/syndicate_lava_base/main)
 "Lq" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small{
@@ -3610,7 +3610,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/plating,
-/area/ruin/unpowered/syndicate_lava_base/main)
+/area/ruin/lavaland/syndicate_lava_base/main)
 "Ls" = (
 /obj/machinery/door/firedoor,
 /obj/effect/decal/cleanable/dirt,
@@ -3619,13 +3619,13 @@
 	},
 /obj/effect/turf_decal/stripes/closeup,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/medbay)
+/area/ruin/lavaland/syndicate_lava_base/medbay)
 "Lt" = (
 /obj/machinery/porta_turret/syndicate{
 	dir = 10
 	},
 /turf/closed/wall/mineral/plastitanium,
-/area/ruin/unpowered/syndicate_lava_base/science)
+/area/ruin/lavaland/syndicate_lava_base/science)
 "Lw" = (
 /obj/machinery/door/airlock{
 	name = "Cabin 1"
@@ -3636,7 +3636,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/dormitories)
+/area/ruin/lavaland/syndicate_lava_base/dormitories)
 "LB" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
@@ -3645,7 +3645,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/lavaland/syndicate_lava_base/engineering)
 "LL" = (
 /obj/machinery/firealarm{
 	dir = 8;
@@ -3656,28 +3656,28 @@
 	dir = 1
 	},
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/main)
+/area/ruin/lavaland/syndicate_lava_base/main)
 "LV" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
 /obj/item/clothing/gloves/artifact_pinchers,
 /turf/open/floor/engine,
-/area/ruin/unpowered/syndicate_lava_base/science)
+/area/ruin/lavaland/syndicate_lava_base/science)
 "LW" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/layer_manifold{
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/lavaland/syndicate_lava_base/engineering)
 "LZ" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/structure/cable/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/plating,
-/area/ruin/unpowered/syndicate_lava_base/main)
+/area/ruin/lavaland/syndicate_lava_base/main)
 "Ml" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
@@ -3687,21 +3687,21 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/arrivals)
+/area/ruin/lavaland/syndicate_lava_base/arrivals)
 "Mo" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/structure/cable/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/plating,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
+/area/ruin/lavaland/syndicate_lava_base/cargo)
 "Mr" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/engine,
-/area/ruin/unpowered/syndicate_lava_base/science)
+/area/ruin/lavaland/syndicate_lava_base/science)
 "Mu" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -3719,7 +3719,7 @@
 	dir = 1
 	},
 /turf/open/floor/plating,
-/area/ruin/unpowered/syndicate_lava_base/main)
+/area/ruin/lavaland/syndicate_lava_base/main)
 "ME" = (
 /obj/machinery/atmospherics/pipe/smart/simple/orange/visible,
 /obj/machinery/airlock_controller/incinerator_syndicatelava{
@@ -3736,7 +3736,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/yellow/anticorner/contrasted,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/lavaland/syndicate_lava_base/engineering)
 "ML" = (
 /obj/structure/table,
 /obj/item/paper_bin,
@@ -3750,13 +3750,13 @@
 	},
 /obj/item/flashlight,
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
+/area/ruin/lavaland/syndicate_lava_base/cargo)
 "MM" = (
 /obj/structure/cable/yellow,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/science)
+/area/ruin/lavaland/syndicate_lava_base/science)
 "MN" = (
 /obj/structure/closet/secure_closet/medical1{
 	req_access = null;
@@ -3771,14 +3771,14 @@
 /turf/open/floor/iron/white/side{
 	dir = 1
 	},
-/area/ruin/unpowered/syndicate_lava_base/chemistry)
+/area/ruin/lavaland/syndicate_lava_base/chemistry)
 "MQ" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/structure/cable/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/plating,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/lavaland/syndicate_lava_base/engineering)
 "MS" = (
 /obj/structure/closet/bombcloset,
 /obj/effect/turf_decal/tile/purple/anticorner/contrasted{
@@ -3786,7 +3786,7 @@
 	},
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/science)
+/area/ruin/lavaland/syndicate_lava_base/science)
 "MT" = (
 /obj/structure/cable/yellow,
 /obj/effect/decal/cleanable/dirt,
@@ -3795,7 +3795,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/science)
+/area/ruin/lavaland/syndicate_lava_base/science)
 "MX" = (
 /obj/effect/turf_decal/tile/yellow/half/contrasted{
 	dir = 4
@@ -3803,14 +3803,14 @@
 /turf/open/floor/iron/white/side{
 	dir = 1
 	},
-/area/ruin/unpowered/syndicate_lava_base/main)
+/area/ruin/lavaland/syndicate_lava_base/main)
 "Nb" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/carpet/grimy,
-/area/ruin/unpowered/syndicate_lava_base/dormitories)
+/area/ruin/lavaland/syndicate_lava_base/dormitories)
 "Np" = (
 /obj/effect/turf_decal/tile/purple/half/contrasted{
 	dir = 8
@@ -3819,7 +3819,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/science)
+/area/ruin/lavaland/syndicate_lava_base/science)
 "Nv" = (
 /obj/effect/turf_decal/bot,
 /obj/effect/decal/cleanable/dirt,
@@ -3828,20 +3828,20 @@
 	dir = 1
 	},
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/lavaland/syndicate_lava_base/engineering)
 "Nz" = (
 /obj/machinery/porta_turret/syndicate{
 	dir = 10
 	},
 /turf/closed/wall/mineral/plastitanium,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/lavaland/syndicate_lava_base/engineering)
 "NF" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/red/half/contrasted{
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/arrivals)
+/area/ruin/lavaland/syndicate_lava_base/arrivals)
 "NI" = (
 /obj/structure/sign/warning/vacuum{
 	pixel_x = -32
@@ -3851,7 +3851,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/ruin/unpowered/syndicate_lava_base/main)
+/area/ruin/lavaland/syndicate_lava_base/main)
 "NS" = (
 /obj/structure/cable/yellow,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
@@ -3863,7 +3863,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/science)
+/area/ruin/lavaland/syndicate_lava_base/science)
 "Oa" = (
 /obj/structure/cable/yellow,
 /obj/effect/decal/cleanable/dirt,
@@ -3875,7 +3875,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/main)
+/area/ruin/lavaland/syndicate_lava_base/main)
 "Ob" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/poddoor/preopen{
@@ -3890,7 +3890,7 @@
 	},
 /obj/effect/mapping_helpers/airlock/access/all/syndicate/general,
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/testlab)
+/area/ruin/lavaland/syndicate_lava_base/testlab)
 "Oc" = (
 /obj/structure/table,
 /obj/item/storage/firstaid/regular,
@@ -3899,7 +3899,7 @@
 /turf/open/floor/iron/white/side{
 	dir = 4
 	},
-/area/ruin/unpowered/syndicate_lava_base/medbay)
+/area/ruin/lavaland/syndicate_lava_base/medbay)
 "Oq" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -3909,14 +3909,14 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/main)
+/area/ruin/lavaland/syndicate_lava_base/main)
 "Os" = (
 /obj/machinery/firealarm/directional/south,
 /obj/machinery/computer/arcade/orion_trail{
 	dir = 4
 	},
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/bar)
+/area/ruin/lavaland/syndicate_lava_base/bar)
 "Ou" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
@@ -3926,14 +3926,14 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/bar)
+/area/ruin/lavaland/syndicate_lava_base/bar)
 "Oy" = (
 /obj/machinery/atmospherics/pipe/layer_manifold{
 	dir = 4
 	},
 /obj/effect/spawner/structure/window/reinforced/plasma/plastitanium,
 /turf/open/floor/plating,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/lavaland/syndicate_lava_base/engineering)
 "OC" = (
 /obj/effect/turf_decal/bot,
 /obj/structure/railing{
@@ -3944,7 +3944,7 @@
 /obj/item/xenoartifact,
 /obj/item/xenoartifact,
 /turf/open/floor/engine,
-/area/ruin/unpowered/syndicate_lava_base/science)
+/area/ruin/lavaland/syndicate_lava_base/science)
 "OF" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
@@ -3953,7 +3953,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/lavaland/syndicate_lava_base/engineering)
 "OJ" = (
 /obj/machinery/light/small,
 /obj/structure/bed/roller,
@@ -3964,17 +3964,17 @@
 	},
 /obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/testlab)
+/area/ruin/lavaland/syndicate_lava_base/testlab)
 "OV" = (
 /turf/open/floor/wood,
-/area/ruin/unpowered/syndicate_lava_base/bar)
+/area/ruin/lavaland/syndicate_lava_base/bar)
 "Pk" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},
 /obj/item/xenoarchaeology_labeler,
 /turf/open/floor/engine,
-/area/ruin/unpowered/syndicate_lava_base/science)
+/area/ruin/lavaland/syndicate_lava_base/science)
 "Pv" = (
 /obj/machinery/computer/atmos_control{
 	dir = 8;
@@ -3986,7 +3986,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/lavaland/syndicate_lava_base/engineering)
 "Pw" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -4002,7 +4002,7 @@
 	dir = 8
 	},
 /turf/open/floor/plating,
-/area/ruin/unpowered/syndicate_lava_base/arrivals)
+/area/ruin/lavaland/syndicate_lava_base/arrivals)
 "Py" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -4011,19 +4011,19 @@
 	dir = 1
 	},
 /turf/open/floor/carpet/grimy,
-/area/ruin/unpowered/syndicate_lava_base/dormitories)
+/area/ruin/lavaland/syndicate_lava_base/dormitories)
 "Pz" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/random/vending/snackvend,
 /obj/machinery/firealarm/directional/east,
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/bar)
+/area/ruin/lavaland/syndicate_lava_base/bar)
 "PC" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
 /obj/structure/chair/stool/bar/directional/east,
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/bar)
+/area/ruin/lavaland/syndicate_lava_base/bar)
 "PG" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/neutral{
@@ -4032,7 +4032,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/dormitories)
+/area/ruin/lavaland/syndicate_lava_base/dormitories)
 "PK" = (
 /obj/structure/table/wood,
 /obj/item/book/manual/wiki/barman_recipes,
@@ -4040,16 +4040,16 @@
 	dir = 8
 	},
 /turf/open/floor/wood,
-/area/ruin/unpowered/syndicate_lava_base/bar)
+/area/ruin/lavaland/syndicate_lava_base/bar)
 "PW" = (
 /obj/machinery/door/window/westright{
 	name = "Kitchen"
 	},
 /turf/open/floor/iron/white,
-/area/ruin/unpowered/syndicate_lava_base/bar)
+/area/ruin/lavaland/syndicate_lava_base/bar)
 "PX" = (
 /turf/open/floor/engine/plasma,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/lavaland/syndicate_lava_base/engineering)
 "PZ" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
 /obj/machinery/computer/security/telescreen/entertainment{
@@ -4058,14 +4058,14 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/bar)
+/area/ruin/lavaland/syndicate_lava_base/bar)
 "Qa" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/red/anticorner/contrasted{
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/arrivals)
+/area/ruin/lavaland/syndicate_lava_base/arrivals)
 "Qe" = (
 /obj/structure/cable/yellow,
 /obj/effect/turf_decal/tile/blue/half/contrasted,
@@ -4074,7 +4074,7 @@
 /turf/open/floor/iron/white/side{
 	dir = 4
 	},
-/area/ruin/unpowered/syndicate_lava_base/arrivals)
+/area/ruin/lavaland/syndicate_lava_base/arrivals)
 "Qf" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/on{
 	dir = 1;
@@ -4082,22 +4082,22 @@
 	name = "toxin out"
 	},
 /turf/open/floor/engine/plasma,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/lavaland/syndicate_lava_base/engineering)
 "Qi" = (
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/science)
+/area/ruin/lavaland/syndicate_lava_base/science)
 "Qj" = (
 /obj/machinery/door/poddoor{
 	id = "lavalandsyndi_arrivals"
 	},
 /obj/effect/spawner/structure/window/reinforced/plasma/plastitanium,
 /turf/open/floor/plating,
-/area/ruin/unpowered/syndicate_lava_base/arrivals)
+/area/ruin/lavaland/syndicate_lava_base/arrivals)
 "Qs" = (
 /obj/effect/spawner/structure/window/reinforced/plasma/plastitanium,
 /turf/open/floor/plating,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/lavaland/syndicate_lava_base/engineering)
 "QA" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -4105,7 +4105,7 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/telecomms)
+/area/ruin/lavaland/syndicate_lava_base/telecomms)
 "QK" = (
 /obj/structure/cable/yellow,
 /obj/effect/turf_decal/tile/red{
@@ -4114,7 +4114,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/arrivals)
+/area/ruin/lavaland/syndicate_lava_base/arrivals)
 "QM" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -4131,12 +4131,12 @@
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
+/area/ruin/lavaland/syndicate_lava_base/cargo)
 "QO" = (
 /obj/structure/chair/office/light,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/science)
+/area/ruin/lavaland/syndicate_lava_base/science)
 "QP" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -4160,7 +4160,7 @@
 /turf/open/floor/iron/white/side{
 	dir = 4
 	},
-/area/ruin/unpowered/syndicate_lava_base/chemistry)
+/area/ruin/lavaland/syndicate_lava_base/chemistry)
 "QQ" = (
 /obj/structure/table/wood,
 /obj/machinery/chem_dispenser/drinks/fullupgrade{
@@ -4170,16 +4170,16 @@
 	dir = 6
 	},
 /turf/open/floor/wood,
-/area/ruin/unpowered/syndicate_lava_base/bar)
+/area/ruin/lavaland/syndicate_lava_base/bar)
 "Ra" = (
 /turf/closed/wall/mineral/plastitanium/explosive,
-/area/ruin/unpowered/syndicate_lava_base/medbay)
+/area/ruin/lavaland/syndicate_lava_base/medbay)
 "Rh" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/chemistry)
+/area/ruin/lavaland/syndicate_lava_base/chemistry)
 "Rl" = (
 /obj/effect/turf_decal/tile/purple/half/contrasted{
 	dir = 8
@@ -4187,7 +4187,7 @@
 /obj/item/storage/firstaid/regular,
 /obj/structure/table_frame,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/science)
+/area/ruin/lavaland/syndicate_lava_base/science)
 "Ru" = (
 /obj/structure/table/glass,
 /obj/item/stack/sheet/mineral/plasma{
@@ -4205,7 +4205,7 @@
 /turf/open/floor/iron/white/side{
 	dir = 1
 	},
-/area/ruin/unpowered/syndicate_lava_base/chemistry)
+/area/ruin/lavaland/syndicate_lava_base/chemistry)
 "Ry" = (
 /obj/structure/railing{
 	dir = 8
@@ -4220,11 +4220,11 @@
 	},
 /obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/testlab)
+/area/ruin/lavaland/syndicate_lava_base/testlab)
 "RD" = (
 /obj/effect/mapping_helpers/no_lava,
 /turf/open/floor/plating,
-/area/ruin/unpowered/syndicate_lava_base/main)
+/area/ruin/lavaland/syndicate_lava_base/main)
 "RT" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
@@ -4233,13 +4233,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/main)
+/area/ruin/lavaland/syndicate_lava_base/main)
 "RU" = (
 /obj/structure/chair{
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
+/area/ruin/lavaland/syndicate_lava_base/cargo)
 "RW" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/medical/glass{
@@ -4247,7 +4247,7 @@
 	},
 /obj/effect/turf_decal/stripes/closeup,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/medbay)
+/area/ruin/lavaland/syndicate_lava_base/medbay)
 "RZ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
@@ -4256,7 +4256,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/random/vending/colavend,
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/bar)
+/area/ruin/lavaland/syndicate_lava_base/bar)
 "Sa" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/public/glass{
@@ -4270,37 +4270,37 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/dormitories)
+/area/ruin/lavaland/syndicate_lava_base/dormitories)
 "Sc" = (
 /obj/item/healthanalyzer,
 /turf/open/floor/plating,
-/area/ruin/unpowered/syndicate_lava_base/science)
+/area/ruin/lavaland/syndicate_lava_base/science)
 "Sd" = (
 /obj/item/reagent_containers/condiment/enzyme,
 /obj/item/food/chocolatebar,
 /obj/structure/closet/secure_closet/freezer/fridge/open,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/white,
-/area/ruin/unpowered/syndicate_lava_base/bar)
+/area/ruin/lavaland/syndicate_lava_base/bar)
 "Sk" = (
 /obj/effect/turf_decal/box,
 /obj/item/xenoartifact,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/engine,
-/area/ruin/unpowered/syndicate_lava_base/science)
+/area/ruin/lavaland/syndicate_lava_base/science)
 "Sl" = (
 /obj/machinery/porta_turret/syndicate{
 	dir = 10
 	},
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
-/area/ruin/unpowered/syndicate_lava_base/science)
+/area/ruin/lavaland/syndicate_lava_base/science)
 "So" = (
 /obj/structure/chair{
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/bar)
+/area/ruin/lavaland/syndicate_lava_base/bar)
 "Sr" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
 	cycle_id = "syndi-outpost1"
@@ -4309,7 +4309,7 @@
 /obj/effect/mapping_helpers/airlock/access/all/syndicate/general,
 /obj/structure/fans/tiny,
 /turf/open/floor/plating,
-/area/ruin/unpowered/syndicate_lava_base/arrivals)
+/area/ruin/lavaland/syndicate_lava_base/arrivals)
 "St" = (
 /obj/structure/fans/tiny,
 /obj/machinery/door/airlock/external,
@@ -4318,7 +4318,7 @@
 	dir = 1
 	},
 /turf/open/floor/plating,
-/area/ruin/unpowered/syndicate_lava_base/arrivals)
+/area/ruin/lavaland/syndicate_lava_base/arrivals)
 "Su" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -4347,7 +4347,7 @@
 	pixel_x = 6
 	},
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/testlab)
+/area/ruin/lavaland/syndicate_lava_base/testlab)
 "Sx" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable/yellow,
@@ -4362,12 +4362,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /obj/structure/barricade/wooden/crude,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/science)
+/area/ruin/lavaland/syndicate_lava_base/science)
 "SE" = (
 /obj/structure/chair/stool/bar,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/bar)
+/area/ruin/lavaland/syndicate_lava_base/bar)
 "SF" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/red/line{
@@ -4377,11 +4377,11 @@
 /obj/structure/closet/crate,
 /obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/main)
+/area/ruin/lavaland/syndicate_lava_base/main)
 "SI" = (
 /obj/structure/closet/crate/bin,
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/bar)
+/area/ruin/lavaland/syndicate_lava_base/bar)
 "SJ" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
@@ -4390,11 +4390,11 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/portable_atmospherics/pump,
 /turf/open/floor/plating,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/lavaland/syndicate_lava_base/engineering)
 "SN" = (
 /obj/effect/turf_decal/tile/red,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/arrivals)
+/area/ruin/lavaland/syndicate_lava_base/arrivals)
 "SW" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/stripes/line,
@@ -4405,7 +4405,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/lavaland/syndicate_lava_base/engineering)
 "Tc" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/components/binary/dp_vent_pump/high_volume/incinerator_syndicatelava{
@@ -4414,7 +4414,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /turf/open/floor/engine,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/lavaland/syndicate_lava_base/engineering)
 "Ti" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/computer/atmos_control{
@@ -4430,10 +4430,10 @@
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/lavaland/syndicate_lava_base/engineering)
 "Tk" = (
 /turf/closed/wall/mineral/plastitanium,
-/area/ruin/unpowered/syndicate_lava_base/main)
+/area/ruin/lavaland/syndicate_lava_base/main)
 "Tq" = (
 /obj/effect/turf_decal/stripes/corner,
 /obj/structure/cable/yellow,
@@ -4441,7 +4441,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/arrivals)
+/area/ruin/lavaland/syndicate_lava_base/arrivals)
 "Tz" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/cup/glass/bottle/beer{
@@ -4449,21 +4449,21 @@
 	pixel_x = 7
 	},
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/bar)
+/area/ruin/lavaland/syndicate_lava_base/bar)
 "TK" = (
 /obj/machinery/light/small{
 	dir = 4
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
 /turf/open/floor/carpet/grimy,
-/area/ruin/unpowered/syndicate_lava_base/dormitories)
+/area/ruin/lavaland/syndicate_lava_base/dormitories)
 "TL" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
+/area/ruin/lavaland/syndicate_lava_base/cargo)
 "TN" = (
 /obj/structure/cable/yellow,
 /obj/effect/decal/cleanable/dirt,
@@ -4472,14 +4472,14 @@
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/lavaland/syndicate_lava_base/engineering)
 "TW" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/red/half/contrasted{
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/arrivals)
+/area/ruin/lavaland/syndicate_lava_base/arrivals)
 "Uh" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/on{
 	dir = 8;
@@ -4487,20 +4487,20 @@
 	name = "oxygen out"
 	},
 /turf/open/floor/engine/o2,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/lavaland/syndicate_lava_base/engineering)
 "Ut" = (
 /obj/effect/mapping_helpers/no_lava,
 /obj/machinery/light/small{
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/ruin/unpowered/syndicate_lava_base/main)
+/area/ruin/lavaland/syndicate_lava_base/main)
 "Uw" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/medbay)
+/area/ruin/lavaland/syndicate_lava_base/medbay)
 "Uz" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "lavalandsyndiwindow";
@@ -4510,7 +4510,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/plating,
-/area/ruin/unpowered/syndicate_lava_base/testlab)
+/area/ruin/lavaland/syndicate_lava_base/testlab)
 "UF" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
@@ -4520,14 +4520,14 @@
 	dir = 1
 	},
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/main)
+/area/ruin/lavaland/syndicate_lava_base/main)
 "UL" = (
 /obj/effect/turf_decal/siding/wood/corner,
 /turf/open/floor/wood,
-/area/ruin/unpowered/syndicate_lava_base/bar)
+/area/ruin/lavaland/syndicate_lava_base/bar)
 "UP" = (
 /turf/closed/wall/mineral/plastitanium/explosive,
-/area/ruin/unpowered/syndicate_lava_base/science)
+/area/ruin/lavaland/syndicate_lava_base/science)
 "UT" = (
 /obj/structure/table,
 /obj/item/storage/box/syringes,
@@ -4540,7 +4540,7 @@
 /turf/open/floor/iron/white/side{
 	dir = 9
 	},
-/area/ruin/unpowered/syndicate_lava_base/medbay)
+/area/ruin/lavaland/syndicate_lava_base/medbay)
 "UW" = (
 /obj/machinery/door/airlock/hatch{
 	name = "Monkey Pen"
@@ -4553,7 +4553,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/testlab)
+/area/ruin/lavaland/syndicate_lava_base/testlab)
 "Vf" = (
 /obj/structure/table/reinforced,
 /obj/item/radio/intercom{
@@ -4563,7 +4563,7 @@
 /obj/item/paper/fluff/ruins/syndicomms,
 /obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/telecomms)
+/area/ruin/lavaland/syndicate_lava_base/telecomms)
 "Vr" = (
 /obj/effect/turf_decal/bot,
 /obj/effect/decal/cleanable/dirt,
@@ -4572,13 +4572,13 @@
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/lavaland/syndicate_lava_base/engineering)
 "Vw" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/window/reinforced/spawner/directional/north,
 /obj/machinery/processor,
 /turf/open/floor/plating,
-/area/ruin/unpowered/syndicate_lava_base/main)
+/area/ruin/lavaland/syndicate_lava_base/main)
 "VH" = (
 /obj/structure/cable/yellow,
 /obj/effect/decal/cleanable/dirt,
@@ -4588,18 +4588,18 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/dormitories)
+/area/ruin/lavaland/syndicate_lava_base/dormitories)
 "VN" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/purple/half/contrasted{
 	dir = 1
 	},
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/main)
+/area/ruin/lavaland/syndicate_lava_base/main)
 "VP" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /turf/open/floor/engine,
-/area/ruin/unpowered/syndicate_lava_base/testlab)
+/area/ruin/lavaland/syndicate_lava_base/testlab)
 "VS" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -4611,7 +4611,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/main)
+/area/ruin/lavaland/syndicate_lava_base/main)
 "VV" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/yellow,
@@ -4619,7 +4619,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/lavaland/syndicate_lava_base/engineering)
 "Wc" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/monitored{
 	dir = 1
@@ -4628,7 +4628,7 @@
 	pixel_y = -32
 	},
 /turf/open/floor/engine/vacuum,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/lavaland/syndicate_lava_base/engineering)
 "Wm" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Dormitories"
@@ -4638,14 +4638,14 @@
 	dir = 1
 	},
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/dormitories)
+/area/ruin/lavaland/syndicate_lava_base/dormitories)
 "Wn" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/arrivals)
+/area/ruin/lavaland/syndicate_lava_base/arrivals)
 "Wq" = (
 /obj/structure/rack{
 	dir = 8
@@ -4658,13 +4658,13 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
+/area/ruin/lavaland/syndicate_lava_base/cargo)
 "Ww" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
+/area/ruin/lavaland/syndicate_lava_base/cargo)
 "Wy" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/shower{
@@ -4672,7 +4672,7 @@
 	desc = "The HS-452. Installed recently by the DonkCo Hygiene Division."
 	},
 /turf/open/floor/noslip/standard,
-/area/ruin/unpowered/syndicate_lava_base/main)
+/area/ruin/lavaland/syndicate_lava_base/main)
 "Wz" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 6
@@ -4683,14 +4683,14 @@
 	pixel_y = 6
 	},
 /turf/open/floor/wood,
-/area/ruin/unpowered/syndicate_lava_base/bar)
+/area/ruin/lavaland/syndicate_lava_base/bar)
 "WF" = (
 /obj/structure/disposaloutlet{
 	dir = 1
 	},
 /obj/structure/disposalpipe/trunk,
 /turf/open/floor/engine,
-/area/ruin/unpowered/syndicate_lava_base/testlab)
+/area/ruin/lavaland/syndicate_lava_base/testlab)
 "WJ" = (
 /obj/machinery/airalarm/directional/west,
 /obj/effect/mapping_helpers/airalarm/syndicate_access,
@@ -4699,13 +4699,13 @@
 	},
 /obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/telecomms)
+/area/ruin/lavaland/syndicate_lava_base/telecomms)
 "WS" = (
 /obj/machinery/porta_turret/syndicate{
 	dir = 5
 	},
 /turf/closed/wall/mineral/plastitanium,
-/area/ruin/unpowered/syndicate_lava_base/testlab)
+/area/ruin/lavaland/syndicate_lava_base/testlab)
 "WU" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
@@ -4717,13 +4717,13 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/plating,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/lavaland/syndicate_lava_base/engineering)
 "WV" = (
 /obj/structure/table,
 /obj/item/storage/toolbox/syndicate,
 /obj/item/multitool,
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/telecomms)
+/area/ruin/lavaland/syndicate_lava_base/telecomms)
 "WY" = (
 /obj/structure/table/reinforced,
 /obj/item/surgicaldrill,
@@ -4734,7 +4734,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/white/side,
-/area/ruin/unpowered/syndicate_lava_base/medbay)
+/area/ruin/lavaland/syndicate_lava_base/medbay)
 "Xc" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
 /obj/machinery/button/door{
@@ -4745,7 +4745,7 @@
 	pixel_y = 25
 	},
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/telecomms)
+/area/ruin/lavaland/syndicate_lava_base/telecomms)
 "Xd" = (
 /obj/machinery/airalarm/directional/west,
 /obj/effect/mapping_helpers/airalarm/syndicate_access,
@@ -4753,7 +4753,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/main)
+/area/ruin/lavaland/syndicate_lava_base/main)
 "Xr" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/toolbox/syndicate,
@@ -4768,7 +4768,7 @@
 	dir = 9
 	},
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/testlab)
+/area/ruin/lavaland/syndicate_lava_base/testlab)
 "Xx" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable/yellow,
@@ -4782,7 +4782,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/main)
+/area/ruin/lavaland/syndicate_lava_base/main)
 "XA" = (
 /obj/machinery/vending/toyliberationstation{
 	req_access_txt = "150"
@@ -4791,7 +4791,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
+/area/ruin/lavaland/syndicate_lava_base/cargo)
 "XH" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/yellow/half/contrasted{
@@ -4800,7 +4800,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/lavaland/syndicate_lava_base/engineering)
 "XR" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -4813,7 +4813,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/chemistry)
+/area/ruin/lavaland/syndicate_lava_base/chemistry)
 "XV" = (
 /obj/structure/table/reinforced,
 /obj/item/scalpel,
@@ -4829,7 +4829,7 @@
 /turf/open/floor/iron/white/side{
 	dir = 4
 	},
-/area/ruin/unpowered/syndicate_lava_base/medbay)
+/area/ruin/lavaland/syndicate_lava_base/medbay)
 "XY" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/brown/half/contrasted{
@@ -4837,7 +4837,7 @@
 	},
 /obj/structure/closet/firecloset,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
+/area/ruin/lavaland/syndicate_lava_base/cargo)
 "Ye" = (
 /obj/machinery/computer/atmos_control{
 	dir = 8;
@@ -4846,21 +4846,21 @@
 /obj/effect/turf_decal/tile/blue/half/contrasted,
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/lavaland/syndicate_lava_base/engineering)
 "Yx" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
 /obj/structure/chair/stool/bar,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/bar)
+/area/ruin/lavaland/syndicate_lava_base/bar)
 "Yz" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
 /obj/machinery/airalarm/directional/west,
 /obj/effect/mapping_helpers/airalarm/syndicate_access,
 /obj/structure/chair/stool,
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/bar)
+/area/ruin/lavaland/syndicate_lava_base/bar)
 "YD" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_y = -29
@@ -4873,7 +4873,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/arrivals)
+/area/ruin/lavaland/syndicate_lava_base/arrivals)
 "YK" = (
 /obj/machinery/door/window/southleft{
 	base_state = "right";
@@ -4887,12 +4887,12 @@
 /turf/open/floor/wood{
 	broken = 1
 	},
-/area/ruin/unpowered/syndicate_lava_base/bar)
+/area/ruin/lavaland/syndicate_lava_base/bar)
 "YL" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/medbay)
+/area/ruin/lavaland/syndicate_lava_base/medbay)
 "YO" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 25
@@ -4902,7 +4902,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/testlab)
+/area/ruin/lavaland/syndicate_lava_base/testlab)
 "YQ" = (
 /obj/effect/turf_decal/tile/purple/anticorner/contrasted{
 	dir = 4
@@ -4914,7 +4914,7 @@
 	},
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/science)
+/area/ruin/lavaland/syndicate_lava_base/science)
 "YU" = (
 /obj/structure/chair{
 	dir = 4
@@ -4928,7 +4928,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/main)
+/area/ruin/lavaland/syndicate_lava_base/main)
 "YV" = (
 /obj/machinery/airalarm/directional/west,
 /obj/effect/mapping_helpers/airalarm/syndicate_access,
@@ -4952,7 +4952,7 @@
 /obj/item/circuitboard/machine/thermomachine,
 /obj/item/analyzer/ranged,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/lavaland/syndicate_lava_base/engineering)
 "Za" = (
 /obj/machinery/door/airlock{
 	name = "Cabin 4"
@@ -4962,7 +4962,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/dormitories)
+/area/ruin/lavaland/syndicate_lava_base/dormitories)
 "Zc" = (
 /obj/machinery/door/firedoor,
 /obj/structure/table/reinforced,
@@ -4972,14 +4972,14 @@
 	req_access_txt = "150"
 	},
 /turf/open/floor/plating,
-/area/ruin/unpowered/syndicate_lava_base/chemistry)
+/area/ruin/lavaland/syndicate_lava_base/chemistry)
 "Zd" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/siding/wood/corner{
 	dir = 8
 	},
 /turf/open/floor/wood,
-/area/ruin/unpowered/syndicate_lava_base/bar)
+/area/ruin/lavaland/syndicate_lava_base/bar)
 "Zf" = (
 /obj/structure/table/wood,
 /obj/effect/decal/cleanable/dirt,
@@ -4988,14 +4988,14 @@
 	dir = 8
 	},
 /turf/open/floor/wood,
-/area/ruin/unpowered/syndicate_lava_base/bar)
+/area/ruin/lavaland/syndicate_lava_base/bar)
 "Zi" = (
 /obj/structure/table/wood,
 /obj/item/ammo_box/magazine/m10mm,
 /obj/machinery/airalarm/directional/north,
 /obj/effect/mapping_helpers/airalarm/syndicate_access,
 /turf/open/floor/carpet/grimy,
-/area/ruin/unpowered/syndicate_lava_base/dormitories)
+/area/ruin/lavaland/syndicate_lava_base/dormitories)
 "Zj" = (
 /obj/structure/rack{
 	dir = 8
@@ -5011,14 +5011,14 @@
 	dir = 1
 	},
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/arrivals)
+/area/ruin/lavaland/syndicate_lava_base/arrivals)
 "Zo" = (
 /obj/machinery/atmospherics/miner/oxygen,
 /obj/machinery/light/small{
 	dir = 4
 	},
 /turf/open/floor/engine/o2,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/lavaland/syndicate_lava_base/engineering)
 "Zy" = (
 /obj/machinery/door/airlock/hatch{
 	name = "Telecommunications"
@@ -5032,7 +5032,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/telecomms)
+/area/ruin/lavaland/syndicate_lava_base/telecomms)
 "ZE" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -5043,12 +5043,12 @@
 	},
 /obj/machinery/firealarm/directional/north,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/dormitories)
+/area/ruin/lavaland/syndicate_lava_base/dormitories)
 "ZT" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/bar)
+/area/ruin/lavaland/syndicate_lava_base/bar)
 "ZX" = (
 /obj/machinery/light/small,
 /obj/structure/extinguisher_cabinet{
@@ -5062,7 +5062,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/medbay)
+/area/ruin/lavaland/syndicate_lava_base/medbay)
 "ZZ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/vending/syndichem,
@@ -5070,7 +5070,7 @@
 /turf/open/floor/iron/white/side{
 	dir = 4
 	},
-/area/ruin/unpowered/syndicate_lava_base/chemistry)
+/area/ruin/lavaland/syndicate_lava_base/chemistry)
 
 (1,1,1) = {"
 aa

--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_syndicate_base2.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_syndicate_base2.dmm
@@ -3,7 +3,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/iron/dark/smooth_large,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/lavaland/syndicate_lava_base/engineering)
 "am" = (
 /obj/structure/lattice/catwalk,
 /obj/item/toy/plush/lizard_plushie{
@@ -30,7 +30,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/iron/techmaint,
-/area/ruin/unpowered/syndicate_lava_base/bridge)
+/area/ruin/lavaland/syndicate_lava_base/bridge)
 "az" = (
 /obj/structure/lattice/catwalk,
 /turf/open/lava/smooth/lava_land_surface,
@@ -40,28 +40,28 @@
 /obj/effect/turf_decal/siding/dark,
 /obj/effect/turf_decal/trimline/red/line,
 /turf/open/floor/iron/dark/textured,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/lavaland/syndicate_lava_base/engineering)
 "aG" = (
 /obj/structure/cable/yellow,
 /obj/machinery/firealarm/directional/west,
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/starboard)
+/area/ruin/lavaland/syndicate_lava_base/starboard)
 "aI" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
 	},
 /turf/open/floor/carpet/red,
-/area/ruin/unpowered/syndicate_lava_base/telecomms)
+/area/ruin/lavaland/syndicate_lava_base/telecomms)
 "aL" = (
 /obj/structure/flora/tree/jungle/small,
 /obj/structure/flora/rock/jungle,
 /turf/open/floor/grass/no_border,
-/area/ruin/unpowered/syndicate_lava_base/port)
+/area/ruin/lavaland/syndicate_lava_base/port)
 "aN" = (
 /obj/machinery/power/apc/syndicate/directional/west,
 /obj/structure/cable/yellow,
 /turf/open/floor/catwalk_floor,
-/area/ruin/unpowered/syndicate_lava_base/starboard)
+/area/ruin/lavaland/syndicate_lava_base/starboard)
 "aS" = (
 /obj/effect/turf_decal/stripes/closeup{
 	dir = 1
@@ -73,7 +73,7 @@
 	},
 /obj/structure/fans/tiny/invisible,
 /turf/open/floor/iron/techmaint,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
+/area/ruin/lavaland/syndicate_lava_base/cargo)
 "aT" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 5
@@ -82,7 +82,7 @@
 	desc = "This might be the only player that ever uses the chameleon stamp unironically (unless they immediately fax CC calling them stupid)"
 	},
 /turf/open/floor/carpet/red,
-/area/ruin/unpowered/syndicate_lava_base/telecomms)
+/area/ruin/lavaland/syndicate_lava_base/telecomms)
 "aV" = (
 /obj/structure/table/reinforced,
 /obj/structure/window/reinforced/spawner/directional/east,
@@ -100,18 +100,18 @@
 	dir = 8
 	},
 /turf/open/floor/iron/techmaint,
-/area/ruin/unpowered/syndicate_lava_base/chemistry)
+/area/ruin/lavaland/syndicate_lava_base/chemistry)
 "aX" = (
 /obj/effect/spawner/structure/window/reinforced/plasma/plastitanium,
 /obj/machinery/door/poddoor/preopen{
 	id = "lavalandsyndi_hall"
 	},
 /turf/open/floor/plating,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
+/area/ruin/lavaland/syndicate_lava_base/cargo)
 "aZ" = (
 /obj/effect/spawner/structure/window/reinforced/plasma/plastitanium,
 /turf/open/floor/plating,
-/area/ruin/unpowered/syndicate_lava_base/virology)
+/area/ruin/lavaland/syndicate_lava_base/virology)
 "ba" = (
 /obj/structure/closet/secure_closet/medical1{
 	req_access = null;
@@ -121,19 +121,19 @@
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/medbay)
+/area/ruin/lavaland/syndicate_lava_base/medbay)
 "bd" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
+/area/ruin/lavaland/syndicate_lava_base/cargo)
 "bf" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/iron/white,
-/area/ruin/unpowered/syndicate_lava_base/virology)
+/area/ruin/lavaland/syndicate_lava_base/virology)
 "bl" = (
 /obj/structure/table/wood,
 /obj/machinery/fax{
@@ -144,10 +144,10 @@
 /obj/machinery/airalarm/directional/east,
 /obj/effect/mapping_helpers/airalarm/syndicate_access,
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/telecomms)
+/area/ruin/lavaland/syndicate_lava_base/telecomms)
 "bw" = (
 /turf/closed/wall/mineral/plastitanium/explosive,
-/area/ruin/unpowered/syndicate_lava_base/medbay)
+/area/ruin/lavaland/syndicate_lava_base/medbay)
 "bx" = (
 /obj/structure/chair/office{
 	dir = 1
@@ -161,13 +161,13 @@
 	pixel_y = 25
 	},
 /turf/open/floor/iron/dark/smooth_large,
-/area/ruin/unpowered/syndicate_lava_base/brig)
+/area/ruin/lavaland/syndicate_lava_base/brig)
 "bA" = (
 /obj/machinery/light/small{
 	dir = 8
 	},
 /turf/open/floor/catwalk_floor,
-/area/ruin/unpowered/syndicate_lava_base/starboard)
+/area/ruin/lavaland/syndicate_lava_base/starboard)
 "bB" = (
 /obj/effect/turf_decal/siding/dark{
 	dir = 6
@@ -176,23 +176,23 @@
 	dir = 6
 	},
 /turf/open/floor/iron/dark/textured,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/lavaland/syndicate_lava_base/engineering)
 "bC" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /obj/structure/cable/yellow,
 /turf/open/floor/catwalk_floor/iron_dark,
-/area/ruin/unpowered/syndicate_lava_base/port)
+/area/ruin/lavaland/syndicate_lava_base/port)
 "bT" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/portable_thermomachine,
 /turf/open/floor/iron/dark/smooth_large,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/lavaland/syndicate_lava_base/engineering)
 "bV" = (
 /obj/structure/table/optable,
 /obj/item/surgical_drapes,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/medbay)
+/area/ruin/lavaland/syndicate_lava_base/medbay)
 "bX" = (
 /obj/effect/turf_decal/stripes/closeup{
 	dir = 1
@@ -202,7 +202,7 @@
 	},
 /obj/structure/fans/tiny/invisible,
 /turf/open/floor/iron/techmaint,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
+/area/ruin/lavaland/syndicate_lava_base/cargo)
 "bY" = (
 /obj/effect/turf_decal/siding/dark{
 	dir = 10
@@ -212,10 +212,10 @@
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
 /turf/open/floor/iron/dark/textured,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/lavaland/syndicate_lava_base/engineering)
 "cb" = (
 /turf/closed/wall/mineral/plastitanium,
-/area/ruin/unpowered/syndicate_lava_base/port)
+/area/ruin/lavaland/syndicate_lava_base/port)
 "cd" = (
 /obj/machinery/computer/shuttle_flight{
 	desc = "Occasionally used to call in a resupply shuttle if one is in range.";
@@ -231,7 +231,7 @@
 /obj/machinery/light/directional/south,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
+/area/ruin/lavaland/syndicate_lava_base/cargo)
 "cf" = (
 /obj/structure/table/wood,
 /obj/effect/turf_decal/tile/neutral/opposingcorners,
@@ -242,14 +242,14 @@
 	pixel_y = 6
 	},
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/bar)
+/area/ruin/lavaland/syndicate_lava_base/bar)
 "cg" = (
 /obj/structure/fluff/hedge,
 /obj/effect/turf_decal/siding/dark/end{
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/medbay)
+/area/ruin/lavaland/syndicate_lava_base/medbay)
 "ch" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 4
@@ -258,13 +258,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
+/area/ruin/lavaland/syndicate_lava_base/cargo)
 "cy" = (
 /obj/machinery/porta_turret/syndicate{
 	dir = 5
 	},
 /turf/closed/wall/mineral/plastitanium,
-/area/ruin/unpowered/syndicate_lava_base/brig)
+/area/ruin/lavaland/syndicate_lava_base/brig)
 "cA" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 8
@@ -273,24 +273,24 @@
 	dir = 4
 	},
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/medbay)
+/area/ruin/lavaland/syndicate_lava_base/medbay)
 "cI" = (
 /obj/structure/table/wood,
 /obj/machinery/light/small/directional/north,
 /obj/item/storage/toolbox/syndicate,
 /turf/open/floor/wood,
-/area/ruin/unpowered/syndicate_lava_base/dormitories)
+/area/ruin/lavaland/syndicate_lava_base/dormitories)
 "cJ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /obj/structure/cable/yellow,
 /turf/open/floor/wood,
-/area/ruin/unpowered/syndicate_lava_base/bar)
+/area/ruin/lavaland/syndicate_lava_base/bar)
 "cO" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/backpack/duffelbag/med/surgery,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/medbay)
+/area/ruin/lavaland/syndicate_lava_base/medbay)
 "cT" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 8
@@ -299,13 +299,13 @@
 	dir = 4
 	},
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/medbay)
+/area/ruin/lavaland/syndicate_lava_base/medbay)
 "cU" = (
 /obj/machinery/porta_turret/syndicate{
 	dir = 9
 	},
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
-/area/ruin/unpowered/syndicate_lava_base/chemistry)
+/area/ruin/lavaland/syndicate_lava_base/chemistry)
 "cV" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/toolbox/syndicate,
@@ -315,7 +315,7 @@
 	},
 /obj/machinery/light/small/directional/south,
 /turf/open/floor/iron/dark/textured,
-/area/ruin/unpowered/syndicate_lava_base/telecomms)
+/area/ruin/lavaland/syndicate_lava_base/telecomms)
 "dc" = (
 /obj/machinery/computer/message_monitor{
 	dir = 4
@@ -331,12 +331,12 @@
 	pixel_y = 6
 	},
 /turf/open/floor/carpet/red,
-/area/ruin/unpowered/syndicate_lava_base/telecomms)
+/area/ruin/lavaland/syndicate_lava_base/telecomms)
 "dh" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/yellow,
 /turf/open/floor/catwalk_floor,
-/area/ruin/unpowered/syndicate_lava_base/starboard)
+/area/ruin/lavaland/syndicate_lava_base/starboard)
 "dk" = (
 /obj/structure/table/wood,
 /obj/item/paper_bin{
@@ -353,13 +353,13 @@
 	pixel_y = 10
 	},
 /turf/open/floor/carpet/red,
-/area/ruin/unpowered/syndicate_lava_base/telecomms)
+/area/ruin/lavaland/syndicate_lava_base/telecomms)
 "dl" = (
 /turf/open/floor/wood,
-/area/ruin/unpowered/syndicate_lava_base/telecomms)
+/area/ruin/lavaland/syndicate_lava_base/telecomms)
 "dq" = (
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
-/area/ruin/unpowered/syndicate_lava_base/virology)
+/area/ruin/lavaland/syndicate_lava_base/virology)
 "ds" = (
 /obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/locked,
@@ -370,33 +370,33 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/engine,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/lavaland/syndicate_lava_base/engineering)
 "dB" = (
 /obj/machinery/porta_turret/syndicate{
 	dir = 6
 	},
 /turf/closed/wall/mineral/plastitanium,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/lavaland/syndicate_lava_base/engineering)
 "dE" = (
 /obj/machinery/atmospherics/pipe/layer_manifold{
 	dir = 4
 	},
 /obj/effect/spawner/structure/window/reinforced/plasma/plastitanium,
 /turf/open/floor/plating,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/lavaland/syndicate_lava_base/engineering)
 "dK" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/medbay)
+/area/ruin/lavaland/syndicate_lava_base/medbay)
 "dN" = (
 /obj/machinery/porta_turret/syndicate{
 	dir = 10
 	},
 /turf/closed/wall/mineral/plastitanium,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/lavaland/syndicate_lava_base/engineering)
 "dO" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/on/layer4{
 	dir = 8;
@@ -404,12 +404,12 @@
 	},
 /obj/effect/mapping_helpers/no_lava,
 /turf/open/floor/plating,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/lavaland/syndicate_lava_base/engineering)
 "dP" = (
 /obj/machinery/airalarm/directional/east,
 /obj/effect/mapping_helpers/airalarm/syndicate_access,
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/port)
+/area/ruin/lavaland/syndicate_lava_base/port)
 "dY" = (
 /obj/effect/turf_decal/stripes/closeup{
 	dir = 1
@@ -422,19 +422,19 @@
 	name = "Port Hall"
 	},
 /turf/open/floor/iron/techmaint,
-/area/ruin/unpowered/syndicate_lava_base/medbay)
+/area/ruin/lavaland/syndicate_lava_base/medbay)
 "dZ" = (
 /obj/structure/closet/crate,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
+/area/ruin/lavaland/syndicate_lava_base/cargo)
 "ed" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 4
 	},
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/starboard)
+/area/ruin/lavaland/syndicate_lava_base/starboard)
 "ee" = (
 /obj/structure/chair/fancy/sofa/old/right{
 	color = "#742925";
@@ -444,20 +444,20 @@
 	dir = 10
 	},
 /turf/open/floor/carpet/red,
-/area/ruin/unpowered/syndicate_lava_base/bar)
+/area/ruin/lavaland/syndicate_lava_base/bar)
 "ei" = (
 /obj/machinery/atmospherics/miner/oxygen,
 /obj/machinery/light/small{
 	dir = 4
 	},
 /turf/open/floor/engine/o2,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/lavaland/syndicate_lava_base/engineering)
 "el" = (
 /obj/effect/turf_decal/tile/bar/opposingcorners,
 /obj/machinery/light/cold/directional/south,
 /obj/machinery/vending/dinnerware,
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/bar)
+/area/ruin/lavaland/syndicate_lava_base/bar)
 "en" = (
 /obj/effect/turf_decal/box/white/corners{
 	dir = 8
@@ -488,7 +488,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
+/area/ruin/lavaland/syndicate_lava_base/cargo)
 "es" = (
 /obj/item/reagent_containers/condiment/enzyme,
 /obj/item/food/chocolatebar,
@@ -498,7 +498,7 @@
 	req_access = null
 	},
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/bar)
+/area/ruin/lavaland/syndicate_lava_base/bar)
 "eA" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 9
@@ -506,7 +506,7 @@
 /obj/structure/closet/crate/bin,
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
+/area/ruin/lavaland/syndicate_lava_base/cargo)
 "eH" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -515,31 +515,31 @@
 	dir = 4
 	},
 /turf/open/floor/engine,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/lavaland/syndicate_lava_base/engineering)
 "eJ" = (
 /obj/structure/reagent_dispensers/fueltank,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
-/area/ruin/unpowered/syndicate_lava_base/starboard)
+/area/ruin/lavaland/syndicate_lava_base/starboard)
 "eL" = (
 /obj/effect/turf_decal/trimline/red/filled/corner{
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/port)
+/area/ruin/lavaland/syndicate_lava_base/port)
 "eM" = (
 /obj/machinery/chem_dispenser/fullupgrade,
 /obj/machinery/airalarm/directional/north,
 /obj/effect/mapping_helpers/airalarm/syndicate_access,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/chemistry)
+/area/ruin/lavaland/syndicate_lava_base/chemistry)
 "eN" = (
 /obj/effect/turf_decal/siding/dark{
 	dir = 10
 	},
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/bridge)
+/area/ruin/lavaland/syndicate_lava_base/bridge)
 "eT" = (
 /obj/effect/turf_decal/stripes/closeup,
 /obj/machinery/door/firedoor,
@@ -551,7 +551,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /obj/structure/cable/yellow,
 /turf/open/floor/iron/techmaint,
-/area/ruin/unpowered/syndicate_lava_base/medbay)
+/area/ruin/lavaland/syndicate_lava_base/medbay)
 "eU" = (
 /obj/structure/chair/office/light{
 	dir = 4
@@ -560,31 +560,31 @@
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/virology)
+/area/ruin/lavaland/syndicate_lava_base/virology)
 "fk" = (
 /obj/effect/turf_decal/stripes/closeup{
 	dir = 1
 	},
 /obj/structure/fans/tiny/invisible,
 /turf/open/floor/iron/techmaint,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
+/area/ruin/lavaland/syndicate_lava_base/cargo)
 "fs" = (
 /obj/structure/cable/yellow,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/starboard)
+/area/ruin/lavaland/syndicate_lava_base/starboard)
 "fw" = (
 /obj/effect/turf_decal/tile/neutral/opposingcorners,
 /obj/machinery/griddle,
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/bar)
+/area/ruin/lavaland/syndicate_lava_base/bar)
 "fA" = (
 /obj/machinery/atmospherics/components/trinary/mixer{
 	dir = 8
 	},
 /turf/open/floor/catwalk_floor/iron_dark,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/lavaland/syndicate_lava_base/engineering)
 "fB" = (
 /obj/machinery/power/terminal{
 	dir = 1
@@ -596,7 +596,7 @@
 /obj/machinery/atmospherics/components/unary/portables_connector/layer4,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron/dark/smooth_large,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/lavaland/syndicate_lava_base/engineering)
 "fP" = (
 /obj/structure/railing{
 	dir = 1
@@ -605,7 +605,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /obj/structure/cable/yellow,
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/port)
+/area/ruin/lavaland/syndicate_lava_base/port)
 "fQ" = (
 /obj/effect/turf_decal/stripes/closeup{
 	dir = 1
@@ -615,19 +615,19 @@
 /obj/effect/mapping_helpers/airlock/access/all/syndicate/general,
 /obj/structure/cable/yellow,
 /turf/open/floor/iron/techmaint,
-/area/ruin/unpowered/syndicate_lava_base/starboard)
+/area/ruin/lavaland/syndicate_lava_base/starboard)
 "fT" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /obj/structure/cable/yellow,
 /turf/open/floor/iron/white,
-/area/ruin/unpowered/syndicate_lava_base/medbay)
+/area/ruin/lavaland/syndicate_lava_base/medbay)
 "gg" = (
 /turf/open/floor/circuit/red,
-/area/ruin/unpowered/syndicate_lava_base/starboard)
+/area/ruin/lavaland/syndicate_lava_base/starboard)
 "go" = (
 /turf/open/floor/plating,
-/area/ruin/unpowered/syndicate_lava_base/medbay)
+/area/ruin/lavaland/syndicate_lava_base/medbay)
 "gs" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 8
@@ -635,7 +635,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/firealarm/directional/west,
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/port)
+/area/ruin/lavaland/syndicate_lava_base/port)
 "gJ" = (
 /obj/machinery/sleeper/syndie{
 	dir = 8
@@ -643,7 +643,7 @@
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/medbay)
+/area/ruin/lavaland/syndicate_lava_base/medbay)
 "gL" = (
 /obj/structure/closet/secure_closet/medical2{
 	req_access = null
@@ -654,13 +654,13 @@
 /obj/machinery/airalarm/directional/east,
 /obj/effect/mapping_helpers/airalarm/syndicate_access,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/medbay)
+/area/ruin/lavaland/syndicate_lava_base/medbay)
 "gM" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 8
 	},
 /turf/open/floor/iron/white,
-/area/ruin/unpowered/syndicate_lava_base/virology)
+/area/ruin/lavaland/syndicate_lava_base/virology)
 "gN" = (
 /obj/effect/turf_decal/stripes/closeup,
 /obj/machinery/door/airlock/hatch{
@@ -669,7 +669,7 @@
 /obj/effect/mapping_helpers/airlock/access/all/syndicate/general,
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron/techmaint,
-/area/ruin/unpowered/syndicate_lava_base/telecomms)
+/area/ruin/lavaland/syndicate_lava_base/telecomms)
 "gQ" = (
 /mob/living/carbon/monkey{
 	faction = list("neutral","Syndicate")
@@ -681,11 +681,11 @@
 	dir = 5
 	},
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/virology)
+/area/ruin/lavaland/syndicate_lava_base/virology)
 "gT" = (
 /obj/effect/turf_decal/siding/dark,
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/bridge)
+/area/ruin/lavaland/syndicate_lava_base/bridge)
 "gZ" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -694,7 +694,7 @@
 	pixel_x = -32
 	},
 /turf/open/floor/plating,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
+/area/ruin/lavaland/syndicate_lava_base/cargo)
 "ha" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 8
@@ -705,25 +705,25 @@
 /obj/structure/cable/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /turf/open/floor/wood,
-/area/ruin/unpowered/syndicate_lava_base/dormitories)
+/area/ruin/lavaland/syndicate_lava_base/dormitories)
 "hb" = (
 /obj/effect/spawner/structure/window/reinforced/plasma/plastitanium,
 /obj/machinery/door/poddoor/preopen{
 	id = "lavalandsyndi_bridge"
 	},
 /turf/open/floor/plating,
-/area/ruin/unpowered/syndicate_lava_base/bridge)
+/area/ruin/lavaland/syndicate_lava_base/bridge)
 "hd" = (
 /obj/machinery/chem_heater,
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/chemistry)
+/area/ruin/lavaland/syndicate_lava_base/chemistry)
 "hm" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
 	},
 /turf/open/floor/wood,
-/area/ruin/unpowered/syndicate_lava_base/bar)
+/area/ruin/lavaland/syndicate_lava_base/bar)
 "hr" = (
 /obj/effect/turf_decal/stripes/closeup{
 	dir = 1
@@ -734,7 +734,7 @@
 	},
 /obj/structure/fans/tiny/invisible,
 /turf/open/floor/iron/techmaint,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
+/area/ruin/lavaland/syndicate_lava_base/cargo)
 "hB" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
@@ -743,7 +743,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /obj/structure/cable/yellow,
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
+/area/ruin/lavaland/syndicate_lava_base/cargo)
 "hF" = (
 /obj/structure/table/reinforced,
 /obj/item/reagent_containers/cup/bottle/cyanide{
@@ -756,7 +756,7 @@
 /obj/item/reagent_containers/syringe,
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/iron/dark/smooth_large,
-/area/ruin/unpowered/syndicate_lava_base/brig)
+/area/ruin/lavaland/syndicate_lava_base/brig)
 "hK" = (
 /turf/template_noop,
 /area/template_noop)
@@ -769,7 +769,7 @@
 	},
 /obj/effect/turf_decal/stripes/closeup,
 /turf/open/floor/iron/techmaint,
-/area/ruin/unpowered/syndicate_lava_base/bar)
+/area/ruin/lavaland/syndicate_lava_base/bar)
 "hN" = (
 /obj/effect/turf_decal/siding/dark{
 	dir = 1
@@ -779,14 +779,14 @@
 	},
 /obj/structure/cable/yellow,
 /turf/open/floor/iron/dark/textured,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
+/area/ruin/lavaland/syndicate_lava_base/cargo)
 "hR" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "lavalandsyndi_med"
 	},
 /obj/effect/spawner/structure/window/reinforced/plasma/plastitanium,
 /turf/open/floor/plating,
-/area/ruin/unpowered/syndicate_lava_base/medbay)
+/area/ruin/lavaland/syndicate_lava_base/medbay)
 "ij" = (
 /obj/effect/turf_decal/siding/dark{
 	dir = 4
@@ -798,13 +798,13 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark/textured,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/lavaland/syndicate_lava_base/engineering)
 "ix" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /obj/item/kirbyplants/random,
 /turf/open/floor/iron/white,
-/area/ruin/unpowered/syndicate_lava_base/virology)
+/area/ruin/lavaland/syndicate_lava_base/virology)
 "iy" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
@@ -816,39 +816,39 @@
 	},
 /obj/structure/cable/yellow,
 /turf/open/floor/iron/dark/textured,
-/area/ruin/unpowered/syndicate_lava_base/brig)
+/area/ruin/lavaland/syndicate_lava_base/brig)
 "iE" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/catwalk_floor/iron_dark,
-/area/ruin/unpowered/syndicate_lava_base/starboard)
+/area/ruin/lavaland/syndicate_lava_base/starboard)
 "iG" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/starboard)
+/area/ruin/lavaland/syndicate_lava_base/starboard)
 "iO" = (
 /obj/structure/railing/corner{
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/starboard)
+/area/ruin/lavaland/syndicate_lava_base/starboard)
 "iS" = (
 /obj/structure/cable/yellow,
 /turf/open/floor/iron/dark/textured,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/lavaland/syndicate_lava_base/engineering)
 "iZ" = (
 /obj/effect/decal/cleanable/blood/splatter,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
-/area/ruin/unpowered/syndicate_lava_base/brig)
+/area/ruin/lavaland/syndicate_lava_base/brig)
 "ja" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 4
 	},
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/port)
+/area/ruin/lavaland/syndicate_lava_base/port)
 "jb" = (
 /obj/effect/turf_decal/box/white/corners{
 	dir = 4
@@ -867,26 +867,26 @@
 	pixel_x = 2
 	},
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
+/area/ruin/lavaland/syndicate_lava_base/cargo)
 "jd" = (
 /obj/machinery/power/apc/syndicate/directional/north,
 /obj/structure/cable/yellow,
 /turf/open/floor/iron/white,
-/area/ruin/unpowered/syndicate_lava_base/virology)
+/area/ruin/lavaland/syndicate_lava_base/virology)
 "jg" = (
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
-/area/ruin/unpowered/syndicate_lava_base/port)
+/area/ruin/lavaland/syndicate_lava_base/port)
 "jm" = (
 /obj/machinery/shower{
 	dir = 1
 	},
 /obj/structure/curtain,
 /turf/open/floor/iron/white/textured,
-/area/ruin/unpowered/syndicate_lava_base/port)
+/area/ruin/lavaland/syndicate_lava_base/port)
 "jn" = (
 /obj/machinery/air_sensor,
 /turf/open/floor/engine/plasma,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/lavaland/syndicate_lava_base/engineering)
 "js" = (
 /obj/structure/reagent_dispensers/watertank,
 /obj/effect/decal/cleanable/dirt,
@@ -894,21 +894,21 @@
 /obj/item/mop,
 /obj/item/reagent_containers/cup/bucket,
 /turf/open/floor/plating,
-/area/ruin/unpowered/syndicate_lava_base/starboard)
+/area/ruin/lavaland/syndicate_lava_base/starboard)
 "jw" = (
 /obj/machinery/atmospherics/miner/plasma,
 /obj/machinery/light/small{
 	dir = 4
 	},
 /turf/open/floor/engine/plasma,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/lavaland/syndicate_lava_base/engineering)
 "jH" = (
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/stripes/closeup,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/iron/techmaint,
-/area/ruin/unpowered/syndicate_lava_base/starboard)
+/area/ruin/lavaland/syndicate_lava_base/starboard)
 "jL" = (
 /obj/effect/turf_decal/stripes/closeup{
 	dir = 1
@@ -921,7 +921,7 @@
 	name = "Starboard Hall"
 	},
 /turf/open/floor/iron/techmaint,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
+/area/ruin/lavaland/syndicate_lava_base/cargo)
 "kd" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
@@ -932,13 +932,13 @@
 	dir = 5
 	},
 /turf/open/floor/iron/dark/textured,
-/area/ruin/unpowered/syndicate_lava_base/brig)
+/area/ruin/lavaland/syndicate_lava_base/brig)
 "kj" = (
 /obj/machinery/portable_atmospherics/canister,
 /obj/effect/turf_decal/bot,
 /obj/machinery/light/small/directional/east,
 /turf/open/floor/catwalk_floor/iron_dark,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/lavaland/syndicate_lava_base/engineering)
 "kp" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -953,7 +953,7 @@
 	dir = 4
 	},
 /turf/open/floor/engine,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/lavaland/syndicate_lava_base/engineering)
 "kz" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/railing{
@@ -983,7 +983,7 @@
 	dir = 1
 	},
 /turf/open/floor/engine,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/lavaland/syndicate_lava_base/engineering)
 "kR" = (
 /obj/effect/turf_decal/tile/neutral/opposingcorners,
 /obj/structure/table/wood,
@@ -991,13 +991,13 @@
 	dir = 1
 	},
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/bar)
+/area/ruin/lavaland/syndicate_lava_base/bar)
 "kY" = (
 /obj/machinery/light/small/directional/east,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/iron/dark/smooth_large,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/lavaland/syndicate_lava_base/engineering)
 "kZ" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/components/binary/dp_vent_pump/high_volume/incinerator_syndicatelava{
@@ -1006,7 +1006,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /turf/open/floor/engine,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/lavaland/syndicate_lava_base/engineering)
 "la" = (
 /obj/structure/cable/yellow,
 /obj/structure/table/reinforced,
@@ -1023,15 +1023,15 @@
 	},
 /obj/item/circuitboard/machine/thermomachine,
 /turf/open/floor/iron/dark/textured,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/lavaland/syndicate_lava_base/engineering)
 "ld" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/iron/white,
-/area/ruin/unpowered/syndicate_lava_base/medbay)
+/area/ruin/lavaland/syndicate_lava_base/medbay)
 "le" = (
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
-/area/ruin/unpowered/syndicate_lava_base/telecomms)
+/area/ruin/lavaland/syndicate_lava_base/telecomms)
 "li" = (
 /obj/effect/turf_decal/tile/bar/opposingcorners,
 /obj/structure/table,
@@ -1040,18 +1040,18 @@
 	pixel_x = 7
 	},
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/bar)
+/area/ruin/lavaland/syndicate_lava_base/bar)
 "lk" = (
 /obj/effect/turf_decal/stripes/closeup,
 /obj/machinery/door/airlock/maintenance,
 /obj/effect/mapping_helpers/airlock/access/all/syndicate/general,
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron/techmaint,
-/area/ruin/unpowered/syndicate_lava_base/starboard)
+/area/ruin/lavaland/syndicate_lava_base/starboard)
 "ln" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/starboard)
+/area/ruin/lavaland/syndicate_lava_base/starboard)
 "lo" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -1059,7 +1059,7 @@
 /obj/machinery/dna_scannernew,
 /obj/structure/window/reinforced/spawner/directional/north,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/virology)
+/area/ruin/lavaland/syndicate_lava_base/virology)
 "lr" = (
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/stripes/closeup{
@@ -1067,7 +1067,7 @@
 	},
 /obj/structure/cable/yellow,
 /turf/open/floor/iron/techmaint,
-/area/ruin/unpowered/syndicate_lava_base/port)
+/area/ruin/lavaland/syndicate_lava_base/port)
 "lw" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
@@ -1075,7 +1075,7 @@
 /obj/machinery/power/apc/syndicate/directional/north,
 /obj/structure/cable/yellow,
 /turf/open/floor/wood,
-/area/ruin/unpowered/syndicate_lava_base/bar)
+/area/ruin/lavaland/syndicate_lava_base/bar)
 "lA" = (
 /obj/structure/closet/crate,
 /obj/item/storage/box/donkpockets{
@@ -1090,7 +1090,7 @@
 	},
 /obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
+/area/ruin/lavaland/syndicate_lava_base/cargo)
 "lB" = (
 /obj/effect/turf_decal/trimline/red/filled/corner{
 	dir = 4
@@ -1100,12 +1100,12 @@
 /obj/structure/cable/yellow,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/starboard)
+/area/ruin/lavaland/syndicate_lava_base/starboard)
 "lG" = (
 /obj/effect/turf_decal/trimline/red/filled/line,
 /obj/structure/cable/yellow,
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/port)
+/area/ruin/lavaland/syndicate_lava_base/port)
 "lH" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
@@ -1115,7 +1115,7 @@
 /obj/structure/cable/yellow,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/medbay)
+/area/ruin/lavaland/syndicate_lava_base/medbay)
 "lI" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
@@ -1124,7 +1124,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /obj/structure/cable/yellow,
 /turf/open/floor/wood,
-/area/ruin/unpowered/syndicate_lava_base/bar)
+/area/ruin/lavaland/syndicate_lava_base/bar)
 "lJ" = (
 /obj/structure/table/reinforced,
 /obj/item/clothing/suit/hazardvest,
@@ -1135,7 +1135,7 @@
 	pixel_x = -8
 	},
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
+/area/ruin/lavaland/syndicate_lava_base/cargo)
 "lK" = (
 /obj/effect/turf_decal/stripes/closeup,
 /obj/machinery/door/firedoor,
@@ -1147,7 +1147,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /obj/structure/cable/yellow,
 /turf/open/floor/iron/techmaint,
-/area/ruin/unpowered/syndicate_lava_base/medbay)
+/area/ruin/lavaland/syndicate_lava_base/medbay)
 "lL" = (
 /obj/structure/table/glass,
 /obj/item/stack/sheet/mineral/plasma{
@@ -1169,31 +1169,31 @@
 	},
 /obj/item/reagent_containers/cup/bottle/epinephrine,
 /turf/open/floor/iron/white,
-/area/ruin/unpowered/syndicate_lava_base/chemistry)
+/area/ruin/lavaland/syndicate_lava_base/chemistry)
 "lU" = (
 /obj/item/kirbyplants/random,
 /obj/structure/cable/yellow,
 /obj/machinery/firealarm/directional/east,
 /obj/machinery/power/apc/syndicate/directional/north,
 /turf/open/floor/wood,
-/area/ruin/unpowered/syndicate_lava_base/telecomms)
+/area/ruin/lavaland/syndicate_lava_base/telecomms)
 "lV" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /obj/structure/cable/yellow,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood,
-/area/ruin/unpowered/syndicate_lava_base/bar)
+/area/ruin/lavaland/syndicate_lava_base/bar)
 "lY" = (
 /obj/effect/turf_decal/trimline/red/filled/line,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /obj/structure/cable/yellow,
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/port)
+/area/ruin/lavaland/syndicate_lava_base/port)
 "me" = (
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
+/area/ruin/lavaland/syndicate_lava_base/cargo)
 "mf" = (
 /obj/structure/rack{
 	dir = 8
@@ -1206,7 +1206,7 @@
 /obj/item/stock_parts/cell/high/plus,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
-/area/ruin/unpowered/syndicate_lava_base/starboard)
+/area/ruin/lavaland/syndicate_lava_base/starboard)
 "mi" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
@@ -1220,21 +1220,21 @@
 /obj/machinery/airalarm/directional/west,
 /obj/effect/mapping_helpers/airalarm/syndicate_access,
 /turf/open/floor/iron/dark/textured,
-/area/ruin/unpowered/syndicate_lava_base/brig)
+/area/ruin/lavaland/syndicate_lava_base/brig)
 "mj" = (
 /obj/machinery/light/floor,
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
+/area/ruin/lavaland/syndicate_lava_base/cargo)
 "mn" = (
 /turf/open/floor/engine/plasma,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/lavaland/syndicate_lava_base/engineering)
 "mo" = (
 /obj/machinery/vending/cigarette/syndicate,
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 9
 	},
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/port)
+/area/ruin/lavaland/syndicate_lava_base/port)
 "mq" = (
 /obj/structure/bed/roller,
 /obj/machinery/iv_drip,
@@ -1242,23 +1242,23 @@
 /obj/machinery/light/cold/directional/east,
 /obj/machinery/firealarm/directional/east,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/medbay)
+/area/ruin/lavaland/syndicate_lava_base/medbay)
 "mr" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/virology)
+/area/ruin/lavaland/syndicate_lava_base/virology)
 "ms" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /obj/structure/cable/yellow,
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/starboard)
+/area/ruin/lavaland/syndicate_lava_base/starboard)
 "mv" = (
 /obj/structure/extinguisher_cabinet/directional/east,
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/port)
+/area/ruin/lavaland/syndicate_lava_base/port)
 "mx" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/railing{
@@ -1282,7 +1282,7 @@
 	pixel_x = 8
 	},
 /turf/open/floor/iron/dark/smooth_large,
-/area/ruin/unpowered/syndicate_lava_base/brig)
+/area/ruin/lavaland/syndicate_lava_base/brig)
 "mE" = (
 /obj/structure/table/reinforced,
 /obj/item/paper_bin,
@@ -1292,22 +1292,22 @@
 	pixel_x = 10
 	},
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/brig)
+/area/ruin/lavaland/syndicate_lava_base/brig)
 "mH" = (
 /obj/structure/cable/yellow,
 /turf/open/floor/iron/white,
-/area/ruin/unpowered/syndicate_lava_base/medbay)
+/area/ruin/lavaland/syndicate_lava_base/medbay)
 "mO" = (
 /obj/structure/sign/warning/fire,
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/lavaland/syndicate_lava_base/engineering)
 "mP" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 4
 	},
 /obj/effect/decal/cleanable/oil,
 /turf/open/floor/iron/white,
-/area/ruin/unpowered/syndicate_lava_base/chemistry)
+/area/ruin/lavaland/syndicate_lava_base/chemistry)
 "mS" = (
 /obj/structure/window/reinforced/spawner/directional/south,
 /obj/structure/table/reinforced,
@@ -1320,13 +1320,13 @@
 	pixel_y = 8
 	},
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/telecomms)
+/area/ruin/lavaland/syndicate_lava_base/telecomms)
 "mU" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/chemistry)
+/area/ruin/lavaland/syndicate_lava_base/chemistry)
 "mY" = (
 /obj/structure/chair/office{
 	dir = 1
@@ -1346,7 +1346,7 @@
 	pixel_x = 30
 	},
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/bridge)
+/area/ruin/lavaland/syndicate_lava_base/bridge)
 "nb" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 5
@@ -1356,10 +1356,10 @@
 	},
 /obj/machinery/firealarm/directional/north,
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
+/area/ruin/lavaland/syndicate_lava_base/cargo)
 "nc" = (
 /turf/open/floor/engine/vacuum,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/lavaland/syndicate_lava_base/engineering)
 "ny" = (
 /obj/effect/turf_decal/stripes/closeup,
 /obj/machinery/door/firedoor,
@@ -1371,30 +1371,30 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /obj/structure/cable/yellow,
 /turf/open/floor/iron/techmaint,
-/area/ruin/unpowered/syndicate_lava_base/chemistry)
+/area/ruin/lavaland/syndicate_lava_base/chemistry)
 "nz" = (
 /obj/structure/closet/crate/freezer/blood,
 /obj/machinery/power/apc/syndicate/directional/east,
 /obj/structure/cable/yellow,
 /turf/open/floor/iron/white,
-/area/ruin/unpowered/syndicate_lava_base/medbay)
+/area/ruin/lavaland/syndicate_lava_base/medbay)
 "nG" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /obj/machinery/power/apc/syndicate/directional/east,
 /obj/structure/cable/yellow,
 /turf/open/floor/iron/white,
-/area/ruin/unpowered/syndicate_lava_base/chemistry)
+/area/ruin/lavaland/syndicate_lava_base/chemistry)
 "nM" = (
 /obj/structure/chair/stool/bar/directional/south,
 /turf/open/floor/wood,
-/area/ruin/unpowered/syndicate_lava_base/bar)
+/area/ruin/lavaland/syndicate_lava_base/bar)
 "nO" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /obj/structure/cable/yellow,
 /turf/open/floor/catwalk_floor/iron_dark,
-/area/ruin/unpowered/syndicate_lava_base/starboard)
+/area/ruin/lavaland/syndicate_lava_base/starboard)
 "nQ" = (
 /mob/living/carbon/monkey{
 	faction = list("neutral","Syndicate")
@@ -1402,48 +1402,48 @@
 /obj/machinery/light/small/directional/south,
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/virology)
+/area/ruin/lavaland/syndicate_lava_base/virology)
 "nU" = (
 /obj/effect/turf_decal/trimline/red/filled/line,
 /obj/structure/cable/yellow,
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/starboard)
+/area/ruin/lavaland/syndicate_lava_base/starboard)
 "nY" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 8
 	},
 /turf/open/floor/wood,
-/area/ruin/unpowered/syndicate_lava_base/telecomms)
+/area/ruin/lavaland/syndicate_lava_base/telecomms)
 "oi" = (
 /obj/machinery/sleeper/syndie{
 	dir = 8
 	},
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/medbay)
+/area/ruin/lavaland/syndicate_lava_base/medbay)
 "on" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /obj/structure/cable/yellow,
 /obj/structure/extinguisher_cabinet/directional/south,
 /turf/open/floor/iron/white,
-/area/ruin/unpowered/syndicate_lava_base/medbay)
+/area/ruin/lavaland/syndicate_lava_base/medbay)
 "or" = (
 /obj/structure/bed,
 /obj/item/bedsheet,
 /obj/machinery/light/small/directional/east,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/brig)
+/area/ruin/lavaland/syndicate_lava_base/brig)
 "oy" = (
 /obj/machinery/light/small{
 	dir = 1
 	},
 /turf/open/floor/iron/showroomfloor,
-/area/ruin/unpowered/syndicate_lava_base/port)
+/area/ruin/lavaland/syndicate_lava_base/port)
 "oz" = (
 /turf/open/floor/iron/white,
-/area/ruin/unpowered/syndicate_lava_base/virology)
+/area/ruin/lavaland/syndicate_lava_base/virology)
 "oB" = (
 /obj/structure/closet/crate/bin,
 /obj/effect/turf_decal/trimline/red/filled/line{
@@ -1451,7 +1451,7 @@
 	},
 /obj/machinery/firealarm/directional/north,
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/starboard)
+/area/ruin/lavaland/syndicate_lava_base/starboard)
 "oG" = (
 /obj/effect/turf_decal/trimline/red/filled/corner{
 	dir = 4
@@ -1460,7 +1460,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /obj/structure/cable/yellow,
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/medbay)
+/area/ruin/lavaland/syndicate_lava_base/medbay)
 "oH" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/belt/utility/full{
@@ -1476,45 +1476,45 @@
 	pixel_x = 5
 	},
 /turf/open/floor/catwalk_floor/iron_dark,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/lavaland/syndicate_lava_base/engineering)
 "oJ" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 1
 	},
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
+/area/ruin/lavaland/syndicate_lava_base/cargo)
 "oL" = (
 /obj/machinery/porta_turret/syndicate{
 	dir = 10
 	},
 /turf/closed/wall/mineral/plastitanium,
-/area/ruin/unpowered/syndicate_lava_base/virology)
+/area/ruin/lavaland/syndicate_lava_base/virology)
 "oM" = (
 /obj/machinery/porta_turret/syndicate{
 	dir = 10
 	},
 /turf/closed/wall/mineral/plastitanium,
-/area/ruin/unpowered/syndicate_lava_base/chemistry)
+/area/ruin/lavaland/syndicate_lava_base/chemistry)
 "oP" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
 	},
 /obj/machinery/light/cold/directional/south,
 /turf/open/floor/wood,
-/area/ruin/unpowered/syndicate_lava_base/bar)
+/area/ruin/lavaland/syndicate_lava_base/bar)
 "oX" = (
 /obj/machinery/power/terminal{
 	dir = 1
 	},
 /obj/structure/cable/yellow,
 /turf/open/floor/catwalk_floor,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
+/area/ruin/lavaland/syndicate_lava_base/cargo)
 "pf" = (
 /obj/structure/sign/warning/fire{
 	pixel_x = 32
 	},
 /turf/open/floor/plating,
-/area/ruin/unpowered/syndicate_lava_base/medbay)
+/area/ruin/lavaland/syndicate_lava_base/medbay)
 "pg" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 8
@@ -1524,19 +1524,19 @@
 /obj/machinery/airalarm/directional/south,
 /obj/effect/mapping_helpers/airalarm/syndicate_access,
 /turf/open/floor/wood,
-/area/ruin/unpowered/syndicate_lava_base/dormitories)
+/area/ruin/lavaland/syndicate_lava_base/dormitories)
 "pk" = (
 /obj/machinery/computer/scan_consolenew{
 	dir = 8;
 	req_access = list(150)
 	},
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/virology)
+/area/ruin/lavaland/syndicate_lava_base/virology)
 "pn" = (
 /obj/effect/turf_decal/trimline/red/filled/corner,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/medbay)
+/area/ruin/lavaland/syndicate_lava_base/medbay)
 "pt" = (
 /obj/structure/chair,
 /obj/effect/turf_decal/trimline/red/filled/line{
@@ -1545,19 +1545,19 @@
 /obj/machinery/light/small/directional/north,
 /obj/machinery/firealarm/directional/east,
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/medbay)
+/area/ruin/lavaland/syndicate_lava_base/medbay)
 "pu" = (
 /obj/machinery/atmospherics/components/binary/pump/on{
 	dir = 8
 	},
 /turf/open/floor/catwalk_floor/iron_dark,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/lavaland/syndicate_lava_base/engineering)
 "pw" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 1
 	},
 /turf/open/floor/catwalk_floor,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
+/area/ruin/lavaland/syndicate_lava_base/cargo)
 "px" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 8
@@ -1569,7 +1569,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/dark/textured,
-/area/ruin/unpowered/syndicate_lava_base/brig)
+/area/ruin/lavaland/syndicate_lava_base/brig)
 "pz" = (
 /obj/structure/table/wood,
 /obj/effect/turf_decal/siding/wood{
@@ -1586,7 +1586,7 @@
 	pixel_y = -6
 	},
 /turf/open/floor/carpet/red,
-/area/ruin/unpowered/syndicate_lava_base/telecomms)
+/area/ruin/lavaland/syndicate_lava_base/telecomms)
 "pB" = (
 /obj/structure/table/wood,
 /obj/effect/turf_decal/siding/wood{
@@ -1601,7 +1601,7 @@
 	pixel_x = 4
 	},
 /turf/open/floor/carpet/red,
-/area/ruin/unpowered/syndicate_lava_base/bar)
+/area/ruin/lavaland/syndicate_lava_base/bar)
 "pJ" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 8
@@ -1614,16 +1614,16 @@
 	pixel_x = -25
 	},
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/port)
+/area/ruin/lavaland/syndicate_lava_base/port)
 "pU" = (
 /turf/open/floor/catwalk_floor,
-/area/ruin/unpowered/syndicate_lava_base/starboard)
+/area/ruin/lavaland/syndicate_lava_base/starboard)
 "qe" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /obj/structure/cable/yellow,
 /turf/open/floor/iron/white,
-/area/ruin/unpowered/syndicate_lava_base/virology)
+/area/ruin/lavaland/syndicate_lava_base/virology)
 "qk" = (
 /obj/structure/railing{
 	dir = 1
@@ -1639,20 +1639,20 @@
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/virology)
+/area/ruin/lavaland/syndicate_lava_base/virology)
 "qA" = (
 /obj/effect/turf_decal/trimline/red/filled/corner{
 	dir = 8
 	},
 /obj/structure/cable/yellow,
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/bridge)
+/area/ruin/lavaland/syndicate_lava_base/bridge)
 "qB" = (
 /obj/machinery/light/small{
 	dir = 4
 	},
 /turf/open/floor/iron/showroomfloor,
-/area/ruin/unpowered/syndicate_lava_base/port)
+/area/ruin/lavaland/syndicate_lava_base/port)
 "qE" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/on{
 	dir = 8;
@@ -1660,12 +1660,12 @@
 	name = "toxin out"
 	},
 /turf/open/floor/engine/plasma,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/lavaland/syndicate_lava_base/engineering)
 "qK" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/floor,
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/medbay)
+/area/ruin/lavaland/syndicate_lava_base/medbay)
 "qL" = (
 /obj/effect/turf_decal/siding/dark{
 	dir = 4
@@ -1675,7 +1675,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible/layer2,
 /turf/open/floor/iron/dark/textured,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/lavaland/syndicate_lava_base/engineering)
 "qM" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 1
@@ -1683,20 +1683,20 @@
 /obj/effect/turf_decal/siding/dark,
 /obj/effect/turf_decal/trimline/red/line,
 /turf/open/floor/iron/dark/textured,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
+/area/ruin/lavaland/syndicate_lava_base/cargo)
 "qT" = (
 /obj/structure/sink/directional/west,
 /obj/structure/mirror/directional/east,
 /turf/open/floor/iron/showroomfloor,
-/area/ruin/unpowered/syndicate_lava_base/port)
+/area/ruin/lavaland/syndicate_lava_base/port)
 "qX" = (
 /turf/closed/wall/mineral/plastitanium,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
+/area/ruin/lavaland/syndicate_lava_base/cargo)
 "rc" = (
 /obj/structure/chair/stool/bar/directional/south,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood,
-/area/ruin/unpowered/syndicate_lava_base/bar)
+/area/ruin/lavaland/syndicate_lava_base/bar)
 "rd" = (
 /obj/machinery/door/airlock/external,
 /obj/effect/mapping_helpers/airlock/access/all/syndicate/general,
@@ -1708,36 +1708,36 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/iron/techmaint,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
+/area/ruin/lavaland/syndicate_lava_base/cargo)
 "re" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},
 /obj/structure/cable/yellow,
 /turf/open/floor/plating,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/lavaland/syndicate_lava_base/engineering)
 "rq" = (
 /obj/structure/chair/stool/bar/directional/south,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 1
 	},
 /turf/open/floor/wood,
-/area/ruin/unpowered/syndicate_lava_base/bar)
+/area/ruin/lavaland/syndicate_lava_base/bar)
 "ru" = (
 /obj/machinery/air_sensor,
 /turf/open/floor/engine/n2,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/lavaland/syndicate_lava_base/engineering)
 "rw" = (
 /obj/machinery/computer/monitor/secret,
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/bridge)
+/area/ruin/lavaland/syndicate_lava_base/bridge)
 "ry" = (
 /obj/structure/cable/orange,
 /obj/effect/mapping_helpers/Mapper_Comment{
 	desc = "These tinyfans are a cope because holofields dont spawn until after roundstart which meant this bay always started depressurised. If that ever gets fixed remind me to remove these."
 	},
 /turf/open/floor/catwalk_floor,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
+/area/ruin/lavaland/syndicate_lava_base/cargo)
 "rB" = (
 /mob/living/carbon/monkey{
 	faction = list("neutral","Syndicate")
@@ -1749,63 +1749,63 @@
 	dir = 9
 	},
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/virology)
+/area/ruin/lavaland/syndicate_lava_base/virology)
 "rC" = (
 /obj/effect/turf_decal/trimline/red/filled/line,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/firealarm/directional/south,
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/medbay)
+/area/ruin/lavaland/syndicate_lava_base/medbay)
 "rF" = (
 /obj/machinery/light/directional/north,
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/starboard)
+/area/ruin/lavaland/syndicate_lava_base/starboard)
 "rG" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/open/floor/grass/no_border,
-/area/ruin/unpowered/syndicate_lava_base/port)
+/area/ruin/lavaland/syndicate_lava_base/port)
 "rJ" = (
 /obj/machinery/computer/atmos_control{
 	name = "Nitrogen Supply Control"
 	},
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/iron/dark/smooth_large,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/lavaland/syndicate_lava_base/engineering)
 "rS" = (
 /obj/structure/table/reinforced,
 /obj/structure/window/reinforced/spawner/directional/west,
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/bridge)
+/area/ruin/lavaland/syndicate_lava_base/bridge)
 "rY" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /obj/structure/cable/yellow,
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/medbay)
+/area/ruin/lavaland/syndicate_lava_base/medbay)
 "sa" = (
 /obj/structure/cable/yellow,
 /obj/machinery/firealarm/directional/west,
 /turf/open/floor/wood,
-/area/ruin/unpowered/syndicate_lava_base/bar)
+/area/ruin/lavaland/syndicate_lava_base/bar)
 "sd" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/starboard)
+/area/ruin/lavaland/syndicate_lava_base/starboard)
 "sk" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /obj/structure/cable/yellow,
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/port)
+/area/ruin/lavaland/syndicate_lava_base/port)
 "sx" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 6
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
+/area/ruin/lavaland/syndicate_lava_base/cargo)
 "sA" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
@@ -1814,16 +1814,16 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /obj/structure/cable/yellow,
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/medbay)
+/area/ruin/lavaland/syndicate_lava_base/medbay)
 "sC" = (
 /obj/effect/turf_decal/trimline/red/filled/corner,
 /obj/structure/cable/yellow,
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/starboard)
+/area/ruin/lavaland/syndicate_lava_base/starboard)
 "sD" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
 /turf/open/floor/iron/white,
-/area/ruin/unpowered/syndicate_lava_base/medbay)
+/area/ruin/lavaland/syndicate_lava_base/medbay)
 "sH" = (
 /obj/effect/turf_decal/stripes/closeup,
 /obj/machinery/door/airlock/engineering{
@@ -1833,7 +1833,7 @@
 /obj/machinery/door/firedoor,
 /obj/structure/cable/yellow,
 /turf/open/floor/iron/techmaint,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/lavaland/syndicate_lava_base/engineering)
 "sO" = (
 /obj/structure/table/wood,
 /obj/effect/turf_decal/siding/wood{
@@ -1842,12 +1842,12 @@
 /obj/effect/turf_decal/tile/bar/opposingcorners,
 /obj/item/food/syndicake,
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/bar)
+/area/ruin/lavaland/syndicate_lava_base/bar)
 "sR" = (
 /obj/effect/turf_decal/trimline/red/filled/line,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
+/area/ruin/lavaland/syndicate_lava_base/cargo)
 "sT" = (
 /obj/structure/table/wood,
 /obj/effect/turf_decal/siding/wood{
@@ -1855,7 +1855,7 @@
 	},
 /obj/item/folder/syndicate/blue,
 /turf/open/floor/carpet/red,
-/area/ruin/unpowered/syndicate_lava_base/telecomms)
+/area/ruin/lavaland/syndicate_lava_base/telecomms)
 "sU" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 8
@@ -1876,10 +1876,10 @@
 	specialfunctions = 4
 	},
 /turf/open/floor/iron/dark/textured,
-/area/ruin/unpowered/syndicate_lava_base/starboard)
+/area/ruin/lavaland/syndicate_lava_base/starboard)
 "to" = (
 /turf/open/floor/engine/o2,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/lavaland/syndicate_lava_base/engineering)
 "tC" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 4
@@ -1887,7 +1887,7 @@
 /obj/machinery/airalarm/directional/south,
 /obj/effect/mapping_helpers/airalarm/syndicate_access,
 /turf/open/floor/wood,
-/area/ruin/unpowered/syndicate_lava_base/dormitories)
+/area/ruin/lavaland/syndicate_lava_base/dormitories)
 "tJ" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 8
@@ -1895,14 +1895,14 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/port)
+/area/ruin/lavaland/syndicate_lava_base/port)
 "tK" = (
 /obj/structure/cable/yellow,
 /obj/machinery/firealarm/directional/west,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/catwalk_floor/iron_dark,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/lavaland/syndicate_lava_base/engineering)
 "tL" = (
 /obj/effect/turf_decal/stripes/closeup{
 	dir = 1
@@ -1915,14 +1915,14 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /obj/structure/cable/yellow,
 /turf/open/floor/iron/techmaint,
-/area/ruin/unpowered/syndicate_lava_base/dormitories)
+/area/ruin/lavaland/syndicate_lava_base/dormitories)
 "ub" = (
 /obj/structure/railing{
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/starboard)
+/area/ruin/lavaland/syndicate_lava_base/starboard)
 "ug" = (
 /obj/effect/turf_decal/siding/dark{
 	dir = 1
@@ -1933,17 +1933,17 @@
 /obj/machinery/power/apc/syndicate/directional/north,
 /obj/structure/cable/yellow,
 /turf/open/floor/iron/dark/textured,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
+/area/ruin/lavaland/syndicate_lava_base/cargo)
 "uj" = (
 /turf/closed/wall/mineral/plastitanium/explosive,
-/area/ruin/unpowered/syndicate_lava_base/bar)
+/area/ruin/lavaland/syndicate_lava_base/bar)
 "ul" = (
 /obj/effect/spawner/structure/window/reinforced/plasma/plastitanium,
 /obj/machinery/door/poddoor{
 	id = "lavalandsyndi_chemistry"
 	},
 /turf/open/floor/plating,
-/area/ruin/unpowered/syndicate_lava_base/chemistry)
+/area/ruin/lavaland/syndicate_lava_base/chemistry)
 "up" = (
 /obj/structure/shuttle/engine/large,
 /turf/open/lava/smooth/lava_land_surface,
@@ -1955,36 +1955,36 @@
 /obj/machinery/power/smes/engineering,
 /obj/structure/cable/yellow,
 /turf/open/floor/plating,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/lavaland/syndicate_lava_base/engineering)
 "ur" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
-/area/ruin/unpowered/syndicate_lava_base/starboard)
+/area/ruin/lavaland/syndicate_lava_base/starboard)
 "ux" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/catwalk_floor/iron_dark,
-/area/ruin/unpowered/syndicate_lava_base/starboard)
+/area/ruin/lavaland/syndicate_lava_base/starboard)
 "uC" = (
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
-/area/ruin/unpowered/syndicate_lava_base/bar)
+/area/ruin/lavaland/syndicate_lava_base/bar)
 "uP" = (
 /obj/structure/cable/yellow,
 /obj/machinery/power/apc/syndicate/directional/east,
 /turf/open/floor/catwalk_floor/iron_dark,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/lavaland/syndicate_lava_base/engineering)
 "uT" = (
 /obj/effect/spawner/structure/window/reinforced/plasma/plastitanium,
 /turf/open/floor/plating,
-/area/ruin/unpowered/syndicate_lava_base/telecomms)
+/area/ruin/lavaland/syndicate_lava_base/telecomms)
 "uY" = (
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/stripes/closeup,
 /turf/open/floor/iron/techmaint,
-/area/ruin/unpowered/syndicate_lava_base/starboard)
+/area/ruin/lavaland/syndicate_lava_base/starboard)
 "vd" = (
 /obj/structure/table/reinforced,
 /obj/structure/window/reinforced/spawner/directional/east,
@@ -1992,7 +1992,7 @@
 /obj/item/pen,
 /obj/item/stamp/syndicate,
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/bridge)
+/area/ruin/lavaland/syndicate_lava_base/bridge)
 "vg" = (
 /obj/effect/turf_decal/box/white/corners,
 /obj/structure/closet/crate/medical,
@@ -2007,41 +2007,41 @@
 	},
 /obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
+/area/ruin/lavaland/syndicate_lava_base/cargo)
 "vh" = (
 /obj/structure/cable,
 /obj/machinery/power/turbine/lavaland{
 	luminosity = 2
 	},
 /turf/open/floor/engine/vacuum,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/lavaland/syndicate_lava_base/engineering)
 "vs" = (
 /obj/effect/spawner/structure/window/reinforced/plasma/plastitanium,
 /obj/machinery/door/poddoor/preopen{
 	id = "lavalandsyndi_hall"
 	},
 /turf/open/floor/plating,
-/area/ruin/unpowered/syndicate_lava_base/dormitories)
+/area/ruin/lavaland/syndicate_lava_base/dormitories)
 "vA" = (
 /obj/effect/spawner/structure/window/reinforced/plasma/plastitanium,
 /obj/machinery/door/poddoor/preopen{
 	id = "lavalandsyndi_brig"
 	},
 /turf/open/floor/plating,
-/area/ruin/unpowered/syndicate_lava_base/brig)
+/area/ruin/lavaland/syndicate_lava_base/brig)
 "vB" = (
 /obj/effect/turf_decal/trimline/red/filled/line,
 /obj/structure/cable/yellow,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/starboard)
+/area/ruin/lavaland/syndicate_lava_base/starboard)
 "vM" = (
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/stripes/closeup{
 	dir = 1
 	},
 /turf/open/floor/iron/techmaint,
-/area/ruin/unpowered/syndicate_lava_base/bar)
+/area/ruin/lavaland/syndicate_lava_base/bar)
 "vN" = (
 /obj/machinery/computer/atmos_control{
 	dir = 8;
@@ -2049,7 +2049,7 @@
 	},
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/iron/dark/smooth_large,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/lavaland/syndicate_lava_base/engineering)
 "vX" = (
 /obj/effect/turf_decal/stripes/closeup{
 	dir = 1
@@ -2065,22 +2065,22 @@
 	name = "Port Hall"
 	},
 /turf/open/floor/iron/techmaint,
-/area/ruin/unpowered/syndicate_lava_base/medbay)
+/area/ruin/lavaland/syndicate_lava_base/medbay)
 "wc" = (
 /obj/structure/cable,
 /obj/machinery/igniter/incinerator_syndicatelava,
 /turf/open/floor/engine/vacuum,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/lavaland/syndicate_lava_base/engineering)
 "wg" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
 	},
 /obj/structure/extinguisher_cabinet/directional/north,
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/port)
+/area/ruin/lavaland/syndicate_lava_base/port)
 "wj" = (
 /turf/closed/wall/mineral/plastitanium,
-/area/ruin/unpowered/syndicate_lava_base/starboard)
+/area/ruin/lavaland/syndicate_lava_base/starboard)
 "wl" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
@@ -2088,12 +2088,12 @@
 	dir = 1
 	},
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/virology)
+/area/ruin/lavaland/syndicate_lava_base/virology)
 "wq" = (
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/stripes/closeup,
 /turf/open/floor/iron/techmaint,
-/area/ruin/unpowered/syndicate_lava_base/port)
+/area/ruin/lavaland/syndicate_lava_base/port)
 "wr" = (
 /obj/structure/chair/office{
 	dir = 1
@@ -2101,7 +2101,7 @@
 /obj/effect/turf_decal/siding/dark,
 /obj/effect/turf_decal/trimline/dark_red,
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/bridge)
+/area/ruin/lavaland/syndicate_lava_base/bridge)
 "wv" = (
 /obj/effect/turf_decal/stripes/closeup,
 /obj/machinery/door/firedoor,
@@ -2112,7 +2112,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/iron/techmaint,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/lavaland/syndicate_lava_base/engineering)
 "ww" = (
 /obj/machinery/button/door/incinerator_vent_syndicatelava_main{
 	pixel_x = 6;
@@ -2126,7 +2126,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/catwalk_floor/iron_dark,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/lavaland/syndicate_lava_base/engineering)
 "wx" = (
 /obj/machinery/computer/atmos_control{
 	dir = 8;
@@ -2134,7 +2134,7 @@
 	},
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/iron/dark/smooth_large,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/lavaland/syndicate_lava_base/engineering)
 "wz" = (
 /obj/effect/turf_decal/box/white/corners{
 	dir = 1
@@ -2157,7 +2157,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
+/area/ruin/lavaland/syndicate_lava_base/cargo)
 "wE" = (
 /obj/structure/shuttle/engine/huge,
 /turf/open/lava/smooth/lava_land_surface,
@@ -2169,13 +2169,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/starboard)
+/area/ruin/lavaland/syndicate_lava_base/starboard)
 "wL" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/virology)
+/area/ruin/lavaland/syndicate_lava_base/virology)
 "wU" = (
 /obj/machinery/door/airlock/external,
 /obj/effect/mapping_helpers/airlock/access/all/syndicate/general,
@@ -2183,43 +2183,43 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /obj/effect/turf_decal/stripes/closeup,
 /turf/open/floor/iron/techmaint,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
+/area/ruin/lavaland/syndicate_lava_base/cargo)
 "wW" = (
 /obj/effect/turf_decal/tile/neutral/opposingcorners,
 /obj/machinery/processor,
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/bar)
+/area/ruin/lavaland/syndicate_lava_base/bar)
 "wY" = (
 /obj/effect/spawner/structure/window/reinforced/plasma/plastitanium,
 /obj/machinery/door/poddoor/preopen{
 	id = "lavalandsyndi_telecomms"
 	},
 /turf/open/floor/plating,
-/area/ruin/unpowered/syndicate_lava_base/telecomms)
+/area/ruin/lavaland/syndicate_lava_base/telecomms)
 "xj" = (
 /obj/structure/cable/yellow,
 /turf/open/floor/wood,
-/area/ruin/unpowered/syndicate_lava_base/bar)
+/area/ruin/lavaland/syndicate_lava_base/bar)
 "xk" = (
 /obj/structure/closet/crate/bin,
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 9
 	},
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/medbay)
+/area/ruin/lavaland/syndicate_lava_base/medbay)
 "xl" = (
 /obj/structure/table/wood,
 /obj/item/toy/plush/nukeplushie,
 /obj/machinery/light/small/directional/north,
 /turf/open/floor/wood,
-/area/ruin/unpowered/syndicate_lava_base/dormitories)
+/area/ruin/lavaland/syndicate_lava_base/dormitories)
 "xm" = (
 /obj/structure/table/reinforced,
 /obj/effect/turf_decal/stripes/closeup{
 	dir = 1
 	},
 /turf/open/floor/iron/techmaint,
-/area/ruin/unpowered/syndicate_lava_base/brig)
+/area/ruin/lavaland/syndicate_lava_base/brig)
 "xs" = (
 /obj/machinery/door/airlock/external,
 /obj/effect/mapping_helpers/airlock/access/all/syndicate/general,
@@ -2227,7 +2227,7 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /obj/effect/turf_decal/stripes/closeup,
 /turf/open/floor/iron/techmaint,
-/area/ruin/unpowered/syndicate_lava_base/medbay)
+/area/ruin/lavaland/syndicate_lava_base/medbay)
 "xt" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/bot,
@@ -2236,7 +2236,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron/dark/smooth_large,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/lavaland/syndicate_lava_base/engineering)
 "xu" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/secure_closet/personal/empty{
@@ -2245,12 +2245,12 @@
 /obj/item/clothing/shoes/sneakers/orange,
 /obj/item/clothing/under/rank/prisoner,
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/brig)
+/area/ruin/lavaland/syndicate_lava_base/brig)
 "xy" = (
 /obj/effect/turf_decal/tile/neutral/opposingcorners,
 /obj/structure/table,
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/bar)
+/area/ruin/lavaland/syndicate_lava_base/bar)
 "xz" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/on{
 	dir = 8;
@@ -2258,7 +2258,7 @@
 	name = "nitrogen out"
 	},
 /turf/open/floor/engine/n2,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/lavaland/syndicate_lava_base/engineering)
 "xA" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
@@ -2269,24 +2269,24 @@
 	pixel_x = -32
 	},
 /turf/open/floor/plating,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/lavaland/syndicate_lava_base/engineering)
 "xE" = (
 /obj/effect/turf_decal/trimline/red/filled/corner{
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
+/area/ruin/lavaland/syndicate_lava_base/cargo)
 "xG" = (
 /obj/effect/turf_decal/trimline/red/filled/line,
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/medbay)
+/area/ruin/lavaland/syndicate_lava_base/medbay)
 "xS" = (
 /obj/item/kirbyplants/random,
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 9
 	},
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/port)
+/area/ruin/lavaland/syndicate_lava_base/port)
 "xU" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 4
@@ -2295,13 +2295,13 @@
 /obj/machinery/light/cold/directional/west,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/starboard)
+/area/ruin/lavaland/syndicate_lava_base/starboard)
 "xX" = (
 /obj/effect/turf_decal/trimline/red/filled/corner,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/starboard)
+/area/ruin/lavaland/syndicate_lava_base/starboard)
 "yd" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
 /obj/effect/turf_decal/siding/dark{
@@ -2313,7 +2313,7 @@
 /obj/structure/cable/yellow,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark/textured,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
+/area/ruin/lavaland/syndicate_lava_base/cargo)
 "yo" = (
 /obj/effect/turf_decal/trimline/red/filled/corner{
 	dir = 1
@@ -2322,7 +2322,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /obj/structure/cable/yellow,
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/port)
+/area/ruin/lavaland/syndicate_lava_base/port)
 "ys" = (
 /obj/effect/turf_decal/stripes/closeup,
 /obj/machinery/door/firedoor,
@@ -2332,13 +2332,13 @@
 /obj/effect/mapping_helpers/airlock/access/all/syndicate/general,
 /obj/structure/cable/yellow,
 /turf/open/floor/iron/techmaint,
-/area/ruin/unpowered/syndicate_lava_base/bridge)
+/area/ruin/lavaland/syndicate_lava_base/bridge)
 "yA" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/virology)
+/area/ruin/lavaland/syndicate_lava_base/virology)
 "yJ" = (
 /obj/structure/table/reinforced,
 /obj/machinery/cell_charger,
@@ -2347,28 +2347,28 @@
 	pixel_y = 12
 	},
 /turf/open/floor/iron/dark/textured,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/lavaland/syndicate_lava_base/engineering)
 "yN" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/wood,
-/area/ruin/unpowered/syndicate_lava_base/bar)
+/area/ruin/lavaland/syndicate_lava_base/bar)
 "yQ" = (
 /obj/effect/turf_decal/trimline/red/filled/line,
 /obj/structure/cable/yellow,
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/bridge)
+/area/ruin/lavaland/syndicate_lava_base/bridge)
 "zk" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 4
 	},
 /turf/open/floor/iron/white,
-/area/ruin/unpowered/syndicate_lava_base/chemistry)
+/area/ruin/lavaland/syndicate_lava_base/chemistry)
 "zp" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/firealarm/directional/north,
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/port)
+/area/ruin/lavaland/syndicate_lava_base/port)
 "zq" = (
 /obj/effect/turf_decal/siding/dark{
 	dir = 8
@@ -2377,7 +2377,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark/textured,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/lavaland/syndicate_lava_base/engineering)
 "zs" = (
 /obj/effect/turf_decal/siding/dark{
 	dir = 9
@@ -2389,12 +2389,12 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark/textured,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/lavaland/syndicate_lava_base/engineering)
 "zC" = (
 /obj/machinery/vending/assist,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
+/area/ruin/lavaland/syndicate_lava_base/cargo)
 "zG" = (
 /obj/structure/railing{
 	dir = 4
@@ -2402,19 +2402,19 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/port)
+/area/ruin/lavaland/syndicate_lava_base/port)
 "zR" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/bridge)
+/area/ruin/lavaland/syndicate_lava_base/bridge)
 "zU" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 4
 	},
 /obj/structure/cable/yellow,
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/bridge)
+/area/ruin/lavaland/syndicate_lava_base/bridge)
 "Ai" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/firstaid/brute{
@@ -2427,13 +2427,13 @@
 	},
 /obj/structure/window/reinforced/spawner/directional/south,
 /turf/open/floor/iron/techmaint,
-/area/ruin/unpowered/syndicate_lava_base/medbay)
+/area/ruin/lavaland/syndicate_lava_base/medbay)
 "AE" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 6
 	},
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/starboard)
+/area/ruin/lavaland/syndicate_lava_base/starboard)
 "AF" = (
 /obj/item/kirbyplants/random,
 /obj/effect/turf_decal/trimline/red/filled/line{
@@ -2441,7 +2441,7 @@
 	},
 /obj/structure/extinguisher_cabinet/directional/south,
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/bridge)
+/area/ruin/lavaland/syndicate_lava_base/bridge)
 "AH" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 6
@@ -2449,7 +2449,7 @@
 /obj/structure/cable/yellow,
 /obj/structure/extinguisher_cabinet/directional/south,
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/starboard)
+/area/ruin/lavaland/syndicate_lava_base/starboard)
 "AI" = (
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/stripes/closeup{
@@ -2457,13 +2457,13 @@
 	},
 /obj/structure/cable/yellow,
 /turf/open/floor/iron/techmaint,
-/area/ruin/unpowered/syndicate_lava_base/starboard)
+/area/ruin/lavaland/syndicate_lava_base/starboard)
 "AR" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/catwalk_floor/iron_dark,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/lavaland/syndicate_lava_base/engineering)
 "AX" = (
 /obj/structure/chair{
 	dir = 1
@@ -2473,17 +2473,17 @@
 	},
 /obj/machinery/light/small/directional/south,
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/medbay)
+/area/ruin/lavaland/syndicate_lava_base/medbay)
 "Bd" = (
 /turf/open/floor/engine/co2,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/lavaland/syndicate_lava_base/engineering)
 "Bg" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
+/area/ruin/lavaland/syndicate_lava_base/cargo)
 "Bl" = (
 /obj/effect/turf_decal/stripes/closeup,
 /obj/machinery/door/firedoor,
@@ -2495,7 +2495,7 @@
 	req_access_txt = "150"
 	},
 /turf/open/floor/iron/techmaint,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
+/area/ruin/lavaland/syndicate_lava_base/cargo)
 "Bo" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 8
@@ -2509,38 +2509,38 @@
 /obj/machinery/power/apc/syndicate/directional/east,
 /obj/structure/cable/yellow,
 /turf/open/floor/iron/dark/textured,
-/area/ruin/unpowered/syndicate_lava_base/brig)
+/area/ruin/lavaland/syndicate_lava_base/brig)
 "Bq" = (
 /obj/machinery/door/poddoor/incinerator_syndicatelava_main,
 /turf/open/floor/engine/vacuum,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/lavaland/syndicate_lava_base/engineering)
 "Bs" = (
 /obj/structure/closet/firecloset{
 	anchored = 1
 	},
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
+/area/ruin/lavaland/syndicate_lava_base/cargo)
 "Bt" = (
 /obj/machinery/porta_turret/syndicate{
 	dir = 6
 	},
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
+/area/ruin/lavaland/syndicate_lava_base/cargo)
 "Bw" = (
 /obj/machinery/atmospherics/pipe/smart/simple/orange/hidden,
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/lavaland/syndicate_lava_base/engineering)
 "BB" = (
 /obj/machinery/air_sensor,
 /turf/open/floor/engine/o2,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/lavaland/syndicate_lava_base/engineering)
 "BE" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/backpack/duffelbag/med/implant,
 /obj/structure/window/reinforced/spawner/directional/south,
 /turf/open/floor/iron/techmaint,
-/area/ruin/unpowered/syndicate_lava_base/medbay)
+/area/ruin/lavaland/syndicate_lava_base/medbay)
 "BG" = (
 /obj/effect/turf_decal/trimline/red/filled/line,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
@@ -2548,7 +2548,7 @@
 /obj/structure/cable/yellow,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/medbay)
+/area/ruin/lavaland/syndicate_lava_base/medbay)
 "BH" = (
 /obj/structure/filingcabinet/security{
 	pixel_x = 8
@@ -2557,13 +2557,13 @@
 	pixel_x = -8
 	},
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/telecomms)
+/area/ruin/lavaland/syndicate_lava_base/telecomms)
 "BI" = (
 /obj/machinery/porta_turret/syndicate{
 	dir = 9
 	},
 /turf/closed/wall/mineral/plastitanium,
-/area/ruin/unpowered/syndicate_lava_base/dormitories)
+/area/ruin/lavaland/syndicate_lava_base/dormitories)
 "Cc" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
@@ -2575,27 +2575,27 @@
 	},
 /obj/structure/cable/yellow,
 /turf/open/floor/iron/dark/textured,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
+/area/ruin/lavaland/syndicate_lava_base/cargo)
 "Cg" = (
 /obj/structure/sign/warning/fire{
 	pixel_x = 32
 	},
 /turf/open/floor/plating,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
+/area/ruin/lavaland/syndicate_lava_base/cargo)
 "Co" = (
 /obj/structure/rack,
 /obj/item/storage/box/handcuffs,
 /turf/open/floor/iron/dark/smooth_large,
-/area/ruin/unpowered/syndicate_lava_base/brig)
+/area/ruin/lavaland/syndicate_lava_base/brig)
 "Cp" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/virology)
+/area/ruin/lavaland/syndicate_lava_base/virology)
 "Ct" = (
 /turf/open/floor/carpet/red,
-/area/ruin/unpowered/syndicate_lava_base/telecomms)
+/area/ruin/lavaland/syndicate_lava_base/telecomms)
 "Cz" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/railing{
@@ -2611,10 +2611,10 @@
 	dir = 4
 	},
 /turf/open/floor/circuit/green,
-/area/ruin/unpowered/syndicate_lava_base/telecomms)
+/area/ruin/lavaland/syndicate_lava_base/telecomms)
 "CG" = (
 /turf/closed/wall/mineral/plastitanium,
-/area/ruin/unpowered/syndicate_lava_base/virology)
+/area/ruin/lavaland/syndicate_lava_base/virology)
 "CH" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/railing{
@@ -2627,7 +2627,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /obj/machinery/firealarm/directional/south,
 /turf/open/floor/wood,
-/area/ruin/unpowered/syndicate_lava_base/dormitories)
+/area/ruin/lavaland/syndicate_lava_base/dormitories)
 "CJ" = (
 /obj/effect/turf_decal/tile/bar/opposingcorners,
 /obj/structure/table,
@@ -2635,16 +2635,16 @@
 	pixel_y = 5
 	},
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/bar)
+/area/ruin/lavaland/syndicate_lava_base/bar)
 "CO" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 1
 	},
 /turf/open/floor/wood,
-/area/ruin/unpowered/syndicate_lava_base/bar)
+/area/ruin/lavaland/syndicate_lava_base/bar)
 "CP" = (
 /turf/open/floor/catwalk_floor,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
+/area/ruin/lavaland/syndicate_lava_base/cargo)
 "CR" = (
 /obj/structure/fluff/hedge,
 /obj/effect/turf_decal/siding/dark,
@@ -2652,7 +2652,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/medbay)
+/area/ruin/lavaland/syndicate_lava_base/medbay)
 "CS" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/monitored{
 	dir = 1
@@ -2661,13 +2661,13 @@
 	pixel_y = -32
 	},
 /turf/open/floor/engine/vacuum,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/lavaland/syndicate_lava_base/engineering)
 "CT" = (
 /obj/structure/railing,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/port)
+/area/ruin/lavaland/syndicate_lava_base/port)
 "Dc" = (
 /obj/effect/spawner/structure/window/reinforced/plasma/plastitanium,
 /obj/machinery/door/firedoor,
@@ -2675,7 +2675,7 @@
 	id = "lavalandsyndi_cargo"
 	},
 /turf/open/floor/plating,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
+/area/ruin/lavaland/syndicate_lava_base/cargo)
 "Dw" = (
 /obj/effect/turf_decal/siding/dark{
 	dir = 4
@@ -2684,7 +2684,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/dark/textured,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
+/area/ruin/lavaland/syndicate_lava_base/cargo)
 "Dy" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/railing{
@@ -2694,11 +2694,11 @@
 /area/lavaland/surface/outdoors)
 "DA" = (
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
-/area/ruin/unpowered/syndicate_lava_base/medbay)
+/area/ruin/lavaland/syndicate_lava_base/medbay)
 "DB" = (
 /obj/machinery/atmospherics/pipe/smart/simple/orange/visible,
 /turf/open/floor/iron/dark/textured,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/lavaland/syndicate_lava_base/engineering)
 "DG" = (
 /obj/effect/turf_decal/tile/bar/opposingcorners,
 /obj/machinery/airalarm/directional/south,
@@ -2707,12 +2707,12 @@
 	},
 /obj/effect/mapping_helpers/airalarm/syndicate_access,
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/bar)
+/area/ruin/lavaland/syndicate_lava_base/bar)
 "DO" = (
 /obj/machinery/airalarm/directional/west,
 /obj/effect/mapping_helpers/airalarm/syndicate_access,
 /turf/open/floor/circuit/red,
-/area/ruin/unpowered/syndicate_lava_base/starboard)
+/area/ruin/lavaland/syndicate_lava_base/starboard)
 "DQ" = (
 /obj/structure/toilet{
 	dir = 4
@@ -2721,23 +2721,23 @@
 	desc = "Skibidi."
 	},
 /turf/open/floor/iron/showroomfloor,
-/area/ruin/unpowered/syndicate_lava_base/port)
+/area/ruin/lavaland/syndicate_lava_base/port)
 "DS" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
-/area/ruin/unpowered/syndicate_lava_base/starboard)
+/area/ruin/lavaland/syndicate_lava_base/starboard)
 "DV" = (
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/port)
+/area/ruin/lavaland/syndicate_lava_base/port)
 "Eg" = (
 /turf/open/floor/iron/white,
-/area/ruin/unpowered/syndicate_lava_base/medbay)
+/area/ruin/lavaland/syndicate_lava_base/medbay)
 "Eh" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 1
 	},
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/medbay)
+/area/ruin/lavaland/syndicate_lava_base/medbay)
 "Ei" = (
 /obj/structure/table/reinforced,
 /obj/structure/window/reinforced/spawner/directional/south,
@@ -2745,7 +2745,7 @@
 /obj/item/restraints/handcuffs,
 /obj/item/gun/syringe/syndicate,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/medbay)
+/area/ruin/lavaland/syndicate_lava_base/medbay)
 "Ek" = (
 /obj/structure/table/glass,
 /obj/item/storage/box/beakers{
@@ -2759,12 +2759,12 @@
 	},
 /obj/item/storage/box/monkeycubes,
 /turf/open/floor/iron/white,
-/area/ruin/unpowered/syndicate_lava_base/virology)
+/area/ruin/lavaland/syndicate_lava_base/virology)
 "Eo" = (
 /obj/effect/turf_decal/tile/bar/opposingcorners,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/bar)
+/area/ruin/lavaland/syndicate_lava_base/bar)
 "Ep" = (
 /obj/effect/turf_decal/siding/dark{
 	dir = 8
@@ -2774,13 +2774,13 @@
 	},
 /obj/machinery/smartfridge/chemistry/preloaded,
 /turf/open/floor/iron/techmaint,
-/area/ruin/unpowered/syndicate_lava_base/chemistry)
+/area/ruin/lavaland/syndicate_lava_base/chemistry)
 "Er" = (
 /obj/structure/chair/office{
 	dir = 1
 	},
 /turf/open/floor/carpet/red,
-/area/ruin/unpowered/syndicate_lava_base/telecomms)
+/area/ruin/lavaland/syndicate_lava_base/telecomms)
 "Ev" = (
 /obj/effect/turf_decal/siding/dark{
 	dir = 4
@@ -2790,38 +2790,38 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark/textured,
-/area/ruin/unpowered/syndicate_lava_base/brig)
+/area/ruin/lavaland/syndicate_lava_base/brig)
 "Ex" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/lavaland/syndicate_lava_base/engineering)
 "EA" = (
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/bridge)
+/area/ruin/lavaland/syndicate_lava_base/bridge)
 "ED" = (
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
-/area/ruin/unpowered/syndicate_lava_base/chemistry)
+/area/ruin/lavaland/syndicate_lava_base/chemistry)
 "EM" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
+/area/ruin/lavaland/syndicate_lava_base/cargo)
 "EN" = (
 /turf/closed/wall/mineral/plastitanium/explosive,
-/area/ruin/unpowered/syndicate_lava_base/port)
+/area/ruin/lavaland/syndicate_lava_base/port)
 "EP" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/catwalk_floor,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
+/area/ruin/lavaland/syndicate_lava_base/cargo)
 "EQ" = (
 /obj/machinery/vending/medical/syndicate_access,
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/medbay)
+/area/ruin/lavaland/syndicate_lava_base/medbay)
 "ES" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
@@ -2829,13 +2829,13 @@
 /obj/effect/decal/cleanable/dirt,
 /mob/living/simple_animal/hostile/carp/cayenne,
 /turf/open/floor/wood,
-/area/ruin/unpowered/syndicate_lava_base/bar)
+/area/ruin/lavaland/syndicate_lava_base/bar)
 "EY" = (
 /obj/machinery/porta_turret/syndicate{
 	dir = 5
 	},
 /turf/closed/wall/mineral/plastitanium,
-/area/ruin/unpowered/syndicate_lava_base/bridge)
+/area/ruin/lavaland/syndicate_lava_base/bridge)
 "Fm" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 5
@@ -2844,12 +2844,12 @@
 	req_access_txt = "150"
 	},
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/starboard)
+/area/ruin/lavaland/syndicate_lava_base/starboard)
 "Fu" = (
 /obj/effect/spawner/structure/window/reinforced/plasma/plastitanium,
 /obj/machinery/door/firedoor,
 /turf/open/floor/plating,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
+/area/ruin/lavaland/syndicate_lava_base/cargo)
 "Fz" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 4
@@ -2861,21 +2861,21 @@
 	dir = 5
 	},
 /turf/open/floor/iron/dark/textured,
-/area/ruin/unpowered/syndicate_lava_base/starboard)
+/area/ruin/lavaland/syndicate_lava_base/starboard)
 "FC" = (
 /turf/closed/wall/mineral/plastitanium/explosive,
-/area/ruin/unpowered/syndicate_lava_base/brig)
+/area/ruin/lavaland/syndicate_lava_base/brig)
 "FD" = (
 /obj/machinery/airalarm/directional/east,
 /obj/effect/mapping_helpers/airalarm/syndicate_access,
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/brig)
+/area/ruin/lavaland/syndicate_lava_base/brig)
 "FI" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /obj/structure/cable/yellow,
 /turf/open/floor/iron/white,
-/area/ruin/unpowered/syndicate_lava_base/chemistry)
+/area/ruin/lavaland/syndicate_lava_base/chemistry)
 "FL" = (
 /obj/effect/turf_decal/stripes/closeup{
 	dir = 1
@@ -2888,7 +2888,7 @@
 	name = "Starboard Hall"
 	},
 /turf/open/floor/iron/techmaint,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
+/area/ruin/lavaland/syndicate_lava_base/cargo)
 "FM" = (
 /obj/structure/table/reinforced,
 /obj/structure/window/reinforced/spawner/directional/east,
@@ -2898,20 +2898,20 @@
 /obj/item/book/manual/wiki/chemistry,
 /obj/item/clothing/glasses/science,
 /turf/open/floor/iron/techmaint,
-/area/ruin/unpowered/syndicate_lava_base/chemistry)
+/area/ruin/lavaland/syndicate_lava_base/chemistry)
 "FQ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible/layer2,
 /turf/open/floor/iron/dark/smooth_large,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/lavaland/syndicate_lava_base/engineering)
 "FS" = (
 /obj/structure/target_stake,
 /obj/item/target/clown,
 /obj/effect/decal/cleanable/blood/drip,
 /turf/open/floor/plating,
-/area/ruin/unpowered/syndicate_lava_base/brig)
+/area/ruin/lavaland/syndicate_lava_base/brig)
 "FT" = (
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
-/area/ruin/unpowered/syndicate_lava_base/starboard)
+/area/ruin/lavaland/syndicate_lava_base/starboard)
 "FV" = (
 /obj/effect/turf_decal/stripes/closeup,
 /obj/machinery/door/firedoor,
@@ -2922,7 +2922,7 @@
 	},
 /obj/effect/mapping_helpers/airlock/access/all/syndicate/general,
 /turf/open/floor/iron/techmaint,
-/area/ruin/unpowered/syndicate_lava_base/virology)
+/area/ruin/lavaland/syndicate_lava_base/virology)
 "FW" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
@@ -2931,19 +2931,19 @@
 	},
 /obj/structure/cable/yellow,
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
+/area/ruin/lavaland/syndicate_lava_base/cargo)
 "FY" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/port)
+/area/ruin/lavaland/syndicate_lava_base/port)
 "Gd" = (
 /obj/effect/turf_decal/trimline/red/line{
 	dir = 8
 	},
 /turf/open/floor/iron/dark/textured,
-/area/ruin/unpowered/syndicate_lava_base/telecomms)
+/area/ruin/lavaland/syndicate_lava_base/telecomms)
 "Gg" = (
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/stripes/closeup{
@@ -2952,10 +2952,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/iron/techmaint,
-/area/ruin/unpowered/syndicate_lava_base/port)
+/area/ruin/lavaland/syndicate_lava_base/port)
 "Gh" = (
 /turf/open/floor/plating,
-/area/ruin/unpowered/syndicate_lava_base/brig)
+/area/ruin/lavaland/syndicate_lava_base/brig)
 "Gi" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
@@ -2964,7 +2964,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /obj/structure/cable/yellow,
 /turf/open/floor/wood,
-/area/ruin/unpowered/syndicate_lava_base/bar)
+/area/ruin/lavaland/syndicate_lava_base/bar)
 "Go" = (
 /obj/structure/closet/crate/internals,
 /obj/item/tank/internals/oxygen/yellow,
@@ -2981,13 +2981,13 @@
 	},
 /obj/structure/cable/orange,
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
+/area/ruin/lavaland/syndicate_lava_base/cargo)
 "Gv" = (
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/telecomms)
+/area/ruin/lavaland/syndicate_lava_base/telecomms)
 "Gw" = (
 /turf/closed/wall/mineral/plastitanium/explosive,
-/area/ruin/unpowered/syndicate_lava_base/telecomms)
+/area/ruin/lavaland/syndicate_lava_base/telecomms)
 "Gz" = (
 /obj/structure/table/glass,
 /obj/machinery/reagentgrinder{
@@ -2995,7 +2995,7 @@
 	},
 /obj/item/reagent_containers/cup/beaker/large,
 /turf/open/floor/iron/white,
-/area/ruin/unpowered/syndicate_lava_base/chemistry)
+/area/ruin/lavaland/syndicate_lava_base/chemistry)
 "GC" = (
 /obj/effect/turf_decal/stripes/closeup{
 	dir = 1
@@ -3006,7 +3006,7 @@
 /obj/effect/mapping_helpers/airlock/access/all/syndicate/general,
 /obj/structure/fans/tiny,
 /turf/open/floor/iron/techmaint,
-/area/ruin/unpowered/syndicate_lava_base/telecomms)
+/area/ruin/lavaland/syndicate_lava_base/telecomms)
 "GJ" = (
 /obj/structure/railing{
 	dir = 4
@@ -3015,36 +3015,36 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /obj/structure/cable/yellow,
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/port)
+/area/ruin/lavaland/syndicate_lava_base/port)
 "GN" = (
 /obj/machinery/porta_turret/syndicate{
 	dir = 5
 	},
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
+/area/ruin/lavaland/syndicate_lava_base/cargo)
 "GR" = (
 /obj/machinery/light/small{
 	dir = 1
 	},
 /turf/open/floor/circuit/red,
-/area/ruin/unpowered/syndicate_lava_base/starboard)
+/area/ruin/lavaland/syndicate_lava_base/starboard)
 "GS" = (
 /obj/structure/cable/yellow,
 /obj/machinery/airalarm/directional/west,
 /obj/effect/mapping_helpers/airalarm/syndicate_access,
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/starboard)
+/area/ruin/lavaland/syndicate_lava_base/starboard)
 "GX" = (
 /obj/machinery/light/small/directional/south,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
-/area/ruin/unpowered/syndicate_lava_base/brig)
+/area/ruin/lavaland/syndicate_lava_base/brig)
 "GZ" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/medbay)
+/area/ruin/lavaland/syndicate_lava_base/medbay)
 "Ha" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
@@ -3053,13 +3053,13 @@
 	},
 /obj/structure/cable/yellow,
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
+/area/ruin/lavaland/syndicate_lava_base/cargo)
 "Hc" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /obj/structure/cable/yellow,
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
+/area/ruin/lavaland/syndicate_lava_base/cargo)
 "Hg" = (
 /obj/machinery/button/door/directional/south{
 	id = "lavalandsyndicate_warehouse"
@@ -3074,16 +3074,16 @@
 /obj/machinery/airalarm/directional/east,
 /obj/effect/mapping_helpers/airalarm/syndicate_access,
 /turf/open/floor/iron/dark/textured,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
+/area/ruin/lavaland/syndicate_lava_base/cargo)
 "Hj" = (
 /obj/structure/sign/warning/secure_area,
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
+/area/ruin/lavaland/syndicate_lava_base/cargo)
 "Ho" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/brig)
+/area/ruin/lavaland/syndicate_lava_base/brig)
 "Hv" = (
 /obj/structure/table/wood,
 /obj/effect/turf_decal/tile/neutral/opposingcorners,
@@ -3091,12 +3091,12 @@
 	dir = 1
 	},
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/bar)
+/area/ruin/lavaland/syndicate_lava_base/bar)
 "Hw" = (
 /obj/machinery/power/apc/syndicate/directional/east,
 /obj/structure/cable/yellow,
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/port)
+/area/ruin/lavaland/syndicate_lava_base/port)
 "HI" = (
 /obj/effect/turf_decal/siding/dark{
 	dir = 4
@@ -3105,14 +3105,14 @@
 	dir = 4
 	},
 /turf/open/floor/iron/dark/textured,
-/area/ruin/unpowered/syndicate_lava_base/brig)
+/area/ruin/lavaland/syndicate_lava_base/brig)
 "HK" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/port)
+/area/ruin/lavaland/syndicate_lava_base/port)
 "HP" = (
 /obj/effect/turf_decal/stripes/closeup{
 	dir = 1
@@ -3128,7 +3128,7 @@
 	name = "Port Hall"
 	},
 /turf/open/floor/iron/techmaint,
-/area/ruin/unpowered/syndicate_lava_base/medbay)
+/area/ruin/lavaland/syndicate_lava_base/medbay)
 "HQ" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 10
@@ -3136,36 +3136,36 @@
 /obj/machinery/power/apc/syndicate/directional/west,
 /obj/structure/cable/yellow,
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/bridge)
+/area/ruin/lavaland/syndicate_lava_base/bridge)
 "HW" = (
 /obj/machinery/porta_turret/syndicate{
 	dir = 10
 	},
 /turf/closed/wall/mineral/plastitanium,
-/area/ruin/unpowered/syndicate_lava_base/telecomms)
+/area/ruin/lavaland/syndicate_lava_base/telecomms)
 "HX" = (
 /obj/structure/railing/corner,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/port)
+/area/ruin/lavaland/syndicate_lava_base/port)
 "HZ" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
 /obj/structure/cable/yellow,
 /turf/open/floor/plating,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/lavaland/syndicate_lava_base/engineering)
 "Ia" = (
 /turf/closed/wall/mineral/plastitanium/explosive,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/lavaland/syndicate_lava_base/engineering)
 "Ic" = (
 /obj/effect/spawner/structure/window/reinforced/plasma/plastitanium,
 /obj/machinery/atmospherics/pipe/layer_manifold{
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/lavaland/syndicate_lava_base/engineering)
 "Id" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/railing{
@@ -3180,23 +3180,23 @@
 	name = "Warehouse Shutters"
 	},
 /turf/open/floor/iron/techmaint,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
+/area/ruin/lavaland/syndicate_lava_base/cargo)
 "Ip" = (
 /obj/structure/closet/emcloset/anchored,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
+/area/ruin/lavaland/syndicate_lava_base/cargo)
 "Iv" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /obj/structure/cable/yellow,
 /obj/machinery/firealarm/directional/south,
 /turf/open/floor/wood,
-/area/ruin/unpowered/syndicate_lava_base/dormitories)
+/area/ruin/lavaland/syndicate_lava_base/dormitories)
 "IF" = (
 /obj/structure/cable/orange,
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
+/area/ruin/lavaland/syndicate_lava_base/cargo)
 "IG" = (
 /obj/structure/cable,
 /obj/machinery/power/compressor{
@@ -3205,37 +3205,37 @@
 	luminosity = 2
 	},
 /turf/open/floor/engine/vacuum,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/lavaland/syndicate_lava_base/engineering)
 "II" = (
 /obj/machinery/computer/crew/syndie,
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/bridge)
+/area/ruin/lavaland/syndicate_lava_base/bridge)
 "IL" = (
 /obj/structure/cable/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/catwalk_floor/iron_dark,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/lavaland/syndicate_lava_base/engineering)
 "IQ" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/medbay)
+/area/ruin/lavaland/syndicate_lava_base/medbay)
 "IR" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 1
 	},
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/brig)
+/area/ruin/lavaland/syndicate_lava_base/brig)
 "IS" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 4
 	},
 /obj/machinery/firealarm/directional/east,
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/starboard)
+/area/ruin/lavaland/syndicate_lava_base/starboard)
 "IW" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
@@ -3247,17 +3247,17 @@
 	},
 /obj/structure/cable/yellow,
 /turf/open/floor/iron/dark/textured,
-/area/ruin/unpowered/syndicate_lava_base/brig)
+/area/ruin/lavaland/syndicate_lava_base/brig)
 "IY" = (
 /obj/structure/sign/warning/secure_area,
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
-/area/ruin/unpowered/syndicate_lava_base/medbay)
+/area/ruin/lavaland/syndicate_lava_base/medbay)
 "Ja" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 1
 	},
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/medbay)
+/area/ruin/lavaland/syndicate_lava_base/medbay)
 "Jh" = (
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/stripes/closeup,
@@ -3269,7 +3269,7 @@
 /obj/effect/mapping_helpers/airlock/access/all/syndicate/general,
 /obj/structure/cable/yellow,
 /turf/open/floor/iron/techmaint,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
+/area/ruin/lavaland/syndicate_lava_base/cargo)
 "Jj" = (
 /obj/effect/turf_decal/siding/dark{
 	dir = 5
@@ -3278,7 +3278,7 @@
 	dir = 5
 	},
 /turf/open/floor/iron/dark/textured,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/lavaland/syndicate_lava_base/engineering)
 "Jl" = (
 /obj/structure/railing{
 	dir = 8
@@ -3287,29 +3287,29 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/starboard)
+/area/ruin/lavaland/syndicate_lava_base/starboard)
 "Jo" = (
 /turf/closed/wall/mineral/plastitanium/explosive,
-/area/ruin/unpowered/syndicate_lava_base/starboard)
+/area/ruin/lavaland/syndicate_lava_base/starboard)
 "Js" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 4
 	},
 /obj/structure/extinguisher_cabinet/directional/east,
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/starboard)
+/area/ruin/lavaland/syndicate_lava_base/starboard)
 "JA" = (
 /obj/machinery/vending/medical/syndicate_access,
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 10
 	},
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/medbay)
+/area/ruin/lavaland/syndicate_lava_base/medbay)
 "JB" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/port)
+/area/ruin/lavaland/syndicate_lava_base/port)
 "JE" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/railing,
@@ -3317,12 +3317,12 @@
 /area/lavaland/surface/outdoors)
 "JM" = (
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/starboard)
+/area/ruin/lavaland/syndicate_lava_base/starboard)
 "JU" = (
 /obj/effect/spawner/structure/window/reinforced/plasma/plastitanium,
 /obj/machinery/door/firedoor,
 /turf/open/floor/plating,
-/area/ruin/unpowered/syndicate_lava_base/brig)
+/area/ruin/lavaland/syndicate_lava_base/brig)
 "JX" = (
 /obj/machinery/button/door{
 	id = "lavalandsyndi_cargo";
@@ -3334,26 +3334,26 @@
 	dir = 4
 	},
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
+/area/ruin/lavaland/syndicate_lava_base/cargo)
 "Kd" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/catwalk_floor/iron_dark,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/lavaland/syndicate_lava_base/engineering)
 "Ke" = (
 /obj/effect/turf_decal/trimline/red/filled/corner{
 	dir = 8
 	},
 /obj/structure/cable/yellow,
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/port)
+/area/ruin/lavaland/syndicate_lava_base/port)
 "Kl" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 6
 	},
 /obj/effect/mob_spawn/human/lavaland_syndicate/officer,
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/dormitories)
+/area/ruin/lavaland/syndicate_lava_base/dormitories)
 "Kp" = (
 /obj/effect/turf_decal/trimline/red/filled/corner{
 	dir = 4
@@ -3361,7 +3361,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/starboard)
+/area/ruin/lavaland/syndicate_lava_base/starboard)
 "Kr" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
@@ -3374,17 +3374,17 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/extinguisher_cabinet/directional/west,
 /turf/open/floor/iron/dark/textured,
-/area/ruin/unpowered/syndicate_lava_base/brig)
+/area/ruin/lavaland/syndicate_lava_base/brig)
 "Kt" = (
 /turf/open/floor/iron/dark/smooth_large,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/lavaland/syndicate_lava_base/engineering)
 "Ku" = (
 /obj/effect/spawner/structure/window/reinforced/plasma/plastitanium,
 /obj/machinery/door/poddoor/preopen{
 	id = "lavalandsyndi_hall"
 	},
 /turf/open/floor/plating,
-/area/ruin/unpowered/syndicate_lava_base/starboard)
+/area/ruin/lavaland/syndicate_lava_base/starboard)
 "Kx" = (
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/stripes/closeup{
@@ -3393,16 +3393,16 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/iron/techmaint,
-/area/ruin/unpowered/syndicate_lava_base/starboard)
+/area/ruin/lavaland/syndicate_lava_base/starboard)
 "KE" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
 	},
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/starboard)
+/area/ruin/lavaland/syndicate_lava_base/starboard)
 "KJ" = (
 /turf/closed/wall/mineral/plastitanium/explosive,
-/area/ruin/unpowered/syndicate_lava_base/dormitories)
+/area/ruin/lavaland/syndicate_lava_base/dormitories)
 "KK" = (
 /obj/item/ammo_box/c10mm{
 	pixel_y = 6
@@ -3419,14 +3419,14 @@
 /obj/structure/closet/syndicate/personal,
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/iron/dark/smooth_large,
-/area/ruin/unpowered/syndicate_lava_base/brig)
+/area/ruin/lavaland/syndicate_lava_base/brig)
 "KL" = (
 /obj/machinery/power/smes{
 	charge = 5e+006
 	},
 /obj/structure/cable/orange,
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
+/area/ruin/lavaland/syndicate_lava_base/cargo)
 "KO" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
@@ -3437,18 +3437,18 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark/textured,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
+/area/ruin/lavaland/syndicate_lava_base/cargo)
 "KV" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 8
 	},
 /obj/machinery/light/cold/directional/east,
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/port)
+/area/ruin/lavaland/syndicate_lava_base/port)
 "KX" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
+/area/ruin/lavaland/syndicate_lava_base/cargo)
 "KZ" = (
 /obj/structure/table/glass,
 /obj/item/reagent_containers/spray/cleaner,
@@ -3463,7 +3463,7 @@
 /obj/item/restraints/handcuffs,
 /obj/item/restraints/handcuffs,
 /turf/open/floor/iron/white,
-/area/ruin/unpowered/syndicate_lava_base/virology)
+/area/ruin/lavaland/syndicate_lava_base/virology)
 "La" = (
 /obj/structure/table/wood,
 /obj/item/stamp/chameleon{
@@ -3483,18 +3483,18 @@
 	pixel_y = -4
 	},
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/telecomms)
+/area/ruin/lavaland/syndicate_lava_base/telecomms)
 "Ld" = (
 /obj/structure/cable/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
+/area/ruin/lavaland/syndicate_lava_base/cargo)
 "Lg" = (
 /obj/effect/turf_decal/siding/dark,
 /obj/effect/turf_decal/trimline/red/line,
 /turf/open/floor/iron/dark/textured,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
+/area/ruin/lavaland/syndicate_lava_base/cargo)
 "Lh" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
@@ -3508,18 +3508,18 @@
 	pixel_y = 25
 	},
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/medbay)
+/area/ruin/lavaland/syndicate_lava_base/medbay)
 "Ln" = (
 /obj/effect/turf_decal/tile/bar/opposingcorners,
 /obj/machinery/oven,
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/bar)
+/area/ruin/lavaland/syndicate_lava_base/bar)
 "Ls" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/medbay)
+/area/ruin/lavaland/syndicate_lava_base/medbay)
 "Lt" = (
 /obj/structure/cable/yellow,
 /obj/effect/turf_decal/siding/dark{
@@ -3532,14 +3532,14 @@
 	name = "O2 to Incinerator"
 	},
 /turf/open/floor/iron/dark/textured,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/lavaland/syndicate_lava_base/engineering)
 "Lv" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/wood,
-/area/ruin/unpowered/syndicate_lava_base/dormitories)
+/area/ruin/lavaland/syndicate_lava_base/dormitories)
 "LB" = (
 /obj/structure/chair/office/light{
 	dir = 4
@@ -3548,7 +3548,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /obj/structure/cable/yellow,
 /turf/open/floor/iron/white,
-/area/ruin/unpowered/syndicate_lava_base/chemistry)
+/area/ruin/lavaland/syndicate_lava_base/chemistry)
 "LG" = (
 /obj/structure/sign/warning/fire{
 	pixel_x = 32
@@ -3560,44 +3560,44 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
+/area/ruin/lavaland/syndicate_lava_base/cargo)
 "LH" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 4
 	},
 /turf/open/floor/wood,
-/area/ruin/unpowered/syndicate_lava_base/telecomms)
+/area/ruin/lavaland/syndicate_lava_base/telecomms)
 "LJ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /obj/structure/cable/yellow,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/catwalk_floor/iron_dark,
-/area/ruin/unpowered/syndicate_lava_base/port)
+/area/ruin/lavaland/syndicate_lava_base/port)
 "LV" = (
 /obj/effect/turf_decal/trimline/red/filled/line,
 /obj/machinery/firealarm/directional/south,
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
+/area/ruin/lavaland/syndicate_lava_base/cargo)
 "Mc" = (
 /obj/machinery/atmospherics/miner/carbon_dioxide,
 /turf/open/floor/engine/co2,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/lavaland/syndicate_lava_base/engineering)
 "Md" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/port)
+/area/ruin/lavaland/syndicate_lava_base/port)
 "Mj" = (
 /obj/structure/cable/yellow,
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/starboard)
+/area/ruin/lavaland/syndicate_lava_base/starboard)
 "Mr" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 8
 	},
 /obj/structure/cable/yellow,
 /turf/open/floor/iron/white,
-/area/ruin/unpowered/syndicate_lava_base/medbay)
+/area/ruin/lavaland/syndicate_lava_base/medbay)
 "Ms" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/portable_atmospherics/pump,
@@ -3605,13 +3605,13 @@
 	dir = 1
 	},
 /turf/open/floor/iron/dark/smooth_large,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/lavaland/syndicate_lava_base/engineering)
 "MF" = (
 /obj/effect/turf_decal/siding/dark{
 	dir = 4
 	},
 /turf/open/floor/circuit/green,
-/area/ruin/unpowered/syndicate_lava_base/telecomms)
+/area/ruin/lavaland/syndicate_lava_base/telecomms)
 "MH" = (
 /obj/structure/chair/fancy/sofa/old/left{
 	color = "#742925";
@@ -3621,13 +3621,13 @@
 	dir = 6
 	},
 /turf/open/floor/carpet/red,
-/area/ruin/unpowered/syndicate_lava_base/bar)
+/area/ruin/lavaland/syndicate_lava_base/bar)
 "MV" = (
 /obj/structure/table/reinforced,
 /obj/structure/window/reinforced/spawner/directional/east,
 /obj/structure/window/reinforced/spawner/directional/south,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/medbay)
+/area/ruin/lavaland/syndicate_lava_base/medbay)
 "Ne" = (
 /obj/structure/chair/office{
 	dir = 1
@@ -3643,35 +3643,35 @@
 	pixel_y = -8
 	},
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/bridge)
+/area/ruin/lavaland/syndicate_lava_base/bridge)
 "Nh" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /obj/structure/cable/yellow,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
+/area/ruin/lavaland/syndicate_lava_base/cargo)
 "Nl" = (
 /obj/structure/table/reinforced,
 /obj/item/taperecorder,
 /turf/open/floor/iron/dark/smooth_large,
-/area/ruin/unpowered/syndicate_lava_base/brig)
+/area/ruin/lavaland/syndicate_lava_base/brig)
 "Nm" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/port)
+/area/ruin/lavaland/syndicate_lava_base/port)
 "Nq" = (
 /obj/effect/spawner/structure/window/reinforced/plasma/plastitanium,
 /turf/open/floor/plating,
-/area/ruin/unpowered/syndicate_lava_base/medbay)
+/area/ruin/lavaland/syndicate_lava_base/medbay)
 "Nr" = (
 /obj/structure/chair/office,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/wood,
-/area/ruin/unpowered/syndicate_lava_base/telecomms)
+/area/ruin/lavaland/syndicate_lava_base/telecomms)
 "NN" = (
 /obj/effect/turf_decal/siding/dark{
 	dir = 10
@@ -3683,7 +3683,7 @@
 /obj/machinery/firealarm/directional/west,
 /obj/machinery/light/small/directional/south,
 /turf/open/floor/iron/dark/textured,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
+/area/ruin/lavaland/syndicate_lava_base/cargo)
 "NO" = (
 /obj/effect/mapping_helpers/airlock/locked,
 /obj/effect/turf_decal/stripes/closeup,
@@ -3695,7 +3695,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/iron/techmaint,
-/area/ruin/unpowered/syndicate_lava_base/starboard)
+/area/ruin/lavaland/syndicate_lava_base/starboard)
 "NR" = (
 /obj/structure/fans/tiny,
 /obj/machinery/door/airlock/external,
@@ -3705,14 +3705,14 @@
 	},
 /obj/effect/turf_decal/stripes/closeup,
 /turf/open/floor/iron/techmaint,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
+/area/ruin/lavaland/syndicate_lava_base/cargo)
 "Od" = (
 /obj/machinery/firealarm/directional/east,
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/port)
+/area/ruin/lavaland/syndicate_lava_base/port)
 "Of" = (
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
-/area/ruin/unpowered/syndicate_lava_base/dormitories)
+/area/ruin/lavaland/syndicate_lava_base/dormitories)
 "Oj" = (
 /obj/structure/cable/yellow,
 /obj/effect/turf_decal/siding/dark{
@@ -3722,14 +3722,14 @@
 	dir = 1
 	},
 /turf/open/floor/iron/dark/textured,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/lavaland/syndicate_lava_base/engineering)
 "Ol" = (
 /obj/machinery/computer/scan_consolenew{
 	dir = 4;
 	req_access = list(150)
 	},
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/virology)
+/area/ruin/lavaland/syndicate_lava_base/virology)
 "Or" = (
 /obj/machinery/chem_master,
 /obj/effect/turf_decal/stripes/line{
@@ -3743,7 +3743,7 @@
 	req_access_txt = "150"
 	},
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/chemistry)
+/area/ruin/lavaland/syndicate_lava_base/chemistry)
 "Ot" = (
 /obj/machinery/computer/camera_advanced/syndie{
 	dir = 4
@@ -3752,44 +3752,44 @@
 	dir = 8
 	},
 /turf/open/floor/carpet/red,
-/area/ruin/unpowered/syndicate_lava_base/telecomms)
+/area/ruin/lavaland/syndicate_lava_base/telecomms)
 "Ow" = (
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/stripes/closeup,
 /obj/structure/cable/yellow,
 /turf/open/floor/iron/techmaint,
-/area/ruin/unpowered/syndicate_lava_base/starboard)
+/area/ruin/lavaland/syndicate_lava_base/starboard)
 "Oz" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/toolbox/syndicate,
 /obj/machinery/airalarm/directional/south,
 /obj/effect/mapping_helpers/airalarm/syndicate_access,
 /turf/open/floor/catwalk_floor/iron_dark,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/lavaland/syndicate_lava_base/engineering)
 "OI" = (
 /obj/structure/chair{
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/red/filled/line,
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/medbay)
+/area/ruin/lavaland/syndicate_lava_base/medbay)
 "OO" = (
 /obj/structure/cable/orange,
 /turf/open/floor/catwalk_floor,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
+/area/ruin/lavaland/syndicate_lava_base/cargo)
 "OS" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 10
 	},
 /obj/machinery/light/directional/south,
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/port)
+/area/ruin/lavaland/syndicate_lava_base/port)
 "OU" = (
 /obj/effect/turf_decal/siding/dark{
 	dir = 6
 	},
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/bridge)
+/area/ruin/lavaland/syndicate_lava_base/bridge)
 "OW" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
@@ -3797,14 +3797,14 @@
 /obj/machinery/light/cold/directional/north,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood,
-/area/ruin/unpowered/syndicate_lava_base/bar)
+/area/ruin/lavaland/syndicate_lava_base/bar)
 "OZ" = (
 /turf/closed/wall/mineral/plastitanium,
-/area/ruin/unpowered/syndicate_lava_base/medbay)
+/area/ruin/lavaland/syndicate_lava_base/medbay)
 "Pa" = (
 /obj/structure/cable/yellow,
 /turf/open/floor/wood,
-/area/ruin/unpowered/syndicate_lava_base/telecomms)
+/area/ruin/lavaland/syndicate_lava_base/telecomms)
 "Pb" = (
 /obj/machinery/syndicatebomb/self_destruct{
 	anchored = 1
@@ -3813,7 +3813,7 @@
 	desc = "Initially I wanted to put a rocket launcher in here because thats badass but the compelling point was made that the bases walls are made of explosives and our players are fucking stupid."
 	},
 /turf/open/floor/circuit/red,
-/area/ruin/unpowered/syndicate_lava_base/starboard)
+/area/ruin/lavaland/syndicate_lava_base/starboard)
 "Pf" = (
 /obj/structure/window/reinforced/spawner/directional/west,
 /obj/structure/table/wood,
@@ -3826,10 +3826,10 @@
 	pixel_x = 8
 	},
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/bar)
+/area/ruin/lavaland/syndicate_lava_base/bar)
 "Pi" = (
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
-/area/ruin/unpowered/syndicate_lava_base/brig)
+/area/ruin/lavaland/syndicate_lava_base/brig)
 "Pj" = (
 /obj/machinery/computer/shuttle_flight{
 	desc = "Controls the Surveillance ship, often taken on planetary recon missions.";
@@ -3840,7 +3840,7 @@
 	req_access_txt = "150"
 	},
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/bridge)
+/area/ruin/lavaland/syndicate_lava_base/bridge)
 "Pr" = (
 /obj/structure/closet/crate,
 /obj/item/storage/toolbox/electrical{
@@ -3850,7 +3850,7 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
 /obj/machinery/light/directional/south,
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
+/area/ruin/lavaland/syndicate_lava_base/cargo)
 "Py" = (
 /obj/structure/closet/secure_closet/medical1{
 	req_access = null;
@@ -3859,17 +3859,17 @@
 /obj/item/storage/box/beakers/bluespace,
 /obj/item/storage/box/beakers/bluespace,
 /turf/open/floor/iron/white,
-/area/ruin/unpowered/syndicate_lava_base/chemistry)
+/area/ruin/lavaland/syndicate_lava_base/chemistry)
 "Pz" = (
 /obj/effect/spawner/structure/window/reinforced/plasma/plastitanium,
 /turf/open/floor/plating,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/lavaland/syndicate_lava_base/engineering)
 "PB" = (
 /obj/machinery/door/window/brigdoor{
 	name = "Telecommunications Servers"
 	},
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/telecomms)
+/area/ruin/lavaland/syndicate_lava_base/telecomms)
 "PH" = (
 /obj/structure/cable/yellow,
 /obj/machinery/atmospherics/components/binary/pump/on/layer4{
@@ -3879,25 +3879,25 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark/smooth_large,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/lavaland/syndicate_lava_base/engineering)
 "PI" = (
 /obj/machinery/air_sensor,
 /turf/open/floor/engine/co2,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/lavaland/syndicate_lava_base/engineering)
 "PM" = (
 /obj/effect/turf_decal/tile/neutral/opposingcorners,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/bar)
+/area/ruin/lavaland/syndicate_lava_base/bar)
 "PR" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
 	},
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/port)
+/area/ruin/lavaland/syndicate_lava_base/port)
 "PW" = (
 /turf/open/floor/plating,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
+/area/ruin/lavaland/syndicate_lava_base/cargo)
 "Qb" = (
 /obj/effect/turf_decal/siding/dark{
 	dir = 4
@@ -3906,20 +3906,20 @@
 	dir = 4
 	},
 /turf/open/floor/iron/dark/textured,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/lavaland/syndicate_lava_base/engineering)
 "Qc" = (
 /obj/structure/cable/yellow,
 /obj/machinery/light/small/directional/west,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/catwalk_floor/iron_dark,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/lavaland/syndicate_lava_base/engineering)
 "Qh" = (
 /obj/effect/turf_decal/trimline/red/filled/line,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/bridge)
+/area/ruin/lavaland/syndicate_lava_base/bridge)
 "Qp" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/on{
 	dir = 8;
@@ -3927,30 +3927,30 @@
 	name = "co2 out"
 	},
 /turf/open/floor/engine/co2,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/lavaland/syndicate_lava_base/engineering)
 "Qt" = (
 /obj/machinery/computer/camera_advanced/syndie,
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/bridge)
+/area/ruin/lavaland/syndicate_lava_base/bridge)
 "Qy" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/iron/dark/smooth_large,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/lavaland/syndicate_lava_base/engineering)
 "Qz" = (
 /obj/effect/mob_spawn/human/lavaland_syndicate,
 /obj/effect/turf_decal/siding/wood{
 	dir = 10
 	},
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/dormitories)
+/area/ruin/lavaland/syndicate_lava_base/dormitories)
 "QF" = (
 /obj/effect/spawner/structure/window/reinforced/plasma/plastitanium,
 /obj/machinery/door/poddoor/preopen{
 	id = "lavalandsyndi_hall"
 	},
 /turf/open/floor/plating,
-/area/ruin/unpowered/syndicate_lava_base/port)
+/area/ruin/lavaland/syndicate_lava_base/port)
 "QH" = (
 /obj/structure/closet/crate,
 /obj/item/storage/box/stockparts/deluxe,
@@ -3967,7 +3967,7 @@
 /obj/machinery/light/small/directional/north,
 /obj/structure/extinguisher_cabinet/directional/north,
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
+/area/ruin/lavaland/syndicate_lava_base/cargo)
 "QM" = (
 /obj/effect/turf_decal/stripes/closeup{
 	dir = 1
@@ -3978,7 +3978,7 @@
 	},
 /obj/effect/mapping_helpers/airlock/access/all/syndicate/general,
 /turf/open/floor/iron/techmaint,
-/area/ruin/unpowered/syndicate_lava_base/telecomms)
+/area/ruin/lavaland/syndicate_lava_base/telecomms)
 "QO" = (
 /obj/effect/mapping_helpers/no_lava,
 /turf/open/floor/plating,
@@ -3990,13 +3990,13 @@
 	name = "oxygen out"
 	},
 /turf/open/floor/engine/o2,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/lavaland/syndicate_lava_base/engineering)
 "QW" = (
 /obj/effect/turf_decal/tile/neutral/opposingcorners,
 /obj/structure/sink/kitchen/directional/south,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/bar)
+/area/ruin/lavaland/syndicate_lava_base/bar)
 "Rd" = (
 /obj/machinery/atmospherics/pipe/smart/simple/orange/visible,
 /obj/machinery/button/ignition/incinerator/syndicatelava{
@@ -4013,7 +4013,7 @@
 	pixel_y = -26
 	},
 /turf/open/floor/catwalk_floor/iron_dark,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/lavaland/syndicate_lava_base/engineering)
 "Rf" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -4022,7 +4022,7 @@
 	pixel_x = -32
 	},
 /turf/open/floor/plating,
-/area/ruin/unpowered/syndicate_lava_base/medbay)
+/area/ruin/lavaland/syndicate_lava_base/medbay)
 "Rh" = (
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/stripes/closeup,
@@ -4034,14 +4034,14 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /obj/structure/cable/yellow,
 /turf/open/floor/iron/techmaint,
-/area/ruin/unpowered/syndicate_lava_base/brig)
+/area/ruin/lavaland/syndicate_lava_base/brig)
 "Rj" = (
 /obj/machinery/door/airlock{
 	name = "Restroom"
 	},
 /obj/effect/turf_decal/stripes/closeup,
 /turf/open/floor/iron/techmaint,
-/area/ruin/unpowered/syndicate_lava_base/port)
+/area/ruin/lavaland/syndicate_lava_base/port)
 "Rn" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/shower{
@@ -4051,16 +4051,16 @@
 /obj/machinery/airalarm/directional/east,
 /obj/effect/mapping_helpers/airalarm/syndicate_access,
 /turf/open/floor/iron/white/textured,
-/area/ruin/unpowered/syndicate_lava_base/virology)
+/area/ruin/lavaland/syndicate_lava_base/virology)
 "Rs" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/medbay)
+/area/ruin/lavaland/syndicate_lava_base/medbay)
 "Ru" = (
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
-/area/ruin/unpowered/syndicate_lava_base/bridge)
+/area/ruin/lavaland/syndicate_lava_base/bridge)
 "Rv" = (
 /obj/effect/turf_decal/stripes/closeup{
 	dir = 1
@@ -4073,14 +4073,14 @@
 	name = "Port Hall"
 	},
 /turf/open/floor/iron/techmaint,
-/area/ruin/unpowered/syndicate_lava_base/medbay)
+/area/ruin/lavaland/syndicate_lava_base/medbay)
 "RD" = (
 /obj/effect/spawner/structure/window/reinforced/plasma/plastitanium,
 /obj/machinery/door/poddoor/preopen{
 	id = "lavalandsyndi_hall"
 	},
 /turf/open/floor/plating,
-/area/ruin/unpowered/syndicate_lava_base/medbay)
+/area/ruin/lavaland/syndicate_lava_base/medbay)
 "RO" = (
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/stripes/closeup,
@@ -4088,11 +4088,11 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /obj/structure/cable/yellow,
 /turf/open/floor/iron/techmaint,
-/area/ruin/unpowered/syndicate_lava_base/port)
+/area/ruin/lavaland/syndicate_lava_base/port)
 "RP" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
-/area/ruin/unpowered/syndicate_lava_base/brig)
+/area/ruin/lavaland/syndicate_lava_base/brig)
 "RU" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
@@ -4105,20 +4105,20 @@
 /obj/structure/cable/yellow,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark/textured,
-/area/ruin/unpowered/syndicate_lava_base/brig)
+/area/ruin/lavaland/syndicate_lava_base/brig)
 "RV" = (
 /obj/effect/turf_decal/trimline/red/filled/line,
 /obj/structure/extinguisher_cabinet/directional/south,
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
+/area/ruin/lavaland/syndicate_lava_base/cargo)
 "Se" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
+/area/ruin/lavaland/syndicate_lava_base/cargo)
 "Sg" = (
 /obj/machinery/modular_computer/console/preset/civilian,
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/bridge)
+/area/ruin/lavaland/syndicate_lava_base/bridge)
 "Sp" = (
 /obj/effect/turf_decal/stripes/closeup{
 	dir = 1
@@ -4128,7 +4128,7 @@
 	name = "Restroom"
 	},
 /turf/open/floor/iron/techmaint,
-/area/ruin/unpowered/syndicate_lava_base/port)
+/area/ruin/lavaland/syndicate_lava_base/port)
 "Sq" = (
 /obj/machinery/computer/atmos_control{
 	dir = 8;
@@ -4137,7 +4137,7 @@
 /obj/effect/turf_decal/delivery,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible/layer2,
 /turf/open/floor/iron/dark/smooth_large,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/lavaland/syndicate_lava_base/engineering)
 "Sy" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 10
@@ -4147,10 +4147,10 @@
 /obj/machinery/airalarm/directional/west,
 /obj/effect/mapping_helpers/airalarm/syndicate_access,
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
+/area/ruin/lavaland/syndicate_lava_base/cargo)
 "Sz" = (
 /turf/closed/wall/mineral/plastitanium/explosive,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
+/area/ruin/lavaland/syndicate_lava_base/cargo)
 "SJ" = (
 /obj/effect/turf_decal/trimline/red/filled/corner{
 	dir = 8
@@ -4159,7 +4159,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /obj/structure/cable/yellow,
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/port)
+/area/ruin/lavaland/syndicate_lava_base/port)
 "SL" = (
 /obj/effect/turf_decal/stripes/closeup{
 	dir = 1
@@ -4172,36 +4172,36 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/iron/techmaint,
-/area/ruin/unpowered/syndicate_lava_base/brig)
+/area/ruin/lavaland/syndicate_lava_base/brig)
 "SM" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/brig)
+/area/ruin/lavaland/syndicate_lava_base/brig)
 "SW" = (
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/medbay)
+/area/ruin/lavaland/syndicate_lava_base/medbay)
 "SY" = (
 /turf/open/floor/engine/n2,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/lavaland/syndicate_lava_base/engineering)
 "Ta" = (
 /turf/open/lava/smooth/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "Tg" = (
 /obj/effect/turf_decal/tile/neutral/opposingcorners,
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/bar)
+/area/ruin/lavaland/syndicate_lava_base/bar)
 "Ti" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /obj/effect/turf_decal/trimline/red/filled/line,
 /obj/structure/cable/yellow,
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
+/area/ruin/lavaland/syndicate_lava_base/cargo)
 "Tq" = (
 /obj/effect/turf_decal/tile/bar/opposingcorners,
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/bar)
+/area/ruin/lavaland/syndicate_lava_base/bar)
 "TB" = (
 /obj/structure/chair/fancy/sofa/old/left{
 	color = "#742925";
@@ -4211,7 +4211,7 @@
 	dir = 9
 	},
 /turf/open/floor/carpet/red,
-/area/ruin/unpowered/syndicate_lava_base/bar)
+/area/ruin/lavaland/syndicate_lava_base/bar)
 "TD" = (
 /obj/structure/fans/tiny,
 /obj/machinery/door/airlock/external,
@@ -4221,56 +4221,56 @@
 	},
 /obj/effect/turf_decal/stripes/closeup,
 /turf/open/floor/iron/techmaint,
-/area/ruin/unpowered/syndicate_lava_base/medbay)
+/area/ruin/lavaland/syndicate_lava_base/medbay)
 "TM" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
 /obj/structure/cable/yellow,
 /turf/open/floor/iron/white,
-/area/ruin/unpowered/syndicate_lava_base/virology)
+/area/ruin/lavaland/syndicate_lava_base/virology)
 "TN" = (
 /obj/effect/turf_decal/siding/dark,
 /obj/effect/turf_decal/trimline/red/line,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark/textured,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
+/area/ruin/lavaland/syndicate_lava_base/cargo)
 "TU" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/starboard)
+/area/ruin/lavaland/syndicate_lava_base/starboard)
 "TX" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/box/lights/bulbs,
 /obj/item/wrench,
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
+/area/ruin/lavaland/syndicate_lava_base/cargo)
 "Ub" = (
 /obj/effect/turf_decal/trimline/red/filled/corner,
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/bridge)
+/area/ruin/lavaland/syndicate_lava_base/bridge)
 "Ud" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
 /turf/open/floor/catwalk_floor,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
+/area/ruin/lavaland/syndicate_lava_base/cargo)
 "Uf" = (
 /obj/machinery/atmospherics/pipe/smart/simple/orange/visible{
 	dir = 6
 	},
 /obj/machinery/suit_storage_unit/radsuit,
 /turf/open/floor/iron/dark/textured,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/lavaland/syndicate_lava_base/engineering)
 "Ui" = (
 /obj/machinery/atmospherics/miner/nitrogen,
 /obj/machinery/light/small{
 	dir = 4
 	},
 /turf/open/floor/engine/n2,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/lavaland/syndicate_lava_base/engineering)
 "Um" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /obj/structure/flora/rock/jungle,
 /turf/open/floor/grass/no_border,
-/area/ruin/unpowered/syndicate_lava_base/port)
+/area/ruin/lavaland/syndicate_lava_base/port)
 "Uw" = (
 /obj/structure/table/reinforced,
 /obj/effect/turf_decal/siding/dark{
@@ -4281,38 +4281,38 @@
 	},
 /obj/item/folder/white,
 /turf/open/floor/iron/techmaint,
-/area/ruin/unpowered/syndicate_lava_base/chemistry)
+/area/ruin/lavaland/syndicate_lava_base/chemistry)
 "Ux" = (
 /obj/effect/spawner/structure/window/reinforced/plasma/plastitanium,
 /turf/open/floor/plating,
-/area/ruin/unpowered/syndicate_lava_base/bridge)
+/area/ruin/lavaland/syndicate_lava_base/bridge)
 "UF" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 10
 	},
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/port)
+/area/ruin/lavaland/syndicate_lava_base/port)
 "UG" = (
 /obj/machinery/porta_turret/syndicate{
 	dir = 9
 	},
 /turf/closed/wall/mineral/plastitanium,
-/area/ruin/unpowered/syndicate_lava_base/medbay)
+/area/ruin/lavaland/syndicate_lava_base/medbay)
 "UJ" = (
 /obj/effect/turf_decal/trimline/red/filled/corner,
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/starboard)
+/area/ruin/lavaland/syndicate_lava_base/starboard)
 "UO" = (
 /obj/machinery/deepfryer,
 /obj/effect/turf_decal/tile/bar/opposingcorners,
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/bar)
+/area/ruin/lavaland/syndicate_lava_base/bar)
 "UU" = (
 /obj/machinery/porta_turret/syndicate{
 	dir = 9
 	},
 /turf/closed/wall/mineral/plastitanium,
-/area/ruin/unpowered/syndicate_lava_base/bridge)
+/area/ruin/lavaland/syndicate_lava_base/bridge)
 "UW" = (
 /obj/structure/filingcabinet,
 /obj/item/folder/syndicate/mining,
@@ -4323,7 +4323,7 @@
 	dir = 6
 	},
 /turf/open/floor/iron/dark/textured,
-/area/ruin/unpowered/syndicate_lava_base/starboard)
+/area/ruin/lavaland/syndicate_lava_base/starboard)
 "UX" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 6
@@ -4331,7 +4331,7 @@
 /obj/machinery/airalarm/directional/east,
 /obj/effect/mapping_helpers/airalarm/syndicate_access,
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/bridge)
+/area/ruin/lavaland/syndicate_lava_base/bridge)
 "Vf" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -4340,7 +4340,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/medbay)
+/area/ruin/lavaland/syndicate_lava_base/medbay)
 "Vj" = (
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/stripes/closeup{
@@ -4350,15 +4350,15 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /obj/structure/cable/yellow,
 /turf/open/floor/iron/techmaint,
-/area/ruin/unpowered/syndicate_lava_base/bar)
+/area/ruin/lavaland/syndicate_lava_base/bar)
 "Vl" = (
 /obj/effect/turf_decal/siding/wood,
 /turf/open/floor/carpet/red,
-/area/ruin/unpowered/syndicate_lava_base/telecomms)
+/area/ruin/lavaland/syndicate_lava_base/telecomms)
 "Vo" = (
 /obj/effect/spawner/structure/window/reinforced/plasma/plastitanium,
 /turf/open/floor/plating,
-/area/ruin/unpowered/syndicate_lava_base/brig)
+/area/ruin/lavaland/syndicate_lava_base/brig)
 "Vw" = (
 /obj/structure/railing/corner{
 	dir = 4
@@ -4370,23 +4370,23 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /obj/structure/cable/yellow,
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/port)
+/area/ruin/lavaland/syndicate_lava_base/port)
 "VG" = (
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/stripes/closeup{
 	dir = 1
 	},
 /turf/open/floor/iron/techmaint,
-/area/ruin/unpowered/syndicate_lava_base/port)
+/area/ruin/lavaland/syndicate_lava_base/port)
 "VP" = (
 /obj/effect/spawner/structure/window/reinforced/plasma/plastitanium,
 /turf/open/floor/plating,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
+/area/ruin/lavaland/syndicate_lava_base/cargo)
 "VQ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/circuit/red,
-/area/ruin/unpowered/syndicate_lava_base/starboard)
+/area/ruin/lavaland/syndicate_lava_base/starboard)
 "VZ" = (
 /obj/effect/turf_decal/siding/dark{
 	dir = 5
@@ -4396,7 +4396,7 @@
 	},
 /obj/machinery/light/directional/north,
 /turf/open/floor/iron/dark/textured,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
+/area/ruin/lavaland/syndicate_lava_base/cargo)
 "Wj" = (
 /obj/effect/turf_decal/stripes/closeup,
 /obj/machinery/door/airlock/hatch{
@@ -4408,37 +4408,37 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /obj/structure/cable/yellow,
 /turf/open/floor/iron/techmaint,
-/area/ruin/unpowered/syndicate_lava_base/telecomms)
+/area/ruin/lavaland/syndicate_lava_base/telecomms)
 "Wk" = (
 /obj/structure/chair,
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
 	},
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/medbay)
+/area/ruin/lavaland/syndicate_lava_base/medbay)
 "Wo" = (
 /turf/closed/wall/mineral/plastitanium,
-/area/ruin/unpowered/syndicate_lava_base/brig)
+/area/ruin/lavaland/syndicate_lava_base/brig)
 "Wu" = (
 /obj/effect/mob_spawn/human/lavaland_syndicate/comms,
 /obj/effect/turf_decal/siding/wood{
 	dir = 6
 	},
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/dormitories)
+/area/ruin/lavaland/syndicate_lava_base/dormitories)
 "Wx" = (
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/stripes/closeup{
 	dir = 1
 	},
 /turf/open/floor/iron/techmaint,
-/area/ruin/unpowered/syndicate_lava_base/starboard)
+/area/ruin/lavaland/syndicate_lava_base/starboard)
 "WB" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/bridge)
+/area/ruin/lavaland/syndicate_lava_base/bridge)
 "WK" = (
 /obj/structure/closet/crate,
 /obj/item/extinguisher{
@@ -4477,7 +4477,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
+/area/ruin/lavaland/syndicate_lava_base/cargo)
 "WN" = (
 /obj/effect/turf_decal/stripes/closeup{
 	dir = 1
@@ -4493,7 +4493,7 @@
 	name = "Starboard Hall"
 	},
 /turf/open/floor/iron/techmaint,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
+/area/ruin/lavaland/syndicate_lava_base/cargo)
 "WP" = (
 /obj/structure/railing/corner{
 	dir = 1
@@ -4503,7 +4503,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /obj/structure/cable/yellow,
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/starboard)
+/area/ruin/lavaland/syndicate_lava_base/starboard)
 "WW" = (
 /obj/structure/rack{
 	dir = 8
@@ -4518,7 +4518,7 @@
 	},
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/medbay)
+/area/ruin/lavaland/syndicate_lava_base/medbay)
 "Xb" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/firstaid/toxin{
@@ -4534,7 +4534,7 @@
 	req_access_txt = "150"
 	},
 /turf/open/floor/iron/techmaint,
-/area/ruin/unpowered/syndicate_lava_base/medbay)
+/area/ruin/lavaland/syndicate_lava_base/medbay)
 "Xg" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
@@ -4545,7 +4545,7 @@
 	},
 /obj/item/hand_labeler,
 /turf/open/floor/iron/dark/textured,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
+/area/ruin/lavaland/syndicate_lava_base/cargo)
 "Xl" = (
 /obj/effect/turf_decal/stripes/closeup{
 	dir = 1
@@ -4557,7 +4557,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/iron/techmaint,
-/area/ruin/unpowered/syndicate_lava_base/dormitories)
+/area/ruin/lavaland/syndicate_lava_base/dormitories)
 "Xs" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 6
@@ -4565,17 +4565,17 @@
 /obj/machinery/photocopier,
 /obj/structure/extinguisher_cabinet/directional/south,
 /turf/open/floor/carpet/red,
-/area/ruin/unpowered/syndicate_lava_base/telecomms)
+/area/ruin/lavaland/syndicate_lava_base/telecomms)
 "Xx" = (
 /turf/closed/wall/mineral/plastitanium/explosive,
-/area/ruin/unpowered/syndicate_lava_base/chemistry)
+/area/ruin/lavaland/syndicate_lava_base/chemistry)
 "Xy" = (
 /obj/structure/closet/l3closet,
 /obj/effect/turf_decal/bot,
 /obj/machinery/light/small/directional/east,
 /obj/structure/extinguisher_cabinet/directional/east,
 /turf/open/floor/iron/white,
-/area/ruin/unpowered/syndicate_lava_base/virology)
+/area/ruin/lavaland/syndicate_lava_base/virology)
 "XE" = (
 /obj/item/kirbyplants/random,
 /obj/effect/turf_decal/trimline/red/filled/line{
@@ -4583,24 +4583,24 @@
 	},
 /obj/machinery/firealarm/directional/south,
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/bridge)
+/area/ruin/lavaland/syndicate_lava_base/bridge)
 "XG" = (
 /obj/machinery/firealarm/directional/north,
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/starboard)
+/area/ruin/lavaland/syndicate_lava_base/starboard)
 "XO" = (
 /obj/machinery/vending/boozeomat/syndicate_access,
 /turf/open/floor/iron/techmaint,
-/area/ruin/unpowered/syndicate_lava_base/bar)
+/area/ruin/lavaland/syndicate_lava_base/bar)
 "XV" = (
 /obj/machinery/vending/syndichem,
 /obj/machinery/firealarm/directional/south,
 /turf/open/floor/iron/white,
-/area/ruin/unpowered/syndicate_lava_base/chemistry)
+/area/ruin/lavaland/syndicate_lava_base/chemistry)
 "XX" = (
 /obj/machinery/door/poddoor/incinerator_syndicatelava_aux,
 /turf/open/floor/engine/vacuum,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/lavaland/syndicate_lava_base/engineering)
 "Ya" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/button/door{
@@ -4613,18 +4613,18 @@
 	specialfunctions = 4
 	},
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/starboard)
+/area/ruin/lavaland/syndicate_lava_base/starboard)
 "Yh" = (
 /obj/structure/rack,
 /obj/item/stack/sheet/iron/fifty,
 /obj/item/stack/sheet/glass/fifty,
 /obj/item/stack/sheet/mineral/copper/five,
 /turf/open/floor/iron/dark/textured,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
+/area/ruin/lavaland/syndicate_lava_base/cargo)
 "Yl" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/port)
+/area/ruin/lavaland/syndicate_lava_base/port)
 "Yn" = (
 /obj/structure/table/reinforced,
 /obj/machinery/cell_charger,
@@ -4632,13 +4632,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/iron/dark/textured,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
+/area/ruin/lavaland/syndicate_lava_base/cargo)
 "Yo" = (
 /obj/effect/turf_decal/trimline/red/filled/line,
 /obj/structure/cable/yellow,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/port)
+/area/ruin/lavaland/syndicate_lava_base/port)
 "Yp" = (
 /obj/effect/turf_decal/siding/dark{
 	dir = 4
@@ -4648,11 +4648,11 @@
 	},
 /obj/machinery/atmospherics/pipe/layer_manifold/visible,
 /turf/open/floor/iron/dark/textured,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/lavaland/syndicate_lava_base/engineering)
 "Yr" = (
 /obj/structure/chair/office,
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/telecomms)
+/area/ruin/lavaland/syndicate_lava_base/telecomms)
 "Yy" = (
 /obj/structure/window/reinforced/spawner/directional/north,
 /obj/effect/turf_decal/stripes/line{
@@ -4660,7 +4660,7 @@
 	},
 /obj/machinery/dna_scannernew,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/virology)
+/area/ruin/lavaland/syndicate_lava_base/virology)
 "YE" = (
 /obj/machinery/power/terminal{
 	dir = 1
@@ -4670,7 +4670,7 @@
 /obj/machinery/atmospherics/components/unary/portables_connector/layer4,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron/dark/smooth_large,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/lavaland/syndicate_lava_base/engineering)
 "YG" = (
 /obj/structure/chair/fancy/sofa/old/right{
 	color = "#742925";
@@ -4680,16 +4680,16 @@
 	dir = 5
 	},
 /turf/open/floor/carpet/red,
-/area/ruin/unpowered/syndicate_lava_base/bar)
+/area/ruin/lavaland/syndicate_lava_base/bar)
 "YL" = (
 /obj/machinery/porta_turret/syndicate{
 	dir = 5
 	},
 /turf/closed/wall/mineral/plastitanium,
-/area/ruin/unpowered/syndicate_lava_base/dormitories)
+/area/ruin/lavaland/syndicate_lava_base/dormitories)
 "YO" = (
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/lavaland/syndicate_lava_base/engineering)
 "YW" = (
 /obj/structure/table/wood,
 /obj/effect/turf_decal/siding/wood,
@@ -4698,33 +4698,33 @@
 	pixel_y = 6
 	},
 /turf/open/floor/carpet/red,
-/area/ruin/unpowered/syndicate_lava_base/bar)
+/area/ruin/lavaland/syndicate_lava_base/bar)
 "YZ" = (
 /obj/effect/decal/cleanable/blood/tracks{
 	dir = 10;
 	icon_state = "tracks"
 	},
 /turf/open/floor/plating,
-/area/ruin/unpowered/syndicate_lava_base/brig)
+/area/ruin/lavaland/syndicate_lava_base/brig)
 "Ze" = (
 /obj/structure/cable/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/catwalk_floor,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
+/area/ruin/lavaland/syndicate_lava_base/cargo)
 "Zh" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /obj/structure/cable/yellow,
 /turf/open/floor/wood,
-/area/ruin/unpowered/syndicate_lava_base/telecomms)
+/area/ruin/lavaland/syndicate_lava_base/telecomms)
 "Zi" = (
 /obj/machinery/atmospherics/components/trinary/mixer/airmix/layer2/flipped{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/catwalk_floor/iron_dark,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/lavaland/syndicate_lava_base/engineering)
 "Zj" = (
 /obj/structure/table/reinforced,
 /obj/item/suppressor,
@@ -4734,7 +4734,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron/techmaint,
-/area/ruin/unpowered/syndicate_lava_base/brig)
+/area/ruin/lavaland/syndicate_lava_base/brig)
 "Zl" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 4
@@ -4747,10 +4747,10 @@
 	pixel_x = 25
 	},
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/starboard)
+/area/ruin/lavaland/syndicate_lava_base/starboard)
 "Zo" = (
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
+/area/ruin/lavaland/syndicate_lava_base/cargo)
 "Zq" = (
 /obj/effect/turf_decal/stripes/closeup{
 	dir = 1
@@ -4766,13 +4766,13 @@
 	name = "Starboard Hall"
 	},
 /turf/open/floor/iron/techmaint,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
+/area/ruin/lavaland/syndicate_lava_base/cargo)
 "Zv" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/bot,
 /obj/machinery/portable_thermomachine,
 /turf/open/floor/iron/dark/smooth_large,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/lavaland/syndicate_lava_base/engineering)
 "Zz" = (
 /obj/structure/closet/crate,
 /obj/item/malf_upgrade,
@@ -4783,14 +4783,14 @@
 	dir = 10
 	},
 /turf/open/floor/iron/dark/textured,
-/area/ruin/unpowered/syndicate_lava_base/starboard)
+/area/ruin/lavaland/syndicate_lava_base/starboard)
 "ZC" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 4
 	},
 /obj/structure/cable/yellow,
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/starboard)
+/area/ruin/lavaland/syndicate_lava_base/starboard)
 "ZH" = (
 /obj/structure/cable/yellow,
 /obj/effect/turf_decal/siding/dark{
@@ -4800,11 +4800,11 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark/textured,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/lavaland/syndicate_lava_base/engineering)
 "ZK" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible/layer2,
 /turf/open/floor/catwalk_floor/iron_dark,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/lavaland/syndicate_lava_base/engineering)
 "ZN" = (
 /obj/effect/turf_decal/stripes/closeup,
 /obj/machinery/door/firedoor,
@@ -4813,7 +4813,7 @@
 	},
 /obj/effect/mapping_helpers/airlock/access/all/syndicate/general,
 /turf/open/floor/iron/techmaint,
-/area/ruin/unpowered/syndicate_lava_base/brig)
+/area/ruin/lavaland/syndicate_lava_base/brig)
 "ZQ" = (
 /obj/structure/table/wood,
 /obj/machinery/chem_dispenser/drinks/beer/fullupgrade{
@@ -4822,7 +4822,7 @@
 /obj/effect/turf_decal/tile/bar/opposingcorners,
 /obj/machinery/firealarm/directional/south,
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/bar)
+/area/ruin/lavaland/syndicate_lava_base/bar)
 
 (1,1,1) = {"
 hK

--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_syndicate_base2.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_syndicate_base2.dmm
@@ -3,7 +3,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/iron/dark/smooth_large,
-/area/ruin/lavaland/syndicate_lava_base/engineering)
+/area/ruin/syndicate_lava_base)
 "am" = (
 /obj/structure/lattice/catwalk,
 /obj/item/toy/plush/lizard_plushie{
@@ -30,7 +30,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/iron/techmaint,
-/area/ruin/lavaland/syndicate_lava_base/bridge)
+/area/ruin/syndicate_lava_base)
 "az" = (
 /obj/structure/lattice/catwalk,
 /turf/open/lava/smooth/lava_land_surface,
@@ -40,28 +40,28 @@
 /obj/effect/turf_decal/siding/dark,
 /obj/effect/turf_decal/trimline/red/line,
 /turf/open/floor/iron/dark/textured,
-/area/ruin/lavaland/syndicate_lava_base/engineering)
+/area/ruin/syndicate_lava_base)
 "aG" = (
 /obj/structure/cable/yellow,
 /obj/machinery/firealarm/directional/west,
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/starboard)
+/area/ruin/syndicate_lava_base)
 "aI" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
 	},
 /turf/open/floor/carpet/red,
-/area/ruin/lavaland/syndicate_lava_base/telecomms)
+/area/ruin/syndicate_lava_base)
 "aL" = (
 /obj/structure/flora/tree/jungle/small,
 /obj/structure/flora/rock/jungle,
 /turf/open/floor/grass/no_border,
-/area/ruin/lavaland/syndicate_lava_base/port)
+/area/ruin/syndicate_lava_base)
 "aN" = (
 /obj/machinery/power/apc/syndicate/directional/west,
 /obj/structure/cable/yellow,
 /turf/open/floor/catwalk_floor,
-/area/ruin/lavaland/syndicate_lava_base/starboard)
+/area/ruin/syndicate_lava_base)
 "aS" = (
 /obj/effect/turf_decal/stripes/closeup{
 	dir = 1
@@ -73,7 +73,7 @@
 	},
 /obj/structure/fans/tiny/invisible,
 /turf/open/floor/iron/techmaint,
-/area/ruin/lavaland/syndicate_lava_base/cargo)
+/area/ruin/syndicate_lava_base)
 "aT" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 5
@@ -82,7 +82,7 @@
 	desc = "This might be the only player that ever uses the chameleon stamp unironically (unless they immediately fax CC calling them stupid)"
 	},
 /turf/open/floor/carpet/red,
-/area/ruin/lavaland/syndicate_lava_base/telecomms)
+/area/ruin/syndicate_lava_base)
 "aV" = (
 /obj/structure/table/reinforced,
 /obj/structure/window/reinforced/spawner/directional/east,
@@ -100,18 +100,18 @@
 	dir = 8
 	},
 /turf/open/floor/iron/techmaint,
-/area/ruin/lavaland/syndicate_lava_base/chemistry)
+/area/ruin/syndicate_lava_base)
 "aX" = (
 /obj/effect/spawner/structure/window/reinforced/plasma/plastitanium,
 /obj/machinery/door/poddoor/preopen{
 	id = "lavalandsyndi_hall"
 	},
 /turf/open/floor/plating,
-/area/ruin/lavaland/syndicate_lava_base/cargo)
+/area/ruin/syndicate_lava_base)
 "aZ" = (
 /obj/effect/spawner/structure/window/reinforced/plasma/plastitanium,
 /turf/open/floor/plating,
-/area/ruin/lavaland/syndicate_lava_base/virology)
+/area/ruin/syndicate_lava_base)
 "ba" = (
 /obj/structure/closet/secure_closet/medical1{
 	req_access = null;
@@ -121,19 +121,19 @@
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/ruin/lavaland/syndicate_lava_base/medbay)
+/area/ruin/syndicate_lava_base)
 "bd" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/cargo)
+/area/ruin/syndicate_lava_base)
 "bf" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/iron/white,
-/area/ruin/lavaland/syndicate_lava_base/virology)
+/area/ruin/syndicate_lava_base)
 "bl" = (
 /obj/structure/table/wood,
 /obj/machinery/fax{
@@ -144,10 +144,10 @@
 /obj/machinery/airalarm/directional/east,
 /obj/effect/mapping_helpers/airalarm/syndicate_access,
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/telecomms)
+/area/ruin/syndicate_lava_base)
 "bw" = (
 /turf/closed/wall/mineral/plastitanium/explosive,
-/area/ruin/lavaland/syndicate_lava_base/medbay)
+/area/ruin/syndicate_lava_base)
 "bx" = (
 /obj/structure/chair/office{
 	dir = 1
@@ -161,13 +161,13 @@
 	pixel_y = 25
 	},
 /turf/open/floor/iron/dark/smooth_large,
-/area/ruin/lavaland/syndicate_lava_base/brig)
+/area/ruin/syndicate_lava_base)
 "bA" = (
 /obj/machinery/light/small{
 	dir = 8
 	},
 /turf/open/floor/catwalk_floor,
-/area/ruin/lavaland/syndicate_lava_base/starboard)
+/area/ruin/syndicate_lava_base)
 "bB" = (
 /obj/effect/turf_decal/siding/dark{
 	dir = 6
@@ -176,23 +176,23 @@
 	dir = 6
 	},
 /turf/open/floor/iron/dark/textured,
-/area/ruin/lavaland/syndicate_lava_base/engineering)
+/area/ruin/syndicate_lava_base)
 "bC" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /obj/structure/cable/yellow,
 /turf/open/floor/catwalk_floor/iron_dark,
-/area/ruin/lavaland/syndicate_lava_base/port)
+/area/ruin/syndicate_lava_base)
 "bT" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/portable_thermomachine,
 /turf/open/floor/iron/dark/smooth_large,
-/area/ruin/lavaland/syndicate_lava_base/engineering)
+/area/ruin/syndicate_lava_base)
 "bV" = (
 /obj/structure/table/optable,
 /obj/item/surgical_drapes,
 /turf/open/floor/iron,
-/area/ruin/lavaland/syndicate_lava_base/medbay)
+/area/ruin/syndicate_lava_base)
 "bX" = (
 /obj/effect/turf_decal/stripes/closeup{
 	dir = 1
@@ -202,7 +202,7 @@
 	},
 /obj/structure/fans/tiny/invisible,
 /turf/open/floor/iron/techmaint,
-/area/ruin/lavaland/syndicate_lava_base/cargo)
+/area/ruin/syndicate_lava_base)
 "bY" = (
 /obj/effect/turf_decal/siding/dark{
 	dir = 10
@@ -212,10 +212,10 @@
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
 /turf/open/floor/iron/dark/textured,
-/area/ruin/lavaland/syndicate_lava_base/engineering)
+/area/ruin/syndicate_lava_base)
 "cb" = (
 /turf/closed/wall/mineral/plastitanium,
-/area/ruin/lavaland/syndicate_lava_base/port)
+/area/ruin/syndicate_lava_base)
 "cd" = (
 /obj/machinery/computer/shuttle_flight{
 	desc = "Occasionally used to call in a resupply shuttle if one is in range.";
@@ -231,7 +231,7 @@
 /obj/machinery/light/directional/south,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/cargo)
+/area/ruin/syndicate_lava_base)
 "cf" = (
 /obj/structure/table/wood,
 /obj/effect/turf_decal/tile/neutral/opposingcorners,
@@ -242,14 +242,14 @@
 	pixel_y = 6
 	},
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/bar)
+/area/ruin/syndicate_lava_base)
 "cg" = (
 /obj/structure/fluff/hedge,
 /obj/effect/turf_decal/siding/dark/end{
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/medbay)
+/area/ruin/syndicate_lava_base)
 "ch" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 4
@@ -258,13 +258,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/cargo)
+/area/ruin/syndicate_lava_base)
 "cy" = (
 /obj/machinery/porta_turret/syndicate{
 	dir = 5
 	},
 /turf/closed/wall/mineral/plastitanium,
-/area/ruin/lavaland/syndicate_lava_base/brig)
+/area/ruin/syndicate_lava_base)
 "cA" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 8
@@ -273,24 +273,24 @@
 	dir = 4
 	},
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/medbay)
+/area/ruin/syndicate_lava_base)
 "cI" = (
 /obj/structure/table/wood,
 /obj/machinery/light/small/directional/north,
 /obj/item/storage/toolbox/syndicate,
 /turf/open/floor/wood,
-/area/ruin/lavaland/syndicate_lava_base/dormitories)
+/area/ruin/syndicate_lava_base)
 "cJ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /obj/structure/cable/yellow,
 /turf/open/floor/wood,
-/area/ruin/lavaland/syndicate_lava_base/bar)
+/area/ruin/syndicate_lava_base)
 "cO" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/backpack/duffelbag/med/surgery,
 /turf/open/floor/iron,
-/area/ruin/lavaland/syndicate_lava_base/medbay)
+/area/ruin/syndicate_lava_base)
 "cT" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 8
@@ -299,13 +299,13 @@
 	dir = 4
 	},
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/medbay)
+/area/ruin/syndicate_lava_base)
 "cU" = (
 /obj/machinery/porta_turret/syndicate{
 	dir = 9
 	},
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
-/area/ruin/lavaland/syndicate_lava_base/chemistry)
+/area/ruin/syndicate_lava_base)
 "cV" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/toolbox/syndicate,
@@ -315,7 +315,7 @@
 	},
 /obj/machinery/light/small/directional/south,
 /turf/open/floor/iron/dark/textured,
-/area/ruin/lavaland/syndicate_lava_base/telecomms)
+/area/ruin/syndicate_lava_base)
 "dc" = (
 /obj/machinery/computer/message_monitor{
 	dir = 4
@@ -331,12 +331,12 @@
 	pixel_y = 6
 	},
 /turf/open/floor/carpet/red,
-/area/ruin/lavaland/syndicate_lava_base/telecomms)
+/area/ruin/syndicate_lava_base)
 "dh" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/yellow,
 /turf/open/floor/catwalk_floor,
-/area/ruin/lavaland/syndicate_lava_base/starboard)
+/area/ruin/syndicate_lava_base)
 "dk" = (
 /obj/structure/table/wood,
 /obj/item/paper_bin{
@@ -353,13 +353,13 @@
 	pixel_y = 10
 	},
 /turf/open/floor/carpet/red,
-/area/ruin/lavaland/syndicate_lava_base/telecomms)
+/area/ruin/syndicate_lava_base)
 "dl" = (
 /turf/open/floor/wood,
-/area/ruin/lavaland/syndicate_lava_base/telecomms)
+/area/ruin/syndicate_lava_base)
 "dq" = (
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
-/area/ruin/lavaland/syndicate_lava_base/virology)
+/area/ruin/syndicate_lava_base)
 "ds" = (
 /obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/locked,
@@ -370,33 +370,33 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/engine,
-/area/ruin/lavaland/syndicate_lava_base/engineering)
+/area/ruin/syndicate_lava_base)
 "dB" = (
 /obj/machinery/porta_turret/syndicate{
 	dir = 6
 	},
 /turf/closed/wall/mineral/plastitanium,
-/area/ruin/lavaland/syndicate_lava_base/engineering)
+/area/ruin/syndicate_lava_base)
 "dE" = (
 /obj/machinery/atmospherics/pipe/layer_manifold{
 	dir = 4
 	},
 /obj/effect/spawner/structure/window/reinforced/plasma/plastitanium,
 /turf/open/floor/plating,
-/area/ruin/lavaland/syndicate_lava_base/engineering)
+/area/ruin/syndicate_lava_base)
 "dK" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/medbay)
+/area/ruin/syndicate_lava_base)
 "dN" = (
 /obj/machinery/porta_turret/syndicate{
 	dir = 10
 	},
 /turf/closed/wall/mineral/plastitanium,
-/area/ruin/lavaland/syndicate_lava_base/engineering)
+/area/ruin/syndicate_lava_base)
 "dO" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/on/layer4{
 	dir = 8;
@@ -404,12 +404,12 @@
 	},
 /obj/effect/mapping_helpers/no_lava,
 /turf/open/floor/plating,
-/area/ruin/lavaland/syndicate_lava_base/engineering)
+/area/ruin/syndicate_lava_base)
 "dP" = (
 /obj/machinery/airalarm/directional/east,
 /obj/effect/mapping_helpers/airalarm/syndicate_access,
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/port)
+/area/ruin/syndicate_lava_base)
 "dY" = (
 /obj/effect/turf_decal/stripes/closeup{
 	dir = 1
@@ -422,19 +422,19 @@
 	name = "Port Hall"
 	},
 /turf/open/floor/iron/techmaint,
-/area/ruin/lavaland/syndicate_lava_base/medbay)
+/area/ruin/syndicate_lava_base)
 "dZ" = (
 /obj/structure/closet/crate,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/cargo)
+/area/ruin/syndicate_lava_base)
 "ed" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 4
 	},
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/starboard)
+/area/ruin/syndicate_lava_base)
 "ee" = (
 /obj/structure/chair/fancy/sofa/old/right{
 	color = "#742925";
@@ -444,20 +444,20 @@
 	dir = 10
 	},
 /turf/open/floor/carpet/red,
-/area/ruin/lavaland/syndicate_lava_base/bar)
+/area/ruin/syndicate_lava_base)
 "ei" = (
 /obj/machinery/atmospherics/miner/oxygen,
 /obj/machinery/light/small{
 	dir = 4
 	},
 /turf/open/floor/engine/o2,
-/area/ruin/lavaland/syndicate_lava_base/engineering)
+/area/ruin/syndicate_lava_base)
 "el" = (
 /obj/effect/turf_decal/tile/bar/opposingcorners,
 /obj/machinery/light/cold/directional/south,
 /obj/machinery/vending/dinnerware,
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/bar)
+/area/ruin/syndicate_lava_base)
 "en" = (
 /obj/effect/turf_decal/box/white/corners{
 	dir = 8
@@ -488,7 +488,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/cargo)
+/area/ruin/syndicate_lava_base)
 "es" = (
 /obj/item/reagent_containers/condiment/enzyme,
 /obj/item/food/chocolatebar,
@@ -498,7 +498,7 @@
 	req_access = null
 	},
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/bar)
+/area/ruin/syndicate_lava_base)
 "eA" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 9
@@ -506,7 +506,7 @@
 /obj/structure/closet/crate/bin,
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/cargo)
+/area/ruin/syndicate_lava_base)
 "eH" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -515,31 +515,31 @@
 	dir = 4
 	},
 /turf/open/floor/engine,
-/area/ruin/lavaland/syndicate_lava_base/engineering)
+/area/ruin/syndicate_lava_base)
 "eJ" = (
 /obj/structure/reagent_dispensers/fueltank,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
-/area/ruin/lavaland/syndicate_lava_base/starboard)
+/area/ruin/syndicate_lava_base)
 "eL" = (
 /obj/effect/turf_decal/trimline/red/filled/corner{
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/port)
+/area/ruin/syndicate_lava_base)
 "eM" = (
 /obj/machinery/chem_dispenser/fullupgrade,
 /obj/machinery/airalarm/directional/north,
 /obj/effect/mapping_helpers/airalarm/syndicate_access,
 /turf/open/floor/iron,
-/area/ruin/lavaland/syndicate_lava_base/chemistry)
+/area/ruin/syndicate_lava_base)
 "eN" = (
 /obj/effect/turf_decal/siding/dark{
 	dir = 10
 	},
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/bridge)
+/area/ruin/syndicate_lava_base)
 "eT" = (
 /obj/effect/turf_decal/stripes/closeup,
 /obj/machinery/door/firedoor,
@@ -551,7 +551,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /obj/structure/cable/yellow,
 /turf/open/floor/iron/techmaint,
-/area/ruin/lavaland/syndicate_lava_base/medbay)
+/area/ruin/syndicate_lava_base)
 "eU" = (
 /obj/structure/chair/office/light{
 	dir = 4
@@ -560,31 +560,31 @@
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/ruin/lavaland/syndicate_lava_base/virology)
+/area/ruin/syndicate_lava_base)
 "fk" = (
 /obj/effect/turf_decal/stripes/closeup{
 	dir = 1
 	},
 /obj/structure/fans/tiny/invisible,
 /turf/open/floor/iron/techmaint,
-/area/ruin/lavaland/syndicate_lava_base/cargo)
+/area/ruin/syndicate_lava_base)
 "fs" = (
 /obj/structure/cable/yellow,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/starboard)
+/area/ruin/syndicate_lava_base)
 "fw" = (
 /obj/effect/turf_decal/tile/neutral/opposingcorners,
 /obj/machinery/griddle,
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/bar)
+/area/ruin/syndicate_lava_base)
 "fA" = (
 /obj/machinery/atmospherics/components/trinary/mixer{
 	dir = 8
 	},
 /turf/open/floor/catwalk_floor/iron_dark,
-/area/ruin/lavaland/syndicate_lava_base/engineering)
+/area/ruin/syndicate_lava_base)
 "fB" = (
 /obj/machinery/power/terminal{
 	dir = 1
@@ -596,7 +596,7 @@
 /obj/machinery/atmospherics/components/unary/portables_connector/layer4,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron/dark/smooth_large,
-/area/ruin/lavaland/syndicate_lava_base/engineering)
+/area/ruin/syndicate_lava_base)
 "fP" = (
 /obj/structure/railing{
 	dir = 1
@@ -605,7 +605,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /obj/structure/cable/yellow,
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/port)
+/area/ruin/syndicate_lava_base)
 "fQ" = (
 /obj/effect/turf_decal/stripes/closeup{
 	dir = 1
@@ -615,19 +615,19 @@
 /obj/effect/mapping_helpers/airlock/access/all/syndicate/general,
 /obj/structure/cable/yellow,
 /turf/open/floor/iron/techmaint,
-/area/ruin/lavaland/syndicate_lava_base/starboard)
+/area/ruin/syndicate_lava_base)
 "fT" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /obj/structure/cable/yellow,
 /turf/open/floor/iron/white,
-/area/ruin/lavaland/syndicate_lava_base/medbay)
+/area/ruin/syndicate_lava_base)
 "gg" = (
 /turf/open/floor/circuit/red,
-/area/ruin/lavaland/syndicate_lava_base/starboard)
+/area/ruin/syndicate_lava_base)
 "go" = (
 /turf/open/floor/plating,
-/area/ruin/lavaland/syndicate_lava_base/medbay)
+/area/ruin/syndicate_lava_base)
 "gs" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 8
@@ -635,7 +635,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/firealarm/directional/west,
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/port)
+/area/ruin/syndicate_lava_base)
 "gJ" = (
 /obj/machinery/sleeper/syndie{
 	dir = 8
@@ -643,7 +643,7 @@
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
-/area/ruin/lavaland/syndicate_lava_base/medbay)
+/area/ruin/syndicate_lava_base)
 "gL" = (
 /obj/structure/closet/secure_closet/medical2{
 	req_access = null
@@ -654,13 +654,13 @@
 /obj/machinery/airalarm/directional/east,
 /obj/effect/mapping_helpers/airalarm/syndicate_access,
 /turf/open/floor/iron,
-/area/ruin/lavaland/syndicate_lava_base/medbay)
+/area/ruin/syndicate_lava_base)
 "gM" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 8
 	},
 /turf/open/floor/iron/white,
-/area/ruin/lavaland/syndicate_lava_base/virology)
+/area/ruin/syndicate_lava_base)
 "gN" = (
 /obj/effect/turf_decal/stripes/closeup,
 /obj/machinery/door/airlock/hatch{
@@ -669,7 +669,7 @@
 /obj/effect/mapping_helpers/airlock/access/all/syndicate/general,
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron/techmaint,
-/area/ruin/lavaland/syndicate_lava_base/telecomms)
+/area/ruin/syndicate_lava_base)
 "gQ" = (
 /mob/living/carbon/monkey{
 	faction = list("neutral","Syndicate")
@@ -681,11 +681,11 @@
 	dir = 5
 	},
 /turf/open/floor/iron,
-/area/ruin/lavaland/syndicate_lava_base/virology)
+/area/ruin/syndicate_lava_base)
 "gT" = (
 /obj/effect/turf_decal/siding/dark,
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/bridge)
+/area/ruin/syndicate_lava_base)
 "gZ" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -694,7 +694,7 @@
 	pixel_x = -32
 	},
 /turf/open/floor/plating,
-/area/ruin/lavaland/syndicate_lava_base/cargo)
+/area/ruin/syndicate_lava_base)
 "ha" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 8
@@ -705,25 +705,25 @@
 /obj/structure/cable/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /turf/open/floor/wood,
-/area/ruin/lavaland/syndicate_lava_base/dormitories)
+/area/ruin/syndicate_lava_base)
 "hb" = (
 /obj/effect/spawner/structure/window/reinforced/plasma/plastitanium,
 /obj/machinery/door/poddoor/preopen{
 	id = "lavalandsyndi_bridge"
 	},
 /turf/open/floor/plating,
-/area/ruin/lavaland/syndicate_lava_base/bridge)
+/area/ruin/syndicate_lava_base)
 "hd" = (
 /obj/machinery/chem_heater,
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron,
-/area/ruin/lavaland/syndicate_lava_base/chemistry)
+/area/ruin/syndicate_lava_base)
 "hm" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
 	},
 /turf/open/floor/wood,
-/area/ruin/lavaland/syndicate_lava_base/bar)
+/area/ruin/syndicate_lava_base)
 "hr" = (
 /obj/effect/turf_decal/stripes/closeup{
 	dir = 1
@@ -734,7 +734,7 @@
 	},
 /obj/structure/fans/tiny/invisible,
 /turf/open/floor/iron/techmaint,
-/area/ruin/lavaland/syndicate_lava_base/cargo)
+/area/ruin/syndicate_lava_base)
 "hB" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
@@ -743,7 +743,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /obj/structure/cable/yellow,
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/cargo)
+/area/ruin/syndicate_lava_base)
 "hF" = (
 /obj/structure/table/reinforced,
 /obj/item/reagent_containers/cup/bottle/cyanide{
@@ -756,7 +756,7 @@
 /obj/item/reagent_containers/syringe,
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/iron/dark/smooth_large,
-/area/ruin/lavaland/syndicate_lava_base/brig)
+/area/ruin/syndicate_lava_base)
 "hK" = (
 /turf/template_noop,
 /area/template_noop)
@@ -769,7 +769,7 @@
 	},
 /obj/effect/turf_decal/stripes/closeup,
 /turf/open/floor/iron/techmaint,
-/area/ruin/lavaland/syndicate_lava_base/bar)
+/area/ruin/syndicate_lava_base)
 "hN" = (
 /obj/effect/turf_decal/siding/dark{
 	dir = 1
@@ -779,14 +779,14 @@
 	},
 /obj/structure/cable/yellow,
 /turf/open/floor/iron/dark/textured,
-/area/ruin/lavaland/syndicate_lava_base/cargo)
+/area/ruin/syndicate_lava_base)
 "hR" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "lavalandsyndi_med"
 	},
 /obj/effect/spawner/structure/window/reinforced/plasma/plastitanium,
 /turf/open/floor/plating,
-/area/ruin/lavaland/syndicate_lava_base/medbay)
+/area/ruin/syndicate_lava_base)
 "ij" = (
 /obj/effect/turf_decal/siding/dark{
 	dir = 4
@@ -798,13 +798,13 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark/textured,
-/area/ruin/lavaland/syndicate_lava_base/engineering)
+/area/ruin/syndicate_lava_base)
 "ix" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /obj/item/kirbyplants/random,
 /turf/open/floor/iron/white,
-/area/ruin/lavaland/syndicate_lava_base/virology)
+/area/ruin/syndicate_lava_base)
 "iy" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
@@ -816,39 +816,39 @@
 	},
 /obj/structure/cable/yellow,
 /turf/open/floor/iron/dark/textured,
-/area/ruin/lavaland/syndicate_lava_base/brig)
+/area/ruin/syndicate_lava_base)
 "iE" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/catwalk_floor/iron_dark,
-/area/ruin/lavaland/syndicate_lava_base/starboard)
+/area/ruin/syndicate_lava_base)
 "iG" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/starboard)
+/area/ruin/syndicate_lava_base)
 "iO" = (
 /obj/structure/railing/corner{
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/starboard)
+/area/ruin/syndicate_lava_base)
 "iS" = (
 /obj/structure/cable/yellow,
 /turf/open/floor/iron/dark/textured,
-/area/ruin/lavaland/syndicate_lava_base/engineering)
+/area/ruin/syndicate_lava_base)
 "iZ" = (
 /obj/effect/decal/cleanable/blood/splatter,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
-/area/ruin/lavaland/syndicate_lava_base/brig)
+/area/ruin/syndicate_lava_base)
 "ja" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 4
 	},
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/port)
+/area/ruin/syndicate_lava_base)
 "jb" = (
 /obj/effect/turf_decal/box/white/corners{
 	dir = 4
@@ -867,26 +867,23 @@
 	pixel_x = 2
 	},
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/cargo)
+/area/ruin/syndicate_lava_base)
 "jd" = (
 /obj/machinery/power/apc/syndicate/directional/north,
 /obj/structure/cable/yellow,
 /turf/open/floor/iron/white,
-/area/ruin/lavaland/syndicate_lava_base/virology)
-"jg" = (
-/turf/closed/wall/mineral/plastitanium/nodiagonal,
-/area/ruin/lavaland/syndicate_lava_base/port)
+/area/ruin/syndicate_lava_base)
 "jm" = (
 /obj/machinery/shower{
 	dir = 1
 	},
 /obj/structure/curtain,
 /turf/open/floor/iron/white/textured,
-/area/ruin/lavaland/syndicate_lava_base/port)
+/area/ruin/syndicate_lava_base)
 "jn" = (
 /obj/machinery/air_sensor,
 /turf/open/floor/engine/plasma,
-/area/ruin/lavaland/syndicate_lava_base/engineering)
+/area/ruin/syndicate_lava_base)
 "js" = (
 /obj/structure/reagent_dispensers/watertank,
 /obj/effect/decal/cleanable/dirt,
@@ -894,21 +891,21 @@
 /obj/item/mop,
 /obj/item/reagent_containers/cup/bucket,
 /turf/open/floor/plating,
-/area/ruin/lavaland/syndicate_lava_base/starboard)
+/area/ruin/syndicate_lava_base)
 "jw" = (
 /obj/machinery/atmospherics/miner/plasma,
 /obj/machinery/light/small{
 	dir = 4
 	},
 /turf/open/floor/engine/plasma,
-/area/ruin/lavaland/syndicate_lava_base/engineering)
+/area/ruin/syndicate_lava_base)
 "jH" = (
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/stripes/closeup,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/iron/techmaint,
-/area/ruin/lavaland/syndicate_lava_base/starboard)
+/area/ruin/syndicate_lava_base)
 "jL" = (
 /obj/effect/turf_decal/stripes/closeup{
 	dir = 1
@@ -921,7 +918,7 @@
 	name = "Starboard Hall"
 	},
 /turf/open/floor/iron/techmaint,
-/area/ruin/lavaland/syndicate_lava_base/cargo)
+/area/ruin/syndicate_lava_base)
 "kd" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
@@ -932,13 +929,13 @@
 	dir = 5
 	},
 /turf/open/floor/iron/dark/textured,
-/area/ruin/lavaland/syndicate_lava_base/brig)
+/area/ruin/syndicate_lava_base)
 "kj" = (
 /obj/machinery/portable_atmospherics/canister,
 /obj/effect/turf_decal/bot,
 /obj/machinery/light/small/directional/east,
 /turf/open/floor/catwalk_floor/iron_dark,
-/area/ruin/lavaland/syndicate_lava_base/engineering)
+/area/ruin/syndicate_lava_base)
 "kp" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -953,7 +950,7 @@
 	dir = 4
 	},
 /turf/open/floor/engine,
-/area/ruin/lavaland/syndicate_lava_base/engineering)
+/area/ruin/syndicate_lava_base)
 "kz" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/railing{
@@ -983,7 +980,7 @@
 	dir = 1
 	},
 /turf/open/floor/engine,
-/area/ruin/lavaland/syndicate_lava_base/engineering)
+/area/ruin/syndicate_lava_base)
 "kR" = (
 /obj/effect/turf_decal/tile/neutral/opposingcorners,
 /obj/structure/table/wood,
@@ -991,13 +988,13 @@
 	dir = 1
 	},
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/bar)
+/area/ruin/syndicate_lava_base)
 "kY" = (
 /obj/machinery/light/small/directional/east,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/iron/dark/smooth_large,
-/area/ruin/lavaland/syndicate_lava_base/engineering)
+/area/ruin/syndicate_lava_base)
 "kZ" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/components/binary/dp_vent_pump/high_volume/incinerator_syndicatelava{
@@ -1006,7 +1003,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /turf/open/floor/engine,
-/area/ruin/lavaland/syndicate_lava_base/engineering)
+/area/ruin/syndicate_lava_base)
 "la" = (
 /obj/structure/cable/yellow,
 /obj/structure/table/reinforced,
@@ -1023,15 +1020,7 @@
 	},
 /obj/item/circuitboard/machine/thermomachine,
 /turf/open/floor/iron/dark/textured,
-/area/ruin/lavaland/syndicate_lava_base/engineering)
-"ld" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
-/turf/open/floor/iron/white,
-/area/ruin/lavaland/syndicate_lava_base/medbay)
-"le" = (
-/turf/closed/wall/mineral/plastitanium/nodiagonal,
-/area/ruin/lavaland/syndicate_lava_base/telecomms)
+/area/ruin/syndicate_lava_base)
 "li" = (
 /obj/effect/turf_decal/tile/bar/opposingcorners,
 /obj/structure/table,
@@ -1040,18 +1029,18 @@
 	pixel_x = 7
 	},
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/bar)
+/area/ruin/syndicate_lava_base)
 "lk" = (
 /obj/effect/turf_decal/stripes/closeup,
 /obj/machinery/door/airlock/maintenance,
 /obj/effect/mapping_helpers/airlock/access/all/syndicate/general,
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron/techmaint,
-/area/ruin/lavaland/syndicate_lava_base/starboard)
+/area/ruin/syndicate_lava_base)
 "ln" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/starboard)
+/area/ruin/syndicate_lava_base)
 "lo" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -1059,7 +1048,7 @@
 /obj/machinery/dna_scannernew,
 /obj/structure/window/reinforced/spawner/directional/north,
 /turf/open/floor/iron,
-/area/ruin/lavaland/syndicate_lava_base/virology)
+/area/ruin/syndicate_lava_base)
 "lr" = (
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/stripes/closeup{
@@ -1067,7 +1056,7 @@
 	},
 /obj/structure/cable/yellow,
 /turf/open/floor/iron/techmaint,
-/area/ruin/lavaland/syndicate_lava_base/port)
+/area/ruin/syndicate_lava_base)
 "lw" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
@@ -1075,7 +1064,7 @@
 /obj/machinery/power/apc/syndicate/directional/north,
 /obj/structure/cable/yellow,
 /turf/open/floor/wood,
-/area/ruin/lavaland/syndicate_lava_base/bar)
+/area/ruin/syndicate_lava_base)
 "lA" = (
 /obj/structure/closet/crate,
 /obj/item/storage/box/donkpockets{
@@ -1090,7 +1079,7 @@
 	},
 /obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/cargo)
+/area/ruin/syndicate_lava_base)
 "lB" = (
 /obj/effect/turf_decal/trimline/red/filled/corner{
 	dir = 4
@@ -1100,12 +1089,12 @@
 /obj/structure/cable/yellow,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/starboard)
+/area/ruin/syndicate_lava_base)
 "lG" = (
 /obj/effect/turf_decal/trimline/red/filled/line,
 /obj/structure/cable/yellow,
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/port)
+/area/ruin/syndicate_lava_base)
 "lH" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
@@ -1115,7 +1104,7 @@
 /obj/structure/cable/yellow,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/medbay)
+/area/ruin/syndicate_lava_base)
 "lI" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
@@ -1124,7 +1113,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /obj/structure/cable/yellow,
 /turf/open/floor/wood,
-/area/ruin/lavaland/syndicate_lava_base/bar)
+/area/ruin/syndicate_lava_base)
 "lJ" = (
 /obj/structure/table/reinforced,
 /obj/item/clothing/suit/hazardvest,
@@ -1135,7 +1124,7 @@
 	pixel_x = -8
 	},
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/cargo)
+/area/ruin/syndicate_lava_base)
 "lK" = (
 /obj/effect/turf_decal/stripes/closeup,
 /obj/machinery/door/firedoor,
@@ -1147,7 +1136,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /obj/structure/cable/yellow,
 /turf/open/floor/iron/techmaint,
-/area/ruin/lavaland/syndicate_lava_base/medbay)
+/area/ruin/syndicate_lava_base)
 "lL" = (
 /obj/structure/table/glass,
 /obj/item/stack/sheet/mineral/plasma{
@@ -1169,31 +1158,31 @@
 	},
 /obj/item/reagent_containers/cup/bottle/epinephrine,
 /turf/open/floor/iron/white,
-/area/ruin/lavaland/syndicate_lava_base/chemistry)
+/area/ruin/syndicate_lava_base)
 "lU" = (
 /obj/item/kirbyplants/random,
 /obj/structure/cable/yellow,
 /obj/machinery/firealarm/directional/east,
 /obj/machinery/power/apc/syndicate/directional/north,
 /turf/open/floor/wood,
-/area/ruin/lavaland/syndicate_lava_base/telecomms)
+/area/ruin/syndicate_lava_base)
 "lV" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /obj/structure/cable/yellow,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood,
-/area/ruin/lavaland/syndicate_lava_base/bar)
+/area/ruin/syndicate_lava_base)
 "lY" = (
 /obj/effect/turf_decal/trimline/red/filled/line,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /obj/structure/cable/yellow,
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/port)
+/area/ruin/syndicate_lava_base)
 "me" = (
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/cargo)
+/area/ruin/syndicate_lava_base)
 "mf" = (
 /obj/structure/rack{
 	dir = 8
@@ -1206,7 +1195,7 @@
 /obj/item/stock_parts/cell/high/plus,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
-/area/ruin/lavaland/syndicate_lava_base/starboard)
+/area/ruin/syndicate_lava_base)
 "mi" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
@@ -1220,21 +1209,21 @@
 /obj/machinery/airalarm/directional/west,
 /obj/effect/mapping_helpers/airalarm/syndicate_access,
 /turf/open/floor/iron/dark/textured,
-/area/ruin/lavaland/syndicate_lava_base/brig)
+/area/ruin/syndicate_lava_base)
 "mj" = (
 /obj/machinery/light/floor,
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/cargo)
+/area/ruin/syndicate_lava_base)
 "mn" = (
 /turf/open/floor/engine/plasma,
-/area/ruin/lavaland/syndicate_lava_base/engineering)
+/area/ruin/syndicate_lava_base)
 "mo" = (
 /obj/machinery/vending/cigarette/syndicate,
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 9
 	},
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/port)
+/area/ruin/syndicate_lava_base)
 "mq" = (
 /obj/structure/bed/roller,
 /obj/machinery/iv_drip,
@@ -1242,23 +1231,23 @@
 /obj/machinery/light/cold/directional/east,
 /obj/machinery/firealarm/directional/east,
 /turf/open/floor/iron,
-/area/ruin/lavaland/syndicate_lava_base/medbay)
+/area/ruin/syndicate_lava_base)
 "mr" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},
 /turf/open/floor/iron,
-/area/ruin/lavaland/syndicate_lava_base/virology)
+/area/ruin/syndicate_lava_base)
 "ms" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /obj/structure/cable/yellow,
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/starboard)
+/area/ruin/syndicate_lava_base)
 "mv" = (
 /obj/structure/extinguisher_cabinet/directional/east,
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/port)
+/area/ruin/syndicate_lava_base)
 "mx" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/railing{
@@ -1282,7 +1271,7 @@
 	pixel_x = 8
 	},
 /turf/open/floor/iron/dark/smooth_large,
-/area/ruin/lavaland/syndicate_lava_base/brig)
+/area/ruin/syndicate_lava_base)
 "mE" = (
 /obj/structure/table/reinforced,
 /obj/item/paper_bin,
@@ -1292,22 +1281,22 @@
 	pixel_x = 10
 	},
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/brig)
+/area/ruin/syndicate_lava_base)
 "mH" = (
 /obj/structure/cable/yellow,
 /turf/open/floor/iron/white,
-/area/ruin/lavaland/syndicate_lava_base/medbay)
+/area/ruin/syndicate_lava_base)
 "mO" = (
 /obj/structure/sign/warning/fire,
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
-/area/ruin/lavaland/syndicate_lava_base/engineering)
+/area/ruin/syndicate_lava_base)
 "mP" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 4
 	},
 /obj/effect/decal/cleanable/oil,
 /turf/open/floor/iron/white,
-/area/ruin/lavaland/syndicate_lava_base/chemistry)
+/area/ruin/syndicate_lava_base)
 "mS" = (
 /obj/structure/window/reinforced/spawner/directional/south,
 /obj/structure/table/reinforced,
@@ -1320,13 +1309,7 @@
 	pixel_y = 8
 	},
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/telecomms)
-"mU" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
-/turf/open/floor/iron,
-/area/ruin/lavaland/syndicate_lava_base/chemistry)
+/area/ruin/syndicate_lava_base)
 "mY" = (
 /obj/structure/chair/office{
 	dir = 1
@@ -1346,7 +1329,7 @@
 	pixel_x = 30
 	},
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/bridge)
+/area/ruin/syndicate_lava_base)
 "nb" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 5
@@ -1356,10 +1339,10 @@
 	},
 /obj/machinery/firealarm/directional/north,
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/cargo)
+/area/ruin/syndicate_lava_base)
 "nc" = (
 /turf/open/floor/engine/vacuum,
-/area/ruin/lavaland/syndicate_lava_base/engineering)
+/area/ruin/syndicate_lava_base)
 "ny" = (
 /obj/effect/turf_decal/stripes/closeup,
 /obj/machinery/door/firedoor,
@@ -1371,30 +1354,24 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /obj/structure/cable/yellow,
 /turf/open/floor/iron/techmaint,
-/area/ruin/lavaland/syndicate_lava_base/chemistry)
+/area/ruin/syndicate_lava_base)
 "nz" = (
 /obj/structure/closet/crate/freezer/blood,
 /obj/machinery/power/apc/syndicate/directional/east,
 /obj/structure/cable/yellow,
 /turf/open/floor/iron/white,
-/area/ruin/lavaland/syndicate_lava_base/medbay)
+/area/ruin/syndicate_lava_base)
 "nG" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /obj/machinery/power/apc/syndicate/directional/east,
 /obj/structure/cable/yellow,
 /turf/open/floor/iron/white,
-/area/ruin/lavaland/syndicate_lava_base/chemistry)
+/area/ruin/syndicate_lava_base)
 "nM" = (
 /obj/structure/chair/stool/bar/directional/south,
 /turf/open/floor/wood,
-/area/ruin/lavaland/syndicate_lava_base/bar)
-"nO" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
-/obj/structure/cable/yellow,
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/ruin/lavaland/syndicate_lava_base/starboard)
+/area/ruin/syndicate_lava_base)
 "nQ" = (
 /mob/living/carbon/monkey{
 	faction = list("neutral","Syndicate")
@@ -1402,48 +1379,43 @@
 /obj/machinery/light/small/directional/south,
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron,
-/area/ruin/lavaland/syndicate_lava_base/virology)
-"nU" = (
-/obj/effect/turf_decal/trimline/red/filled/line,
-/obj/structure/cable/yellow,
-/turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/starboard)
+/area/ruin/syndicate_lava_base)
 "nY" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 8
 	},
 /turf/open/floor/wood,
-/area/ruin/lavaland/syndicate_lava_base/telecomms)
+/area/ruin/syndicate_lava_base)
 "oi" = (
 /obj/machinery/sleeper/syndie{
 	dir = 8
 	},
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
-/area/ruin/lavaland/syndicate_lava_base/medbay)
+/area/ruin/syndicate_lava_base)
 "on" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /obj/structure/cable/yellow,
 /obj/structure/extinguisher_cabinet/directional/south,
 /turf/open/floor/iron/white,
-/area/ruin/lavaland/syndicate_lava_base/medbay)
+/area/ruin/syndicate_lava_base)
 "or" = (
 /obj/structure/bed,
 /obj/item/bedsheet,
 /obj/machinery/light/small/directional/east,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/brig)
+/area/ruin/syndicate_lava_base)
 "oy" = (
 /obj/machinery/light/small{
 	dir = 1
 	},
 /turf/open/floor/iron/showroomfloor,
-/area/ruin/lavaland/syndicate_lava_base/port)
+/area/ruin/syndicate_lava_base)
 "oz" = (
 /turf/open/floor/iron/white,
-/area/ruin/lavaland/syndicate_lava_base/virology)
+/area/ruin/syndicate_lava_base)
 "oB" = (
 /obj/structure/closet/crate/bin,
 /obj/effect/turf_decal/trimline/red/filled/line{
@@ -1451,7 +1423,7 @@
 	},
 /obj/machinery/firealarm/directional/north,
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/starboard)
+/area/ruin/syndicate_lava_base)
 "oG" = (
 /obj/effect/turf_decal/trimline/red/filled/corner{
 	dir = 4
@@ -1460,7 +1432,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /obj/structure/cable/yellow,
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/medbay)
+/area/ruin/syndicate_lava_base)
 "oH" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/belt/utility/full{
@@ -1476,45 +1448,33 @@
 	pixel_x = 5
 	},
 /turf/open/floor/catwalk_floor/iron_dark,
-/area/ruin/lavaland/syndicate_lava_base/engineering)
+/area/ruin/syndicate_lava_base)
 "oJ" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 1
 	},
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/cargo)
-"oL" = (
-/obj/machinery/porta_turret/syndicate{
-	dir = 10
-	},
-/turf/closed/wall/mineral/plastitanium,
-/area/ruin/lavaland/syndicate_lava_base/virology)
-"oM" = (
-/obj/machinery/porta_turret/syndicate{
-	dir = 10
-	},
-/turf/closed/wall/mineral/plastitanium,
-/area/ruin/lavaland/syndicate_lava_base/chemistry)
+/area/ruin/syndicate_lava_base)
 "oP" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
 	},
 /obj/machinery/light/cold/directional/south,
 /turf/open/floor/wood,
-/area/ruin/lavaland/syndicate_lava_base/bar)
+/area/ruin/syndicate_lava_base)
 "oX" = (
 /obj/machinery/power/terminal{
 	dir = 1
 	},
 /obj/structure/cable/yellow,
 /turf/open/floor/catwalk_floor,
-/area/ruin/lavaland/syndicate_lava_base/cargo)
+/area/ruin/syndicate_lava_base)
 "pf" = (
 /obj/structure/sign/warning/fire{
 	pixel_x = 32
 	},
 /turf/open/floor/plating,
-/area/ruin/lavaland/syndicate_lava_base/medbay)
+/area/ruin/syndicate_lava_base)
 "pg" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 8
@@ -1524,19 +1484,19 @@
 /obj/machinery/airalarm/directional/south,
 /obj/effect/mapping_helpers/airalarm/syndicate_access,
 /turf/open/floor/wood,
-/area/ruin/lavaland/syndicate_lava_base/dormitories)
+/area/ruin/syndicate_lava_base)
 "pk" = (
 /obj/machinery/computer/scan_consolenew{
 	dir = 8;
 	req_access = list(150)
 	},
 /turf/open/floor/iron,
-/area/ruin/lavaland/syndicate_lava_base/virology)
+/area/ruin/syndicate_lava_base)
 "pn" = (
 /obj/effect/turf_decal/trimline/red/filled/corner,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/medbay)
+/area/ruin/syndicate_lava_base)
 "pt" = (
 /obj/structure/chair,
 /obj/effect/turf_decal/trimline/red/filled/line{
@@ -1545,19 +1505,19 @@
 /obj/machinery/light/small/directional/north,
 /obj/machinery/firealarm/directional/east,
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/medbay)
+/area/ruin/syndicate_lava_base)
 "pu" = (
 /obj/machinery/atmospherics/components/binary/pump/on{
 	dir = 8
 	},
 /turf/open/floor/catwalk_floor/iron_dark,
-/area/ruin/lavaland/syndicate_lava_base/engineering)
+/area/ruin/syndicate_lava_base)
 "pw" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 1
 	},
 /turf/open/floor/catwalk_floor,
-/area/ruin/lavaland/syndicate_lava_base/cargo)
+/area/ruin/syndicate_lava_base)
 "px" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 8
@@ -1569,7 +1529,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/dark/textured,
-/area/ruin/lavaland/syndicate_lava_base/brig)
+/area/ruin/syndicate_lava_base)
 "pz" = (
 /obj/structure/table/wood,
 /obj/effect/turf_decal/siding/wood{
@@ -1586,7 +1546,7 @@
 	pixel_y = -6
 	},
 /turf/open/floor/carpet/red,
-/area/ruin/lavaland/syndicate_lava_base/telecomms)
+/area/ruin/syndicate_lava_base)
 "pB" = (
 /obj/structure/table/wood,
 /obj/effect/turf_decal/siding/wood{
@@ -1601,7 +1561,7 @@
 	pixel_x = 4
 	},
 /turf/open/floor/carpet/red,
-/area/ruin/lavaland/syndicate_lava_base/bar)
+/area/ruin/syndicate_lava_base)
 "pJ" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 8
@@ -1614,16 +1574,10 @@
 	pixel_x = -25
 	},
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/port)
+/area/ruin/syndicate_lava_base)
 "pU" = (
 /turf/open/floor/catwalk_floor,
-/area/ruin/lavaland/syndicate_lava_base/starboard)
-"qe" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
-/obj/structure/cable/yellow,
-/turf/open/floor/iron/white,
-/area/ruin/lavaland/syndicate_lava_base/virology)
+/area/ruin/syndicate_lava_base)
 "qk" = (
 /obj/structure/railing{
 	dir = 1
@@ -1639,20 +1593,20 @@
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/ruin/lavaland/syndicate_lava_base/virology)
+/area/ruin/syndicate_lava_base)
 "qA" = (
 /obj/effect/turf_decal/trimline/red/filled/corner{
 	dir = 8
 	},
 /obj/structure/cable/yellow,
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/bridge)
+/area/ruin/syndicate_lava_base)
 "qB" = (
 /obj/machinery/light/small{
 	dir = 4
 	},
 /turf/open/floor/iron/showroomfloor,
-/area/ruin/lavaland/syndicate_lava_base/port)
+/area/ruin/syndicate_lava_base)
 "qE" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/on{
 	dir = 8;
@@ -1660,12 +1614,12 @@
 	name = "toxin out"
 	},
 /turf/open/floor/engine/plasma,
-/area/ruin/lavaland/syndicate_lava_base/engineering)
+/area/ruin/syndicate_lava_base)
 "qK" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/floor,
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/medbay)
+/area/ruin/syndicate_lava_base)
 "qL" = (
 /obj/effect/turf_decal/siding/dark{
 	dir = 4
@@ -1675,7 +1629,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible/layer2,
 /turf/open/floor/iron/dark/textured,
-/area/ruin/lavaland/syndicate_lava_base/engineering)
+/area/ruin/syndicate_lava_base)
 "qM" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 1
@@ -1683,20 +1637,17 @@
 /obj/effect/turf_decal/siding/dark,
 /obj/effect/turf_decal/trimline/red/line,
 /turf/open/floor/iron/dark/textured,
-/area/ruin/lavaland/syndicate_lava_base/cargo)
+/area/ruin/syndicate_lava_base)
 "qT" = (
 /obj/structure/sink/directional/west,
 /obj/structure/mirror/directional/east,
 /turf/open/floor/iron/showroomfloor,
-/area/ruin/lavaland/syndicate_lava_base/port)
-"qX" = (
-/turf/closed/wall/mineral/plastitanium,
-/area/ruin/lavaland/syndicate_lava_base/cargo)
+/area/ruin/syndicate_lava_base)
 "rc" = (
 /obj/structure/chair/stool/bar/directional/south,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood,
-/area/ruin/lavaland/syndicate_lava_base/bar)
+/area/ruin/syndicate_lava_base)
 "rd" = (
 /obj/machinery/door/airlock/external,
 /obj/effect/mapping_helpers/airlock/access/all/syndicate/general,
@@ -1708,36 +1659,36 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/iron/techmaint,
-/area/ruin/lavaland/syndicate_lava_base/cargo)
+/area/ruin/syndicate_lava_base)
 "re" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},
 /obj/structure/cable/yellow,
 /turf/open/floor/plating,
-/area/ruin/lavaland/syndicate_lava_base/engineering)
+/area/ruin/syndicate_lava_base)
 "rq" = (
 /obj/structure/chair/stool/bar/directional/south,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 1
 	},
 /turf/open/floor/wood,
-/area/ruin/lavaland/syndicate_lava_base/bar)
+/area/ruin/syndicate_lava_base)
 "ru" = (
 /obj/machinery/air_sensor,
 /turf/open/floor/engine/n2,
-/area/ruin/lavaland/syndicate_lava_base/engineering)
+/area/ruin/syndicate_lava_base)
 "rw" = (
 /obj/machinery/computer/monitor/secret,
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/bridge)
+/area/ruin/syndicate_lava_base)
 "ry" = (
 /obj/structure/cable/orange,
 /obj/effect/mapping_helpers/Mapper_Comment{
 	desc = "These tinyfans are a cope because holofields dont spawn until after roundstart which meant this bay always started depressurised. If that ever gets fixed remind me to remove these."
 	},
 /turf/open/floor/catwalk_floor,
-/area/ruin/lavaland/syndicate_lava_base/cargo)
+/area/ruin/syndicate_lava_base)
 "rB" = (
 /mob/living/carbon/monkey{
 	faction = list("neutral","Syndicate")
@@ -1749,81 +1700,60 @@
 	dir = 9
 	},
 /turf/open/floor/iron,
-/area/ruin/lavaland/syndicate_lava_base/virology)
+/area/ruin/syndicate_lava_base)
 "rC" = (
 /obj/effect/turf_decal/trimline/red/filled/line,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/firealarm/directional/south,
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/medbay)
+/area/ruin/syndicate_lava_base)
 "rF" = (
 /obj/machinery/light/directional/north,
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/starboard)
+/area/ruin/syndicate_lava_base)
 "rG" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/open/floor/grass/no_border,
-/area/ruin/lavaland/syndicate_lava_base/port)
+/area/ruin/syndicate_lava_base)
 "rJ" = (
 /obj/machinery/computer/atmos_control{
 	name = "Nitrogen Supply Control"
 	},
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/iron/dark/smooth_large,
-/area/ruin/lavaland/syndicate_lava_base/engineering)
+/area/ruin/syndicate_lava_base)
 "rS" = (
 /obj/structure/table/reinforced,
 /obj/structure/window/reinforced/spawner/directional/west,
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/bridge)
-"rY" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
-/obj/structure/cable/yellow,
-/turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/medbay)
+/area/ruin/syndicate_lava_base)
 "sa" = (
 /obj/structure/cable/yellow,
 /obj/machinery/firealarm/directional/west,
 /turf/open/floor/wood,
-/area/ruin/lavaland/syndicate_lava_base/bar)
+/area/ruin/syndicate_lava_base)
 "sd" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/starboard)
-"sk" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
-/obj/structure/cable/yellow,
-/turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/port)
+/area/ruin/syndicate_lava_base)
 "sx" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 6
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/cargo)
-"sA" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
-/obj/structure/cable/yellow,
-/turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/medbay)
+/area/ruin/syndicate_lava_base)
 "sC" = (
 /obj/effect/turf_decal/trimline/red/filled/corner,
 /obj/structure/cable/yellow,
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/starboard)
+/area/ruin/syndicate_lava_base)
 "sD" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
 /turf/open/floor/iron/white,
-/area/ruin/lavaland/syndicate_lava_base/medbay)
+/area/ruin/syndicate_lava_base)
 "sH" = (
 /obj/effect/turf_decal/stripes/closeup,
 /obj/machinery/door/airlock/engineering{
@@ -1833,7 +1763,7 @@
 /obj/machinery/door/firedoor,
 /obj/structure/cable/yellow,
 /turf/open/floor/iron/techmaint,
-/area/ruin/lavaland/syndicate_lava_base/engineering)
+/area/ruin/syndicate_lava_base)
 "sO" = (
 /obj/structure/table/wood,
 /obj/effect/turf_decal/siding/wood{
@@ -1842,12 +1772,12 @@
 /obj/effect/turf_decal/tile/bar/opposingcorners,
 /obj/item/food/syndicake,
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/bar)
+/area/ruin/syndicate_lava_base)
 "sR" = (
 /obj/effect/turf_decal/trimline/red/filled/line,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/cargo)
+/area/ruin/syndicate_lava_base)
 "sT" = (
 /obj/structure/table/wood,
 /obj/effect/turf_decal/siding/wood{
@@ -1855,7 +1785,7 @@
 	},
 /obj/item/folder/syndicate/blue,
 /turf/open/floor/carpet/red,
-/area/ruin/lavaland/syndicate_lava_base/telecomms)
+/area/ruin/syndicate_lava_base)
 "sU" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 8
@@ -1876,10 +1806,10 @@
 	specialfunctions = 4
 	},
 /turf/open/floor/iron/dark/textured,
-/area/ruin/lavaland/syndicate_lava_base/starboard)
+/area/ruin/syndicate_lava_base)
 "to" = (
 /turf/open/floor/engine/o2,
-/area/ruin/lavaland/syndicate_lava_base/engineering)
+/area/ruin/syndicate_lava_base)
 "tC" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 4
@@ -1887,7 +1817,7 @@
 /obj/machinery/airalarm/directional/south,
 /obj/effect/mapping_helpers/airalarm/syndicate_access,
 /turf/open/floor/wood,
-/area/ruin/lavaland/syndicate_lava_base/dormitories)
+/area/ruin/syndicate_lava_base)
 "tJ" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 8
@@ -1895,14 +1825,14 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/port)
+/area/ruin/syndicate_lava_base)
 "tK" = (
 /obj/structure/cable/yellow,
 /obj/machinery/firealarm/directional/west,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/catwalk_floor/iron_dark,
-/area/ruin/lavaland/syndicate_lava_base/engineering)
+/area/ruin/syndicate_lava_base)
 "tL" = (
 /obj/effect/turf_decal/stripes/closeup{
 	dir = 1
@@ -1915,14 +1845,14 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /obj/structure/cable/yellow,
 /turf/open/floor/iron/techmaint,
-/area/ruin/lavaland/syndicate_lava_base/dormitories)
+/area/ruin/syndicate_lava_base)
 "ub" = (
 /obj/structure/railing{
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/starboard)
+/area/ruin/syndicate_lava_base)
 "ug" = (
 /obj/effect/turf_decal/siding/dark{
 	dir = 1
@@ -1933,17 +1863,14 @@
 /obj/machinery/power/apc/syndicate/directional/north,
 /obj/structure/cable/yellow,
 /turf/open/floor/iron/dark/textured,
-/area/ruin/lavaland/syndicate_lava_base/cargo)
-"uj" = (
-/turf/closed/wall/mineral/plastitanium/explosive,
-/area/ruin/lavaland/syndicate_lava_base/bar)
+/area/ruin/syndicate_lava_base)
 "ul" = (
 /obj/effect/spawner/structure/window/reinforced/plasma/plastitanium,
 /obj/machinery/door/poddoor{
 	id = "lavalandsyndi_chemistry"
 	},
 /turf/open/floor/plating,
-/area/ruin/lavaland/syndicate_lava_base/chemistry)
+/area/ruin/syndicate_lava_base)
 "up" = (
 /obj/structure/shuttle/engine/large,
 /turf/open/lava/smooth/lava_land_surface,
@@ -1955,36 +1882,29 @@
 /obj/machinery/power/smes/engineering,
 /obj/structure/cable/yellow,
 /turf/open/floor/plating,
-/area/ruin/lavaland/syndicate_lava_base/engineering)
+/area/ruin/syndicate_lava_base)
 "ur" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
-/area/ruin/lavaland/syndicate_lava_base/starboard)
+/area/ruin/syndicate_lava_base)
 "ux" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/catwalk_floor/iron_dark,
-/area/ruin/lavaland/syndicate_lava_base/starboard)
-"uC" = (
-/turf/closed/wall/mineral/plastitanium/nodiagonal,
-/area/ruin/lavaland/syndicate_lava_base/bar)
+/area/ruin/syndicate_lava_base)
 "uP" = (
 /obj/structure/cable/yellow,
 /obj/machinery/power/apc/syndicate/directional/east,
 /turf/open/floor/catwalk_floor/iron_dark,
-/area/ruin/lavaland/syndicate_lava_base/engineering)
-"uT" = (
-/obj/effect/spawner/structure/window/reinforced/plasma/plastitanium,
-/turf/open/floor/plating,
-/area/ruin/lavaland/syndicate_lava_base/telecomms)
+/area/ruin/syndicate_lava_base)
 "uY" = (
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/stripes/closeup,
 /turf/open/floor/iron/techmaint,
-/area/ruin/lavaland/syndicate_lava_base/starboard)
+/area/ruin/syndicate_lava_base)
 "vd" = (
 /obj/structure/table/reinforced,
 /obj/structure/window/reinforced/spawner/directional/east,
@@ -1992,7 +1912,7 @@
 /obj/item/pen,
 /obj/item/stamp/syndicate,
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/bridge)
+/area/ruin/syndicate_lava_base)
 "vg" = (
 /obj/effect/turf_decal/box/white/corners,
 /obj/structure/closet/crate/medical,
@@ -2007,41 +1927,34 @@
 	},
 /obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/cargo)
+/area/ruin/syndicate_lava_base)
 "vh" = (
 /obj/structure/cable,
 /obj/machinery/power/turbine/lavaland{
 	luminosity = 2
 	},
 /turf/open/floor/engine/vacuum,
-/area/ruin/lavaland/syndicate_lava_base/engineering)
-"vs" = (
-/obj/effect/spawner/structure/window/reinforced/plasma/plastitanium,
-/obj/machinery/door/poddoor/preopen{
-	id = "lavalandsyndi_hall"
-	},
-/turf/open/floor/plating,
-/area/ruin/lavaland/syndicate_lava_base/dormitories)
+/area/ruin/syndicate_lava_base)
 "vA" = (
 /obj/effect/spawner/structure/window/reinforced/plasma/plastitanium,
 /obj/machinery/door/poddoor/preopen{
 	id = "lavalandsyndi_brig"
 	},
 /turf/open/floor/plating,
-/area/ruin/lavaland/syndicate_lava_base/brig)
+/area/ruin/syndicate_lava_base)
 "vB" = (
 /obj/effect/turf_decal/trimline/red/filled/line,
 /obj/structure/cable/yellow,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/starboard)
+/area/ruin/syndicate_lava_base)
 "vM" = (
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/stripes/closeup{
 	dir = 1
 	},
 /turf/open/floor/iron/techmaint,
-/area/ruin/lavaland/syndicate_lava_base/bar)
+/area/ruin/syndicate_lava_base)
 "vN" = (
 /obj/machinery/computer/atmos_control{
 	dir = 8;
@@ -2049,7 +1962,7 @@
 	},
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/iron/dark/smooth_large,
-/area/ruin/lavaland/syndicate_lava_base/engineering)
+/area/ruin/syndicate_lava_base)
 "vX" = (
 /obj/effect/turf_decal/stripes/closeup{
 	dir = 1
@@ -2065,22 +1978,19 @@
 	name = "Port Hall"
 	},
 /turf/open/floor/iron/techmaint,
-/area/ruin/lavaland/syndicate_lava_base/medbay)
+/area/ruin/syndicate_lava_base)
 "wc" = (
 /obj/structure/cable,
 /obj/machinery/igniter/incinerator_syndicatelava,
 /turf/open/floor/engine/vacuum,
-/area/ruin/lavaland/syndicate_lava_base/engineering)
+/area/ruin/syndicate_lava_base)
 "wg" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
 	},
 /obj/structure/extinguisher_cabinet/directional/north,
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/port)
-"wj" = (
-/turf/closed/wall/mineral/plastitanium,
-/area/ruin/lavaland/syndicate_lava_base/starboard)
+/area/ruin/syndicate_lava_base)
 "wl" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
@@ -2088,12 +1998,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron,
-/area/ruin/lavaland/syndicate_lava_base/virology)
-"wq" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/stripes/closeup,
-/turf/open/floor/iron/techmaint,
-/area/ruin/lavaland/syndicate_lava_base/port)
+/area/ruin/syndicate_lava_base)
 "wr" = (
 /obj/structure/chair/office{
 	dir = 1
@@ -2101,7 +2006,7 @@
 /obj/effect/turf_decal/siding/dark,
 /obj/effect/turf_decal/trimline/dark_red,
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/bridge)
+/area/ruin/syndicate_lava_base)
 "wv" = (
 /obj/effect/turf_decal/stripes/closeup,
 /obj/machinery/door/firedoor,
@@ -2112,7 +2017,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/iron/techmaint,
-/area/ruin/lavaland/syndicate_lava_base/engineering)
+/area/ruin/syndicate_lava_base)
 "ww" = (
 /obj/machinery/button/door/incinerator_vent_syndicatelava_main{
 	pixel_x = 6;
@@ -2126,7 +2031,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/catwalk_floor/iron_dark,
-/area/ruin/lavaland/syndicate_lava_base/engineering)
+/area/ruin/syndicate_lava_base)
 "wx" = (
 /obj/machinery/computer/atmos_control{
 	dir = 8;
@@ -2134,7 +2039,7 @@
 	},
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/iron/dark/smooth_large,
-/area/ruin/lavaland/syndicate_lava_base/engineering)
+/area/ruin/syndicate_lava_base)
 "wz" = (
 /obj/effect/turf_decal/box/white/corners{
 	dir = 1
@@ -2157,7 +2062,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/cargo)
+/area/ruin/syndicate_lava_base)
 "wE" = (
 /obj/structure/shuttle/engine/huge,
 /turf/open/lava/smooth/lava_land_surface,
@@ -2169,13 +2074,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/starboard)
+/area/ruin/syndicate_lava_base)
 "wL" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},
 /turf/open/floor/iron,
-/area/ruin/lavaland/syndicate_lava_base/virology)
+/area/ruin/syndicate_lava_base)
 "wU" = (
 /obj/machinery/door/airlock/external,
 /obj/effect/mapping_helpers/airlock/access/all/syndicate/general,
@@ -2183,51 +2088,43 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /obj/effect/turf_decal/stripes/closeup,
 /turf/open/floor/iron/techmaint,
-/area/ruin/lavaland/syndicate_lava_base/cargo)
+/area/ruin/syndicate_lava_base)
 "wW" = (
 /obj/effect/turf_decal/tile/neutral/opposingcorners,
 /obj/machinery/processor,
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/bar)
+/area/ruin/syndicate_lava_base)
 "wY" = (
 /obj/effect/spawner/structure/window/reinforced/plasma/plastitanium,
 /obj/machinery/door/poddoor/preopen{
 	id = "lavalandsyndi_telecomms"
 	},
 /turf/open/floor/plating,
-/area/ruin/lavaland/syndicate_lava_base/telecomms)
+/area/ruin/syndicate_lava_base)
 "xj" = (
 /obj/structure/cable/yellow,
 /turf/open/floor/wood,
-/area/ruin/lavaland/syndicate_lava_base/bar)
+/area/ruin/syndicate_lava_base)
 "xk" = (
 /obj/structure/closet/crate/bin,
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 9
 	},
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/medbay)
+/area/ruin/syndicate_lava_base)
 "xl" = (
 /obj/structure/table/wood,
 /obj/item/toy/plush/nukeplushie,
 /obj/machinery/light/small/directional/north,
 /turf/open/floor/wood,
-/area/ruin/lavaland/syndicate_lava_base/dormitories)
+/area/ruin/syndicate_lava_base)
 "xm" = (
 /obj/structure/table/reinforced,
 /obj/effect/turf_decal/stripes/closeup{
 	dir = 1
 	},
 /turf/open/floor/iron/techmaint,
-/area/ruin/lavaland/syndicate_lava_base/brig)
-"xs" = (
-/obj/machinery/door/airlock/external,
-/obj/effect/mapping_helpers/airlock/access/all/syndicate/general,
-/obj/structure/fans/tiny,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/obj/effect/turf_decal/stripes/closeup,
-/turf/open/floor/iron/techmaint,
-/area/ruin/lavaland/syndicate_lava_base/medbay)
+/area/ruin/syndicate_lava_base)
 "xt" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/bot,
@@ -2236,7 +2133,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron/dark/smooth_large,
-/area/ruin/lavaland/syndicate_lava_base/engineering)
+/area/ruin/syndicate_lava_base)
 "xu" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/secure_closet/personal/empty{
@@ -2245,12 +2142,12 @@
 /obj/item/clothing/shoes/sneakers/orange,
 /obj/item/clothing/under/rank/prisoner,
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/brig)
+/area/ruin/syndicate_lava_base)
 "xy" = (
 /obj/effect/turf_decal/tile/neutral/opposingcorners,
 /obj/structure/table,
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/bar)
+/area/ruin/syndicate_lava_base)
 "xz" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/on{
 	dir = 8;
@@ -2258,7 +2155,7 @@
 	name = "nitrogen out"
 	},
 /turf/open/floor/engine/n2,
-/area/ruin/lavaland/syndicate_lava_base/engineering)
+/area/ruin/syndicate_lava_base)
 "xA" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
@@ -2269,24 +2166,18 @@
 	pixel_x = -32
 	},
 /turf/open/floor/plating,
-/area/ruin/lavaland/syndicate_lava_base/engineering)
-"xE" = (
-/obj/effect/turf_decal/trimline/red/filled/corner{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/cargo)
+/area/ruin/syndicate_lava_base)
 "xG" = (
 /obj/effect/turf_decal/trimline/red/filled/line,
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/medbay)
+/area/ruin/syndicate_lava_base)
 "xS" = (
 /obj/item/kirbyplants/random,
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 9
 	},
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/port)
+/area/ruin/syndicate_lava_base)
 "xU" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 4
@@ -2295,13 +2186,13 @@
 /obj/machinery/light/cold/directional/west,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/starboard)
+/area/ruin/syndicate_lava_base)
 "xX" = (
 /obj/effect/turf_decal/trimline/red/filled/corner,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/starboard)
+/area/ruin/syndicate_lava_base)
 "yd" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
 /obj/effect/turf_decal/siding/dark{
@@ -2313,7 +2204,7 @@
 /obj/structure/cable/yellow,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark/textured,
-/area/ruin/lavaland/syndicate_lava_base/cargo)
+/area/ruin/syndicate_lava_base)
 "yo" = (
 /obj/effect/turf_decal/trimline/red/filled/corner{
 	dir = 1
@@ -2322,7 +2213,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /obj/structure/cable/yellow,
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/port)
+/area/ruin/syndicate_lava_base)
 "ys" = (
 /obj/effect/turf_decal/stripes/closeup,
 /obj/machinery/door/firedoor,
@@ -2332,13 +2223,13 @@
 /obj/effect/mapping_helpers/airlock/access/all/syndicate/general,
 /obj/structure/cable/yellow,
 /turf/open/floor/iron/techmaint,
-/area/ruin/lavaland/syndicate_lava_base/bridge)
+/area/ruin/syndicate_lava_base)
 "yA" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
 /turf/open/floor/iron,
-/area/ruin/lavaland/syndicate_lava_base/virology)
+/area/ruin/syndicate_lava_base)
 "yJ" = (
 /obj/structure/table/reinforced,
 /obj/machinery/cell_charger,
@@ -2347,28 +2238,23 @@
 	pixel_y = 12
 	},
 /turf/open/floor/iron/dark/textured,
-/area/ruin/lavaland/syndicate_lava_base/engineering)
+/area/ruin/syndicate_lava_base)
 "yN" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/wood,
-/area/ruin/lavaland/syndicate_lava_base/bar)
-"yQ" = (
-/obj/effect/turf_decal/trimline/red/filled/line,
-/obj/structure/cable/yellow,
-/turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/bridge)
+/area/ruin/syndicate_lava_base)
 "zk" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 4
 	},
 /turf/open/floor/iron/white,
-/area/ruin/lavaland/syndicate_lava_base/chemistry)
+/area/ruin/syndicate_lava_base)
 "zp" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/firealarm/directional/north,
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/port)
+/area/ruin/syndicate_lava_base)
 "zq" = (
 /obj/effect/turf_decal/siding/dark{
 	dir = 8
@@ -2377,7 +2263,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark/textured,
-/area/ruin/lavaland/syndicate_lava_base/engineering)
+/area/ruin/syndicate_lava_base)
 "zs" = (
 /obj/effect/turf_decal/siding/dark{
 	dir = 9
@@ -2389,12 +2275,12 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark/textured,
-/area/ruin/lavaland/syndicate_lava_base/engineering)
+/area/ruin/syndicate_lava_base)
 "zC" = (
 /obj/machinery/vending/assist,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/cargo)
+/area/ruin/syndicate_lava_base)
 "zG" = (
 /obj/structure/railing{
 	dir = 4
@@ -2402,19 +2288,19 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/port)
+/area/ruin/syndicate_lava_base)
 "zR" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/bridge)
+/area/ruin/syndicate_lava_base)
 "zU" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 4
 	},
 /obj/structure/cable/yellow,
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/bridge)
+/area/ruin/syndicate_lava_base)
 "Ai" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/firstaid/brute{
@@ -2427,13 +2313,13 @@
 	},
 /obj/structure/window/reinforced/spawner/directional/south,
 /turf/open/floor/iron/techmaint,
-/area/ruin/lavaland/syndicate_lava_base/medbay)
+/area/ruin/syndicate_lava_base)
 "AE" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 6
 	},
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/starboard)
+/area/ruin/syndicate_lava_base)
 "AF" = (
 /obj/item/kirbyplants/random,
 /obj/effect/turf_decal/trimline/red/filled/line{
@@ -2441,7 +2327,7 @@
 	},
 /obj/structure/extinguisher_cabinet/directional/south,
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/bridge)
+/area/ruin/syndicate_lava_base)
 "AH" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 6
@@ -2449,21 +2335,13 @@
 /obj/structure/cable/yellow,
 /obj/structure/extinguisher_cabinet/directional/south,
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/starboard)
-"AI" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/stripes/closeup{
-	dir = 1
-	},
-/obj/structure/cable/yellow,
-/turf/open/floor/iron/techmaint,
-/area/ruin/lavaland/syndicate_lava_base/starboard)
+/area/ruin/syndicate_lava_base)
 "AR" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/catwalk_floor/iron_dark,
-/area/ruin/lavaland/syndicate_lava_base/engineering)
+/area/ruin/syndicate_lava_base)
 "AX" = (
 /obj/structure/chair{
 	dir = 1
@@ -2473,17 +2351,17 @@
 	},
 /obj/machinery/light/small/directional/south,
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/medbay)
+/area/ruin/syndicate_lava_base)
 "Bd" = (
 /turf/open/floor/engine/co2,
-/area/ruin/lavaland/syndicate_lava_base/engineering)
+/area/ruin/syndicate_lava_base)
 "Bg" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/cargo)
+/area/ruin/syndicate_lava_base)
 "Bl" = (
 /obj/effect/turf_decal/stripes/closeup,
 /obj/machinery/door/firedoor,
@@ -2495,7 +2373,7 @@
 	req_access_txt = "150"
 	},
 /turf/open/floor/iron/techmaint,
-/area/ruin/lavaland/syndicate_lava_base/cargo)
+/area/ruin/syndicate_lava_base)
 "Bo" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 8
@@ -2509,38 +2387,38 @@
 /obj/machinery/power/apc/syndicate/directional/east,
 /obj/structure/cable/yellow,
 /turf/open/floor/iron/dark/textured,
-/area/ruin/lavaland/syndicate_lava_base/brig)
+/area/ruin/syndicate_lava_base)
 "Bq" = (
 /obj/machinery/door/poddoor/incinerator_syndicatelava_main,
 /turf/open/floor/engine/vacuum,
-/area/ruin/lavaland/syndicate_lava_base/engineering)
+/area/ruin/syndicate_lava_base)
 "Bs" = (
 /obj/structure/closet/firecloset{
 	anchored = 1
 	},
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/cargo)
+/area/ruin/syndicate_lava_base)
 "Bt" = (
 /obj/machinery/porta_turret/syndicate{
 	dir = 6
 	},
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
-/area/ruin/lavaland/syndicate_lava_base/cargo)
+/area/ruin/syndicate_lava_base)
 "Bw" = (
 /obj/machinery/atmospherics/pipe/smart/simple/orange/hidden,
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
-/area/ruin/lavaland/syndicate_lava_base/engineering)
+/area/ruin/syndicate_lava_base)
 "BB" = (
 /obj/machinery/air_sensor,
 /turf/open/floor/engine/o2,
-/area/ruin/lavaland/syndicate_lava_base/engineering)
+/area/ruin/syndicate_lava_base)
 "BE" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/backpack/duffelbag/med/implant,
 /obj/structure/window/reinforced/spawner/directional/south,
 /turf/open/floor/iron/techmaint,
-/area/ruin/lavaland/syndicate_lava_base/medbay)
+/area/ruin/syndicate_lava_base)
 "BG" = (
 /obj/effect/turf_decal/trimline/red/filled/line,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
@@ -2548,7 +2426,7 @@
 /obj/structure/cable/yellow,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/medbay)
+/area/ruin/syndicate_lava_base)
 "BH" = (
 /obj/structure/filingcabinet/security{
 	pixel_x = 8
@@ -2557,13 +2435,13 @@
 	pixel_x = -8
 	},
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/telecomms)
+/area/ruin/syndicate_lava_base)
 "BI" = (
 /obj/machinery/porta_turret/syndicate{
 	dir = 9
 	},
 /turf/closed/wall/mineral/plastitanium,
-/area/ruin/lavaland/syndicate_lava_base/dormitories)
+/area/ruin/syndicate_lava_base)
 "Cc" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
@@ -2575,27 +2453,21 @@
 	},
 /obj/structure/cable/yellow,
 /turf/open/floor/iron/dark/textured,
-/area/ruin/lavaland/syndicate_lava_base/cargo)
-"Cg" = (
-/obj/structure/sign/warning/fire{
-	pixel_x = 32
-	},
-/turf/open/floor/plating,
-/area/ruin/lavaland/syndicate_lava_base/cargo)
+/area/ruin/syndicate_lava_base)
 "Co" = (
 /obj/structure/rack,
 /obj/item/storage/box/handcuffs,
 /turf/open/floor/iron/dark/smooth_large,
-/area/ruin/lavaland/syndicate_lava_base/brig)
+/area/ruin/syndicate_lava_base)
 "Cp" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
 /turf/open/floor/iron,
-/area/ruin/lavaland/syndicate_lava_base/virology)
+/area/ruin/syndicate_lava_base)
 "Ct" = (
 /turf/open/floor/carpet/red,
-/area/ruin/lavaland/syndicate_lava_base/telecomms)
+/area/ruin/syndicate_lava_base)
 "Cz" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/railing{
@@ -2611,10 +2483,7 @@
 	dir = 4
 	},
 /turf/open/floor/circuit/green,
-/area/ruin/lavaland/syndicate_lava_base/telecomms)
-"CG" = (
-/turf/closed/wall/mineral/plastitanium,
-/area/ruin/lavaland/syndicate_lava_base/virology)
+/area/ruin/syndicate_lava_base)
 "CH" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/railing{
@@ -2627,7 +2496,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /obj/machinery/firealarm/directional/south,
 /turf/open/floor/wood,
-/area/ruin/lavaland/syndicate_lava_base/dormitories)
+/area/ruin/syndicate_lava_base)
 "CJ" = (
 /obj/effect/turf_decal/tile/bar/opposingcorners,
 /obj/structure/table,
@@ -2635,16 +2504,13 @@
 	pixel_y = 5
 	},
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/bar)
+/area/ruin/syndicate_lava_base)
 "CO" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 1
 	},
 /turf/open/floor/wood,
-/area/ruin/lavaland/syndicate_lava_base/bar)
-"CP" = (
-/turf/open/floor/catwalk_floor,
-/area/ruin/lavaland/syndicate_lava_base/cargo)
+/area/ruin/syndicate_lava_base)
 "CR" = (
 /obj/structure/fluff/hedge,
 /obj/effect/turf_decal/siding/dark,
@@ -2652,7 +2518,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/medbay)
+/area/ruin/syndicate_lava_base)
 "CS" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/monitored{
 	dir = 1
@@ -2661,13 +2527,13 @@
 	pixel_y = -32
 	},
 /turf/open/floor/engine/vacuum,
-/area/ruin/lavaland/syndicate_lava_base/engineering)
+/area/ruin/syndicate_lava_base)
 "CT" = (
 /obj/structure/railing,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/port)
+/area/ruin/syndicate_lava_base)
 "Dc" = (
 /obj/effect/spawner/structure/window/reinforced/plasma/plastitanium,
 /obj/machinery/door/firedoor,
@@ -2675,7 +2541,7 @@
 	id = "lavalandsyndi_cargo"
 	},
 /turf/open/floor/plating,
-/area/ruin/lavaland/syndicate_lava_base/cargo)
+/area/ruin/syndicate_lava_base)
 "Dw" = (
 /obj/effect/turf_decal/siding/dark{
 	dir = 4
@@ -2684,7 +2550,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/dark/textured,
-/area/ruin/lavaland/syndicate_lava_base/cargo)
+/area/ruin/syndicate_lava_base)
 "Dy" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/railing{
@@ -2692,13 +2558,10 @@
 	},
 /turf/open/lava/smooth/lava_land_surface,
 /area/lavaland/surface/outdoors)
-"DA" = (
-/turf/closed/wall/mineral/plastitanium/nodiagonal,
-/area/ruin/lavaland/syndicate_lava_base/medbay)
 "DB" = (
 /obj/machinery/atmospherics/pipe/smart/simple/orange/visible,
 /turf/open/floor/iron/dark/textured,
-/area/ruin/lavaland/syndicate_lava_base/engineering)
+/area/ruin/syndicate_lava_base)
 "DG" = (
 /obj/effect/turf_decal/tile/bar/opposingcorners,
 /obj/machinery/airalarm/directional/south,
@@ -2707,12 +2570,12 @@
 	},
 /obj/effect/mapping_helpers/airalarm/syndicate_access,
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/bar)
+/area/ruin/syndicate_lava_base)
 "DO" = (
 /obj/machinery/airalarm/directional/west,
 /obj/effect/mapping_helpers/airalarm/syndicate_access,
 /turf/open/floor/circuit/red,
-/area/ruin/lavaland/syndicate_lava_base/starboard)
+/area/ruin/syndicate_lava_base)
 "DQ" = (
 /obj/structure/toilet{
 	dir = 4
@@ -2721,23 +2584,11 @@
 	desc = "Skibidi."
 	},
 /turf/open/floor/iron/showroomfloor,
-/area/ruin/lavaland/syndicate_lava_base/port)
+/area/ruin/syndicate_lava_base)
 "DS" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
-/area/ruin/lavaland/syndicate_lava_base/starboard)
-"DV" = (
-/turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/port)
-"Eg" = (
-/turf/open/floor/iron/white,
-/area/ruin/lavaland/syndicate_lava_base/medbay)
-"Eh" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 1
-	},
-/turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/medbay)
+/area/ruin/syndicate_lava_base)
 "Ei" = (
 /obj/structure/table/reinforced,
 /obj/structure/window/reinforced/spawner/directional/south,
@@ -2745,7 +2596,7 @@
 /obj/item/restraints/handcuffs,
 /obj/item/gun/syringe/syndicate,
 /turf/open/floor/iron,
-/area/ruin/lavaland/syndicate_lava_base/medbay)
+/area/ruin/syndicate_lava_base)
 "Ek" = (
 /obj/structure/table/glass,
 /obj/item/storage/box/beakers{
@@ -2759,12 +2610,12 @@
 	},
 /obj/item/storage/box/monkeycubes,
 /turf/open/floor/iron/white,
-/area/ruin/lavaland/syndicate_lava_base/virology)
+/area/ruin/syndicate_lava_base)
 "Eo" = (
 /obj/effect/turf_decal/tile/bar/opposingcorners,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/bar)
+/area/ruin/syndicate_lava_base)
 "Ep" = (
 /obj/effect/turf_decal/siding/dark{
 	dir = 8
@@ -2774,13 +2625,13 @@
 	},
 /obj/machinery/smartfridge/chemistry/preloaded,
 /turf/open/floor/iron/techmaint,
-/area/ruin/lavaland/syndicate_lava_base/chemistry)
+/area/ruin/syndicate_lava_base)
 "Er" = (
 /obj/structure/chair/office{
 	dir = 1
 	},
 /turf/open/floor/carpet/red,
-/area/ruin/lavaland/syndicate_lava_base/telecomms)
+/area/ruin/syndicate_lava_base)
 "Ev" = (
 /obj/effect/turf_decal/siding/dark{
 	dir = 4
@@ -2790,38 +2641,29 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark/textured,
-/area/ruin/lavaland/syndicate_lava_base/brig)
+/area/ruin/syndicate_lava_base)
 "Ex" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
-/area/ruin/lavaland/syndicate_lava_base/engineering)
-"EA" = (
-/turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/bridge)
-"ED" = (
-/turf/closed/wall/mineral/plastitanium/nodiagonal,
-/area/ruin/lavaland/syndicate_lava_base/chemistry)
+/area/ruin/syndicate_lava_base)
 "EM" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/cargo)
-"EN" = (
-/turf/closed/wall/mineral/plastitanium/explosive,
-/area/ruin/lavaland/syndicate_lava_base/port)
+/area/ruin/syndicate_lava_base)
 "EP" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/catwalk_floor,
-/area/ruin/lavaland/syndicate_lava_base/cargo)
+/area/ruin/syndicate_lava_base)
 "EQ" = (
 /obj/machinery/vending/medical/syndicate_access,
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/ruin/lavaland/syndicate_lava_base/medbay)
+/area/ruin/syndicate_lava_base)
 "ES" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
@@ -2829,13 +2671,7 @@
 /obj/effect/decal/cleanable/dirt,
 /mob/living/simple_animal/hostile/carp/cayenne,
 /turf/open/floor/wood,
-/area/ruin/lavaland/syndicate_lava_base/bar)
-"EY" = (
-/obj/machinery/porta_turret/syndicate{
-	dir = 5
-	},
-/turf/closed/wall/mineral/plastitanium,
-/area/ruin/lavaland/syndicate_lava_base/bridge)
+/area/ruin/syndicate_lava_base)
 "Fm" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 5
@@ -2844,12 +2680,12 @@
 	req_access_txt = "150"
 	},
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/starboard)
+/area/ruin/syndicate_lava_base)
 "Fu" = (
 /obj/effect/spawner/structure/window/reinforced/plasma/plastitanium,
 /obj/machinery/door/firedoor,
 /turf/open/floor/plating,
-/area/ruin/lavaland/syndicate_lava_base/cargo)
+/area/ruin/syndicate_lava_base)
 "Fz" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 4
@@ -2861,21 +2697,7 @@
 	dir = 5
 	},
 /turf/open/floor/iron/dark/textured,
-/area/ruin/lavaland/syndicate_lava_base/starboard)
-"FC" = (
-/turf/closed/wall/mineral/plastitanium/explosive,
-/area/ruin/lavaland/syndicate_lava_base/brig)
-"FD" = (
-/obj/machinery/airalarm/directional/east,
-/obj/effect/mapping_helpers/airalarm/syndicate_access,
-/turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/brig)
-"FI" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
-/obj/structure/cable/yellow,
-/turf/open/floor/iron/white,
-/area/ruin/lavaland/syndicate_lava_base/chemistry)
+/area/ruin/syndicate_lava_base)
 "FL" = (
 /obj/effect/turf_decal/stripes/closeup{
 	dir = 1
@@ -2888,7 +2710,7 @@
 	name = "Starboard Hall"
 	},
 /turf/open/floor/iron/techmaint,
-/area/ruin/lavaland/syndicate_lava_base/cargo)
+/area/ruin/syndicate_lava_base)
 "FM" = (
 /obj/structure/table/reinforced,
 /obj/structure/window/reinforced/spawner/directional/east,
@@ -2898,20 +2720,17 @@
 /obj/item/book/manual/wiki/chemistry,
 /obj/item/clothing/glasses/science,
 /turf/open/floor/iron/techmaint,
-/area/ruin/lavaland/syndicate_lava_base/chemistry)
+/area/ruin/syndicate_lava_base)
 "FQ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible/layer2,
 /turf/open/floor/iron/dark/smooth_large,
-/area/ruin/lavaland/syndicate_lava_base/engineering)
+/area/ruin/syndicate_lava_base)
 "FS" = (
 /obj/structure/target_stake,
 /obj/item/target/clown,
 /obj/effect/decal/cleanable/blood/drip,
 /turf/open/floor/plating,
-/area/ruin/lavaland/syndicate_lava_base/brig)
-"FT" = (
-/turf/closed/wall/mineral/plastitanium/nodiagonal,
-/area/ruin/lavaland/syndicate_lava_base/starboard)
+/area/ruin/syndicate_lava_base)
 "FV" = (
 /obj/effect/turf_decal/stripes/closeup,
 /obj/machinery/door/firedoor,
@@ -2922,7 +2741,7 @@
 	},
 /obj/effect/mapping_helpers/airlock/access/all/syndicate/general,
 /turf/open/floor/iron/techmaint,
-/area/ruin/lavaland/syndicate_lava_base/virology)
+/area/ruin/syndicate_lava_base)
 "FW" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
@@ -2931,19 +2750,19 @@
 	},
 /obj/structure/cable/yellow,
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/cargo)
+/area/ruin/syndicate_lava_base)
 "FY" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/port)
+/area/ruin/syndicate_lava_base)
 "Gd" = (
 /obj/effect/turf_decal/trimline/red/line{
 	dir = 8
 	},
 /turf/open/floor/iron/dark/textured,
-/area/ruin/lavaland/syndicate_lava_base/telecomms)
+/area/ruin/syndicate_lava_base)
 "Gg" = (
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/stripes/closeup{
@@ -2952,10 +2771,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/iron/techmaint,
-/area/ruin/lavaland/syndicate_lava_base/port)
-"Gh" = (
-/turf/open/floor/plating,
-/area/ruin/lavaland/syndicate_lava_base/brig)
+/area/ruin/syndicate_lava_base)
 "Gi" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
@@ -2964,7 +2780,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /obj/structure/cable/yellow,
 /turf/open/floor/wood,
-/area/ruin/lavaland/syndicate_lava_base/bar)
+/area/ruin/syndicate_lava_base)
 "Go" = (
 /obj/structure/closet/crate/internals,
 /obj/item/tank/internals/oxygen/yellow,
@@ -2981,13 +2797,7 @@
 	},
 /obj/structure/cable/orange,
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/cargo)
-"Gv" = (
-/turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/telecomms)
-"Gw" = (
-/turf/closed/wall/mineral/plastitanium/explosive,
-/area/ruin/lavaland/syndicate_lava_base/telecomms)
+/area/ruin/syndicate_lava_base)
 "Gz" = (
 /obj/structure/table/glass,
 /obj/machinery/reagentgrinder{
@@ -2995,7 +2805,7 @@
 	},
 /obj/item/reagent_containers/cup/beaker/large,
 /turf/open/floor/iron/white,
-/area/ruin/lavaland/syndicate_lava_base/chemistry)
+/area/ruin/syndicate_lava_base)
 "GC" = (
 /obj/effect/turf_decal/stripes/closeup{
 	dir = 1
@@ -3006,7 +2816,7 @@
 /obj/effect/mapping_helpers/airlock/access/all/syndicate/general,
 /obj/structure/fans/tiny,
 /turf/open/floor/iron/techmaint,
-/area/ruin/lavaland/syndicate_lava_base/telecomms)
+/area/ruin/syndicate_lava_base)
 "GJ" = (
 /obj/structure/railing{
 	dir = 4
@@ -3015,36 +2825,36 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /obj/structure/cable/yellow,
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/port)
+/area/ruin/syndicate_lava_base)
 "GN" = (
 /obj/machinery/porta_turret/syndicate{
 	dir = 5
 	},
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
-/area/ruin/lavaland/syndicate_lava_base/cargo)
+/area/ruin/syndicate_lava_base)
 "GR" = (
 /obj/machinery/light/small{
 	dir = 1
 	},
 /turf/open/floor/circuit/red,
-/area/ruin/lavaland/syndicate_lava_base/starboard)
+/area/ruin/syndicate_lava_base)
 "GS" = (
 /obj/structure/cable/yellow,
 /obj/machinery/airalarm/directional/west,
 /obj/effect/mapping_helpers/airalarm/syndicate_access,
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/starboard)
+/area/ruin/syndicate_lava_base)
 "GX" = (
 /obj/machinery/light/small/directional/south,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
-/area/ruin/lavaland/syndicate_lava_base/brig)
+/area/ruin/syndicate_lava_base)
 "GZ" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/ruin/lavaland/syndicate_lava_base/medbay)
+/area/ruin/syndicate_lava_base)
 "Ha" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
@@ -3053,13 +2863,7 @@
 	},
 /obj/structure/cable/yellow,
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/cargo)
-"Hc" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
-/obj/structure/cable/yellow,
-/turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/cargo)
+/area/ruin/syndicate_lava_base)
 "Hg" = (
 /obj/machinery/button/door/directional/south{
 	id = "lavalandsyndicate_warehouse"
@@ -3074,16 +2878,16 @@
 /obj/machinery/airalarm/directional/east,
 /obj/effect/mapping_helpers/airalarm/syndicate_access,
 /turf/open/floor/iron/dark/textured,
-/area/ruin/lavaland/syndicate_lava_base/cargo)
+/area/ruin/syndicate_lava_base)
 "Hj" = (
 /obj/structure/sign/warning/secure_area,
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
-/area/ruin/lavaland/syndicate_lava_base/cargo)
+/area/ruin/syndicate_lava_base)
 "Ho" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/brig)
+/area/ruin/syndicate_lava_base)
 "Hv" = (
 /obj/structure/table/wood,
 /obj/effect/turf_decal/tile/neutral/opposingcorners,
@@ -3091,28 +2895,12 @@
 	dir = 1
 	},
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/bar)
+/area/ruin/syndicate_lava_base)
 "Hw" = (
 /obj/machinery/power/apc/syndicate/directional/east,
 /obj/structure/cable/yellow,
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/port)
-"HI" = (
-/obj/effect/turf_decal/siding/dark{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/red/line{
-	dir = 4
-	},
-/turf/open/floor/iron/dark/textured,
-/area/ruin/lavaland/syndicate_lava_base/brig)
-"HK" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/port)
+/area/ruin/syndicate_lava_base)
 "HP" = (
 /obj/effect/turf_decal/stripes/closeup{
 	dir = 1
@@ -3128,7 +2916,7 @@
 	name = "Port Hall"
 	},
 /turf/open/floor/iron/techmaint,
-/area/ruin/lavaland/syndicate_lava_base/medbay)
+/area/ruin/syndicate_lava_base)
 "HQ" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 10
@@ -3136,36 +2924,27 @@
 /obj/machinery/power/apc/syndicate/directional/west,
 /obj/structure/cable/yellow,
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/bridge)
-"HW" = (
-/obj/machinery/porta_turret/syndicate{
-	dir = 10
-	},
-/turf/closed/wall/mineral/plastitanium,
-/area/ruin/lavaland/syndicate_lava_base/telecomms)
+/area/ruin/syndicate_lava_base)
 "HX" = (
 /obj/structure/railing/corner,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/port)
+/area/ruin/syndicate_lava_base)
 "HZ" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
 /obj/structure/cable/yellow,
 /turf/open/floor/plating,
-/area/ruin/lavaland/syndicate_lava_base/engineering)
-"Ia" = (
-/turf/closed/wall/mineral/plastitanium/explosive,
-/area/ruin/lavaland/syndicate_lava_base/engineering)
+/area/ruin/syndicate_lava_base)
 "Ic" = (
 /obj/effect/spawner/structure/window/reinforced/plasma/plastitanium,
 /obj/machinery/atmospherics/pipe/layer_manifold{
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/ruin/lavaland/syndicate_lava_base/engineering)
+/area/ruin/syndicate_lava_base)
 "Id" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/railing{
@@ -3180,23 +2959,23 @@
 	name = "Warehouse Shutters"
 	},
 /turf/open/floor/iron/techmaint,
-/area/ruin/lavaland/syndicate_lava_base/cargo)
+/area/ruin/syndicate_lava_base)
 "Ip" = (
 /obj/structure/closet/emcloset/anchored,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/cargo)
+/area/ruin/syndicate_lava_base)
 "Iv" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /obj/structure/cable/yellow,
 /obj/machinery/firealarm/directional/south,
 /turf/open/floor/wood,
-/area/ruin/lavaland/syndicate_lava_base/dormitories)
+/area/ruin/syndicate_lava_base)
 "IF" = (
 /obj/structure/cable/orange,
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/cargo)
+/area/ruin/syndicate_lava_base)
 "IG" = (
 /obj/structure/cable,
 /obj/machinery/power/compressor{
@@ -3205,37 +2984,31 @@
 	luminosity = 2
 	},
 /turf/open/floor/engine/vacuum,
-/area/ruin/lavaland/syndicate_lava_base/engineering)
+/area/ruin/syndicate_lava_base)
 "II" = (
 /obj/machinery/computer/crew/syndie,
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/bridge)
+/area/ruin/syndicate_lava_base)
 "IL" = (
 /obj/structure/cable/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/catwalk_floor/iron_dark,
-/area/ruin/lavaland/syndicate_lava_base/engineering)
+/area/ruin/syndicate_lava_base)
 "IQ" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/iron,
-/area/ruin/lavaland/syndicate_lava_base/medbay)
-"IR" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 1
-	},
-/turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/brig)
+/area/ruin/syndicate_lava_base)
 "IS" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 4
 	},
 /obj/machinery/firealarm/directional/east,
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/starboard)
+/area/ruin/syndicate_lava_base)
 "IW" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
@@ -3247,17 +3020,13 @@
 	},
 /obj/structure/cable/yellow,
 /turf/open/floor/iron/dark/textured,
-/area/ruin/lavaland/syndicate_lava_base/brig)
-"IY" = (
-/obj/structure/sign/warning/secure_area,
-/turf/closed/wall/mineral/plastitanium/nodiagonal,
-/area/ruin/lavaland/syndicate_lava_base/medbay)
+/area/ruin/syndicate_lava_base)
 "Ja" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 1
 	},
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/medbay)
+/area/ruin/syndicate_lava_base)
 "Jh" = (
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/stripes/closeup,
@@ -3269,7 +3038,7 @@
 /obj/effect/mapping_helpers/airlock/access/all/syndicate/general,
 /obj/structure/cable/yellow,
 /turf/open/floor/iron/techmaint,
-/area/ruin/lavaland/syndicate_lava_base/cargo)
+/area/ruin/syndicate_lava_base)
 "Jj" = (
 /obj/effect/turf_decal/siding/dark{
 	dir = 5
@@ -3278,7 +3047,7 @@
 	dir = 5
 	},
 /turf/open/floor/iron/dark/textured,
-/area/ruin/lavaland/syndicate_lava_base/engineering)
+/area/ruin/syndicate_lava_base)
 "Jl" = (
 /obj/structure/railing{
 	dir = 8
@@ -3287,42 +3056,26 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/starboard)
-"Jo" = (
-/turf/closed/wall/mineral/plastitanium/explosive,
-/area/ruin/lavaland/syndicate_lava_base/starboard)
+/area/ruin/syndicate_lava_base)
 "Js" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 4
 	},
 /obj/structure/extinguisher_cabinet/directional/east,
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/starboard)
+/area/ruin/syndicate_lava_base)
 "JA" = (
 /obj/machinery/vending/medical/syndicate_access,
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 10
 	},
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/medbay)
-"JB" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
-/turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/port)
+/area/ruin/syndicate_lava_base)
 "JE" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/railing,
 /turf/open/lava/smooth/lava_land_surface,
 /area/lavaland/surface/outdoors)
-"JM" = (
-/turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/starboard)
-"JU" = (
-/obj/effect/spawner/structure/window/reinforced/plasma/plastitanium,
-/obj/machinery/door/firedoor,
-/turf/open/floor/plating,
-/area/ruin/lavaland/syndicate_lava_base/brig)
 "JX" = (
 /obj/machinery/button/door{
 	id = "lavalandsyndi_cargo";
@@ -3334,26 +3087,14 @@
 	dir = 4
 	},
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/cargo)
-"Kd" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/ruin/lavaland/syndicate_lava_base/engineering)
-"Ke" = (
-/obj/effect/turf_decal/trimline/red/filled/corner{
-	dir = 8
-	},
-/obj/structure/cable/yellow,
-/turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/port)
+/area/ruin/syndicate_lava_base)
 "Kl" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 6
 	},
 /obj/effect/mob_spawn/human/lavaland_syndicate/officer,
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/dormitories)
+/area/ruin/syndicate_lava_base)
 "Kp" = (
 /obj/effect/turf_decal/trimline/red/filled/corner{
 	dir = 4
@@ -3361,7 +3102,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/starboard)
+/area/ruin/syndicate_lava_base)
 "Kr" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
@@ -3374,35 +3115,16 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/extinguisher_cabinet/directional/west,
 /turf/open/floor/iron/dark/textured,
-/area/ruin/lavaland/syndicate_lava_base/brig)
+/area/ruin/syndicate_lava_base)
 "Kt" = (
 /turf/open/floor/iron/dark/smooth_large,
-/area/ruin/lavaland/syndicate_lava_base/engineering)
-"Ku" = (
-/obj/effect/spawner/structure/window/reinforced/plasma/plastitanium,
-/obj/machinery/door/poddoor/preopen{
-	id = "lavalandsyndi_hall"
-	},
-/turf/open/floor/plating,
-/area/ruin/lavaland/syndicate_lava_base/starboard)
-"Kx" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/stripes/closeup{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
-/turf/open/floor/iron/techmaint,
-/area/ruin/lavaland/syndicate_lava_base/starboard)
+/area/ruin/syndicate_lava_base)
 "KE" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
 	},
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/starboard)
-"KJ" = (
-/turf/closed/wall/mineral/plastitanium/explosive,
-/area/ruin/lavaland/syndicate_lava_base/dormitories)
+/area/ruin/syndicate_lava_base)
 "KK" = (
 /obj/item/ammo_box/c10mm{
 	pixel_y = 6
@@ -3419,14 +3141,14 @@
 /obj/structure/closet/syndicate/personal,
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/iron/dark/smooth_large,
-/area/ruin/lavaland/syndicate_lava_base/brig)
+/area/ruin/syndicate_lava_base)
 "KL" = (
 /obj/machinery/power/smes{
 	charge = 5e+006
 	},
 /obj/structure/cable/orange,
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/cargo)
+/area/ruin/syndicate_lava_base)
 "KO" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
@@ -3437,18 +3159,14 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark/textured,
-/area/ruin/lavaland/syndicate_lava_base/cargo)
+/area/ruin/syndicate_lava_base)
 "KV" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 8
 	},
 /obj/machinery/light/cold/directional/east,
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/port)
-"KX" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
-/turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/cargo)
+/area/ruin/syndicate_lava_base)
 "KZ" = (
 /obj/structure/table/glass,
 /obj/item/reagent_containers/spray/cleaner,
@@ -3463,7 +3181,7 @@
 /obj/item/restraints/handcuffs,
 /obj/item/restraints/handcuffs,
 /turf/open/floor/iron/white,
-/area/ruin/lavaland/syndicate_lava_base/virology)
+/area/ruin/syndicate_lava_base)
 "La" = (
 /obj/structure/table/wood,
 /obj/item/stamp/chameleon{
@@ -3483,18 +3201,18 @@
 	pixel_y = -4
 	},
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/telecomms)
+/area/ruin/syndicate_lava_base)
 "Ld" = (
 /obj/structure/cable/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/cargo)
+/area/ruin/syndicate_lava_base)
 "Lg" = (
 /obj/effect/turf_decal/siding/dark,
 /obj/effect/turf_decal/trimline/red/line,
 /turf/open/floor/iron/dark/textured,
-/area/ruin/lavaland/syndicate_lava_base/cargo)
+/area/ruin/syndicate_lava_base)
 "Lh" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
@@ -3508,18 +3226,12 @@
 	pixel_y = 25
 	},
 /turf/open/floor/iron,
-/area/ruin/lavaland/syndicate_lava_base/medbay)
+/area/ruin/syndicate_lava_base)
 "Ln" = (
 /obj/effect/turf_decal/tile/bar/opposingcorners,
 /obj/machinery/oven,
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/bar)
-"Ls" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
-/turf/open/floor/iron,
-/area/ruin/lavaland/syndicate_lava_base/medbay)
+/area/ruin/syndicate_lava_base)
 "Lt" = (
 /obj/structure/cable/yellow,
 /obj/effect/turf_decal/siding/dark{
@@ -3532,14 +3244,14 @@
 	name = "O2 to Incinerator"
 	},
 /turf/open/floor/iron/dark/textured,
-/area/ruin/lavaland/syndicate_lava_base/engineering)
+/area/ruin/syndicate_lava_base)
 "Lv" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/wood,
-/area/ruin/lavaland/syndicate_lava_base/dormitories)
+/area/ruin/syndicate_lava_base)
 "LB" = (
 /obj/structure/chair/office/light{
 	dir = 4
@@ -3548,7 +3260,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /obj/structure/cable/yellow,
 /turf/open/floor/iron/white,
-/area/ruin/lavaland/syndicate_lava_base/chemistry)
+/area/ruin/syndicate_lava_base)
 "LG" = (
 /obj/structure/sign/warning/fire{
 	pixel_x = 32
@@ -3560,44 +3272,44 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/cargo)
+/area/ruin/syndicate_lava_base)
 "LH" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 4
 	},
 /turf/open/floor/wood,
-/area/ruin/lavaland/syndicate_lava_base/telecomms)
+/area/ruin/syndicate_lava_base)
 "LJ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /obj/structure/cable/yellow,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/catwalk_floor/iron_dark,
-/area/ruin/lavaland/syndicate_lava_base/port)
+/area/ruin/syndicate_lava_base)
 "LV" = (
 /obj/effect/turf_decal/trimline/red/filled/line,
 /obj/machinery/firealarm/directional/south,
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/cargo)
+/area/ruin/syndicate_lava_base)
 "Mc" = (
 /obj/machinery/atmospherics/miner/carbon_dioxide,
 /turf/open/floor/engine/co2,
-/area/ruin/lavaland/syndicate_lava_base/engineering)
+/area/ruin/syndicate_lava_base)
 "Md" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/port)
+/area/ruin/syndicate_lava_base)
 "Mj" = (
 /obj/structure/cable/yellow,
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/starboard)
+/area/ruin/syndicate_lava_base)
 "Mr" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 8
 	},
 /obj/structure/cable/yellow,
 /turf/open/floor/iron/white,
-/area/ruin/lavaland/syndicate_lava_base/medbay)
+/area/ruin/syndicate_lava_base)
 "Ms" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/portable_atmospherics/pump,
@@ -3605,13 +3317,13 @@
 	dir = 1
 	},
 /turf/open/floor/iron/dark/smooth_large,
-/area/ruin/lavaland/syndicate_lava_base/engineering)
+/area/ruin/syndicate_lava_base)
 "MF" = (
 /obj/effect/turf_decal/siding/dark{
 	dir = 4
 	},
 /turf/open/floor/circuit/green,
-/area/ruin/lavaland/syndicate_lava_base/telecomms)
+/area/ruin/syndicate_lava_base)
 "MH" = (
 /obj/structure/chair/fancy/sofa/old/left{
 	color = "#742925";
@@ -3621,13 +3333,13 @@
 	dir = 6
 	},
 /turf/open/floor/carpet/red,
-/area/ruin/lavaland/syndicate_lava_base/bar)
+/area/ruin/syndicate_lava_base)
 "MV" = (
 /obj/structure/table/reinforced,
 /obj/structure/window/reinforced/spawner/directional/east,
 /obj/structure/window/reinforced/spawner/directional/south,
 /turf/open/floor/iron,
-/area/ruin/lavaland/syndicate_lava_base/medbay)
+/area/ruin/syndicate_lava_base)
 "Ne" = (
 /obj/structure/chair/office{
 	dir = 1
@@ -3643,35 +3355,25 @@
 	pixel_y = -8
 	},
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/bridge)
+/area/ruin/syndicate_lava_base)
 "Nh" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /obj/structure/cable/yellow,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/cargo)
+/area/ruin/syndicate_lava_base)
 "Nl" = (
 /obj/structure/table/reinforced,
 /obj/item/taperecorder,
 /turf/open/floor/iron/dark/smooth_large,
-/area/ruin/lavaland/syndicate_lava_base/brig)
-"Nm" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/port)
-"Nq" = (
-/obj/effect/spawner/structure/window/reinforced/plasma/plastitanium,
-/turf/open/floor/plating,
-/area/ruin/lavaland/syndicate_lava_base/medbay)
+/area/ruin/syndicate_lava_base)
 "Nr" = (
 /obj/structure/chair/office,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/wood,
-/area/ruin/lavaland/syndicate_lava_base/telecomms)
+/area/ruin/syndicate_lava_base)
 "NN" = (
 /obj/effect/turf_decal/siding/dark{
 	dir = 10
@@ -3683,7 +3385,7 @@
 /obj/machinery/firealarm/directional/west,
 /obj/machinery/light/small/directional/south,
 /turf/open/floor/iron/dark/textured,
-/area/ruin/lavaland/syndicate_lava_base/cargo)
+/area/ruin/syndicate_lava_base)
 "NO" = (
 /obj/effect/mapping_helpers/airlock/locked,
 /obj/effect/turf_decal/stripes/closeup,
@@ -3695,7 +3397,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/iron/techmaint,
-/area/ruin/lavaland/syndicate_lava_base/starboard)
+/area/ruin/syndicate_lava_base)
 "NR" = (
 /obj/structure/fans/tiny,
 /obj/machinery/door/airlock/external,
@@ -3705,14 +3407,11 @@
 	},
 /obj/effect/turf_decal/stripes/closeup,
 /turf/open/floor/iron/techmaint,
-/area/ruin/lavaland/syndicate_lava_base/cargo)
+/area/ruin/syndicate_lava_base)
 "Od" = (
 /obj/machinery/firealarm/directional/east,
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/port)
-"Of" = (
-/turf/closed/wall/mineral/plastitanium/nodiagonal,
-/area/ruin/lavaland/syndicate_lava_base/dormitories)
+/area/ruin/syndicate_lava_base)
 "Oj" = (
 /obj/structure/cable/yellow,
 /obj/effect/turf_decal/siding/dark{
@@ -3722,14 +3421,14 @@
 	dir = 1
 	},
 /turf/open/floor/iron/dark/textured,
-/area/ruin/lavaland/syndicate_lava_base/engineering)
+/area/ruin/syndicate_lava_base)
 "Ol" = (
 /obj/machinery/computer/scan_consolenew{
 	dir = 4;
 	req_access = list(150)
 	},
 /turf/open/floor/iron,
-/area/ruin/lavaland/syndicate_lava_base/virology)
+/area/ruin/syndicate_lava_base)
 "Or" = (
 /obj/machinery/chem_master,
 /obj/effect/turf_decal/stripes/line{
@@ -3743,7 +3442,7 @@
 	req_access_txt = "150"
 	},
 /turf/open/floor/iron,
-/area/ruin/lavaland/syndicate_lava_base/chemistry)
+/area/ruin/syndicate_lava_base)
 "Ot" = (
 /obj/machinery/computer/camera_advanced/syndie{
 	dir = 4
@@ -3752,44 +3451,44 @@
 	dir = 8
 	},
 /turf/open/floor/carpet/red,
-/area/ruin/lavaland/syndicate_lava_base/telecomms)
+/area/ruin/syndicate_lava_base)
 "Ow" = (
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/stripes/closeup,
 /obj/structure/cable/yellow,
 /turf/open/floor/iron/techmaint,
-/area/ruin/lavaland/syndicate_lava_base/starboard)
+/area/ruin/syndicate_lava_base)
 "Oz" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/toolbox/syndicate,
 /obj/machinery/airalarm/directional/south,
 /obj/effect/mapping_helpers/airalarm/syndicate_access,
 /turf/open/floor/catwalk_floor/iron_dark,
-/area/ruin/lavaland/syndicate_lava_base/engineering)
+/area/ruin/syndicate_lava_base)
 "OI" = (
 /obj/structure/chair{
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/red/filled/line,
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/medbay)
+/area/ruin/syndicate_lava_base)
 "OO" = (
 /obj/structure/cable/orange,
 /turf/open/floor/catwalk_floor,
-/area/ruin/lavaland/syndicate_lava_base/cargo)
+/area/ruin/syndicate_lava_base)
 "OS" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 10
 	},
 /obj/machinery/light/directional/south,
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/port)
+/area/ruin/syndicate_lava_base)
 "OU" = (
 /obj/effect/turf_decal/siding/dark{
 	dir = 6
 	},
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/bridge)
+/area/ruin/syndicate_lava_base)
 "OW" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
@@ -3797,14 +3496,7 @@
 /obj/machinery/light/cold/directional/north,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood,
-/area/ruin/lavaland/syndicate_lava_base/bar)
-"OZ" = (
-/turf/closed/wall/mineral/plastitanium,
-/area/ruin/lavaland/syndicate_lava_base/medbay)
-"Pa" = (
-/obj/structure/cable/yellow,
-/turf/open/floor/wood,
-/area/ruin/lavaland/syndicate_lava_base/telecomms)
+/area/ruin/syndicate_lava_base)
 "Pb" = (
 /obj/machinery/syndicatebomb/self_destruct{
 	anchored = 1
@@ -3813,7 +3505,7 @@
 	desc = "Initially I wanted to put a rocket launcher in here because thats badass but the compelling point was made that the bases walls are made of explosives and our players are fucking stupid."
 	},
 /turf/open/floor/circuit/red,
-/area/ruin/lavaland/syndicate_lava_base/starboard)
+/area/ruin/syndicate_lava_base)
 "Pf" = (
 /obj/structure/window/reinforced/spawner/directional/west,
 /obj/structure/table/wood,
@@ -3826,10 +3518,7 @@
 	pixel_x = 8
 	},
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/bar)
-"Pi" = (
-/turf/closed/wall/mineral/plastitanium/nodiagonal,
-/area/ruin/lavaland/syndicate_lava_base/brig)
+/area/ruin/syndicate_lava_base)
 "Pj" = (
 /obj/machinery/computer/shuttle_flight{
 	desc = "Controls the Surveillance ship, often taken on planetary recon missions.";
@@ -3840,7 +3529,7 @@
 	req_access_txt = "150"
 	},
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/bridge)
+/area/ruin/syndicate_lava_base)
 "Pr" = (
 /obj/structure/closet/crate,
 /obj/item/storage/toolbox/electrical{
@@ -3850,7 +3539,7 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
 /obj/machinery/light/directional/south,
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/cargo)
+/area/ruin/syndicate_lava_base)
 "Py" = (
 /obj/structure/closet/secure_closet/medical1{
 	req_access = null;
@@ -3859,17 +3548,13 @@
 /obj/item/storage/box/beakers/bluespace,
 /obj/item/storage/box/beakers/bluespace,
 /turf/open/floor/iron/white,
-/area/ruin/lavaland/syndicate_lava_base/chemistry)
-"Pz" = (
-/obj/effect/spawner/structure/window/reinforced/plasma/plastitanium,
-/turf/open/floor/plating,
-/area/ruin/lavaland/syndicate_lava_base/engineering)
+/area/ruin/syndicate_lava_base)
 "PB" = (
 /obj/machinery/door/window/brigdoor{
 	name = "Telecommunications Servers"
 	},
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/telecomms)
+/area/ruin/syndicate_lava_base)
 "PH" = (
 /obj/structure/cable/yellow,
 /obj/machinery/atmospherics/components/binary/pump/on/layer4{
@@ -3879,47 +3564,29 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark/smooth_large,
-/area/ruin/lavaland/syndicate_lava_base/engineering)
+/area/ruin/syndicate_lava_base)
 "PI" = (
 /obj/machinery/air_sensor,
 /turf/open/floor/engine/co2,
-/area/ruin/lavaland/syndicate_lava_base/engineering)
+/area/ruin/syndicate_lava_base)
 "PM" = (
 /obj/effect/turf_decal/tile/neutral/opposingcorners,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/bar)
-"PR" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 1
-	},
-/turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/port)
-"PW" = (
-/turf/open/floor/plating,
-/area/ruin/lavaland/syndicate_lava_base/cargo)
-"Qb" = (
-/obj/effect/turf_decal/siding/dark{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/red/line{
-	dir = 4
-	},
-/turf/open/floor/iron/dark/textured,
-/area/ruin/lavaland/syndicate_lava_base/engineering)
+/area/ruin/syndicate_lava_base)
 "Qc" = (
 /obj/structure/cable/yellow,
 /obj/machinery/light/small/directional/west,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/catwalk_floor/iron_dark,
-/area/ruin/lavaland/syndicate_lava_base/engineering)
+/area/ruin/syndicate_lava_base)
 "Qh" = (
 /obj/effect/turf_decal/trimline/red/filled/line,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/bridge)
+/area/ruin/syndicate_lava_base)
 "Qp" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/on{
 	dir = 8;
@@ -3927,30 +3594,23 @@
 	name = "co2 out"
 	},
 /turf/open/floor/engine/co2,
-/area/ruin/lavaland/syndicate_lava_base/engineering)
+/area/ruin/syndicate_lava_base)
 "Qt" = (
 /obj/machinery/computer/camera_advanced/syndie,
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/bridge)
+/area/ruin/syndicate_lava_base)
 "Qy" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/iron/dark/smooth_large,
-/area/ruin/lavaland/syndicate_lava_base/engineering)
+/area/ruin/syndicate_lava_base)
 "Qz" = (
 /obj/effect/mob_spawn/human/lavaland_syndicate,
 /obj/effect/turf_decal/siding/wood{
 	dir = 10
 	},
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/dormitories)
-"QF" = (
-/obj/effect/spawner/structure/window/reinforced/plasma/plastitanium,
-/obj/machinery/door/poddoor/preopen{
-	id = "lavalandsyndi_hall"
-	},
-/turf/open/floor/plating,
-/area/ruin/lavaland/syndicate_lava_base/port)
+/area/ruin/syndicate_lava_base)
 "QH" = (
 /obj/structure/closet/crate,
 /obj/item/storage/box/stockparts/deluxe,
@@ -3967,7 +3627,7 @@
 /obj/machinery/light/small/directional/north,
 /obj/structure/extinguisher_cabinet/directional/north,
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/cargo)
+/area/ruin/syndicate_lava_base)
 "QM" = (
 /obj/effect/turf_decal/stripes/closeup{
 	dir = 1
@@ -3978,7 +3638,7 @@
 	},
 /obj/effect/mapping_helpers/airlock/access/all/syndicate/general,
 /turf/open/floor/iron/techmaint,
-/area/ruin/lavaland/syndicate_lava_base/telecomms)
+/area/ruin/syndicate_lava_base)
 "QO" = (
 /obj/effect/mapping_helpers/no_lava,
 /turf/open/floor/plating,
@@ -3990,13 +3650,13 @@
 	name = "oxygen out"
 	},
 /turf/open/floor/engine/o2,
-/area/ruin/lavaland/syndicate_lava_base/engineering)
+/area/ruin/syndicate_lava_base)
 "QW" = (
 /obj/effect/turf_decal/tile/neutral/opposingcorners,
 /obj/structure/sink/kitchen/directional/south,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/bar)
+/area/ruin/syndicate_lava_base)
 "Rd" = (
 /obj/machinery/atmospherics/pipe/smart/simple/orange/visible,
 /obj/machinery/button/ignition/incinerator/syndicatelava{
@@ -4013,16 +3673,7 @@
 	pixel_y = -26
 	},
 /turf/open/floor/catwalk_floor/iron_dark,
-/area/ruin/lavaland/syndicate_lava_base/engineering)
-"Rf" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
-/obj/structure/sign/warning/xeno_mining{
-	pixel_x = -32
-	},
-/turf/open/floor/plating,
-/area/ruin/lavaland/syndicate_lava_base/medbay)
+/area/ruin/syndicate_lava_base)
 "Rh" = (
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/stripes/closeup,
@@ -4034,14 +3685,14 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /obj/structure/cable/yellow,
 /turf/open/floor/iron/techmaint,
-/area/ruin/lavaland/syndicate_lava_base/brig)
+/area/ruin/syndicate_lava_base)
 "Rj" = (
 /obj/machinery/door/airlock{
 	name = "Restroom"
 	},
 /obj/effect/turf_decal/stripes/closeup,
 /turf/open/floor/iron/techmaint,
-/area/ruin/lavaland/syndicate_lava_base/port)
+/area/ruin/syndicate_lava_base)
 "Rn" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/shower{
@@ -4051,16 +3702,13 @@
 /obj/machinery/airalarm/directional/east,
 /obj/effect/mapping_helpers/airalarm/syndicate_access,
 /turf/open/floor/iron/white/textured,
-/area/ruin/lavaland/syndicate_lava_base/virology)
+/area/ruin/syndicate_lava_base)
 "Rs" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/ruin/lavaland/syndicate_lava_base/medbay)
-"Ru" = (
-/turf/closed/wall/mineral/plastitanium/nodiagonal,
-/area/ruin/lavaland/syndicate_lava_base/bridge)
+/area/ruin/syndicate_lava_base)
 "Rv" = (
 /obj/effect/turf_decal/stripes/closeup{
 	dir = 1
@@ -4073,14 +3721,7 @@
 	name = "Port Hall"
 	},
 /turf/open/floor/iron/techmaint,
-/area/ruin/lavaland/syndicate_lava_base/medbay)
-"RD" = (
-/obj/effect/spawner/structure/window/reinforced/plasma/plastitanium,
-/obj/machinery/door/poddoor/preopen{
-	id = "lavalandsyndi_hall"
-	},
-/turf/open/floor/plating,
-/area/ruin/lavaland/syndicate_lava_base/medbay)
+/area/ruin/syndicate_lava_base)
 "RO" = (
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/stripes/closeup,
@@ -4088,11 +3729,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /obj/structure/cable/yellow,
 /turf/open/floor/iron/techmaint,
-/area/ruin/lavaland/syndicate_lava_base/port)
-"RP" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/ruin/lavaland/syndicate_lava_base/brig)
+/area/ruin/syndicate_lava_base)
 "RU" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
@@ -4105,20 +3742,20 @@
 /obj/structure/cable/yellow,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark/textured,
-/area/ruin/lavaland/syndicate_lava_base/brig)
+/area/ruin/syndicate_lava_base)
 "RV" = (
 /obj/effect/turf_decal/trimline/red/filled/line,
 /obj/structure/extinguisher_cabinet/directional/south,
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/cargo)
+/area/ruin/syndicate_lava_base)
 "Se" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/cargo)
+/area/ruin/syndicate_lava_base)
 "Sg" = (
 /obj/machinery/modular_computer/console/preset/civilian,
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/bridge)
+/area/ruin/syndicate_lava_base)
 "Sp" = (
 /obj/effect/turf_decal/stripes/closeup{
 	dir = 1
@@ -4128,7 +3765,7 @@
 	name = "Restroom"
 	},
 /turf/open/floor/iron/techmaint,
-/area/ruin/lavaland/syndicate_lava_base/port)
+/area/ruin/syndicate_lava_base)
 "Sq" = (
 /obj/machinery/computer/atmos_control{
 	dir = 8;
@@ -4137,7 +3774,7 @@
 /obj/effect/turf_decal/delivery,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible/layer2,
 /turf/open/floor/iron/dark/smooth_large,
-/area/ruin/lavaland/syndicate_lava_base/engineering)
+/area/ruin/syndicate_lava_base)
 "Sy" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 10
@@ -4147,10 +3784,7 @@
 /obj/machinery/airalarm/directional/west,
 /obj/effect/mapping_helpers/airalarm/syndicate_access,
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/cargo)
-"Sz" = (
-/turf/closed/wall/mineral/plastitanium/explosive,
-/area/ruin/lavaland/syndicate_lava_base/cargo)
+/area/ruin/syndicate_lava_base)
 "SJ" = (
 /obj/effect/turf_decal/trimline/red/filled/corner{
 	dir = 8
@@ -4159,7 +3793,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /obj/structure/cable/yellow,
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/port)
+/area/ruin/syndicate_lava_base)
 "SL" = (
 /obj/effect/turf_decal/stripes/closeup{
 	dir = 1
@@ -4172,36 +3806,28 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/iron/techmaint,
-/area/ruin/lavaland/syndicate_lava_base/brig)
-"SM" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
-/turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/brig)
-"SW" = (
-/turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/medbay)
+/area/ruin/syndicate_lava_base)
 "SY" = (
 /turf/open/floor/engine/n2,
-/area/ruin/lavaland/syndicate_lava_base/engineering)
+/area/ruin/syndicate_lava_base)
 "Ta" = (
 /turf/open/lava/smooth/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "Tg" = (
 /obj/effect/turf_decal/tile/neutral/opposingcorners,
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/bar)
+/area/ruin/syndicate_lava_base)
 "Ti" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /obj/effect/turf_decal/trimline/red/filled/line,
 /obj/structure/cable/yellow,
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/cargo)
+/area/ruin/syndicate_lava_base)
 "Tq" = (
 /obj/effect/turf_decal/tile/bar/opposingcorners,
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/bar)
+/area/ruin/syndicate_lava_base)
 "TB" = (
 /obj/structure/chair/fancy/sofa/old/left{
 	color = "#742925";
@@ -4211,66 +3837,51 @@
 	dir = 9
 	},
 /turf/open/floor/carpet/red,
-/area/ruin/lavaland/syndicate_lava_base/bar)
-"TD" = (
-/obj/structure/fans/tiny,
-/obj/machinery/door/airlock/external,
-/obj/effect/mapping_helpers/airlock/access/all/syndicate/general,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/closeup,
-/turf/open/floor/iron/techmaint,
-/area/ruin/lavaland/syndicate_lava_base/medbay)
+/area/ruin/syndicate_lava_base)
 "TM" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
 /obj/structure/cable/yellow,
 /turf/open/floor/iron/white,
-/area/ruin/lavaland/syndicate_lava_base/virology)
+/area/ruin/syndicate_lava_base)
 "TN" = (
 /obj/effect/turf_decal/siding/dark,
 /obj/effect/turf_decal/trimline/red/line,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark/textured,
-/area/ruin/lavaland/syndicate_lava_base/cargo)
-"TU" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
-/turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/starboard)
+/area/ruin/syndicate_lava_base)
 "TX" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/box/lights/bulbs,
 /obj/item/wrench,
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/cargo)
+/area/ruin/syndicate_lava_base)
 "Ub" = (
 /obj/effect/turf_decal/trimline/red/filled/corner,
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/bridge)
+/area/ruin/syndicate_lava_base)
 "Ud" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
 /turf/open/floor/catwalk_floor,
-/area/ruin/lavaland/syndicate_lava_base/cargo)
+/area/ruin/syndicate_lava_base)
 "Uf" = (
 /obj/machinery/atmospherics/pipe/smart/simple/orange/visible{
 	dir = 6
 	},
 /obj/machinery/suit_storage_unit/radsuit,
 /turf/open/floor/iron/dark/textured,
-/area/ruin/lavaland/syndicate_lava_base/engineering)
+/area/ruin/syndicate_lava_base)
 "Ui" = (
 /obj/machinery/atmospherics/miner/nitrogen,
 /obj/machinery/light/small{
 	dir = 4
 	},
 /turf/open/floor/engine/n2,
-/area/ruin/lavaland/syndicate_lava_base/engineering)
+/area/ruin/syndicate_lava_base)
 "Um" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /obj/structure/flora/rock/jungle,
 /turf/open/floor/grass/no_border,
-/area/ruin/lavaland/syndicate_lava_base/port)
+/area/ruin/syndicate_lava_base)
 "Uw" = (
 /obj/structure/table/reinforced,
 /obj/effect/turf_decal/siding/dark{
@@ -4281,38 +3892,18 @@
 	},
 /obj/item/folder/white,
 /turf/open/floor/iron/techmaint,
-/area/ruin/lavaland/syndicate_lava_base/chemistry)
-"Ux" = (
-/obj/effect/spawner/structure/window/reinforced/plasma/plastitanium,
-/turf/open/floor/plating,
-/area/ruin/lavaland/syndicate_lava_base/bridge)
+/area/ruin/syndicate_lava_base)
 "UF" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 10
 	},
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/port)
-"UG" = (
-/obj/machinery/porta_turret/syndicate{
-	dir = 9
-	},
-/turf/closed/wall/mineral/plastitanium,
-/area/ruin/lavaland/syndicate_lava_base/medbay)
-"UJ" = (
-/obj/effect/turf_decal/trimline/red/filled/corner,
-/turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/starboard)
+/area/ruin/syndicate_lava_base)
 "UO" = (
 /obj/machinery/deepfryer,
 /obj/effect/turf_decal/tile/bar/opposingcorners,
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/bar)
-"UU" = (
-/obj/machinery/porta_turret/syndicate{
-	dir = 9
-	},
-/turf/closed/wall/mineral/plastitanium,
-/area/ruin/lavaland/syndicate_lava_base/bridge)
+/area/ruin/syndicate_lava_base)
 "UW" = (
 /obj/structure/filingcabinet,
 /obj/item/folder/syndicate/mining,
@@ -4323,7 +3914,7 @@
 	dir = 6
 	},
 /turf/open/floor/iron/dark/textured,
-/area/ruin/lavaland/syndicate_lava_base/starboard)
+/area/ruin/syndicate_lava_base)
 "UX" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 6
@@ -4331,7 +3922,7 @@
 /obj/machinery/airalarm/directional/east,
 /obj/effect/mapping_helpers/airalarm/syndicate_access,
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/bridge)
+/area/ruin/syndicate_lava_base)
 "Vf" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -4340,7 +3931,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/ruin/lavaland/syndicate_lava_base/medbay)
+/area/ruin/syndicate_lava_base)
 "Vj" = (
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/stripes/closeup{
@@ -4350,15 +3941,11 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /obj/structure/cable/yellow,
 /turf/open/floor/iron/techmaint,
-/area/ruin/lavaland/syndicate_lava_base/bar)
+/area/ruin/syndicate_lava_base)
 "Vl" = (
 /obj/effect/turf_decal/siding/wood,
 /turf/open/floor/carpet/red,
-/area/ruin/lavaland/syndicate_lava_base/telecomms)
-"Vo" = (
-/obj/effect/spawner/structure/window/reinforced/plasma/plastitanium,
-/turf/open/floor/plating,
-/area/ruin/lavaland/syndicate_lava_base/brig)
+/area/ruin/syndicate_lava_base)
 "Vw" = (
 /obj/structure/railing/corner{
 	dir = 4
@@ -4370,23 +3957,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /obj/structure/cable/yellow,
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/port)
-"VG" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/stripes/closeup{
-	dir = 1
-	},
-/turf/open/floor/iron/techmaint,
-/area/ruin/lavaland/syndicate_lava_base/port)
-"VP" = (
-/obj/effect/spawner/structure/window/reinforced/plasma/plastitanium,
-/turf/open/floor/plating,
-/area/ruin/lavaland/syndicate_lava_base/cargo)
+/area/ruin/syndicate_lava_base)
 "VQ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/circuit/red,
-/area/ruin/lavaland/syndicate_lava_base/starboard)
+/area/ruin/syndicate_lava_base)
 "VZ" = (
 /obj/effect/turf_decal/siding/dark{
 	dir = 5
@@ -4396,7 +3972,7 @@
 	},
 /obj/machinery/light/directional/north,
 /turf/open/floor/iron/dark/textured,
-/area/ruin/lavaland/syndicate_lava_base/cargo)
+/area/ruin/syndicate_lava_base)
 "Wj" = (
 /obj/effect/turf_decal/stripes/closeup,
 /obj/machinery/door/airlock/hatch{
@@ -4408,37 +3984,21 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /obj/structure/cable/yellow,
 /turf/open/floor/iron/techmaint,
-/area/ruin/lavaland/syndicate_lava_base/telecomms)
+/area/ruin/syndicate_lava_base)
 "Wk" = (
 /obj/structure/chair,
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
 	},
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/medbay)
-"Wo" = (
-/turf/closed/wall/mineral/plastitanium,
-/area/ruin/lavaland/syndicate_lava_base/brig)
+/area/ruin/syndicate_lava_base)
 "Wu" = (
 /obj/effect/mob_spawn/human/lavaland_syndicate/comms,
 /obj/effect/turf_decal/siding/wood{
 	dir = 6
 	},
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/dormitories)
-"Wx" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/stripes/closeup{
-	dir = 1
-	},
-/turf/open/floor/iron/techmaint,
-/area/ruin/lavaland/syndicate_lava_base/starboard)
-"WB" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/bridge)
+/area/ruin/syndicate_lava_base)
 "WK" = (
 /obj/structure/closet/crate,
 /obj/item/extinguisher{
@@ -4477,7 +4037,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/cargo)
+/area/ruin/syndicate_lava_base)
 "WN" = (
 /obj/effect/turf_decal/stripes/closeup{
 	dir = 1
@@ -4493,7 +4053,7 @@
 	name = "Starboard Hall"
 	},
 /turf/open/floor/iron/techmaint,
-/area/ruin/lavaland/syndicate_lava_base/cargo)
+/area/ruin/syndicate_lava_base)
 "WP" = (
 /obj/structure/railing/corner{
 	dir = 1
@@ -4503,7 +4063,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /obj/structure/cable/yellow,
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/starboard)
+/area/ruin/syndicate_lava_base)
 "WW" = (
 /obj/structure/rack{
 	dir = 8
@@ -4518,7 +4078,7 @@
 	},
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/iron,
-/area/ruin/lavaland/syndicate_lava_base/medbay)
+/area/ruin/syndicate_lava_base)
 "Xb" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/firstaid/toxin{
@@ -4534,7 +4094,7 @@
 	req_access_txt = "150"
 	},
 /turf/open/floor/iron/techmaint,
-/area/ruin/lavaland/syndicate_lava_base/medbay)
+/area/ruin/syndicate_lava_base)
 "Xg" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
@@ -4545,7 +4105,7 @@
 	},
 /obj/item/hand_labeler,
 /turf/open/floor/iron/dark/textured,
-/area/ruin/lavaland/syndicate_lava_base/cargo)
+/area/ruin/syndicate_lava_base)
 "Xl" = (
 /obj/effect/turf_decal/stripes/closeup{
 	dir = 1
@@ -4557,7 +4117,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/iron/techmaint,
-/area/ruin/lavaland/syndicate_lava_base/dormitories)
+/area/ruin/syndicate_lava_base)
 "Xs" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 6
@@ -4565,17 +4125,14 @@
 /obj/machinery/photocopier,
 /obj/structure/extinguisher_cabinet/directional/south,
 /turf/open/floor/carpet/red,
-/area/ruin/lavaland/syndicate_lava_base/telecomms)
-"Xx" = (
-/turf/closed/wall/mineral/plastitanium/explosive,
-/area/ruin/lavaland/syndicate_lava_base/chemistry)
+/area/ruin/syndicate_lava_base)
 "Xy" = (
 /obj/structure/closet/l3closet,
 /obj/effect/turf_decal/bot,
 /obj/machinery/light/small/directional/east,
 /obj/structure/extinguisher_cabinet/directional/east,
 /turf/open/floor/iron/white,
-/area/ruin/lavaland/syndicate_lava_base/virology)
+/area/ruin/syndicate_lava_base)
 "XE" = (
 /obj/item/kirbyplants/random,
 /obj/effect/turf_decal/trimline/red/filled/line{
@@ -4583,24 +4140,24 @@
 	},
 /obj/machinery/firealarm/directional/south,
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/bridge)
+/area/ruin/syndicate_lava_base)
 "XG" = (
 /obj/machinery/firealarm/directional/north,
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/starboard)
+/area/ruin/syndicate_lava_base)
 "XO" = (
 /obj/machinery/vending/boozeomat/syndicate_access,
 /turf/open/floor/iron/techmaint,
-/area/ruin/lavaland/syndicate_lava_base/bar)
+/area/ruin/syndicate_lava_base)
 "XV" = (
 /obj/machinery/vending/syndichem,
 /obj/machinery/firealarm/directional/south,
 /turf/open/floor/iron/white,
-/area/ruin/lavaland/syndicate_lava_base/chemistry)
+/area/ruin/syndicate_lava_base)
 "XX" = (
 /obj/machinery/door/poddoor/incinerator_syndicatelava_aux,
 /turf/open/floor/engine/vacuum,
-/area/ruin/lavaland/syndicate_lava_base/engineering)
+/area/ruin/syndicate_lava_base)
 "Ya" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/button/door{
@@ -4613,18 +4170,18 @@
 	specialfunctions = 4
 	},
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/starboard)
+/area/ruin/syndicate_lava_base)
 "Yh" = (
 /obj/structure/rack,
 /obj/item/stack/sheet/iron/fifty,
 /obj/item/stack/sheet/glass/fifty,
 /obj/item/stack/sheet/mineral/copper/five,
 /turf/open/floor/iron/dark/textured,
-/area/ruin/lavaland/syndicate_lava_base/cargo)
+/area/ruin/syndicate_lava_base)
 "Yl" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/port)
+/area/ruin/syndicate_lava_base)
 "Yn" = (
 /obj/structure/table/reinforced,
 /obj/machinery/cell_charger,
@@ -4632,13 +4189,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/iron/dark/textured,
-/area/ruin/lavaland/syndicate_lava_base/cargo)
-"Yo" = (
-/obj/effect/turf_decal/trimline/red/filled/line,
-/obj/structure/cable/yellow,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/port)
+/area/ruin/syndicate_lava_base)
 "Yp" = (
 /obj/effect/turf_decal/siding/dark{
 	dir = 4
@@ -4648,11 +4199,11 @@
 	},
 /obj/machinery/atmospherics/pipe/layer_manifold/visible,
 /turf/open/floor/iron/dark/textured,
-/area/ruin/lavaland/syndicate_lava_base/engineering)
+/area/ruin/syndicate_lava_base)
 "Yr" = (
 /obj/structure/chair/office,
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/telecomms)
+/area/ruin/syndicate_lava_base)
 "Yy" = (
 /obj/structure/window/reinforced/spawner/directional/north,
 /obj/effect/turf_decal/stripes/line{
@@ -4660,7 +4211,7 @@
 	},
 /obj/machinery/dna_scannernew,
 /turf/open/floor/iron,
-/area/ruin/lavaland/syndicate_lava_base/virology)
+/area/ruin/syndicate_lava_base)
 "YE" = (
 /obj/machinery/power/terminal{
 	dir = 1
@@ -4670,7 +4221,7 @@
 /obj/machinery/atmospherics/components/unary/portables_connector/layer4,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron/dark/smooth_large,
-/area/ruin/lavaland/syndicate_lava_base/engineering)
+/area/ruin/syndicate_lava_base)
 "YG" = (
 /obj/structure/chair/fancy/sofa/old/right{
 	color = "#742925";
@@ -4680,16 +4231,7 @@
 	dir = 5
 	},
 /turf/open/floor/carpet/red,
-/area/ruin/lavaland/syndicate_lava_base/bar)
-"YL" = (
-/obj/machinery/porta_turret/syndicate{
-	dir = 5
-	},
-/turf/closed/wall/mineral/plastitanium,
-/area/ruin/lavaland/syndicate_lava_base/dormitories)
-"YO" = (
-/turf/closed/wall/mineral/plastitanium/nodiagonal,
-/area/ruin/lavaland/syndicate_lava_base/engineering)
+/area/ruin/syndicate_lava_base)
 "YW" = (
 /obj/structure/table/wood,
 /obj/effect/turf_decal/siding/wood,
@@ -4698,33 +4240,27 @@
 	pixel_y = 6
 	},
 /turf/open/floor/carpet/red,
-/area/ruin/lavaland/syndicate_lava_base/bar)
+/area/ruin/syndicate_lava_base)
 "YZ" = (
 /obj/effect/decal/cleanable/blood/tracks{
 	dir = 10;
 	icon_state = "tracks"
 	},
 /turf/open/floor/plating,
-/area/ruin/lavaland/syndicate_lava_base/brig)
+/area/ruin/syndicate_lava_base)
 "Ze" = (
 /obj/structure/cable/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/catwalk_floor,
-/area/ruin/lavaland/syndicate_lava_base/cargo)
-"Zh" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
-/obj/structure/cable/yellow,
-/turf/open/floor/wood,
-/area/ruin/lavaland/syndicate_lava_base/telecomms)
+/area/ruin/syndicate_lava_base)
 "Zi" = (
 /obj/machinery/atmospherics/components/trinary/mixer/airmix/layer2/flipped{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/catwalk_floor/iron_dark,
-/area/ruin/lavaland/syndicate_lava_base/engineering)
+/area/ruin/syndicate_lava_base)
 "Zj" = (
 /obj/structure/table/reinforced,
 /obj/item/suppressor,
@@ -4734,7 +4270,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron/techmaint,
-/area/ruin/lavaland/syndicate_lava_base/brig)
+/area/ruin/syndicate_lava_base)
 "Zl" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 4
@@ -4747,10 +4283,7 @@
 	pixel_x = 25
 	},
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/starboard)
-"Zo" = (
-/turf/closed/wall/mineral/plastitanium/nodiagonal,
-/area/ruin/lavaland/syndicate_lava_base/cargo)
+/area/ruin/syndicate_lava_base)
 "Zq" = (
 /obj/effect/turf_decal/stripes/closeup{
 	dir = 1
@@ -4766,13 +4299,13 @@
 	name = "Starboard Hall"
 	},
 /turf/open/floor/iron/techmaint,
-/area/ruin/lavaland/syndicate_lava_base/cargo)
+/area/ruin/syndicate_lava_base)
 "Zv" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/bot,
 /obj/machinery/portable_thermomachine,
 /turf/open/floor/iron/dark/smooth_large,
-/area/ruin/lavaland/syndicate_lava_base/engineering)
+/area/ruin/syndicate_lava_base)
 "Zz" = (
 /obj/structure/closet/crate,
 /obj/item/malf_upgrade,
@@ -4783,14 +4316,14 @@
 	dir = 10
 	},
 /turf/open/floor/iron/dark/textured,
-/area/ruin/lavaland/syndicate_lava_base/starboard)
+/area/ruin/syndicate_lava_base)
 "ZC" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 4
 	},
 /obj/structure/cable/yellow,
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/starboard)
+/area/ruin/syndicate_lava_base)
 "ZH" = (
 /obj/structure/cable/yellow,
 /obj/effect/turf_decal/siding/dark{
@@ -4800,11 +4333,11 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark/textured,
-/area/ruin/lavaland/syndicate_lava_base/engineering)
+/area/ruin/syndicate_lava_base)
 "ZK" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible/layer2,
 /turf/open/floor/catwalk_floor/iron_dark,
-/area/ruin/lavaland/syndicate_lava_base/engineering)
+/area/ruin/syndicate_lava_base)
 "ZN" = (
 /obj/effect/turf_decal/stripes/closeup,
 /obj/machinery/door/firedoor,
@@ -4813,7 +4346,7 @@
 	},
 /obj/effect/mapping_helpers/airlock/access/all/syndicate/general,
 /turf/open/floor/iron/techmaint,
-/area/ruin/lavaland/syndicate_lava_base/brig)
+/area/ruin/syndicate_lava_base)
 "ZQ" = (
 /obj/structure/table/wood,
 /obj/machinery/chem_dispenser/drinks/beer/fullupgrade{
@@ -4822,7 +4355,7 @@
 /obj/effect/turf_decal/tile/bar/opposingcorners,
 /obj/machinery/firealarm/directional/south,
 /turf/open/floor/iron/dark,
-/area/ruin/lavaland/syndicate_lava_base/bar)
+/area/ruin/syndicate_lava_base)
 
 (1,1,1) = {"
 hK
@@ -5285,12 +4818,12 @@ Ta
 Ta
 Ta
 cU
-ED
+dq
 ul
 ul
 ul
-ED
-oM
+dq
+dN
 Ta
 Ta
 Ta
@@ -5343,19 +4876,19 @@ Ta
 Ta
 Ta
 Ta
-OZ
-DA
-DA
-ED
+cb
+dq
+dq
+dq
 eM
 hd
 lL
 Gz
 XV
-ED
 dq
 dq
-CG
+dq
+cb
 Ta
 Ta
 Ta
@@ -5401,25 +4934,25 @@ Ta
 Ta
 Ta
 Ta
-OZ
+cb
 hR
 hR
 hR
-DA
+dq
 EQ
 WW
-ED
+dq
 Or
-mU
+mr
 zk
 mP
 Py
-ED
+dq
 Ek
 KZ
 dq
 dq
-CG
+cb
 Ta
 Ta
 Ta
@@ -5462,22 +4995,22 @@ Ta
 Ta
 Ta
 Ta
-UG
-DA
+BI
+dq
 Vf
 bV
 cO
 Ei
-Eg
+oz
 fT
 ny
-FI
-FI
+fT
+fT
 LB
-FI
+fT
 nG
 ny
-qe
+fT
 ix
 lo
 Ol
@@ -5485,7 +5018,7 @@ dq
 dq
 dq
 dq
-oL
+dN
 Ta
 Ta
 Ta
@@ -5530,15 +5063,15 @@ Lh
 IQ
 GZ
 MV
-Eg
+oz
 on
-ED
+dq
 Ep
 FM
 Uw
 aV
-Xx
-ED
+bw
+dq
 jd
 bf
 wL
@@ -5588,19 +5121,19 @@ Ta
 Ta
 hR
 Xb
-Eg
-Eg
+oz
+oz
 sD
-ld
-ld
+bf
+bf
 fT
-Nq
+aZ
 xk
 cA
 dK
 cT
 JA
-Nq
+aZ
 TM
 bf
 bf
@@ -5652,18 +5185,18 @@ hR
 BE
 Rs
 Rs
-Ls
+yA
 Mr
 mH
 fT
 eT
 lH
-rY
-rY
-rY
+ms
+ms
+ms
 BG
 lK
-qe
+fT
 bf
 Cp
 eU
@@ -5710,21 +5243,21 @@ Ta
 Ta
 Ta
 Ta
-DA
-DA
+dq
+dq
 oi
 mq
 gJ
 nz
-Eg
-Eg
-Nq
+oz
+oz
+aZ
 Wk
-rY
+ms
 cg
-SW
+me
 OI
-Nq
+aZ
 oz
 gM
 Yy
@@ -5733,7 +5266,7 @@ dq
 dq
 dq
 dq
-CG
+cb
 Ta
 Ta
 Ta
@@ -5772,12 +5305,12 @@ Ta
 Ta
 Ta
 Ta
-OZ
-DA
-DA
-DA
-DA
-DA
+cb
+dq
+dq
+dq
+dq
+dq
 ba
 gL
 bw
@@ -5786,12 +5319,12 @@ oG
 CR
 pn
 AX
-DA
+dq
 Rn
 Xy
 dq
 dq
-CG
+cb
 Ta
 Ta
 Ta
@@ -5839,19 +5372,19 @@ Ta
 Ta
 Ta
 Ta
-OZ
-DA
-DA
-DA
-DA
+cb
+dq
+dq
+dq
+dq
 vX
-Nq
+aZ
 dY
-DA
-DA
 dq
 dq
-CG
+dq
+dq
+cb
 Ta
 Ta
 Ta
@@ -5905,13 +5438,13 @@ Ta
 Ta
 az
 qk
-RD
-sA
-Eh
+aX
+hB
+oJ
 rC
-DA
-Rf
-IY
+dq
+gZ
+Hj
 JE
 Ta
 Ta
@@ -5967,13 +5500,13 @@ Ta
 Ta
 az
 qk
-RD
+aX
 lH
 qK
 xG
-xs
+wU
 go
-TD
+NR
 az
 Ta
 Ta
@@ -6029,13 +5562,13 @@ Ta
 Ta
 am
 qk
-RD
-sA
+aX
+hB
 Ja
 xG
-DA
+dq
 pf
-IY
+Hj
 JE
 Ta
 Ta
@@ -6085,21 +5618,21 @@ Ta
 Ta
 Ta
 cb
-jg
-QF
-QF
-jg
-jg
-EN
-DA
+dq
+aX
+aX
+dq
+dq
+bw
+dq
 HP
-Nq
+aZ
 Rv
-DA
-EN
-jg
-jg
-QF
+dq
+bw
+dq
+dq
+aX
 cb
 Ta
 kz
@@ -6146,30 +5679,30 @@ Ta
 Ta
 Ta
 cb
-jg
+dq
 xS
 FY
 FY
 pJ
 FY
-wq
-HK
+uY
+dK
 yo
 ja
 eL
 gs
-wq
+uY
 FY
 pJ
 UF
-jg
-le
+dq
+dq
 wY
 GC
 wY
 wY
-le
-HW
+dq
+dN
 Ta
 Ta
 Ta
@@ -6205,12 +5738,12 @@ Ta
 Ta
 Ta
 BI
-vs
-Of
-Of
+aX
+dq
+dq
 mo
 yo
-sk
+ms
 bC
 bC
 bC
@@ -6225,20 +5758,20 @@ bC
 bC
 SJ
 UF
-uT
+aZ
 dl
 LH
 dk
 Ot
 dc
-le
-le
-le
-le
-le
-le
-le
-le
+dq
+dq
+dq
+dq
+dq
+dq
+dq
+dq
 Ta
 Ta
 Ta
@@ -6266,40 +5799,40 @@ Ta
 Ta
 Ta
 Ta
-Of
+dq
 Wu
 tC
-Of
-PR
-sk
-DV
-DV
+dq
+KE
+ms
+me
+me
 Od
-DV
-wq
+me
+uY
 Hw
 mv
 KV
-DV
+me
 dP
-wq
-DV
+uY
+me
 Md
-sk
+ms
 lY
 Wj
-Zh
+cJ
 Nr
 pz
 Er
 Vl
-le
+dq
 Yr
 mS
 MF
 MF
 CC
-le
+dq
 QO
 up
 Ta
@@ -6328,40 +5861,40 @@ Ta
 Ta
 Ta
 Ta
-Of
+dq
 cI
 Lv
-KJ
+bw
 wg
-sk
-DV
-uC
-uC
-uj
-uC
-uC
-jg
-jg
+ms
+me
+dq
+dq
+bw
+dq
+dq
+dq
+dq
 Sp
-jg
-EN
-jg
+dq
+bw
+dq
 zp
-JB
+zR
 lG
-uT
-Pa
+aZ
+xj
 nY
 sT
 Ct
 Vl
 gN
-Gv
+me
 PB
 Gd
 Gd
 cV
-le
+dq
 QO
 Ta
 Ta
@@ -6386,45 +5919,45 @@ Ta
 Ta
 Ta
 Ta
-UU
+BI
 hb
-Ru
-Ru
-Of
+dq
+dq
+dq
 Qz
 CI
-Of
+dq
 vM
 Vj
 vM
-uC
+dq
 Ln
 fw
 CJ
-uC
+dq
 DQ
-jg
+dq
 oy
 jm
-jg
-jg
-VG
+dq
+dq
+vM
 Gg
 lr
-le
+dq
 lU
 dl
 aT
 aI
 Xs
-le
+dq
 QM
-Gw
-le
-le
-le
-le
-le
+bw
+dq
+dq
+dq
+dq
+dq
 QO
 up
 Ta
@@ -6452,10 +5985,10 @@ hb
 II
 Ne
 HQ
-Of
-Of
+dq
+dq
 Xl
-Of
+dq
 OW
 Gi
 hm
@@ -6463,30 +5996,30 @@ XO
 Tg
 Eo
 xy
-uC
+dq
 qB
 Rj
 qT
 jm
-jg
-jg
-DV
-Nm
-Yo
-le
-le
+dq
+dq
+me
+sd
+vB
+dq
+dq
 BH
 La
 bl
-le
-le
+dq
+dq
 HZ
 xA
 fB
-Kd
+iE
 Ms
 bT
-YO
+dq
 QO
 Ta
 Ta
@@ -6515,7 +6048,7 @@ vd
 OU
 qA
 AF
-Ru
+dq
 cJ
 sa
 xj
@@ -6525,33 +6058,33 @@ hM
 Tq
 Tg
 li
-uC
-jg
-jg
-jg
-jg
-jg
-DV
+dq
+dq
+dq
+dq
+dq
+dq
+me
 Yl
-JB
-Ke
+zR
+qA
 OS
-le
-Gw
-le
-le
-le
-YO
+dq
+bw
+dq
+dq
+dq
+dq
 re
 uq
 YE
 AR
 xt
 Zv
-YO
-YO
-YO
-YO
+dq
+dq
+dq
+dq
 dN
 Ta
 Ta
@@ -6574,9 +6107,9 @@ Ta
 hb
 Sg
 gT
-EA
+me
 zU
-yQ
+lG
 ys
 cJ
 TB
@@ -6587,12 +6120,12 @@ Pf
 Tg
 Tq
 wW
-uC
+dq
 UW
 DO
 Fz
-FT
-DV
+dq
+me
 HX
 zG
 zG
@@ -6600,22 +6133,22 @@ GJ
 Vw
 tJ
 wv
-Kd
-Kd
+iE
+iE
 Qc
 tK
 IL
-Kd
-Kd
-Kd
-Kd
+iE
+iE
+iE
+iE
 ww
-YO
+dq
 eH
-YO
+dq
 nc
-YO
-YO
+dq
+dq
 mO
 Ta
 Ta
@@ -6636,10 +6169,10 @@ Ta
 hb
 Pj
 wr
-EA
+me
 zR
 Qh
-Ux
+aZ
 lV
 pB
 YW
@@ -6649,19 +6182,19 @@ Hv
 Eo
 Tg
 el
-uC
+dq
 GR
 Pb
 VQ
 NO
-JB
+zR
 CT
 rG
 aL
 Um
 fP
-DV
-Pz
+me
+aZ
 af
 zs
 ZH
@@ -6698,8 +6231,8 @@ Ta
 hb
 rw
 gT
-EA
-WB
+me
+iG
 Qh
 ao
 lV
@@ -6711,11 +6244,11 @@ sO
 Tg
 Tq
 kR
-uC
+dq
 Zz
 gg
 sU
-FT
+dq
 Ya
 iO
 ub
@@ -6738,8 +6271,8 @@ Bw
 kp
 Bw
 CS
-YO
-YO
+dq
+dq
 mO
 Ta
 Ta
@@ -6763,7 +6296,7 @@ rS
 eN
 Ub
 XE
-Ru
+dq
 cJ
 yN
 yN
@@ -6773,32 +6306,32 @@ cf
 Tq
 Tg
 ZQ
-uC
-FT
-FT
-FT
-FT
-FT
+dq
+dq
+dq
+dq
+dq
+dq
 rF
 ln
 sd
 sC
 AH
-YO
-YO
+dq
+dq
 Qy
 Jj
 qL
 Lt
 Yp
 ij
-Qb
-Qb
+Dw
+Dw
 bB
 Oz
-Ia
-YO
-YO
+bw
+dq
+dq
 XX
 dB
 Ta
@@ -6824,14 +6357,14 @@ hb
 Qt
 mY
 UX
-Of
-Of
+dq
+dq
 tL
-Of
+dq
 lw
 lI
 oP
-uC
+dq
 QW
 Tq
 PM
@@ -6840,13 +6373,13 @@ pU
 bA
 aN
 mf
-FT
-FT
+dq
+dq
 XG
-TU
-nU
-YO
-YO
+zR
+lG
+dq
+dq
 Kt
 Zi
 ZK
@@ -6858,7 +6391,7 @@ kj
 fA
 vN
 oH
-YO
+dq
 QO
 up
 Ta
@@ -6882,45 +6415,45 @@ Ta
 Ta
 Ta
 Ta
-EY
+cy
 hb
-Ru
-Ru
-Of
+dq
+dq
+dq
 Kl
 Iv
-Of
+dq
 vM
 Vj
 vM
-uC
+dq
 UO
 es
 DG
-uC
+dq
 eJ
 js
 dh
 DS
 ur
-FT
-Wx
-Kx
-AI
-YO
+dq
+vM
+Gg
+lr
+dq
 rJ
 FQ
 kY
 Kt
 Sq
-YO
-Pz
+dq
+aZ
 Ic
-YO
+dq
 dE
-Pz
-YO
-YO
+aZ
+dq
+dq
 QO
 Ta
 Ta
@@ -6948,40 +6481,40 @@ Ta
 Ta
 Ta
 Ta
-Of
+dq
 xl
 ha
-KJ
+bw
 KE
 ms
-JM
-uC
-uC
-uj
-uC
-uC
-FT
-FT
+me
+dq
+dq
+bw
+dq
+dq
+dq
+dq
 fQ
-FT
-Jo
-FT
-JM
-TU
+dq
+bw
+dq
+me
+zR
 vB
-YO
-Pz
+dq
+aZ
 dE
 Ex
-Pz
+aZ
 dE
-YO
+dq
 jn
 qE
-YO
+dq
 Qp
 PI
-YO
+dq
 QO
 up
 Ta
@@ -7010,10 +6543,10 @@ Ta
 Ta
 Ta
 Ta
-Of
+dq
 Qz
 pg
-Of
+dq
 KE
 ms
 fs
@@ -7031,19 +6564,19 @@ Mj
 fs
 ms
 vB
-YO
+dq
 ru
 xz
 Ex
 BB
 QU
-Ia
+bw
 jw
 mn
-YO
+dq
 Mc
 Bd
-YO
+dq
 QO
 Ta
 Ta
@@ -7072,19 +6605,19 @@ Ta
 Ta
 Ta
 Ta
-YL
-vs
-Of
-Of
+cy
+aX
+dq
+dq
 Fm
 Kp
-TU
+zR
 iE
 iE
 iE
 jH
 iE
-nO
+bC
 iE
 iE
 ux
@@ -7093,20 +6626,20 @@ iE
 iE
 xX
 AE
-YO
+dq
 Ui
 SY
 Ex
 ei
 to
-YO
-YO
-YO
-YO
-YO
-YO
-YO
-YO
+dq
+dq
+dq
+dq
+dq
+dq
+dq
+dq
 Ta
 Ta
 Ta
@@ -7137,8 +6670,8 @@ Ta
 Ta
 Ta
 Ta
-wj
-FT
+cb
+dq
 oB
 ed
 ed
@@ -7148,19 +6681,19 @@ uY
 ed
 lB
 iG
-UJ
+Ub
 ed
 uY
 IS
 Zl
 AE
-FT
-YO
-YO
-YO
+dq
+dq
+dq
+dq
 Ex
-YO
-YO
+dq
+dq
 dB
 Ta
 Ta
@@ -7200,23 +6733,23 @@ Ta
 Ta
 Ta
 Ta
-wj
-FT
-Ku
-Ku
-FT
-FT
-FT
-Zo
+cb
+dq
+aX
+aX
+dq
+dq
+dq
+dq
 WN
-VP
+aZ
 FL
-Zo
-Jo
-FT
-FT
-Ku
-wj
+dq
+bw
+dq
+dq
+aX
+cb
 Ta
 Ta
 Ta
@@ -7273,7 +6806,7 @@ aX
 hB
 Bg
 RV
-Zo
+dq
 gZ
 Hj
 JE
@@ -7336,7 +6869,7 @@ hB
 mj
 sR
 wU
-PW
+go
 NR
 az
 Ta
@@ -7397,8 +6930,8 @@ aX
 hB
 oJ
 LV
-Zo
-Cg
+dq
+pf
 Hj
 JE
 Ta
@@ -7451,19 +6984,19 @@ Ta
 Ta
 Ta
 Ta
-Wo
-Pi
-Pi
-FC
-Zo
+cb
+dq
+dq
+bw
+dq
 Zq
-VP
+aZ
 jL
-Zo
-Zo
-Zo
-Zo
-qX
+dq
+dq
+dq
+dq
+cb
 Ta
 Ta
 Ta
@@ -7508,26 +7041,26 @@ Ta
 Ta
 Ta
 Ta
-Wo
-Pi
-Pi
-Pi
-Pi
-Pi
+cb
+dq
+dq
+dq
+dq
+dq
 KK
 Co
-JU
+Fu
 eA
 Ha
 me
-xE
+eL
 Sy
 Fu
 TX
 zC
-Zo
-Zo
-qX
+dq
+dq
+cb
 Ta
 Ta
 Ta
@@ -7580,20 +7113,20 @@ iy
 RU
 Rh
 FW
-Hc
+ms
 Nh
-Hc
+ms
 Ti
 Jh
 Cc
 KO
 NN
-Zo
-Zo
-Zo
-Zo
-Zo
-Zo
+dq
+dq
+dq
+dq
+dq
+dq
 Ta
 Ta
 Ta
@@ -7636,13 +7169,13 @@ vA
 mD
 Nl
 kd
-HI
+Dw
 Bo
 Ev
 px
-JU
+Fu
 bd
-KX
+ln
 Ld
 EM
 sR
@@ -7654,7 +7187,7 @@ Io
 wz
 lA
 en
-Zo
+dq
 QO
 Ta
 wE
@@ -7694,15 +7227,15 @@ Ta
 Ta
 Ta
 Ta
-Pi
-Vo
-Vo
+dq
+aZ
+aZ
 SL
-Vo
-Pi
+aZ
+dq
 Zj
 xm
-Pi
+dq
 nb
 LG
 ch
@@ -7716,7 +7249,7 @@ Io
 Se
 WK
 Pr
-Zo
+dq
 QO
 Ta
 Ta
@@ -7756,21 +7289,21 @@ Ta
 Ta
 Ta
 Ta
-Pi
+dq
 xu
 Ho
-SM
-IR
-Pi
-RP
-Gh
-Zo
+zR
+oJ
+dq
+DS
+go
+dq
 Dc
-Zo
+dq
 rd
-Zo
+dq
 Dc
-Zo
+dq
 ug
 Yh
 Lg
@@ -7778,7 +7311,7 @@ Io
 jb
 dZ
 vg
-Zo
+dq
 QO
 Ta
 Ta
@@ -7819,28 +7352,28 @@ Ta
 Ta
 Ta
 cy
-Pi
+dq
 mE
 or
-FD
+dP
 ZN
 YZ
 GX
-Zo
+dq
 KL
 oX
 Ze
-CP
+pU
 lJ
-Sz
+bw
 VZ
 Dw
 Hg
-Zo
-Zo
-Zo
-Zo
-Zo
+dq
+dq
+dq
+dq
+dq
 Bt
 Ta
 Ta
@@ -7881,25 +7414,25 @@ Ta
 Ta
 Ta
 Ta
-Wo
-Pi
-Pi
-Pi
-Pi
+cb
+dq
+dq
+dq
+dq
 iZ
 FS
-Zo
+dq
 QH
 Ud
 EP
 pw
 cd
-Zo
+dq
 Ip
 Bs
-Zo
-Zo
-qX
+dq
+dq
+cb
 Ta
 Ta
 Ta
@@ -7947,19 +7480,19 @@ Ta
 Ta
 Ta
 Ta
-Wo
-Pi
-Pi
-Zo
+cb
+dq
+dq
+dq
 Go
 OO
 ry
 OO
 IF
-Zo
-Zo
-Zo
-qX
+dq
+dq
+dq
+cb
 Ta
 Ta
 Ta

--- a/code/game/area/areas/ruins/_ruins.dm
+++ b/code/game/area/areas/ruins/_ruins.dm
@@ -17,3 +17,6 @@
 
 /area/ruin/powered
 	requires_power = FALSE
+
+/area/ruin/lavaland
+	requires_power = TRUE

--- a/code/game/area/areas/ruins/_ruins.dm
+++ b/code/game/area/areas/ruins/_ruins.dm
@@ -17,6 +17,3 @@
 
 /area/ruin/powered
 	requires_power = FALSE
-
-/area/ruin/lavaland
-	requires_power = TRUE

--- a/code/game/area/areas/ruins/lavaland.dm
+++ b/code/game/area/areas/ruins/lavaland.dm
@@ -31,59 +31,59 @@
 
 //Syndicate lavaland base
 
-/area/ruin/lavaland/syndicate_lava_base
+/area/ruin/syndicate_lava_base
 	name = "Secret Base"
 	icon_state = "dk_yellow"
 	ambience_index = AMBIENCE_DANGER
 	ambient_buzz = 'sound/ambience/magma.ogg'
 	ambient_buzz_vol = 10
 
-/area/ruin/lavaland/syndicate_lava_base/brig
+/area/ruin/syndicate_lava_base/brig
 	name = "Syndicate Lavaland Brig"
 
-/area/ruin/lavaland/syndicate_lava_base/bridge
+/area/ruin/syndicate_lava_base/bridge
 	name = "Syndicate Lavaland Bridge"
 
-/area/ruin/lavaland/syndicate_lava_base/starboard
+/area/ruin/syndicate_lava_base/starboard
 	name = "Syndicate Lavaland Starboard Primary Hallway"
 
-/area/ruin/lavaland/syndicate_lava_base/port
+/area/ruin/syndicate_lava_base/port
 	name = "Syndicate Lavaland Port Primary Hallway"
 
-/area/ruin/lavaland/syndicate_lava_base/engineering
+/area/ruin/syndicate_lava_base/engineering
 	name = "Syndicate Lavaland Engineering"
 
-/area/ruin/lavaland/syndicate_lava_base/medbay
+/area/ruin/syndicate_lava_base/medbay
 	name = "Syndicate Lavaland Medbay"
 
-/area/ruin/lavaland/syndicate_lava_base/arrivals
+/area/ruin/syndicate_lava_base/arrivals
 	name = "Syndicate Lavaland Arrivals"
 
-/area/ruin/lavaland/syndicate_lava_base/bar
+/area/ruin/syndicate_lava_base/bar
 	name = "\improper Syndicate Lavaland Bar"
 
-/area/ruin/lavaland/syndicate_lava_base/main
+/area/ruin/syndicate_lava_base/main
 	name = "\improper Syndicate Lavaland Primary Hallway"
 
-/area/ruin/lavaland/syndicate_lava_base/cargo
+/area/ruin/syndicate_lava_base/cargo
 	name = "\improper Syndicate Lavaland Cargo Bay"
 
-/area/ruin/lavaland/syndicate_lava_base/chemistry
+/area/ruin/syndicate_lava_base/chemistry
 	name = "Syndicate Lavaland Chemistry"
 
-/area/ruin/lavaland/syndicate_lava_base/virology
+/area/ruin/syndicate_lava_base/virology
 	name = "Syndicate Lavaland Virology"
 
-/area/ruin/lavaland/syndicate_lava_base/science
+/area/ruin/syndicate_lava_base/science
 	name = "Syndicate Lavaland Science"
 
-/area/ruin/lavaland/syndicate_lava_base/testlab
+/area/ruin/syndicate_lava_base/testlab
 	name = "\improper Syndicate Lavaland Experimentation Lab"
 
-/area/ruin/lavaland/syndicate_lava_base/dormitories
+/area/ruin/syndicate_lava_base/dormitories
 	name = "\improper Syndicate Lavaland Dormitories"
 
-/area/ruin/lavaland/syndicate_lava_base/telecomms
+/area/ruin/syndicate_lava_base/telecomms
 	name = "\improper Syndicate Lavaland Telecommunications"
 
 /area/ruin/unpowered/standruin

--- a/code/game/area/areas/ruins/lavaland.dm
+++ b/code/game/area/areas/ruins/lavaland.dm
@@ -31,59 +31,59 @@
 
 //Syndicate lavaland base
 
-/area/ruin/unpowered/syndicate_lava_base
+/area/ruin/lavaland/syndicate_lava_base
 	name = "Secret Base"
 	icon_state = "dk_yellow"
 	ambience_index = AMBIENCE_DANGER
 	ambient_buzz = 'sound/ambience/magma.ogg'
 	ambient_buzz_vol = 10
 
-/area/ruin/unpowered/syndicate_lava_base/brig
+/area/ruin/lavaland/syndicate_lava_base/brig
 	name = "Syndicate Lavaland Brig"
 
-/area/ruin/unpowered/syndicate_lava_base/bridge
+/area/ruin/lavaland/syndicate_lava_base/bridge
 	name = "Syndicate Lavaland Bridge"
 
-/area/ruin/unpowered/syndicate_lava_base/starboard
+/area/ruin/lavaland/syndicate_lava_base/starboard
 	name = "Syndicate Lavaland Starboard Primary Hallway"
 
-/area/ruin/unpowered/syndicate_lava_base/port
+/area/ruin/lavaland/syndicate_lava_base/port
 	name = "Syndicate Lavaland Port Primary Hallway"
 
-/area/ruin/unpowered/syndicate_lava_base/engineering
+/area/ruin/lavaland/syndicate_lava_base/engineering
 	name = "Syndicate Lavaland Engineering"
 
-/area/ruin/unpowered/syndicate_lava_base/medbay
+/area/ruin/lavaland/syndicate_lava_base/medbay
 	name = "Syndicate Lavaland Medbay"
 
-/area/ruin/unpowered/syndicate_lava_base/arrivals
+/area/ruin/lavaland/syndicate_lava_base/arrivals
 	name = "Syndicate Lavaland Arrivals"
 
-/area/ruin/unpowered/syndicate_lava_base/bar
+/area/ruin/lavaland/syndicate_lava_base/bar
 	name = "\improper Syndicate Lavaland Bar"
 
-/area/ruin/unpowered/syndicate_lava_base/main
+/area/ruin/lavaland/syndicate_lava_base/main
 	name = "\improper Syndicate Lavaland Primary Hallway"
 
-/area/ruin/unpowered/syndicate_lava_base/cargo
+/area/ruin/lavaland/syndicate_lava_base/cargo
 	name = "\improper Syndicate Lavaland Cargo Bay"
 
-/area/ruin/unpowered/syndicate_lava_base/chemistry
+/area/ruin/lavaland/syndicate_lava_base/chemistry
 	name = "Syndicate Lavaland Chemistry"
 
-/area/ruin/unpowered/syndicate_lava_base/virology
+/area/ruin/lavaland/syndicate_lava_base/virology
 	name = "Syndicate Lavaland Virology"
 
-/area/ruin/unpowered/syndicate_lava_base/science
+/area/ruin/lavaland/syndicate_lava_base/science
 	name = "Syndicate Lavaland Science"
 
-/area/ruin/unpowered/syndicate_lava_base/testlab
+/area/ruin/lavaland/syndicate_lava_base/testlab
 	name = "\improper Syndicate Lavaland Experimentation Lab"
 
-/area/ruin/unpowered/syndicate_lava_base/dormitories
+/area/ruin/lavaland/syndicate_lava_base/dormitories
 	name = "\improper Syndicate Lavaland Dormitories"
 
-/area/ruin/unpowered/syndicate_lava_base/telecomms
+/area/ruin/lavaland/syndicate_lava_base/telecomms
 	name = "\improper Syndicate Lavaland Telecommunications"
 
 /area/ruin/unpowered/standruin

--- a/tools/UpdatePaths/Scripts/14431_lavalandbase.txt
+++ b/tools/UpdatePaths/Scripts/14431_lavalandbase.txt
@@ -1,3 +1,2 @@
 # Lavaland Base update
-/area/ruin/lavaland/syndicate_lava_base/@SUBTYPES : /area/ruin/syndicate_lava_base{@OLD}
 /area/ruin/unpowered/syndicate_lava_base/@SUBTYPES : /area/ruin/syndicate_lava_base{@OLD}

--- a/tools/UpdatePaths/Scripts/14431_lavalandbase.txt
+++ b/tools/UpdatePaths/Scripts/14431_lavalandbase.txt
@@ -1,0 +1,19 @@
+# Lavaland Base update
+
+/area/ruin/unpowered/syndicate_lava_base : /area/ruin/lavaland/syndicate_lava_base{@OLD}
+/area/ruin/unpowered/syndicate_lava_base/brig : /area/ruin/lavaland/syndicate_lava_base/brig{@OLD}
+/area/ruin/unpowered/syndicate_lava_base/bridge : /area/ruin/lavaland/syndicate_lava_base/bridge{@OLD}
+/area/ruin/unpowered/syndicate_lava_base/starboard : /area/ruin/lavaland/syndicate_lava_base/starboard{@OLD}
+/area/ruin/unpowered/syndicate_lava_base/port : /area/ruin/lavaland/syndicate_lava_base/port{@OLD}
+/area/ruin/unpowered/syndicate_lava_base/engineering : /area/ruin/lavaland/syndicate_lava_base/engineering{@OLD}
+/area/ruin/unpowered/syndicate_lava_base/medbay : /area/ruin/lavaland/syndicate_lava_base/medbay{@OLD}
+/area/ruin/unpowered/syndicate_lava_base/arrivals : /area/ruin/lavaland/syndicate_lava_base/arrivals{@OLD}
+/area/ruin/unpowered/syndicate_lava_base/bar : /area/ruin/lavaland/syndicate_lava_base/bar{@OLD}
+/area/ruin/unpowered/syndicate_lava_base/main : /area/ruin/lavaland/syndicate_lava_base/main{@OLD}
+/area/ruin/unpowered/syndicate_lava_base/cargo : /area/ruin/lavaland/syndicate_lava_base/cargo{@OLD}
+/area/ruin/unpowered/syndicate_lava_base/chemistry : /area/ruin/lavaland/syndicate_lava_base/chemistry{@OLD}
+/area/ruin/unpowered/syndicate_lava_base/virology : /area/ruin/lavaland/syndicate_lava_base/virology{@OLD}
+/area/ruin/unpowered/syndicate_lava_base/science : /area/ruin/lavaland/syndicate_lava_base/science{@OLD}
+/area/ruin/unpowered/syndicate_lava_base/testlab : /area/ruin/lavaland/syndicate_lava_base/testlab{@OLD}
+/area/ruin/unpowered/syndicate_lava_base/dormitories : /area/ruin/lavaland/syndicate_lava_base/dormitories{@OLD}
+/area/ruin/unpowered/syndicate_lava_base/telecomms : /area/ruin/lavaland/syndicate_lava_base/telecomms{@OLD}

--- a/tools/UpdatePaths/Scripts/14431_lavalandbase.txt
+++ b/tools/UpdatePaths/Scripts/14431_lavalandbase.txt
@@ -1,19 +1,3 @@
 # Lavaland Base update
-
-/area/ruin/unpowered/syndicate_lava_base : /area/ruin/lavaland/syndicate_lava_base{@OLD}
-/area/ruin/unpowered/syndicate_lava_base/brig : /area/ruin/lavaland/syndicate_lava_base/brig{@OLD}
-/area/ruin/unpowered/syndicate_lava_base/bridge : /area/ruin/lavaland/syndicate_lava_base/bridge{@OLD}
-/area/ruin/unpowered/syndicate_lava_base/starboard : /area/ruin/lavaland/syndicate_lava_base/starboard{@OLD}
-/area/ruin/unpowered/syndicate_lava_base/port : /area/ruin/lavaland/syndicate_lava_base/port{@OLD}
-/area/ruin/unpowered/syndicate_lava_base/engineering : /area/ruin/lavaland/syndicate_lava_base/engineering{@OLD}
-/area/ruin/unpowered/syndicate_lava_base/medbay : /area/ruin/lavaland/syndicate_lava_base/medbay{@OLD}
-/area/ruin/unpowered/syndicate_lava_base/arrivals : /area/ruin/lavaland/syndicate_lava_base/arrivals{@OLD}
-/area/ruin/unpowered/syndicate_lava_base/bar : /area/ruin/lavaland/syndicate_lava_base/bar{@OLD}
-/area/ruin/unpowered/syndicate_lava_base/main : /area/ruin/lavaland/syndicate_lava_base/main{@OLD}
-/area/ruin/unpowered/syndicate_lava_base/cargo : /area/ruin/lavaland/syndicate_lava_base/cargo{@OLD}
-/area/ruin/unpowered/syndicate_lava_base/chemistry : /area/ruin/lavaland/syndicate_lava_base/chemistry{@OLD}
-/area/ruin/unpowered/syndicate_lava_base/virology : /area/ruin/lavaland/syndicate_lava_base/virology{@OLD}
-/area/ruin/unpowered/syndicate_lava_base/science : /area/ruin/lavaland/syndicate_lava_base/science{@OLD}
-/area/ruin/unpowered/syndicate_lava_base/testlab : /area/ruin/lavaland/syndicate_lava_base/testlab{@OLD}
-/area/ruin/unpowered/syndicate_lava_base/dormitories : /area/ruin/lavaland/syndicate_lava_base/dormitories{@OLD}
-/area/ruin/unpowered/syndicate_lava_base/telecomms : /area/ruin/lavaland/syndicate_lava_base/telecomms{@OLD}
+/area/ruin/lavaland/syndicate_lava_base/@SUBTYPES : /area/ruin/syndicate_lava_base{@OLD}
+/area/ruin/unpowered/syndicate_lava_base/@SUBTYPES : /area/ruin/syndicate_lava_base{@OLD}


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Mostly self-explanatory
https://github.com/BeeStation/BeeStation-Hornet/pull/14238

 Changed ruins to be fully unpowered
 Syndie base inherits from the same unpowered area
 
 This just changes it to it's own category that actually needs power
 
## Why It's Good For The Game

Fix man good

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

<img width="1128" height="997" alt="image" src="https://github.com/user-attachments/assets/d83c80f7-9575-45cf-a1a3-64a8af4bb250" />

</details>

## Changelog
:cl:
fix: Lavaland syndicate base is no longer unpowered 24/7
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
