### PR TITLE
Energy Crossbow + Nukie Ship addition 

### DIFF
--- a/_maps/shuttles/infiltrator/infiltrator_advanced.dmm
+++ b/_maps/shuttles/infiltrator/infiltrator_advanced.dmm
@@ -1562,9 +1562,9 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/bot,
-/obj/machinery/airalarm/directional/east,
-/obj/effect/mapping_helpers/airalarm/syndicate_access,
 /obj/effect/turf_decal/stripes/line,
+/obj/machinery/airalarm/directional/west,
+/obj/effect/mapping_helpers/airalarm/syndicate_access,
 /turf/open/floor/pod/dark,
 /area/shuttle/syndicate/medical)
 "dU" = (
@@ -1886,6 +1886,11 @@
 /obj/machinery/light/small,
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/shuttle/syndicate/airlock)
+"od" = (
+/obj/structure/cable/yellow,
+/mob/living/simple_animal/bot/medbot/nukie,
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/shuttle/syndicate/medical)
 "op" = (
 /obj/structure/chair/fancy/shuttle{
 	dir = 4;
@@ -2009,7 +2014,8 @@
 /area/shuttle/syndicate/medical)
 "JN" = (
 /obj/structure/mirror{
-	pixel_y = 28
+	pixel_y = 35;
+	pixel_x = -1
 	},
 /obj/structure/sink/directional/south,
 /turf/open/floor/catwalk_floor/iron_dark,
@@ -2217,7 +2223,7 @@ aJ
 aO
 bf
 JN
-Ak
+od
 Jr
 Ll
 bV

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -808,7 +808,7 @@ GLOBAL_LIST_INIT(illegal_tech_blacklist, typecacheof(list(
 	toxin that will damage and disorient targets, causing them to \
 	slur as if inebriated. It can produce an infinite number \
 	of bolts, but takes a small amount of time to automatically recharge after each shot."
-	item = /obj/item/ammo_casing/energy/bolt
+	item = /obj/item/gun/energy/recharge/ebow
 	cost = 10
 	reputation_required = REPUTATION_GOOD
 	surplus = 50


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds Oppenheimer + fixes a misaligned sink and air alarm

Also fixes the uplink Miniature energy crossbow, it was giving the casing instead of the gun

(Not using the mapping cl, since it just doesn't work)

## Why It's Good For The Game

Oppenheimer was removed at some point during the nukie base rework and never added
Bugs bad

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

<img width="256" height="352" alt="image" src="https://github.com/user-attachments/assets/8b084221-5a1d-463e-aff9-437b4c95301b" />

</details>

## Changelog
:cl:
add: Nukies have their stolen medibot back
fix: Uplink wont give you an energy lens instead of a miniature energy crossbow anymore
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
