### PR TITLE
Moth Eye Swap + Roundstart Burnt Wing Toggle

### DIFF
--- a/code/modules/client/preferences/entries/character/species_features/moth.dm
+++ b/code/modules/client/preferences/entries/character/species_features/moth.dm
@@ -115,3 +115,17 @@
 
 /datum/preference/choiced/moth_eyes/create_default_value()
 	return "Default"
+
+/datum/preference/toggle/moth_burnt_wings
+	db_key = "feature_moth_burnt_wings"
+	preference_type = PREFERENCE_CHARACTER
+	category = PREFERENCE_CATEGORY_SECONDARY_FEATURES
+	default_value = FALSE
+	relevant_mutant_bodypart = "moth_wings"
+	can_randomize = FALSE
+
+/datum/preference/toggle/moth_burnt_wings/apply_to_human(mob/living/carbon/human/target, value)
+	if(value)
+		ADD_TRAIT(target, TRAIT_MOTH_BURNT, "fire")
+	else
+		REMOVE_TRAIT(target, TRAIT_MOTH_BURNT, "fire")

--- a/code/modules/mob/living/carbon/human/species_types/mothmen.dm
+++ b/code/modules/mob/living/carbon/human/species_types/mothmen.dm
@@ -57,7 +57,7 @@
 	return ..()
 
 /datum/species/moth/on_species_gain(mob/living/carbon/human/human_who_gained_species, datum/species/old_species, pref_load)
-	if(human_who_gained_species.dna?.features["moth_eyes"] == "Domestic")
+	if(human_who_gained_species.dna?.features["moth_eyes"] == "Default")
 		mutanteyes = /obj/item/organ/eyes/moth/domestic
 	else
 		mutanteyes = /obj/item/organ/eyes/moth

--- a/code/modules/mob/living/carbon/human/species_types/mothmen.dm
+++ b/code/modules/mob/living/carbon/human/species_types/mothmen.dm
@@ -58,9 +58,9 @@
 
 /datum/species/moth/on_species_gain(mob/living/carbon/human/human_who_gained_species, datum/species/old_species, pref_load)
 	if(human_who_gained_species.dna?.features["moth_eyes"] == "Default")
-		mutanteyes = /obj/item/organ/eyes/moth/domestic
-	else
 		mutanteyes = /obj/item/organ/eyes/moth
+	else
+		mutanteyes = /obj/item/organ/eyes/moth/domestic
 	if(!pref_load)
 		human_who_gained_species.dna?.features["mcolor"] = "#f4d697"
 	. = ..()

--- a/code/modules/surgery/organs/eyes.dm
+++ b/code/modules/surgery/organs/eyes.dm
@@ -490,7 +490,7 @@ CREATION_TEST_IGNORE_SUBTYPES(/obj/effect/abstract/eye_lighting)
 	name = "moth eyes"
 	desc = "These eyes seem to have increased sensitivity to bright light, with a small improvement to low light vision."
 	eye_icon = 'icons/mob/human/species/moth/eyes.dmi'
-	eye_icon_state = "eyes"
+	eye_icon_state = "motheyes"
 	icon_state = "eyeballs-moth"
 	see_in_dark = NIGHTVISION_FOV_RANGE/2 //4 tiles compared to 8 of the apids
 	flash_protect = FLASH_PROTECTION_SENSITIVE
@@ -498,7 +498,7 @@ CREATION_TEST_IGNORE_SUBTYPES(/obj/effect/abstract/eye_lighting)
 /obj/item/organ/eyes/moth/domestic
 	name = "domestic moth eyes"
 	desc = "A mutation of natural moth eyes present in more gregarious specimens."
-	eye_icon_state = "motheyes"
+	eye_icon_state = "eyes"
 
 /obj/item/organ/eyes/jelly
 	name = "jelly eyes"

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/character_preferences/species_features.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/character_preferences/species_features.tsx
@@ -1,7 +1,9 @@
 import {
+  CheckboxInput,
   Feature,
   FeatureChoiced,
   FeatureColorInput,
+  FeatureToggle,
   FeatureValueProps,
 } from '../base';
 import {
@@ -227,4 +229,9 @@ export const feature_insect_type: FeatureChoiced = {
 export const feature_moth_eyes: FeatureChoiced = {
   name: 'Eye Type',
   component: FeatureButtonedDropdownInput,
+};
+
+export const feature_moth_burnt_wings: FeatureToggle = {
+  name: 'Burnt Wings',
+  component: CheckboxInput,
 };


### PR DESCRIPTION
## About The Pull Request

Greetings Moth and Moffs, i come to the moffia council with a humble moth pr, its berry limited in scope and does **two** things;

1. Swaps Domestic and Default eyes at their core. Default moth eyes are now the " + + " shape, with the newly imported eye shape being changed to domestic. 
<sub> Headcannon is that the "+ +" are the Moths as we know them in the *lore*, whereas moths who've been cloned enough, or from a long line of station-bound moths are given the eye shape thats commonly found on other servers all in station. Again, headcannon </sub>
2. Gives moths, in their Character Preference menu a toggle that gives adds roundstart burnt wings. These show up in the menu, and are fixable in game as-if they had been otherwise set on fire <sub> (comfy cocoon) </sub>

## Why It's Good For The Game

The default moth option **should** be the eye's we've always used, and I absolutely love the addition of an alternative, but it should remain a secondary option. I could've achieved this by retaining the "+ +" eyes as Domestic as it is without this PR, but the eyes we always have used feel like a better fit for the term "Default" *especially when its the default option in the menu*

As for burnt wings, its a customization option that adds increased diversity to the moth species. A player should not need to resort to setting themself on fire for a character backstory involving wings damaged before station arrival, and this costs nothing to offer them, with the continued choice in round to fix it should the player want. 

## Testing Photographs and Procedure

<details>
<summary>Screenshots&Videos</summary>

https://github.com/user-attachments/assets/863b3b15-d1da-48e6-8e6f-519d4a86681e

</details>

## Changelog
:cl:
add: Added a toggle for moth players to join with burnt and crippled wings.
tweak: Swapped the "Domestic" and "Default" moth eyes, Plus Shaped Eyes are now the Default.
/:cl:

