### PR TITLE
Mass Antag Conversion Secret: Vampire Addition

### DIFF
--- a/code/modules/antagonists/_common/antag_datum.dm
+++ b/code/modules/antagonists/_common/antag_datum.dm
@@ -451,6 +451,7 @@ GLOBAL_LIST(admin_antag_list)
 		/datum/antagonist/ninja,
 		/datum/antagonist/nukeop,
 		/datum/antagonist/wizard,
+		/datum/antagonist/vampire,
 	)
 
 	for(var/datum/antagonist/antag_type as anything in allowed_types)


### PR DESCRIPTION
## About The Pull Request

Allows those with access to the SECRETS panel to have an additional option when using the Mass Antag Convert secret. Vampire is now included in the allowed list of antagonists. 

## Why It's Good For The Game

Someone who has access to the secrets panel, especially permissions to use said panel shouldn't be restricted by outdated mechanical limits. Running custom rounds should not require excess and additional effort from those trying to contribute. This PR helps make the conversion process easier by giving a vampire option rather then requiring individual player conversions. 

## Testing Photographs and Procedure

<details>
<summary>Screenshots&Videos</summary>

https://github.com/user-attachments/assets/44967519-730d-4031-a8b0-c010c42033d9

</details>

## Changelog
:cl:
admin: Mass Antag Conversion Secret Now Allows For Vampire Conversion
/:cl:
