### PR TITLE
Radstation Cloning Room Adjustments + Typo fixes

### DIFF
--- a/_maps/map_files/RadStation/RadStation.dmm
+++ b/_maps/map_files/RadStation/RadStation.dmm
@@ -14283,12 +14283,12 @@
 /turf/open/floor/iron/dark,
 /area/station/maintenance/department/bridge)
 "fmV" = (
-/obj/machinery/clonepod/prefilled,
 /obj/effect/turf_decal/bot,
 /obj/machinery/light_switch{
 	pixel_x = 22;
 	pixel_y = 23
 	},
+/obj/machinery/dna_scannernew,
 /turf/open/floor/iron,
 /area/station/medical/genetics/cloning)
 "fmZ" = (
@@ -57328,7 +57328,6 @@
 /turf/open/floor/circuit/red,
 /area/station/ai_monitored/turret_protected/ai)
 "vMQ" = (
-/obj/machinery/dna_scannernew,
 /obj/effect/turf_decal/bot,
 /obj/item/radio/intercom{
 	dir = 1;
@@ -57337,6 +57336,7 @@
 	},
 /obj/structure/window/reinforced/spawner/directional/east,
 /obj/item/radio/intercom/directional/west,
+/obj/machinery/clonepod/prefilled,
 /turf/open/floor/iron,
 /area/station/medical/genetics/cloning)
 "vMX" = (

--- a/_maps/map_files/RadStation/RadStation.dmm
+++ b/_maps/map_files/RadStation/RadStation.dmm
@@ -15740,7 +15740,6 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 4
 	},
-/obj/structure/cable/yellow,
 /turf/open/floor/iron/white,
 /area/station/medical/genetics/cloning)
 "fUi" = (
@@ -18573,6 +18572,8 @@
 	dir = 4
 	},
 /obj/machinery/camera/directional/west,
+/obj/machinery/power/apc/auto_name/directional/west,
+/obj/structure/cable/yellow,
 /turf/open/floor/iron/white/side{
 	dir = 4
 	},
@@ -22570,13 +22571,11 @@
 /turf/open/floor/iron/dark/textured_large,
 /area/station/ai_monitored/turret_protected/ai)
 "iJK" = (
-/obj/machinery/power/apc/auto_name/directional/west,
 /obj/machinery/shower{
 	dir = 4
 	},
 /obj/effect/turf_decal/bot,
 /obj/structure/window/reinforced/spawner/directional/east,
-/obj/structure/cable/yellow,
 /turf/open/floor/iron/white/side{
 	dir = 4
 	},
@@ -25602,6 +25601,7 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 1
 	},
+/obj/structure/cable/yellow,
 /turf/open/floor/iron/white/side{
 	dir = 8
 	},
@@ -36587,6 +36587,7 @@
 /obj/effect/turf_decal/tile/blue/half{
 	dir = 4
 	},
+/obj/structure/cable/yellow,
 /turf/open/floor/iron/white,
 /area/station/medical/genetics/cloning)
 "nKI" = (
@@ -51945,6 +51946,7 @@
 /area/station/hallway/primary/fore)
 "tAc" = (
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable/yellow,
 /turf/open/floor/iron/white/side{
 	dir = 8
 	},
@@ -57329,11 +57331,6 @@
 /area/station/ai_monitored/turret_protected/ai)
 "vMQ" = (
 /obj/effect/turf_decal/bot,
-/obj/item/radio/intercom{
-	dir = 1;
-	pixel_x = 1;
-	pixel_y = 23
-	},
 /obj/structure/window/reinforced/spawner/directional/east,
 /obj/item/radio/intercom/directional/west,
 /obj/machinery/clonepod/prefilled,

--- a/code/modules/mob_spawn/ghost_roles/mining_roles.dm
+++ b/code/modules/mob_spawn/ghost_roles/mining_roles.dm
@@ -24,7 +24,7 @@
 		if(1)
 			flavour_text += "you were a [pick("arms dealer", "shipwright", "docking manager")]'s assistant on a small trading station several sectors from here. Raiders attacked, and there was \
 			only one pod left when you got to the escape bay. You took it and launched it alone, and the crowd of terrified faces crowding at the airlock door as your pod's engines burst to \
-			life and sent you to this hell are forever branded into your memory.</b>"
+			life and sent you to this hell are forever branded into your memory."
 			outfit.uniform = /obj/item/clothing/under/misc/assistantformal
 		if(2)
 			flavour_text += "you're an exile from the Tiger Cooperative. Their technological fanaticism drove you to question the power and beliefs of the Exolitics, and they saw you as a \

--- a/code/modules/xenoarchaeology/traits/malfunction/animal.dm
+++ b/code/modules/xenoarchaeology/traits/malfunction/animal.dm
@@ -56,7 +56,7 @@
 /datum/xenoartifact_trait/malfunction/animal/twin
 	label_name = "M.B.C."
 	alt_label_name = "Mirrored Bluespace Collapse"
-	label_desc = "Mirrored Bluespace Collapse: The Artifact produces an arguably maleviolent clone of target."
+	label_desc = "Mirrored Bluespace Collapse: The Artifact produces an arguably malevolent clone of target."
 	flags = XENOA_BLUESPACE_TRAIT| XENOA_PLASMA_TRAIT | XENOA_URANIUM_TRAIT | XENOA_BANANIUM_TRAIT | XENOA_PEARL_TRAIT
 	register_targets = TRUE
 

--- a/code/modules/xenoarchaeology/traits/minors/sentient.dm
+++ b/code/modules/xenoarchaeology/traits/minors/sentient.dm
@@ -42,7 +42,7 @@
 
 /datum/xenoartifact_trait/minor/sentient/proc/get_canidate()
 	var/datum/poll_config/config = new(
-		question = "Do you want to play as the maleviolent force inside the [component_parent?.parent]?",
+		question = "Do you want to play as the malevolent force inside the [component_parent?.parent]?",
 		check_jobban = ROLE_SENTIENT_XENOARTIFACT,
 		poll_time = 10 SECONDS,
 		jump_target = component_parent?.parent,
@@ -103,7 +103,7 @@
 /obj/effect/mob_spawn/sentient_artifact
 	death = FALSE
 	name = "Sentient Xenoartifact"
-	short_desc = "You're a maleviolent sentience, possesing an ancient alien artifact."
+	short_desc = "You're a malevolent sentience, possessing an ancient alien artifact."
 	flavour_text = "Return to your master..."
 	use_cooldown = TRUE
 	ghost_usable = TRUE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Tiny fixes.
- Swapped over the radstation cloner machinery so that you exit out the correct side (where shower is)
- Moved the extra intercom because it was next to an intercom already.
- Moved the apc because I think an apc next to a shower is a bit of an odd choice realistically.
- Corrected three instances of "Malevolent" being misspelled as "Maleviolent"
- Corrected "possesed" typo in sentient artifact text
- Removed a stray `</b>` in lavaland hermit text
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Fixes some silly spelling mistakes. Cloner now makes better sense. Closing issues brings me joy

Closes #14290
Closes #14316
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

<img width="321" height="383" alt="image" src="https://github.com/user-attachments/assets/5299fa0a-a9f1-41aa-8435-cabff40bf24d" />

</details>

## Changelog
:cl:
map: Adjusted some stuff on the walls in Rad's cloning room, and swapped the cloning machinery around.
spellcheck: Fixed a few minor misspellings.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
