### PR TITLE
Fixes Runtime's Held Sprite

### DIFF
--- a/code/modules/mob/living/basic/pets/cat/runtime.dm
+++ b/code/modules/mob/living/basic/pets/cat/runtime.dm
@@ -8,6 +8,7 @@
 	icon_state = "cat"
 	icon_living = "cat"
 	icon_dead = "cat_dead"
+	held_state = "cat"
 	gender = FEMALE
 	gold_core_spawnable = NO_SPAWN
 	unique_pet = TRUE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

I simply added held_state "cat" to runtime, it had the regular cat held sprite 

## Why It's Good For The Game

I love runtime

Closes https://github.com/BeeStation/BeeStation-Hornet/issues/14437


## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

<img width="212" height="207" alt="image" src="https://github.com/user-attachments/assets/32a81a6b-aea1-4115-a5f5-21afa19e9bf4" />


</details>

## Changelog
:cl: Isaac
fix: Runtime has it's own sprite when held again
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
