### PR TITLE
Removes Skin Suit Cell Remove Ability

### DIFF
--- a/code/modules/clothing/spacesuits/miscellaneous.dm
+++ b/code/modules/clothing/spacesuits/miscellaneous.dm
@@ -635,7 +635,7 @@ Contains:
 
 /obj/item/clothing/suit/space/hardsuit/skinsuit
 	name = "skinsuit"
-	desc = "A slim, compression-based spacesuit meant to protect the user during emergency situations. It's only a little warmer than your uniform."
+	desc = "A slim, compression-based spacesuit meant to protect the user during emergency situations. It's only a little warmer than your uniform. Has a non-replaceable cell for thermal regulation."
 	icon = 'icons/obj/clothing/suits/spacesuit.dmi'
 	worn_icon = 'icons/mob/clothing/suits/spacesuit.dmi'
 	icon_state = "skinsuit"
@@ -658,6 +658,15 @@ Contains:
 	bleed = 10
 
 /obj/item/clothing/suit/space/hardsuit/skinsuit/attackby(obj/item/I, mob/user, params)
+	return
+
+
+/// Single Use, No Cell cover to open up.
+/obj/item/clothing/suit/space/hardsuit/skinsuit/AltClick(mob/living/user)
+	return
+
+/// Single Use, No Cell to remove
+/obj/item/clothing/suit/space/hardsuit/skinsuit/CtrlClick(mob/living/user)
 	return
 
 /obj/item/clothing/head/helmet/space/hunter

--- a/code/modules/clothing/spacesuits/miscellaneous.dm
+++ b/code/modules/clothing/spacesuits/miscellaneous.dm
@@ -630,6 +630,9 @@ Contains:
 	. = ..()
 	AddElement(/datum/element/empprotection, EMP_PROTECT_ALL)
 
+/obj/item/clothing/head/helmet/space/hardsuit/skinsuit/attack_self(mob/user)
+	return
+
 /obj/item/clothing/suit/space/hardsuit/skinsuit
 	name = "skinsuit"
 	desc = "A slim, compression-based spacesuit meant to protect the user during emergency situations. It's only a little warmer than your uniform."
@@ -654,6 +657,8 @@ Contains:
 	bio = 50
 	bleed = 10
 
+/obj/item/clothing/suit/space/hardsuit/skinsuit/attackby(obj/item/I, mob/user, params)
+	return
 
 /obj/item/clothing/head/helmet/space/hunter
 	name = "bounty hunting helmet"

--- a/code/modules/clothing/spacesuits/miscellaneous.dm
+++ b/code/modules/clothing/spacesuits/miscellaneous.dm
@@ -630,9 +630,6 @@ Contains:
 	. = ..()
 	AddElement(/datum/element/empprotection, EMP_PROTECT_ALL)
 
-/obj/item/clothing/head/helmet/space/hardsuit/skinsuit/attack_self(mob/user)
-	return
-
 /obj/item/clothing/suit/space/hardsuit/skinsuit
 	name = "skinsuit"
 	desc = "A slim, compression-based spacesuit meant to protect the user during emergency situations. It's only a little warmer than your uniform."
@@ -657,8 +654,6 @@ Contains:
 	bio = 50
 	bleed = 10
 
-/obj/item/clothing/suit/space/hardsuit/skinsuit/attackby(obj/item/I, mob/user, params)
-	return
 
 /obj/item/clothing/head/helmet/space/hunter
 	name = "bounty hunting helmet"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Skinsuits could have their cells removed, but not replaced. Bugs bad. Clarity Good. 

I tried removing the offending proc that was blocking reinstall, but that allowed you to install jetpack mods on skinsuits, which I feel was _not_ intended, so I went the other way and made the skin suits single use cells (and updated the description to match.)

Closes #14454 

## Why It's Good For The Game
Bugs bad.

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

Helmet still works.

<img width="284" height="255" alt="helmet works" src="https://github.com/user-attachments/assets/080fc224-db83-4679-995a-811fbb43381b" />

Thermal Regulator Off/On and still works
<img width="1089" height="689" alt="cold when lizard" src="https://github.com/user-attachments/assets/b92b195b-2c63-410f-9e66-8e4f7777ee1e" />

<img width="1643" height="890" alt="thermal regulator on lizard warm" src="https://github.com/user-attachments/assets/ec72bd1e-116b-4662-bacb-eb5f841cc850" />

</details>

## Changelog
:cl:
fix: Skinsuits can no longer have their cells removed and suit temperature regulator adjusted
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
