### PR TITLE
Fixes the Express Console 

### DIFF
--- a/code/modules/cargo/expressconsole.dm
+++ b/code/modules/cargo/expressconsole.dm
@@ -75,7 +75,7 @@
 		))
 
 /obj/machinery/computer/cargo/express/ui_interact(mob/user, datum/tgui/ui)
-	. = ..()
+	SHOULD_CALL_PARENT(FALSE)
 	ui = SStgui.try_update_ui(user, src, ui)
 	if(!ui)
 		ui = new(user, src, "CargoExpress")

--- a/code/modules/cargo/supplypod_beacon.dm
+++ b/code/modules/cargo/supplypod_beacon.dm
@@ -12,6 +12,7 @@
 	var/linked = FALSE
 	var/ready = FALSE
 	var/launched = FALSE
+	max_integrity = 600 // Will survive  about 10 drop-pods before having to be printed again
 
 /obj/item/supplypod_beacon/proc/update_status(consoleStatus)
 	switch(consoleStatus)

--- a/code/modules/cargo/supplypod_beacon.dm
+++ b/code/modules/cargo/supplypod_beacon.dm
@@ -12,7 +12,7 @@
 	var/linked = FALSE
 	var/ready = FALSE
 	var/launched = FALSE
-	max_integrity = 600 // Will survive  about 10 drop-pods before having to be printed again
+	max_integrity = 400 // Will survive  about 6 drop-pods before having to be printed again
 
 /obj/item/supplypod_beacon/proc/update_status(consoleStatus)
 	switch(consoleStatus)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

https://github.com/BeeStation/BeeStation-Hornet/pull/14383

Made Express Consoles call it's parent UI interact, which completely messed with the express's console own UI

Aswell as increased the HP the beacon had, it can last a big longer without having to reprint a new one, instead of reprinting one every 3 drop-pods

## Why It's Good For The Game

Bug Fix Good, makes the express console just a tiny bit more useful aswell

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

<img width="712" height="706" alt="image" src="https://github.com/user-attachments/assets/edfe97bc-5b56-4d59-b085-063ccfff6458" />

</details>

## Changelog
:cl: Isaac
fix: Express Cargo Console uses it's own UI again
balance: Express Cargo Beacons will last about 6 drop-pods instead of 3
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
