### PR TITLE
Fixes VV minour issue - checks vv bitflags correctly, and revert special list change

### DIFF
--- a/code/__DEFINES/vv.dm
+++ b/code/__DEFINES/vv.dm
@@ -194,49 +194,36 @@
 #define VV_ALWAYS_CONTRACT_LIST (1<<0)
 #define VV_READ_ONLY (1<<1)
 
-
-#define VV_LIST_PROTECTED (1) /// Can not vv the list. Doing vv this list is not safe.
-#define VV_LIST_READ_ONLY (2) /// Can vv the list, but can not edit.
-#define VV_LIST_EDITABLE (3) /// Can vv the list, and edit.
+#define VV_LIST_PROTECTED (1) //! Can not vv the list. Doing vv this list is not safe.
+#define VV_LIST_READ_ONLY (2) //! Can vv the list, but can not edit.
+#define VV_LIST_EDITABLE (3) //! Can vv the list, and edit.
 
 // Becomes read only at live, editable at debug, dynamically
 #ifdef DEBUG
-#define VV_LIST_READ_ONLY___DEBUG_EDITABLE (3)
+#define VV_LIST_READ_ONLY___DEBUG_EDITABLE (VV_LIST_EDITABLE)
 #else
-#define VV_LIST_READ_ONLY___DEBUG_EDITABLE (2)
+#define VV_LIST_READ_ONLY___DEBUG_EDITABLE (VV_LIST_READ_ONLY)
 #endif
-
-// A list of all the special byond lists that need to be handled different by vv
+/// A list of all the special byond lists that need to be handled different by vv.
+/// manually adding var name is recommanded.
+GLOBAL_LIST_INIT(vv_special_lists, list(
+	// /datum
+	"vars" = VV_LIST_READ_ONLY,
+	// /atoms
+	"overlays" = VV_LIST_EDITABLE,
+	"underlays" = VV_LIST_EDITABLE,
+	"vis_contents" = VV_LIST_EDITABLE,
+	"vis_locs" = VV_LIST_READ_ONLY___DEBUG_EDITABLE,
+	"contents" = VV_LIST_EDITABLE,
+	"locs" = VV_LIST_READ_ONLY___DEBUG_EDITABLE,
+	"verbs" = VV_LIST_READ_ONLY___DEBUG_EDITABLE, // verb is not safe to edit in live server
+	"filters" = VV_LIST_PROTECTED, // This is not good to change in vv, yet.
+	// /client
+	"bounds" = VV_LIST_PROTECTED, // DM document says it's read-only. Better not to edit this.
+	"images" = VV_LIST_EDITABLE,
+	"screen" = VV_LIST_EDITABLE,
+))
 // NOTE: this is highly attached to how /datum/vv_ghost works.
-GLOBAL_LIST_INIT(vv_special_lists, init_special_list_names())
-
-/proc/init_special_list_names()
-	var/list/output = list(
-		// datum
-		"vars" = VV_LIST_READ_ONLY,
-		// atom
-		"vis_locs" = VV_LIST_READ_ONLY___DEBUG_EDITABLE,
-		"locs" = VV_LIST_READ_ONLY___DEBUG_EDITABLE,
-		"verbs" = VV_LIST_READ_ONLY___DEBUG_EDITABLE, // verb is not safe to edit in live server
-		"filters" = VV_LIST_PROTECTED, // This is not good to change in vv, yet.
-		// client
-		"bounds" = VV_LIST_PROTECTED, // DM document says it's read-only. Better not to edit this.
-	)
-
-	// Get the remaining special lists & default to VV_LIST_EDITABLE
-	var/obj/sacrifice = new
-	for(var/varname in sacrifice.vars)
-		if(output[varname])
-			continue
-		var/value = sacrifice.vars[varname]
-		if(!islist(value))
-			if(!isdatum(value) && hascall(value, "Cut"))
-				output[varname] = VV_LIST_EDITABLE
-			continue
-		if(isnull(locate(REF(value))))
-			output[varname] = VV_LIST_EDITABLE
-
-	return output
 
 #ifndef DEBUG
 GLOBAL_PROTECT(vv_special_lists) // changing this in live server is a bad idea

--- a/code/modules/admin/view_variables/debug_variables.dm
+++ b/code/modules/admin/view_variables/debug_variables.dm
@@ -80,6 +80,14 @@
 	if(istext(value))
 		return span_value("\"[VV_HTML_ENCODE(value)]\"")
 
+	if(isnum(value) && istext(name) && GLOB.bitfields[name])
+		var/list/matching_bitflags = get_matching_bitflags(name, value)
+
+		if(!isnull(matching_bitflags))
+			if(length(matching_bitflags))
+				return "[VV_HTML_ENCODE(matching_bitflags.Join(", "))]"
+			return "NONE"
+
 	// Warning - isicon(value) is misleading
 	// 		isicon('some.dmi') => returns TRUE
 	// 		isicon(/icon[0xINSTANCE]) => returns TRUE
@@ -160,14 +168,6 @@
 				items += debug_variable(key, val, level + 1, sanitize = sanitize, display_flags = flag)
 
 			return "[a_open][list_type] ([length(list_value)])[a_close]<ul>[items.Join()]</ul>"
-
-	// if it's a number, is it a bitflag?
-	var/list/matching_bitflags = get_matching_bitflags(name, value)
-
-	if(!isnull(matching_bitflags))
-		if(length(matching_bitflags))
-			return "[VV_HTML_ENCODE(matching_bitflags.Join(", "))]"
-		return "NONE"
 
 	return span_value("[VV_HTML_ENCODE(value)]")
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
* Caused by: https://github.com/BeeStation/BeeStation-Hornet/pull/14438
  * Fixed that the game throws a runtime regarding bitfields.
  * Partial revert of special list change - This cannot be automatically managed.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Suppresses vv bug
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

<img width="826" height="443" alt="image" src="https://github.com/user-attachments/assets/f79d2659-42ba-4f59-9e7e-446e1194765a" />

<img width="495" height="970" alt="image" src="https://github.com/user-attachments/assets/c396771f-ab91-4551-b534-3f7616ecc671" />

</details>

## Changelog
:cl:
code: VV'ing mobs no longer throws a runtime unnecessarily. Also changed some VV code
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
