### PR TITLE
Adds a verb to let admins set round start AI laws

### DIFF
--- a/code/datums/ai_laws/ai_laws.dm
+++ b/code/datums/ai_laws/ai_laws.dm
@@ -202,11 +202,11 @@ GLOBAL_VAR(round_default_lawset)
 /* General ai_law functions */
 
 /datum/ai_laws/proc/set_laws_config()
-	var/default_lawset = get_round_default_lawset()
+	var/datum/ai_laws/default_laws = get_round_default_lawset()
 	// get_round_default_lawset() can return an instance if an admin set it to a custom lawset
-	if(ispath(default_laws)
+	if(ispath(default_laws))
 		default_laws = new default_laws()
-	else if(istype(default_lawset)
+	else if(istype(default_laws))
 		default_laws = default_laws.copy_lawset()
 	else
 		stack_trace("Invalid round default lawset, falling back to Asimov.")

--- a/code/datums/ai_laws/ai_laws.dm
+++ b/code/datums/ai_laws/ai_laws.dm
@@ -8,6 +8,7 @@ GLOBAL_VAR(round_default_lawset)
  * A getter that sets up the round default if it has not been yet.
  *
  * round_default_lawset is what is considered the default for the round. Aka, new AI and other silicons would get this.
+ * This is usually a typepath, but admins can set it to a datum instance for one-off custom roundstart laws.
  * You might recognize the fact that 99% of the time it is asimov.
  *
  * This requires config, so it is generated at the first request to use this var.
@@ -163,6 +164,8 @@ GLOBAL_VAR(round_default_lawset)
 /// Makes a copy of the lawset and returns a new law datum.
 /datum/ai_laws/proc/copy_lawset()
 	var/datum/ai_laws/new_lawset = new type()
+	new_lawset.name = name
+	new_lawset.id = id
 	new_lawset.protected_zeroth = protected_zeroth
 	new_lawset.zeroth = zeroth
 	new_lawset.zeroth_borg = zeroth_borg
@@ -199,9 +202,26 @@ GLOBAL_VAR(round_default_lawset)
 /* General ai_law functions */
 
 /datum/ai_laws/proc/set_laws_config()
-	var/datum/ai_laws/default_laws = get_round_default_lawset()
-	default_laws = new default_laws()
-	inherent = default_laws.inherent
+	var/default_lawset = get_round_default_lawset()
+	var/datum/ai_laws/default_laws
+	if(ispath(default_lawset, /datum/ai_laws))
+		default_laws = new default_lawset()
+	else if(istype(default_lawset, /datum/ai_laws))
+		var/datum/ai_laws/default_law_datum = default_lawset
+		default_laws = default_law_datum.copy_lawset()
+	else
+		stack_trace("Invalid round default lawset, falling back to Asimov.")
+		default_laws = new /datum/ai_laws/default/asimov()
+
+	name = default_laws.name
+	id = default_laws.id
+	protected_zeroth = default_laws.protected_zeroth
+	zeroth = default_laws.zeroth
+	zeroth_borg = default_laws.zeroth_borg
+	inherent = default_laws.inherent.Copy()
+	supplied = default_laws.supplied.Copy()
+	ion = default_laws.ion.Copy()
+	hacked = default_laws.hacked.Copy()
 
 /**
  * Gets the number of how many laws this AI has

--- a/code/datums/ai_laws/ai_laws.dm
+++ b/code/datums/ai_laws/ai_laws.dm
@@ -203,12 +203,11 @@ GLOBAL_VAR(round_default_lawset)
 
 /datum/ai_laws/proc/set_laws_config()
 	var/default_lawset = get_round_default_lawset()
-	var/datum/ai_laws/default_laws
-	if(ispath(default_lawset, /datum/ai_laws))
-		default_laws = new default_lawset()
-	else if(istype(default_lawset, /datum/ai_laws))
-		var/datum/ai_laws/default_law_datum = default_lawset
-		default_laws = default_law_datum.copy_lawset()
+	// get_round_default_lawset() can return an instance if an admin set it to a custom lawset
+	if(ispath(default_laws)
+		default_laws = new default_laws()
+	else if(istype(default_lawset)
+		default_laws = default_laws.copy_lawset()
 	else
 		stack_trace("Invalid round default lawset, falling back to Asimov.")
 		default_laws = new /datum/ai_laws/default/asimov()

--- a/code/game/objects/items/ai_modules/ai_modules.dm
+++ b/code/game/objects/items/ai_modules/ai_modules.dm
@@ -190,9 +190,9 @@
 	. = ..()
 	var/datum/ai_laws/default_laws = get_round_default_lawset()
 	// get_round_default_lawset() can return an instance if an admin set it to a custom lawset
-	if(ispath(default_laws)
+	if(ispath(default_laws))
 		default_laws = new default_laws()
-	else if(istype(default_lawset)
+	else if(istype(default_laws))
 		default_laws = default_laws.copy_lawset()
 	else
 		stack_trace("Invalid round default lawset, falling back to Asimov.")

--- a/code/game/objects/items/ai_modules/ai_modules.dm
+++ b/code/game/objects/items/ai_modules/ai_modules.dm
@@ -158,6 +158,7 @@
 
 /obj/item/ai_module/core/full/handle_unique_ai()
 	var/datum/ai_laws/default_laws = get_round_default_lawset()
+
 	if(law_id == initial(default_laws.id))
 		return
 	return SHOULD_QDEL_MODULE
@@ -171,6 +172,7 @@
 /obj/effect/spawner/round_default_module/Initialize(mapload)
 	. = ..()
 	var/datum/ai_laws/default_laws = get_round_default_lawset()
+
 	//try to spawn a law board, since they may have special functionality (asimov setting subjects)
 	for(var/obj/item/ai_module/core/full/potential_lawboard as anything in subtypesof(/obj/item/ai_module/core/full))
 		if(initial(potential_lawboard.law_id) != initial(default_laws.id))
@@ -187,7 +189,15 @@
 /obj/item/ai_module/core/round_default_fallback/Initialize(mapload)
 	. = ..()
 	var/datum/ai_laws/default_laws = get_round_default_lawset()
-	default_laws = new default_laws()
+	// get_round_default_lawset() can return an instance if an admin set it to a custom lawset
+	if(ispath(default_laws)
+		default_laws = new default_laws()
+	else if(istype(default_lawset)
+		default_laws = default_laws.copy_lawset()
+	else
+		stack_trace("Invalid round default lawset, falling back to Asimov.")
+		default_laws = new /datum/ai_laws/default/asimov()
+
 	name = "'[default_laws.name]' Core AI Module"
 	laws = default_laws.inherent
 

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -93,6 +93,7 @@ GLOBAL_LIST_INIT(admin_verbs_fun, list(
 	/client/proc/cinematic,
 	/client/proc/create_ert,
 	/client/proc/cmd_admin_add_freeform_ai_law,
+	/client/proc/cmd_admin_set_roundstart_ai_lawset,
 	/client/proc/object_say,
 	/client/proc/toggle_random_events,
 	/client/proc/set_ooc,

--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -540,7 +540,7 @@ Traitors and the like can also be revived with the previous role mostly intact.
 				if(tgui_alert(src, "No laws were entered.", "Custom Roundstart AI Lawset", list("Try Again", "Cancel")) == "Try Again")
 					continue
 				return
-
+			custom_laws += law
 		var/datum/ai_laws/custom_lawset = new /datum/ai_laws()
 		custom_lawset.name = "Admin Custom Laws"
 		custom_lawset.id = "admin_custom"
@@ -548,6 +548,7 @@ Traitors and the like can also be revived with the previous role mostly intact.
 		GLOB.round_default_lawset = custom_lawset
 
 		log_admin("[key_name(src)] set a custom roundstart AI lawset: [custom_laws.Join(" | ")]")
+		message_admins("[key_name(src)] set a custom roundstart AI lawset: [custom_laws.Join(" | ")]")
 		SSblackbox.record_feedback("tally", "admin_verb", 1, "Set Roundstart AI Lawset")
 		return
 
@@ -568,6 +569,7 @@ Traitors and the like can also be revived with the previous role mostly intact.
 	GLOB.round_default_lawset = lawset_choices[chosen]
 
 	log_admin("[key_name(src)] set the roundstart AI lawset to [chosen].")
+	message_admins("[key_name(src)] set the roundstart AI lawset to [chosen].")
 	SSblackbox.record_feedback("tally", "admin_verb", 1, "Set Roundstart AI Lawset")
 
 /client/proc/cmd_admin_add_freeform_ai_law()

--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -515,6 +515,74 @@ Traitors and the like can also be revived with the previous role mostly intact.
 	SSblackbox.record_feedback("tally", "admin_verb", 1, "Respawn Character") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 	return new_character
 
+/client/proc/cmd_admin_set_roundstart_ai_lawset()
+	set category = "Round"
+	set name = "Set Roundstart AI Lawset"
+
+	if(!check_rights(R_ADMIN))
+		return
+
+	if(SSticker.current_state > GAME_STATE_PREGAME)
+		to_chat(src, span_warning("The round has already started."))
+		return
+
+	var/mode = tgui_alert(src, "Use an existing lawset or enter a custom lawset?", "Roundstart AI Lawset", list("Existing Lawset", "Custom Lawset", "Cancel"))
+	if(mode == "Cancel" || !mode)
+		return
+
+	if(mode == "Custom Lawset")
+		var/list/custom_laws = list()
+		while(TRUE)
+			var/law = capped_input(src, "Enter law #[length(custom_laws) + 1]. Leave blank when finished.", "Custom Roundstart AI Lawset")
+			if(!law)
+				if(length(custom_laws))
+					break
+				if(tgui_alert(src, "No laws were entered.", "Custom Roundstart AI Lawset", list("Try Again", "Cancel")) == "Try Again")
+					continue
+				return
+
+			custom_laws += law
+			if(tgui_alert(src, "Add another law?", "Custom Roundstart AI Lawset", list("Add Another", "Finish")) != "Add Another")
+				break
+
+		var/datum/ai_laws/custom_lawset = new /datum/ai_laws()
+		custom_lawset.name = "Admin Custom Laws"
+		custom_lawset.id = "admin_custom"
+		custom_lawset.inherent = custom_laws.Copy()
+		GLOB.round_default_lawset = custom_lawset
+
+		var/law_log_text = custom_laws.Join(" | ")
+		log_admin("[key_name(src)] set a custom roundstart AI lawset: [law_log_text]")
+		message_admins("[key_name_admin(src)] set a custom roundstart AI lawset with [length(custom_laws)] laws.")
+		SSblackbox.record_feedback("tally", "admin_verb", 1, "Set Roundstart AI Lawset")
+		return
+
+	var/list/lawset_choices = list()
+
+	for(var/law_type in subtypesof(/datum/ai_laws))
+		var/datum/ai_laws/law_path = law_type
+
+		if(law_type == /datum/ai_laws/pai)
+			continue
+
+		if(initial(law_path.name) == "Unknown Laws")
+			continue
+
+		lawset_choices["[initial(law_path.name)] ([law_type])"] = law_type
+
+	lawset_choices["Config Default"] = null
+
+	var/chosen = tgui_input_list(src, "Choose the lawset the roundstart AI will spawn with.", "Roundstart AI Lawset", sort_list(lawset_choices))
+	if(isnull(chosen))
+		return
+
+	var/selected_lawset = lawset_choices[chosen]
+	GLOB.round_default_lawset = selected_lawset
+
+	log_admin("[key_name(src)] set the roundstart AI lawset to [chosen].")
+	message_admins("[key_name_admin(src)] set the roundstart AI lawset to [chosen].")
+	SSblackbox.record_feedback("tally", "admin_verb", 1, "Set Roundstart AI Lawset")
+
 /client/proc/cmd_admin_add_freeform_ai_law()
 	set category = "Fun"
 	set name = "Add Custom AI law"

--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -519,7 +519,7 @@ Traitors and the like can also be revived with the previous role mostly intact.
 	set category = "Round"
 	set name = "Set Roundstart AI Lawset"
 
-	if(!check_rights(R_ADMIN))
+	if(!check_rights(R_FUN))
 		return
 
 	if(SSticker.current_state > GAME_STATE_PREGAME)
@@ -541,46 +541,32 @@ Traitors and the like can also be revived with the previous role mostly intact.
 					continue
 				return
 
-			custom_laws += law
-			if(tgui_alert(src, "Add another law?", "Custom Roundstart AI Lawset", list("Add Another", "Finish")) != "Add Another")
-				break
-
 		var/datum/ai_laws/custom_lawset = new /datum/ai_laws()
 		custom_lawset.name = "Admin Custom Laws"
 		custom_lawset.id = "admin_custom"
-		custom_lawset.inherent = custom_laws.Copy()
+		custom_lawset.inherent = custom_laws
 		GLOB.round_default_lawset = custom_lawset
 
-		var/law_log_text = custom_laws.Join(" | ")
-		log_admin("[key_name(src)] set a custom roundstart AI lawset: [law_log_text]")
-		message_admins("[key_name_admin(src)] set a custom roundstart AI lawset with [length(custom_laws)] laws.")
+		log_admin("[key_name(src)] set a custom roundstart AI lawset: [custom_laws.Join(" | ")]")
 		SSblackbox.record_feedback("tally", "admin_verb", 1, "Set Roundstart AI Lawset")
 		return
 
 	var/list/lawset_choices = list()
 
-	for(var/law_type in subtypesof(/datum/ai_laws))
-		var/datum/ai_laws/law_path = law_type
+	for(var/datum/ai_laws/law_path as anything in subtypesof(/datum/ai_laws))
 
 		if(law_type == /datum/ai_laws/pai)
 			continue
 
-		if(initial(law_path.name) == "Unknown Laws")
-			continue
-
 		lawset_choices["[initial(law_path.name)] ([law_type])"] = law_type
-
-	lawset_choices["Config Default"] = null
 
 	var/chosen = tgui_input_list(src, "Choose the lawset the roundstart AI will spawn with.", "Roundstart AI Lawset", sort_list(lawset_choices))
 	if(isnull(chosen))
 		return
 
-	var/selected_lawset = lawset_choices[chosen]
-	GLOB.round_default_lawset = selected_lawset
+	GLOB.round_default_lawset = lawset_choices[chosen]
 
 	log_admin("[key_name(src)] set the roundstart AI lawset to [chosen].")
-	message_admins("[key_name_admin(src)] set the roundstart AI lawset to [chosen].")
 	SSblackbox.record_feedback("tally", "admin_verb", 1, "Set Roundstart AI Lawset")
 
 /client/proc/cmd_admin_add_freeform_ai_law()

--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -553,7 +553,8 @@ Traitors and the like can also be revived with the previous role mostly intact.
 
 	var/list/lawset_choices = list()
 
-	for(var/datum/ai_laws/law_path as anything in subtypesof(/datum/ai_laws))
+	for(var/law_type in subtypesof(/datum/ai_laws))
+		var/datum/ai_laws/law_path = law_type
 
 		if(law_type == /datum/ai_laws/pai)
 			continue


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Ive thought for a while now that the tools admins have to fuck with AI laws are insufficient. 
Theres a button to add custom ion laws, but for evrything else you either work with view variables to manually fuck around with the AIs laws... or your spawn yourself in with an upload and the repective law boards to do the changes "manually".

This adds a verb which lets admins set the AIs roundstart lawset to one of the predefined lawsets, or a custom law set.
Thats only pre-round, ill have to look into something for ongoing rounds later perhaps.


## Why It's Good For The Game

Admin funny button = good :)

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Videos</summary>
Lets admins set laws from the list:

https://github.com/user-attachments/assets/f2312976-f388-439d-88f4-80c1829dd59b



Lets admins set custom lawsets for round-start:


https://github.com/user-attachments/assets/3c18fad9-186e-43b2-9ac9-a37c3bcc1274


Not using the button means laws get assigned normally:


https://github.com/user-attachments/assets/80d279c2-caba-45bb-a332-edfd27e5ec2c



</details>

## AI Disclosure
Originally, I only wanted to use a coding agent to help me navigate the repo, ala "where are laws asigned?"
Before i knew it, however, it just did the whole work for me. What do you know.
As this all seems to work just fine, i see no reason to not just use the code that codex has produced.
But i also do not want to keep that fact from you, as i understand people may have concerns about slop-code.  I get that, so let me know if i should just close this, or something. Its all cool.

## Changelog
:cl:
add: Adds a verb for admins to change what laws the AI will spawn with
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
