### PR TITLE
Berry Simple Custom Vendor Fix

### DIFF
--- a/code/modules/vending/_vending.dm
+++ b/code/modules/vending/_vending.dm
@@ -1301,7 +1301,7 @@
 			var/list/data = list(
 				name = O,
 				price = item_price,
-				img = base64,
+				image = base64,
 				amount = vending_machine_input[O],
 				colorable = FALSE,
 				path = "[replacetext(replacetext("[item_path]", "/obj/item/", ""), "/", "-")]-[O]"

--- a/tgui/packages/tgui/interfaces/Vending.tsx
+++ b/tgui/packages/tgui/interfaces/Vending.tsx
@@ -291,7 +291,7 @@ const Product = (props) => {
     onClick: () => {
       custom
         ? act('dispense', {
-            item: product.path,
+            item: product.name,
           })
         : act('vend', {
             ref: product.ref,


### PR DESCRIPTION
## About The Pull Request

Custom Vendors are broken #14257 - TLDR: They aren't properly drawing the image anymore, which results in a different visual compared to the sales item, furthermore items in a vendor are currently unable to be sold fundamentally.

Both of these issues are caused by the vendor trying to incorrectly send and use different information, this PR tries to solve that by adjusting the information being used. Technically, the vendor now uses the product name instead of product path, and the icon uses image instead of img which I saw used in baseprops albiet im not 1000% certain in this since im not sure when or how it broke...


## Why It's Good For The Game

Custom Vendors are a delightful gimmick machine, not just for gimmicks but these custom vendors allow for alot of functionality. It is a shame that they arent currently working, and ideally this PR brings the vendors back to a usable state. 

*also*

closes #14257 

## Testing Photographs and Procedure

<details>
<summary>Screenshots&Videos</summary>

### Look it works!
<img width="753" height="548" alt="Screenshot 2026-06-13 000341" src="https://github.com/user-attachments/assets/653f9563-8800-46f2-bd87-3148fad625a9" />

</details>

## Changelog
:cl:
fix: Fixes Custom Vendor's: They should use the correct image and sell items properly once again.
/:cl:

