### PR TITLE
CardStation SM Area alteration

### DIFF
--- a/_maps/map_files/CardinalStation/CardinalStation.dmm
+++ b/_maps/map_files/CardinalStation/CardinalStation.dmm
@@ -8120,7 +8120,7 @@
 	name = "Shutter button"
 	},
 /turf/open/floor/plating/airless,
-/area/station/engineering/supermatter/room)
+/area/station/engineering/main)
 "bXE" = (
 /obj/structure/cable/yellow,
 /obj/structure/disposalpipe/junction/yjunction,
@@ -10895,7 +10895,7 @@
 "cDN" = (
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plating/airless,
-/area/station/engineering/supermatter/room)
+/area/station/engineering/main)
 "cDS" = (
 /obj/effect/turf_decal/tile/brown/opposingcorners,
 /obj/effect/turf_decal/tile/red/opposingcorners,
@@ -11733,7 +11733,7 @@
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/cable/yellow,
 /turf/open/floor/plating/airless,
-/area/station/engineering/supermatter/room)
+/area/station/engineering/main)
 "cNS" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 6
@@ -17461,7 +17461,7 @@
 	id = "PA2"
 	},
 /turf/open/floor/plating/airless,
-/area/station/engineering/supermatter/room)
+/area/station/engineering/main)
 "eii" = (
 /turf/closed/wall,
 /area/station/cargo/qm_bedroom)
@@ -21136,7 +21136,7 @@
 	id = "PA"
 	},
 /turf/open/floor/plating/airless,
-/area/station/engineering/supermatter/room)
+/area/station/engineering/main)
 "eYg" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -33098,7 +33098,7 @@
 /obj/structure/cable/orange,
 /obj/structure/cable/yellow,
 /turf/open/floor/plating/airless,
-/area/station/engineering/supermatter/room)
+/area/station/engineering/main)
 "hNP" = (
 /obj/machinery/power/apc/auto_name/directional/east,
 /obj/structure/cable/yellow,
@@ -36929,7 +36929,7 @@
 /obj/effect/turf_decal/bot,
 /obj/machinery/light/directional/north,
 /turf/open/floor/plating/airless,
-/area/station/engineering/supermatter/room)
+/area/station/engineering/main)
 "iFi" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/extinguisher_cabinet/directional/north,
@@ -40070,7 +40070,7 @@
 	},
 /obj/structure/cable/yellow,
 /turf/open/floor/plating/airless,
-/area/station/engineering/supermatter/room)
+/area/station/engineering/main)
 "jsI" = (
 /obj/effect/turf_decal/siding/blue,
 /obj/machinery/light/floor,
@@ -40440,7 +40440,7 @@
 	name = "Shutter button"
 	},
 /turf/open/space/basic,
-/area/station/engineering/supermatter/room)
+/area/station/engineering/main)
 "jwg" = (
 /obj/effect/turf_decal/siding/dark/end{
 	dir = 4
@@ -40637,13 +40637,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/station/science/research)
-"jyE" = (
-/obj/machinery/door/poddoor/shutters/radiation/preopen{
-	id = "smrad"
-	},
-/obj/effect/spawner/structure/window/reinforced/plasma,
-/turf/open/floor/plating,
-/area/station/engineering/main)
 "jyI" = (
 /obj/structure/cable/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
@@ -43446,7 +43439,7 @@
 "kkl" = (
 /obj/machinery/power/energy_accumulator/grounding_rod,
 /turf/open/floor/plating/airless,
-/area/station/engineering/supermatter/room)
+/area/station/engineering/main)
 "kko" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
@@ -47713,7 +47706,7 @@
 "lig" = (
 /obj/structure/cable/yellow,
 /turf/open/floor/plating/airless,
-/area/station/engineering/supermatter/room)
+/area/station/engineering/main)
 "lii" = (
 /obj/effect/turf_decal/trimline/white/filled/warning{
 	dir = 8
@@ -52291,7 +52284,7 @@
 /obj/machinery/field/generator,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plating/airless,
-/area/station/engineering/supermatter/room)
+/area/station/engineering/main)
 "mmm" = (
 /obj/structure/grille,
 /obj/structure/lattice,
@@ -54559,7 +54552,7 @@
 	id = "PA2"
 	},
 /turf/open/floor/plating/airless,
-/area/station/engineering/supermatter/room)
+/area/station/engineering/main)
 "mNb" = (
 /obj/effect/turf_decal/siding/white{
 	dir = 1;
@@ -55447,7 +55440,7 @@
 /obj/machinery/power/energy_accumulator/grounding_rod,
 /obj/structure/cable/yellow,
 /turf/open/floor/plating/airless,
-/area/station/engineering/supermatter/room)
+/area/station/engineering/main)
 "mWy" = (
 /obj/structure/cable/yellow,
 /obj/machinery/vending/cigarette,
@@ -56439,9 +56432,6 @@
 /obj/structure/cable,
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/station/tcommsat/server)
-"niS" = (
-/turf/closed/wall/mineral/plastitanium,
-/area/station/engineering/supermatter/room)
 "nja" = (
 /obj/effect/turf_decal/siding/brown,
 /obj/effect/turf_decal/tile/neutral/opposingcorners,
@@ -59464,7 +59454,7 @@
 "nUL" = (
 /obj/effect/spawner/structure/window/reinforced/plasma/plastitanium,
 /turf/open/floor/plating/airless,
-/area/station/engineering/supermatter/room)
+/area/station/engineering/main)
 "nUO" = (
 /obj/machinery/door/window/eastleft{
 	color = "#9b1d70"
@@ -59781,7 +59771,7 @@
 	},
 /obj/structure/lattice/catwalk,
 /turf/open/space/basic,
-/area/station/engineering/supermatter/room)
+/area/station/engineering/main)
 "nYJ" = (
 /obj/structure/cable/yellow,
 /obj/effect/turf_decal/tile/techfloor/diagonal,
@@ -60708,7 +60698,7 @@
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/cable/orange,
 /turf/open/floor/plating/airless,
-/area/station/engineering/supermatter/room)
+/area/station/engineering/main)
 "olj" = (
 /obj/machinery/navbeacon{
 	codes_txt = "patrol;next_patrol=9-CARGO";
@@ -63307,9 +63297,6 @@
 	},
 /turf/open/floor/iron/smooth_large,
 /area/station/engineering/hallway)
-"oOq" = (
-/turf/closed/wall/mineral/plastitanium/nodiagonal,
-/area/station/engineering/main)
 "oOr" = (
 /obj/effect/turf_decal/trimline/yellow/filled/warning{
 	dir = 1
@@ -65846,7 +65833,7 @@
 /area/station/security/courtroom)
 "pyF" = (
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
-/area/station/engineering/supermatter/room)
+/area/station/engineering/main)
 "pyJ" = (
 /obj/effect/turf_decal/edges/borderfloor,
 /obj/structure/disposalpipe/segment{
@@ -69911,7 +69898,7 @@
 	},
 /obj/structure/cable/yellow,
 /turf/open/floor/plating/airless,
-/area/station/engineering/supermatter/room)
+/area/station/engineering/main)
 "quy" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
@@ -71234,7 +71221,7 @@
 /obj/machinery/light_switch/directional/west,
 /obj/machinery/camera/directional/west,
 /turf/open/floor/plating/airless,
-/area/station/engineering/supermatter/room)
+/area/station/engineering/main)
 "qKs" = (
 /obj/structure/cable/yellow,
 /obj/effect/turf_decal/tile/neutral/opposingcorners{
@@ -75061,7 +75048,7 @@
 	id = "PA"
 	},
 /turf/open/floor/plating/airless,
-/area/station/engineering/supermatter/room)
+/area/station/engineering/main)
 "rFw" = (
 /obj/structure/chair{
 	dir = 1
@@ -82144,7 +82131,7 @@
 	id = "PA2"
 	},
 /turf/open/floor/plating/airless,
-/area/station/engineering/supermatter/room)
+/area/station/engineering/main)
 "tpG" = (
 /obj/structure/table,
 /obj/item/storage/crayons,
@@ -84014,7 +84001,7 @@
 	dir = 1
 	},
 /turf/open/floor/plating/airless,
-/area/station/engineering/supermatter/room)
+/area/station/engineering/main)
 "tNh" = (
 /obj/structure/table/reinforced,
 /obj/item/paper_bin{
@@ -85507,7 +85494,7 @@
 	},
 /obj/structure/cable/orange,
 /turf/open/floor/plating/airless,
-/area/station/engineering/supermatter/room)
+/area/station/engineering/main)
 "ueV" = (
 /obj/structure/closet/secure_closet/miner,
 /obj/item/clothing/suit/hooded/wintercoat/miner,
@@ -87904,7 +87891,7 @@
 "uGS" = (
 /obj/structure/sign/departments/minsky/engineering/engineering,
 /turf/closed/wall/mineral/plastitanium,
-/area/station/engineering/supermatter/room)
+/area/station/engineering/main)
 "uHe" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment{
@@ -89368,7 +89355,7 @@
 	name = "Shutter button"
 	},
 /turf/open/floor/plating/airless,
-/area/station/engineering/supermatter/room)
+/area/station/engineering/main)
 "uYW" = (
 /obj/structure/table/wood,
 /obj/item/storage/box/beanbag{
@@ -90314,7 +90301,7 @@
 /obj/machinery/light/directional/south,
 /obj/machinery/power/apc/auto_name/directional/south,
 /turf/open/floor/plating/airless,
-/area/station/engineering/supermatter/room)
+/area/station/engineering/main)
 "vla" = (
 /obj/machinery/disposal/bin,
 /obj/effect/turf_decal/siding/dark{
@@ -90615,8 +90602,11 @@
 /turf/open/floor/iron/dark/smooth_edge,
 /area/station/science/robotics/lab)
 "vov" = (
-/obj/effect/spawner/structure/window/reinforced/plasma/plastitanium,
-/turf/open/floor/plating/airless,
+/obj/machinery/door/poddoor/shutters/radiation/preopen{
+	id = "smrad"
+	},
+/obj/effect/spawner/structure/window/reinforced/plasma,
+/turf/open/floor/plating,
 /area/station/engineering/main)
 "voK" = (
 /obj/structure/chair/fancy/comfy{
@@ -132596,11 +132586,11 @@ iqF
 auU
 vPx
 hzT
-oOq
-oOq
-vov
-oOq
-oOq
+pyF
+pyF
+nUL
+pyF
+pyF
 qYq
 fvO
 fvO
@@ -132858,7 +132848,7 @@ omD
 bWl
 omD
 jQS
-oOq
+pyF
 hDf
 dFS
 fvO
@@ -133115,7 +133105,7 @@ mlH
 wcd
 mlH
 nfg
-oOq
+pyF
 hDf
 imz
 dFS
@@ -133372,7 +133362,7 @@ blW
 ssX
 tbm
 rHG
-oOq
+pyF
 hDf
 fvO
 hDf
@@ -134917,7 +134907,7 @@ cMA
 dmK
 tKI
 vVZ
-jyE
+vov
 fvO
 hDf
 qjh
@@ -135431,7 +135421,7 @@ aSU
 kwV
 tdY
 mXL
-jyE
+vov
 hDf
 qjh
 qjh
@@ -135945,7 +135935,7 @@ aSU
 iDp
 xlx
 xHP
-jyE
+vov
 hDf
 qjh
 qjh
@@ -136459,7 +136449,7 @@ cMA
 dmK
 rLA
 tbB
-jyE
+vov
 fvO
 qjh
 hDf
@@ -137992,13 +137982,13 @@ jex
 jOW
 djW
 jOW
-oOq
+pyF
 gsm
 uNA
 xAR
 gsm
-oOq
-oOq
+pyF
+pyF
 hDf
 fvO
 hDf
@@ -138255,7 +138245,7 @@ sfA
 fqh
 uDD
 wOD
-oOq
+pyF
 hDf
 imz
 dFS
@@ -138512,7 +138502,7 @@ jNI
 jNI
 sog
 sbw
-oOq
+pyF
 hDf
 dFS
 fvO
@@ -138769,7 +138759,7 @@ uAC
 pJo
 svy
 ulk
-oOq
+pyF
 fvO
 fvO
 fvO
@@ -139026,7 +139016,7 @@ rbT
 dLM
 aFX
 kUL
-oOq
+pyF
 fvO
 fvO
 fvO
@@ -139277,12 +139267,12 @@ hDf
 jOW
 lKm
 jOW
-oOq
-oOq
-oOq
-oOq
-oOq
-oOq
+pyF
+pyF
+pyF
+pyF
+pyF
+pyF
 qYq
 fvO
 fvO
@@ -143130,13 +143120,13 @@ fvO
 fvO
 fvO
 fvO
-niS
+qYq
 pyF
 rFr
 jsr
 eYa
 pyF
-niS
+qYq
 fvO
 fvO
 fvO
@@ -143901,13 +143891,13 @@ mmm
 fvO
 fvO
 fvO
-niS
+qYq
 iFg
 tMY
 lig
 cNP
 vkU
-niS
+qYq
 fvO
 fvO
 fvO
@@ -144672,13 +144662,13 @@ hDf
 hDf
 hDf
 hDf
-niS
+qYq
 pyF
 mMS
 tpl
 eia
 pyF
-niS
+qYq
 hDf
 hDf
 hDf

--- a/_maps/map_files/CardinalStation/CardinalStation.dmm
+++ b/_maps/map_files/CardinalStation/CardinalStation.dmm
@@ -827,7 +827,7 @@
 	dir = 6
 	},
 /turf/open/floor/iron/techmaint,
-/area/station/engineering/supermatter)
+/area/station/engineering/main)
 "ajv" = (
 /obj/structure/closet/firecloset,
 /obj/effect/turf_decal/siding/white{
@@ -2914,7 +2914,7 @@
 /obj/effect/turf_decal/bot/right,
 /obj/machinery/camera/directional/east,
 /turf/open/floor/iron/dark/smooth_large,
-/area/station/engineering/supermatter)
+/area/station/engineering/main)
 "aGb" = (
 /obj/effect/turf_decal/trimline/red/line,
 /obj/machinery/power/apc/auto_name/directional/south,
@@ -2989,7 +2989,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron/dark/textured,
-/area/station/engineering/supermatter)
+/area/station/engineering/main)
 "aIb" = (
 /obj/effect/landmark/start/roboticist,
 /obj/structure/chair/office/light{
@@ -3261,7 +3261,7 @@
 	},
 /obj/machinery/requests_console/auto_name/directional/north,
 /turf/open/floor/iron/smooth,
-/area/station/engineering/supermatter)
+/area/station/engineering/main)
 "aLo" = (
 /obj/structure/chair{
 	dir = 1
@@ -4124,7 +4124,7 @@
 	},
 /obj/effect/turf_decal/tile/yellow/half/contrasted,
 /turf/open/floor/iron/smooth,
-/area/station/engineering/supermatter)
+/area/station/engineering/main)
 "aYj" = (
 /obj/effect/spawner/structure/window/reinforced/plasma,
 /turf/open/floor/plating,
@@ -4428,7 +4428,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/tech,
-/area/station/engineering/supermatter)
+/area/station/engineering/main)
 "bbr" = (
 /obj/effect/turf_decal/siding/thinplating_new/light{
 	dir = 1
@@ -5180,7 +5180,7 @@
 	dir = 4
 	},
 /turf/open/floor/vault/rock,
-/area/station/engineering/supermatter)
+/area/station/engineering/main)
 "blX" = (
 /obj/machinery/door/window/brigdoor/westright{
 	name = "Creature Pen";
@@ -6354,7 +6354,7 @@
 /obj/machinery/light/directional/east,
 /obj/item/radio/intercom/directional/east,
 /turf/open/floor/iron/smooth,
-/area/station/engineering/supermatter)
+/area/station/engineering/main)
 "bzx" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
@@ -7181,7 +7181,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/iron/techmaint,
-/area/station/engineering/supermatter)
+/area/station/engineering/main)
 "bKu" = (
 /obj/structure/table/glass,
 /obj/item/storage/backpack/duffelbag/med/surgery,
@@ -7274,7 +7274,7 @@
 	dir = 6
 	},
 /turf/open/floor/iron/smooth,
-/area/station/engineering/supermatter)
+/area/station/engineering/main)
 "bMh" = (
 /obj/structure/railing/perspective/gray{
 	dir = 1
@@ -7651,7 +7651,7 @@
 	},
 /obj/machinery/light/small/directional/south,
 /turf/open/floor/catwalk_floor/iron_smooth,
-/area/station/engineering/supermatter)
+/area/station/engineering/main)
 "bRZ" = (
 /obj/structure/platform/wood,
 /turf/open/floor/iron/smooth_edge,
@@ -8024,7 +8024,7 @@
 	dir = 8
 	},
 /turf/open/floor/vault/rock,
-/area/station/engineering/supermatter)
+/area/station/engineering/main)
 "bWv" = (
 /obj/effect/turf_decal/siding/dark,
 /obj/structure/cable/yellow,
@@ -8306,7 +8306,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron/smooth,
-/area/station/engineering/supermatter)
+/area/station/engineering/main)
 "bZZ" = (
 /obj/structure/railing/perspective/wood{
 	dir = 8
@@ -8417,7 +8417,7 @@
 	},
 /obj/structure/cable/yellow,
 /turf/open/floor/iron/techmaint,
-/area/station/engineering/supermatter)
+/area/station/engineering/main)
 "cbN" = (
 /obj/effect/turf_decal/edges/borderfloor,
 /obj/structure/disposalpipe/segment{
@@ -9409,7 +9409,7 @@
 /obj/effect/landmark/event_spawn,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
 /turf/open/floor/iron/smooth,
-/area/station/engineering/supermatter)
+/area/station/engineering/main)
 "cmE" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
@@ -10661,7 +10661,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron/smooth,
-/area/station/engineering/supermatter)
+/area/station/engineering/main)
 "cAV" = (
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "Maintenance Hatch"
@@ -11513,7 +11513,7 @@
 /obj/effect/turf_decal/box/corners,
 /obj/structure/cable/yellow,
 /turf/open/floor/iron/tech/grid,
-/area/station/engineering/supermatter)
+/area/station/engineering/main)
 "cKq" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8
@@ -12123,7 +12123,7 @@
 	},
 /obj/machinery/incident_display/delam/directional/north,
 /turf/open/floor/vault/rock,
-/area/station/engineering/supermatter)
+/area/station/engineering/main)
 "cTP" = (
 /turf/open/floor/wood,
 /area/station/commons/vacant_room/office)
@@ -13280,7 +13280,7 @@
 /obj/machinery/light/directional/east,
 /obj/structure/cable/yellow,
 /turf/open/floor/iron/dark/textured,
-/area/station/engineering/supermatter)
+/area/station/engineering/main)
 "dgx" = (
 /obj/structure/window/reinforced/spawner/directional/north,
 /obj/structure/window/reinforced/spawner/directional/west,
@@ -13568,7 +13568,7 @@
 	dir = 5
 	},
 /turf/open/floor/iron/smooth_half,
-/area/station/engineering/supermatter)
+/area/station/engineering/main)
 "djX" = (
 /obj/machinery/conveyor{
 	dir = 8;
@@ -13817,7 +13817,7 @@
 /turf/open/floor/iron/textured_half{
 	dir = 1
 	},
-/area/station/engineering/supermatter)
+/area/station/engineering/main)
 "dmf" = (
 /obj/structure/lattice,
 /obj/structure/window/reinforced/corner/spawner/directional/south,
@@ -13890,7 +13890,7 @@
 /obj/structure/railing/perspective/black,
 /obj/structure/cable,
 /turf/open/floor/plating,
-/area/station/engineering/supermatter)
+/area/station/engineering/main)
 "dmM" = (
 /obj/effect/decal/cleanable/food/tomato_smudge,
 /obj/effect/turf_decal/stripes/line{
@@ -14010,7 +14010,7 @@
 /obj/structure/cable/yellow,
 /obj/structure/cable,
 /turf/open/floor/iron/smooth,
-/area/station/engineering/supermatter)
+/area/station/engineering/main)
 "doq" = (
 /obj/effect/turf_decal/tile/red/opposingcorners,
 /obj/effect/turf_decal/siding/wideplating_new/dark{
@@ -14487,7 +14487,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/orange/visible,
 /obj/machinery/meter,
 /turf/open/floor/iron/smooth,
-/area/station/engineering/supermatter)
+/area/station/engineering/main)
 "dxi" = (
 /obj/effect/spawner/structure/window,
 /obj/machinery/door/poddoor/shutters{
@@ -14634,7 +14634,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/station/engineering/supermatter)
+/area/station/engineering/main)
 "dyT" = (
 /obj/structure/filingcabinet{
 	pixel_x = 2
@@ -15757,7 +15757,7 @@
 /obj/effect/turf_decal/bot/left,
 /obj/machinery/status_display/ai/directional/east,
 /turf/open/floor/iron/dark/smooth_large,
-/area/station/engineering/supermatter)
+/area/station/engineering/main)
 "dLN" = (
 /obj/structure/cable/yellow,
 /obj/structure/disposalpipe/segment{
@@ -15918,7 +15918,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark/textured,
-/area/station/engineering/supermatter)
+/area/station/engineering/main)
 "dOj" = (
 /obj/effect/turf_decal/siding/dark{
 	dir = 1
@@ -16159,7 +16159,7 @@
 "dQJ" = (
 /obj/effect/spawner/structure/window/reinforced/tinted,
 /turf/open/floor/plating,
-/area/station/engineering/supermatter)
+/area/station/engineering/main)
 "dQM" = (
 /obj/effect/turf_decal/stripes/closeup,
 /obj/machinery/door/airlock/highsecurity{
@@ -17008,7 +17008,7 @@
 /obj/machinery/light/small/directional/south,
 /obj/machinery/status_display/ai/directional/south,
 /turf/open/floor/iron/grid/steel,
-/area/station/engineering/supermatter)
+/area/station/engineering/main)
 "eaC" = (
 /obj/effect/turf_decal/siding/blue/corner,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
@@ -17030,7 +17030,7 @@
 	dir = 5
 	},
 /turf/open/floor/iron/tech/grid,
-/area/station/engineering/supermatter)
+/area/station/engineering/main)
 "eaR" = (
 /obj/structure/cable/yellow,
 /obj/structure/disposalpipe/segment{
@@ -17893,7 +17893,7 @@
 	name = "Cooling Loop Bypass"
 	},
 /turf/open/floor/engine/light,
-/area/station/engineering/supermatter)
+/area/station/engineering/main)
 "enq" = (
 /obj/effect/turf_decal/stripes/white{
 	dir = 1
@@ -18401,7 +18401,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/smooth,
-/area/station/engineering/supermatter)
+/area/station/engineering/main)
 "esZ" = (
 /obj/effect/decal/fakestairs/newstairs/right{
 	dir = 4
@@ -18642,7 +18642,7 @@
 	},
 /obj/effect/decal/fakestairs,
 /turf/open/floor/iron/grid/steel,
-/area/station/engineering/supermatter)
+/area/station/engineering/main)
 "ewA" = (
 /obj/structure/flora/ausbushes/ppflowers{
 	pixel_y = 4;
@@ -20084,7 +20084,7 @@
 	pixel_y = -28
 	},
 /turf/open/floor/iron/grid/steel,
-/area/station/engineering/supermatter)
+/area/station/engineering/main)
 "eNj" = (
 /obj/effect/turf_decal/siding/white{
 	dir = 5
@@ -21209,7 +21209,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/iron/smooth_half,
-/area/station/engineering/supermatter)
+/area/station/engineering/main)
 "eYy" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -22508,7 +22508,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/tech/grid,
-/area/station/engineering/supermatter)
+/area/station/engineering/main)
 "fql" = (
 /obj/effect/landmark/blobstart,
 /turf/open/floor/engine,
@@ -22671,7 +22671,7 @@
 /turf/open/floor/iron/dark/textured_half{
 	dir = 1
 	},
-/area/station/engineering/supermatter)
+/area/station/engineering/main)
 "frD" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 8
@@ -23030,7 +23030,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron/techmaint,
-/area/station/engineering/supermatter)
+/area/station/engineering/main)
 "fvO" = (
 /turf/open/space/basic,
 /area/misc/space)
@@ -24058,7 +24058,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/simple/green/visible,
 /turf/open/floor/iron/smooth,
-/area/station/engineering/supermatter)
+/area/station/engineering/main)
 "fIE" = (
 /obj/effect/turf_decal/siding/dark{
 	dir = 4
@@ -24768,7 +24768,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/techmaint,
-/area/station/engineering/supermatter)
+/area/station/engineering/main)
 "fRg" = (
 /turf/open/floor/wood/big,
 /area/station/service/kitchen)
@@ -25615,7 +25615,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
 /turf/open/floor/iron/smooth,
-/area/station/engineering/supermatter)
+/area/station/engineering/main)
 "fZQ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8
@@ -26050,7 +26050,7 @@
 /obj/structure/extinguisher_cabinet/directional/east,
 /obj/machinery/camera/directional/east,
 /turf/open/floor/iron/smooth,
-/area/station/engineering/supermatter)
+/area/station/engineering/main)
 "gfq" = (
 /obj/machinery/light/directional/north,
 /obj/machinery/button/door{
@@ -27025,7 +27025,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/smooth,
-/area/station/engineering/supermatter)
+/area/station/engineering/main)
 "grR" = (
 /obj/structure/platform/warning/stair_cutoff{
 	dir = 1
@@ -27065,7 +27065,7 @@
 /turf/open/floor/iron/dark/textured_half{
 	dir = 1
 	},
-/area/station/engineering/supermatter)
+/area/station/engineering/main)
 "gsF" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/yellow,
@@ -28773,7 +28773,7 @@
 	},
 /obj/machinery/airalarm/directional/west,
 /turf/open/floor/iron/smooth,
-/area/station/engineering/supermatter)
+/area/station/engineering/main)
 "gOv" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -29129,7 +29129,7 @@
 	id = "smrad"
 	},
 /turf/open/floor/plating,
-/area/station/engineering/supermatter)
+/area/station/engineering/main)
 "gTk" = (
 /obj/machinery/computer/objective,
 /obj/effect/turf_decal/siding/dark,
@@ -30210,7 +30210,7 @@
 /obj/effect/mapping_helpers/airlock/access/all/engineering/general,
 /obj/effect/turf_decal/stripes/closeup,
 /turf/open/floor/iron/smooth_half,
-/area/station/engineering/supermatter)
+/area/station/engineering/main)
 "hfD" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 4
@@ -30477,7 +30477,7 @@
 	name = "Output Release"
 	},
 /turf/open/floor/iron/tech,
-/area/station/engineering/supermatter)
+/area/station/engineering/main)
 "hkb" = (
 /obj/effect/turf_decal/tile/green/opposingcorners,
 /obj/machinery/camera/directional/north,
@@ -30581,7 +30581,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/techmaint,
-/area/station/engineering/supermatter)
+/area/station/engineering/main)
 "hkM" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
@@ -31145,7 +31145,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /turf/open/floor/iron/smooth,
-/area/station/engineering/supermatter)
+/area/station/engineering/main)
 "hsB" = (
 /obj/structure/table/wood,
 /obj/item/clothing/head/wig/random{
@@ -32182,7 +32182,7 @@
 	dir = 8
 	},
 /turf/open/floor/engine/light,
-/area/station/engineering/supermatter)
+/area/station/engineering/main)
 "hDs" = (
 /obj/effect/turf_decal/trimline/white/filled/corner{
 	dir = 1
@@ -32211,7 +32211,7 @@
 	},
 /obj/machinery/firealarm/directional/south,
 /turf/open/floor/iron/smooth,
-/area/station/engineering/supermatter)
+/area/station/engineering/main)
 "hDP" = (
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /obj/structure/disposalpipe/segment{
@@ -33500,7 +33500,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/iron/smooth,
-/area/station/engineering/supermatter)
+/area/station/engineering/main)
 "hSL" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
@@ -34305,7 +34305,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/iron/smooth,
-/area/station/engineering/supermatter)
+/area/station/engineering/main)
 "idj" = (
 /obj/structure/transit_tube,
 /obj/structure/lattice/catwalk,
@@ -35325,7 +35325,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/smooth,
-/area/station/engineering/supermatter)
+/area/station/engineering/main)
 "ipI" = (
 /obj/effect/turf_decal/edges/techfloor{
 	dir = 8
@@ -35504,7 +35504,7 @@
 /obj/effect/turf_decal/box/corners,
 /obj/structure/cable/yellow,
 /turf/open/floor/iron/tech/grid,
-/area/station/engineering/supermatter)
+/area/station/engineering/main)
 "iqX" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -35697,7 +35697,7 @@
 	},
 /obj/effect/decal/fakestairs,
 /turf/open/floor/iron/grid/steel,
-/area/station/engineering/supermatter)
+/area/station/engineering/main)
 "isX" = (
 /obj/structure/disposalpipe/segment{
 	dir = 1
@@ -36140,7 +36140,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron/techmaint,
-/area/station/engineering/supermatter)
+/area/station/engineering/main)
 "ixv" = (
 /turf/open/floor/iron/edge{
 	dir = 8
@@ -36204,7 +36204,7 @@
 /obj/structure/cable/yellow,
 /obj/structure/cable,
 /turf/open/floor/iron/techmaint,
-/area/station/engineering/supermatter)
+/area/station/engineering/main)
 "iyn" = (
 /obj/effect/turf_decal/trimline/purple/filled/warning,
 /obj/structure/cable/yellow,
@@ -36558,7 +36558,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron/smooth,
-/area/station/engineering/supermatter)
+/area/station/engineering/main)
 "iBP" = (
 /obj/effect/turf_decal/trimline/white/filled/line{
 	dir = 8
@@ -36729,7 +36729,7 @@
 /obj/structure/cable,
 /obj/structure/grille,
 /turf/open/floor/plating,
-/area/station/engineering/supermatter)
+/area/station/engineering/main)
 "iDC" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line,
 /obj/structure/cable/yellow,
@@ -36765,7 +36765,7 @@
 /turf/open/floor/iron/smooth_half{
 	dir = 1
 	},
-/area/station/engineering/supermatter)
+/area/station/engineering/main)
 "iDL" = (
 /obj/structure/window/reinforced/spawner/directional/south,
 /obj/structure/lattice/catwalk,
@@ -36887,7 +36887,7 @@
 /obj/structure/plasticflaps,
 /obj/machinery/atmospherics/pipe/bridge_pipe/green/visible,
 /turf/open/floor/plating,
-/area/station/engineering/supermatter)
+/area/station/engineering/main)
 "iEU" = (
 /obj/structure/table,
 /obj/structure/cable/yellow,
@@ -38062,7 +38062,7 @@
 	},
 /obj/machinery/light/directional/west,
 /turf/open/floor/iron/smooth,
-/area/station/engineering/supermatter)
+/area/station/engineering/main)
 "iSI" = (
 /obj/effect/turf_decal/siding/thinplating_new/light{
 	dir = 4
@@ -38732,7 +38732,7 @@
 	},
 /obj/structure/cable/yellow,
 /turf/open/floor/iron/smooth,
-/area/station/engineering/supermatter)
+/area/station/engineering/main)
 "jch" = (
 /obj/structure/sign/poster/official/random/directional/north,
 /turf/open/floor/iron,
@@ -38937,14 +38937,14 @@
 /obj/structure/extinguisher_cabinet/directional/west,
 /obj/machinery/camera/directional/west,
 /turf/open/floor/iron/smooth,
-/area/station/engineering/supermatter)
+/area/station/engineering/main)
 "jex" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/radiation/preopen{
 	id = "smrad"
 	},
 /turf/open/floor/plating,
-/area/station/engineering/supermatter)
+/area/station/engineering/main)
 "jey" = (
 /obj/structure/flora/tree/jungle{
 	pixel_y = -30;
@@ -39036,7 +39036,7 @@
 	},
 /obj/structure/cable/yellow,
 /turf/open/floor/iron/tech/grid,
-/area/station/engineering/supermatter)
+/area/station/engineering/main)
 "jfm" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8
@@ -39181,7 +39181,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/orange/hidden,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /turf/open/floor/iron/smooth,
-/area/station/engineering/supermatter)
+/area/station/engineering/main)
 "jgR" = (
 /obj/machinery/light/floor{
 	name = "moody floor light";
@@ -39411,7 +39411,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/dark/textured,
-/area/station/engineering/supermatter)
+/area/station/engineering/main)
 "jjX" = (
 /obj/structure/cable/yellow,
 /obj/effect/spawner/structure/window/reinforced,
@@ -39807,7 +39807,7 @@
 	pixel_x = 32
 	},
 /turf/open/floor/iron/smooth,
-/area/station/engineering/supermatter)
+/area/station/engineering/main)
 "jpb" = (
 /obj/effect/turf_decal/stripes/closeup,
 /obj/machinery/door/airlock/command{
@@ -40340,7 +40340,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/smooth,
-/area/station/engineering/supermatter)
+/area/station/engineering/main)
 "jvG" = (
 /obj/structure/cable/yellow,
 /obj/structure/disposalpipe/segment{
@@ -40638,10 +40638,12 @@
 /turf/open/floor/iron/dark,
 /area/station/science/research)
 "jyE" = (
-/obj/structure/cable/yellow,
-/obj/structure/cable,
-/turf/open/floor/iron/smooth,
-/area/station/engineering/supermatter)
+/obj/machinery/door/poddoor/shutters/radiation/preopen{
+	id = "smrad"
+	},
+/obj/effect/spawner/structure/window/reinforced/plasma,
+/turf/open/floor/plating,
+/area/station/engineering/main)
 "jyI" = (
 /obj/structure/cable/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
@@ -41695,7 +41697,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark/smooth_large,
-/area/station/engineering/supermatter)
+/area/station/engineering/main)
 "jNK" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 4
@@ -41916,7 +41918,7 @@
 	dir = 10
 	},
 /turf/open/floor/vault/rock,
-/area/station/engineering/supermatter)
+/area/station/engineering/main)
 "jQU" = (
 /obj/structure/table,
 /obj/effect/turf_decal/tile/blue/fourcorners/contrasted,
@@ -42289,7 +42291,7 @@
 	},
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/iron/smooth,
-/area/station/engineering/supermatter)
+/area/station/engineering/main)
 "jVH" = (
 /obj/effect/turf_decal/siding/dark_blue{
 	dir = 1
@@ -42509,7 +42511,7 @@
 	pixel_x = 32
 	},
 /turf/open/floor/iron/smooth,
-/area/station/engineering/supermatter)
+/area/station/engineering/main)
 "jYE" = (
 /obj/structure/cable/yellow,
 /obj/structure/disposalpipe/segment{
@@ -43382,7 +43384,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/orange/visible,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /turf/open/floor/iron/smooth,
-/area/station/engineering/supermatter)
+/area/station/engineering/main)
 "kjQ" = (
 /obj/structure/cable/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
@@ -43417,7 +43419,7 @@
 	req_access_txt = "11"
 	},
 /turf/open/floor/iron/smooth,
-/area/station/engineering/supermatter)
+/area/station/engineering/main)
 "kkh" = (
 /obj/machinery/button/door{
 	id = "hopblast";
@@ -44201,7 +44203,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/simple/green/visible,
 /turf/open/floor/iron/smooth,
-/area/station/engineering/supermatter)
+/area/station/engineering/main)
 "ktX" = (
 /obj/effect/turf_decal/siding/dark{
 	dir = 4
@@ -44481,7 +44483,7 @@
 /obj/structure/cable,
 /obj/structure/grille,
 /turf/open/floor/plating,
-/area/station/engineering/supermatter)
+/area/station/engineering/main)
 "kwY" = (
 /obj/effect/turf_decal/edges/borderfloor{
 	dir = 1
@@ -45004,7 +45006,7 @@
 	},
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/iron/grid/steel,
-/area/station/engineering/supermatter)
+/area/station/engineering/main)
 "kBz" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -45259,13 +45261,13 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
 /obj/machinery/meter,
 /turf/open/floor/iron/smooth,
-/area/station/engineering/supermatter)
+/area/station/engineering/main)
 "kFK" = (
 /obj/machinery/atmospherics/pipe/smart/simple/green/visible{
 	dir = 8
 	},
 /turf/open/floor/iron/smooth,
-/area/station/engineering/supermatter)
+/area/station/engineering/main)
 "kFR" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -46569,7 +46571,7 @@
 	},
 /obj/effect/turf_decal/bot/left,
 /turf/open/floor/iron/dark/smooth_large,
-/area/station/engineering/supermatter)
+/area/station/engineering/main)
 "kUO" = (
 /obj/effect/turf_decal/tile/brown/opposingcorners,
 /obj/structure/ore_box,
@@ -46689,7 +46691,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron/grid/steel,
-/area/station/engineering/supermatter)
+/area/station/engineering/main)
 "kWt" = (
 /obj/structure/window/reinforced/spawner/directional/east,
 /obj/effect/turf_decal/bot,
@@ -46775,7 +46777,7 @@
 "kXG" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/catwalk_floor/iron_smooth,
-/area/station/engineering/supermatter)
+/area/station/engineering/main)
 "kXS" = (
 /obj/machinery/telecomms/server/presets/security,
 /obj/effect/turf_decal/bot_white,
@@ -46903,7 +46905,7 @@
 /obj/structure/cable/yellow,
 /obj/structure/cable,
 /turf/open/floor/iron/smooth,
-/area/station/engineering/supermatter)
+/area/station/engineering/main)
 "kZV" = (
 /obj/structure/chair/fancy/sofa/corp{
 	dir = 1
@@ -47846,7 +47848,7 @@
 /turf/open/floor/iron/textured_half{
 	dir = 1
 	},
-/area/station/engineering/supermatter)
+/area/station/engineering/main)
 "ljF" = (
 /obj/machinery/light/directional/north,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
@@ -48428,7 +48430,7 @@
 /obj/structure/cable,
 /obj/structure/cable/yellow,
 /turf/open/floor/iron/techmaint,
-/area/station/engineering/supermatter)
+/area/station/engineering/main)
 "lqs" = (
 /obj/machinery/navbeacon{
 	codes_txt = "patrol;next_patrol=6-XENOBIO";
@@ -48971,7 +48973,7 @@
 /obj/machinery/light/directional/west,
 /obj/item/radio/intercom/directional/west,
 /turf/open/floor/iron/smooth,
-/area/station/engineering/supermatter)
+/area/station/engineering/main)
 "lxn" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
 /obj/effect/turf_decal/trimline/white/line{
@@ -50037,7 +50039,7 @@
 /turf/open/floor/iron/smooth_half{
 	dir = 1
 	},
-/area/station/engineering/supermatter)
+/area/station/engineering/main)
 "lKw" = (
 /obj/effect/turf_decal/stripes/closeup,
 /obj/machinery/door/airlock/security/glass{
@@ -50547,7 +50549,7 @@
 	pixel_y = -32
 	},
 /turf/open/floor/iron/smooth,
-/area/station/engineering/supermatter)
+/area/station/engineering/main)
 "lQz" = (
 /turf/open/floor/iron/dark/textured,
 /area/station/science/explab)
@@ -50846,7 +50848,7 @@
 	filter_type = list(/datum/gas/nitrogen)
 	},
 /turf/open/floor/iron/smooth,
-/area/station/engineering/supermatter)
+/area/station/engineering/main)
 "lTl" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line,
 /obj/machinery/light/directional/south,
@@ -51524,7 +51526,7 @@
 /obj/machinery/light/directional/west,
 /obj/structure/cable/yellow,
 /turf/open/floor/iron/dark/textured,
-/area/station/engineering/supermatter)
+/area/station/engineering/main)
 "mcY" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 1
@@ -52233,7 +52235,7 @@
 "mlH" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/general/visible,
 /turf/open/floor/catwalk_floor/iron,
-/area/station/engineering/supermatter)
+/area/station/engineering/main)
 "mlI" = (
 /obj/structure/table/reinforced,
 /obj/item/stack/sheet/iron/fifty{
@@ -53145,7 +53147,7 @@
 /obj/effect/turf_decal/stripes/closeup,
 /obj/structure/cable,
 /turf/open/floor/iron/smooth_half,
-/area/station/engineering/supermatter)
+/area/station/engineering/main)
 "mvn" = (
 /obj/structure/cable/yellow,
 /obj/structure/disposalpipe/segment{
@@ -53339,7 +53341,7 @@
 	dir = 10
 	},
 /turf/open/floor/iron/techmaint,
-/area/station/engineering/supermatter)
+/area/station/engineering/main)
 "mxN" = (
 /obj/structure/disposalpipe/segment{
 	dir = 1
@@ -54268,7 +54270,7 @@
 /turf/open/floor/iron/dark/smooth_half{
 	dir = 1
 	},
-/area/station/engineering/supermatter)
+/area/station/engineering/main)
 "mJS" = (
 /obj/structure/chair/stool/bar/directional/west,
 /obj/effect/turf_decal/siding/wood{
@@ -54545,7 +54547,7 @@
 	},
 /obj/effect/turf_decal/siding/thinplating_new/dark/corner,
 /turf/open/floor/iron/smooth,
-/area/station/engineering/supermatter)
+/area/station/engineering/main)
 "mMS" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -55628,7 +55630,7 @@
 	req_access_txt = "10"
 	},
 /turf/open/floor/iron/grid/steel,
-/area/station/engineering/supermatter)
+/area/station/engineering/main)
 "mXN" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 1
@@ -55772,7 +55774,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/dark/textured,
-/area/station/engineering/supermatter)
+/area/station/engineering/main)
 "mZg" = (
 /obj/machinery/door/airlock/atmos,
 /obj/effect/mapping_helpers/airlock/access/all/engineering/atmos,
@@ -56213,7 +56215,7 @@
 	dir = 9
 	},
 /turf/open/floor/vault/rock,
-/area/station/engineering/supermatter)
+/area/station/engineering/main)
 "nfh" = (
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/prison,
@@ -57571,7 +57573,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/iron/smooth,
-/area/station/engineering/supermatter)
+/area/station/engineering/main)
 "nwR" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
@@ -58555,7 +58557,7 @@
 	pixel_x = -32
 	},
 /turf/open/floor/iron/smooth,
-/area/station/engineering/supermatter)
+/area/station/engineering/main)
 "nHu" = (
 /obj/machinery/portable_atmospherics/canister/nitrogen,
 /obj/effect/turf_decal/bot,
@@ -59449,7 +59451,7 @@
 	dir = 6
 	},
 /turf/open/floor/iron/techmaint,
-/area/station/engineering/supermatter)
+/area/station/engineering/main)
 "nUH" = (
 /obj/structure/disposalpipe/segment{
 	dir = 1
@@ -59657,7 +59659,7 @@
 /area/misc/space/nearstation)
 "nXm" = (
 /turf/open/floor/iron/tech,
-/area/station/engineering/supermatter)
+/area/station/engineering/main)
 "nXp" = (
 /obj/effect/turf_decal/siding/dirt/corner{
 	dir = 8
@@ -60292,7 +60294,7 @@
 /obj/structure/cable,
 /obj/structure/cable/yellow,
 /turf/open/floor/iron/techmaint,
-/area/station/engineering/supermatter)
+/area/station/engineering/main)
 "ofw" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
@@ -60798,7 +60800,7 @@
 	},
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/vault/rock,
-/area/station/engineering/supermatter)
+/area/station/engineering/main)
 "omE" = (
 /obj/structure/cable/orange,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
@@ -62055,7 +62057,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/smooth,
-/area/station/engineering/supermatter)
+/area/station/engineering/main)
 "oyz" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 10
@@ -63307,7 +63309,7 @@
 /area/station/engineering/hallway)
 "oOq" = (
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
-/area/station/engineering/supermatter)
+/area/station/engineering/main)
 "oOr" = (
 /obj/effect/turf_decal/trimline/yellow/filled/warning{
 	dir = 1
@@ -63609,7 +63611,7 @@
 	name = "Atmos to Loop"
 	},
 /turf/open/floor/iron/smooth,
-/area/station/engineering/supermatter)
+/area/station/engineering/main)
 "oSE" = (
 /obj/effect/turf_decal/siding/yellow{
 	dir = 4
@@ -63893,7 +63895,7 @@
 	name = "Mix Bypass"
 	},
 /turf/open/floor/iron/smooth,
-/area/station/engineering/supermatter)
+/area/station/engineering/main)
 "oVN" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
@@ -64313,7 +64315,7 @@
 	},
 /obj/effect/turf_decal/bot/left,
 /turf/open/floor/iron/dark/smooth_large,
-/area/station/engineering/supermatter)
+/area/station/engineering/main)
 "pdU" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
@@ -64698,7 +64700,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/iron/smooth,
-/area/station/engineering/supermatter)
+/area/station/engineering/main)
 "pjE" = (
 /obj/effect/turf_decal/trimline/white/filled/warning{
 	dir = 1
@@ -65027,7 +65029,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron/grid/steel,
-/area/station/engineering/supermatter)
+/area/station/engineering/main)
 "pnY" = (
 /turf/closed/wall/r_wall,
 /area/station/security/checkpoint/engineering)
@@ -65129,7 +65131,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron/techmaint,
-/area/station/engineering/supermatter)
+/area/station/engineering/main)
 "poT" = (
 /obj/effect/turf_decal/siding/yellow{
 	dir = 10
@@ -66804,7 +66806,7 @@
 /obj/machinery/field/generator,
 /obj/effect/turf_decal/bot/right,
 /turf/open/floor/iron/dark/smooth_large,
-/area/station/engineering/supermatter)
+/area/station/engineering/main)
 "pJq" = (
 /obj/structure/table,
 /obj/machinery/cell_charger,
@@ -67325,7 +67327,7 @@
 /area/station/maintenance/department/cargo)
 "pPj" = (
 /turf/open/floor/iron/smooth,
-/area/station/engineering/supermatter)
+/area/station/engineering/main)
 "pPs" = (
 /obj/effect/decal/fakestairs/newstairs/right{
 	dir = 1
@@ -67391,7 +67393,7 @@
 /turf/open/floor/iron/textured_half{
 	dir = 1
 	},
-/area/station/engineering/supermatter)
+/area/station/engineering/main)
 "pPL" = (
 /obj/effect/turf_decal/siding/purple{
 	dir = 1
@@ -67421,7 +67423,7 @@
 /obj/effect/spawner/structure/window/reinforced/plasma,
 /obj/machinery/atmospherics/pipe/layer_manifold/general/visible,
 /turf/open/floor/plating,
-/area/station/engineering/supermatter)
+/area/station/engineering/main)
 "pQf" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
@@ -67862,7 +67864,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron/grid/steel,
-/area/station/engineering/supermatter)
+/area/station/engineering/main)
 "pVI" = (
 /obj/effect/turf_decal/edges/borderfloor{
 	dir = 8
@@ -68255,7 +68257,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /turf/open/floor/iron/smooth,
-/area/station/engineering/supermatter)
+/area/station/engineering/main)
 "qbb" = (
 /obj/machinery/camera/motion/directional/south,
 /turf/open/space/basic,
@@ -68644,7 +68646,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/iron/smooth,
-/area/station/engineering/supermatter)
+/area/station/engineering/main)
 "qgK" = (
 /obj/effect/turf_decal/siding/wideplating_new{
 	dir = 8
@@ -70101,7 +70103,7 @@
 /turf/open/floor/iron/textured_half{
 	dir = 1
 	},
-/area/station/engineering/supermatter)
+/area/station/engineering/main)
 "qwL" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 10
@@ -70722,7 +70724,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/iron/smooth,
-/area/station/engineering/supermatter)
+/area/station/engineering/main)
 "qDV" = (
 /obj/structure/lattice,
 /obj/structure/railing{
@@ -71457,7 +71459,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/smooth,
-/area/station/engineering/supermatter)
+/area/station/engineering/main)
 "qMP" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
 /obj/structure/disposalpipe/segment{
@@ -72164,7 +72166,7 @@
 	name = "Supermatter Ejection Door"
 	},
 /turf/open/floor/engine/light,
-/area/station/engineering/supermatter)
+/area/station/engineering/main)
 "qUG" = (
 /obj/effect/turf_decal/siding/red/corner{
 	dir = 8
@@ -72466,7 +72468,7 @@
 /area/station/medical/pharmacy)
 "qYq" = (
 /turf/closed/wall/mineral/plastitanium,
-/area/station/engineering/supermatter)
+/area/station/engineering/main)
 "qYG" = (
 /obj/effect/turf_decal/siding/thinplating_new/terracotta,
 /obj/effect/turf_decal/siding/thinplating_new/terracotta/corner{
@@ -72493,7 +72495,7 @@
 /obj/machinery/power/apc/auto_name/directional/south,
 /obj/structure/cable/yellow,
 /turf/open/floor/iron/tech/grid,
-/area/station/engineering/supermatter)
+/area/station/engineering/main)
 "qZb" = (
 /obj/structure/platform/warning{
 	dir = 8
@@ -72670,7 +72672,7 @@
 /turf/open/floor/iron/dark/smooth_half{
 	dir = 1
 	},
-/area/station/engineering/supermatter)
+/area/station/engineering/main)
 "rbn" = (
 /obj/effect/turf_decal/siding/red{
 	dir = 1
@@ -72695,7 +72697,7 @@
 /obj/effect/turf_decal/bot/right,
 /obj/structure/sign/poster/official/random/directional/east,
 /turf/open/floor/iron/dark/smooth_large,
-/area/station/engineering/supermatter)
+/area/station/engineering/main)
 "rcc" = (
 /obj/effect/turf_decal/siding/white{
 	dir = 10
@@ -73144,7 +73146,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/smooth,
-/area/station/engineering/supermatter)
+/area/station/engineering/main)
 "rih" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -73343,7 +73345,7 @@
 	pixel_x = -32
 	},
 /turf/open/floor/iron/smooth,
-/area/station/engineering/supermatter)
+/area/station/engineering/main)
 "rkG" = (
 /obj/structure/flora/ausbushes/lavendergrass{
 	pixel_y = 4
@@ -73404,7 +73406,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/smooth,
-/area/station/engineering/supermatter)
+/area/station/engineering/main)
 "rlg" = (
 /obj/effect/turf_decal/siding/wood,
 /obj/structure/bookcase/random/religion,
@@ -74818,7 +74820,7 @@
 "rCG" = (
 /obj/effect/turf_decal/siding/thinplating_new/dark/corner,
 /turf/open/floor/iron/smooth,
-/area/station/engineering/supermatter)
+/area/station/engineering/main)
 "rCH" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
@@ -74923,7 +74925,7 @@
 	pixel_y = -28
 	},
 /turf/open/floor/iron/grid/steel,
-/area/station/engineering/supermatter)
+/area/station/engineering/main)
 "rDO" = (
 /obj/effect/landmark/event_spawn,
 /obj/structure/cable/yellow,
@@ -75238,7 +75240,7 @@
 /obj/effect/mapping_helpers/make_non_slip,
 /obj/machinery/portable_atmospherics/pump,
 /turf/open/floor/vault/rock,
-/area/station/engineering/supermatter)
+/area/station/engineering/main)
 "rHZ" = (
 /obj/item/clipboard{
 	pixel_y = -4;
@@ -75376,7 +75378,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/smooth,
-/area/station/engineering/supermatter)
+/area/station/engineering/main)
 "rJM" = (
 /obj/effect/turf_decal/siding/dark/corner{
 	dir = 4
@@ -75506,7 +75508,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/grid/steel,
-/area/station/engineering/supermatter)
+/area/station/engineering/main)
 "rLH" = (
 /obj/structure/cable/yellow,
 /obj/structure/disposalpipe/segment{
@@ -75524,7 +75526,7 @@
 	},
 /obj/machinery/incident_display/delam/directional/north,
 /turf/open/floor/iron/tech/grid,
-/area/station/engineering/supermatter)
+/area/station/engineering/main)
 "rLQ" = (
 /obj/machinery/computer/shuttle_flight/custom_shuttle/exploration,
 /obj/effect/turf_decal/siding/dark,
@@ -75932,7 +75934,7 @@
 /turf/open/floor/iron/dark/textured_half{
 	dir = 1
 	},
-/area/station/engineering/supermatter)
+/area/station/engineering/main)
 "rQi" = (
 /obj/machinery/vending/autodrobe,
 /obj/effect/turf_decal/trimline/white/line,
@@ -76077,7 +76079,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/smooth,
-/area/station/engineering/supermatter)
+/area/station/engineering/main)
 "rRQ" = (
 /obj/machinery/teleport/station,
 /obj/effect/turf_decal/bot,
@@ -76590,7 +76592,7 @@
 /obj/structure/cable,
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron/techmaint,
-/area/station/engineering/supermatter)
+/area/station/engineering/main)
 "rZs" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
@@ -76695,7 +76697,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron/grid/steel,
-/area/station/engineering/supermatter)
+/area/station/engineering/main)
 "sbt" = (
 /obj/structure/disposalpipe/segment{
 	dir = 1
@@ -76709,7 +76711,7 @@
 	},
 /obj/effect/turf_decal/siding/dark,
 /turf/open/floor/iron/dark/smooth_large,
-/area/station/engineering/supermatter)
+/area/station/engineering/main)
 "sbx" = (
 /obj/effect/turf_decal/siding/wideplating_new/dark{
 	dir = 10
@@ -77125,7 +77127,7 @@
 	},
 /obj/effect/landmark/blobstart,
 /turf/open/floor/iron/tech/grid,
-/area/station/engineering/supermatter)
+/area/station/engineering/main)
 "sfJ" = (
 /obj/effect/turf_decal/guideline/guideline_in/yellow{
 	dir = 8
@@ -77778,7 +77780,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark/smooth_large,
-/area/station/engineering/supermatter)
+/area/station/engineering/main)
 "sok" = (
 /obj/structure/marker_beacon/burgundy,
 /obj/structure/lattice/catwalk,
@@ -77949,7 +77951,7 @@
 /turf/open/floor/iron/textured_half{
 	dir = 1
 	},
-/area/station/engineering/supermatter)
+/area/station/engineering/main)
 "sqd" = (
 /obj/structure/bed{
 	dir = 8
@@ -78199,7 +78201,7 @@
 	},
 /obj/effect/mapping_helpers/make_non_slip,
 /turf/open/floor/vault/rock,
-/area/station/engineering/supermatter)
+/area/station/engineering/main)
 "stp" = (
 /obj/structure/chair/fancy/plastic{
 	dir = 8
@@ -78443,7 +78445,7 @@
 /obj/machinery/shieldgen,
 /obj/effect/turf_decal/bot/left,
 /turf/open/floor/iron/dark/smooth_large,
-/area/station/engineering/supermatter)
+/area/station/engineering/main)
 "svG" = (
 /obj/structure/cable/yellow,
 /obj/effect/turf_decal/trimline/dark/filled/warning{
@@ -78575,7 +78577,7 @@
 	pixel_x = 25
 	},
 /turf/open/floor/iron/tech/grid,
-/area/station/engineering/supermatter)
+/area/station/engineering/main)
 "swG" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
@@ -79387,7 +79389,7 @@
 /obj/machinery/power/emitter,
 /obj/effect/turf_decal/bot/right,
 /turf/open/floor/iron/dark/smooth_large,
-/area/station/engineering/supermatter)
+/area/station/engineering/main)
 "sFn" = (
 /obj/effect/turf_decal/siding/blue{
 	dir = 1
@@ -79639,7 +79641,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/iron/techmaint,
-/area/station/engineering/supermatter)
+/area/station/engineering/main)
 "sIP" = (
 /obj/machinery/door/airlock/command{
 	name = "Chief Medical Officer's Quarters"
@@ -81019,7 +81021,7 @@
 	dir = 4
 	},
 /turf/open/floor/vault/rock,
-/area/station/engineering/supermatter)
+/area/station/engineering/main)
 "tbu" = (
 /obj/structure/cable/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
@@ -81028,7 +81030,7 @@
 "tbB" = (
 /obj/effect/turf_decal/edges/borderfloor,
 /turf/open/floor/iron/grid/steel,
-/area/station/engineering/supermatter)
+/area/station/engineering/main)
 "tbC" = (
 /obj/effect/landmark/start/exploration,
 /obj/effect/turf_decal/siding/white{
@@ -81164,7 +81166,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/grid/steel,
-/area/station/engineering/supermatter)
+/area/station/engineering/main)
 "tcR" = (
 /obj/effect/landmark/start/security_officer,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
@@ -81229,7 +81231,7 @@
 	dir = 5
 	},
 /turf/open/floor/iron/smooth,
-/area/station/engineering/supermatter)
+/area/station/engineering/main)
 "tdL" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/box,
@@ -81276,7 +81278,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/grid/steel,
-/area/station/engineering/supermatter)
+/area/station/engineering/main)
 "tdZ" = (
 /obj/structure/cable/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
@@ -81666,7 +81668,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/tech,
-/area/station/engineering/supermatter)
+/area/station/engineering/main)
 "tjC" = (
 /obj/effect/turf_decal/siding/wideplating_new/dark{
 	dir = 9
@@ -81831,7 +81833,7 @@
 /obj/effect/turf_decal/delivery,
 /obj/structure/plasticflaps,
 /turf/open/floor/plating,
-/area/station/engineering/supermatter)
+/area/station/engineering/main)
 "tlZ" = (
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /obj/structure/table/reinforced,
@@ -82328,7 +82330,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron/dark/smooth_large,
-/area/station/engineering/supermatter)
+/area/station/engineering/main)
 "trw" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/gravity_generator/main,
@@ -82500,7 +82502,7 @@
 	},
 /obj/structure/cable/yellow,
 /turf/open/floor/iron/tech/grid,
-/area/station/engineering/supermatter)
+/area/station/engineering/main)
 "ttu" = (
 /obj/effect/turf_decal/tile/yellow/opposingcorners,
 /obj/structure/cable/yellow,
@@ -83884,7 +83886,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/grid/steel,
-/area/station/engineering/supermatter)
+/area/station/engineering/main)
 "tKT" = (
 /obj/structure/table,
 /obj/item/wrench,
@@ -83927,7 +83929,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron/grid/steel,
-/area/station/engineering/supermatter)
+/area/station/engineering/main)
 "tMe" = (
 /mob/living/simple_animal/kalo,
 /turf/open/floor/iron/ameridiner,
@@ -83982,7 +83984,7 @@
 	},
 /obj/effect/turf_decal/bot/left,
 /turf/open/floor/iron/dark/smooth_large,
-/area/station/engineering/supermatter)
+/area/station/engineering/main)
 "tME" = (
 /turf/closed/wall/r_wall,
 /area/station/service/lawoffice)
@@ -85713,7 +85715,7 @@
 	},
 /obj/effect/turf_decal/bot/right,
 /turf/open/floor/iron/dark/smooth_large,
-/area/station/engineering/supermatter)
+/area/station/engineering/main)
 "ugZ" = (
 /obj/effect/turf_decal/siding/wood,
 /obj/effect/turf_decal/siding/blue{
@@ -85738,7 +85740,7 @@
 /obj/structure/extinguisher_cabinet/directional/south,
 /obj/machinery/camera/directional/south,
 /turf/open/floor/iron/grid/steel,
-/area/station/engineering/supermatter)
+/area/station/engineering/main)
 "uhz" = (
 /mob/living/carbon/monkey,
 /obj/effect/turf_decal/siding/white{
@@ -85965,7 +85967,7 @@
 	},
 /obj/structure/cable/yellow,
 /turf/open/floor/iron/tech/grid,
-/area/station/engineering/supermatter)
+/area/station/engineering/main)
 "ujP" = (
 /obj/effect/spawner/structure/window/reinforced/tinted,
 /obj/structure/cable/yellow,
@@ -86079,7 +86081,7 @@
 /obj/effect/turf_decal/siding/dark,
 /obj/effect/turf_decal/bot/right,
 /turf/open/floor/iron/dark/smooth_large,
-/area/station/engineering/supermatter)
+/area/station/engineering/main)
 "ulw" = (
 /obj/effect/turf_decal/siding/red/corner{
 	dir = 8
@@ -86603,7 +86605,7 @@
 /obj/structure/cable/yellow,
 /obj/structure/cable,
 /turf/open/floor/iron/techmaint,
-/area/station/engineering/supermatter)
+/area/station/engineering/main)
 "uru" = (
 /obj/machinery/vending/snack/orange,
 /obj/effect/turf_decal/tile/yellow/fourcorners/contrasted,
@@ -86668,7 +86670,7 @@
 	},
 /obj/item/radio/intercom/directional/north,
 /turf/open/floor/iron/tech/grid,
-/area/station/engineering/supermatter)
+/area/station/engineering/main)
 "usK" = (
 /obj/effect/mapping_helpers/make_non_slip,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -86854,7 +86856,7 @@
 	dir = 10
 	},
 /turf/open/floor/iron/techmaint,
-/area/station/engineering/supermatter)
+/area/station/engineering/main)
 "uuT" = (
 /obj/effect/landmark/start/clown,
 /obj/structure/cable/yellow,
@@ -86876,7 +86878,7 @@
 /turf/open/floor/iron/dark/smooth_half{
 	dir = 1
 	},
-/area/station/engineering/supermatter)
+/area/station/engineering/main)
 "uve" = (
 /obj/effect/turf_decal/siding/thinplating_new/terracotta{
 	dir = 4
@@ -87290,7 +87292,7 @@
 /obj/structure/cable,
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron/techmaint,
-/area/station/engineering/supermatter)
+/area/station/engineering/main)
 "uzm" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/closed/wall,
@@ -87404,7 +87406,7 @@
 /obj/machinery/field/generator,
 /obj/effect/turf_decal/bot/left,
 /turf/open/floor/iron/dark/smooth_large,
-/area/station/engineering/supermatter)
+/area/station/engineering/main)
 "uAK" = (
 /obj/structure/platform/black{
 	dir = 1
@@ -87428,7 +87430,7 @@
 	dir = 6
 	},
 /turf/open/floor/iron/smooth,
-/area/station/engineering/supermatter)
+/area/station/engineering/main)
 "uAP" = (
 /obj/effect/turf_decal/siding/thinplating_new{
 	dir = 4
@@ -87693,7 +87695,7 @@
 	dir = 6
 	},
 /turf/open/floor/iron/tech/grid,
-/area/station/engineering/supermatter)
+/area/station/engineering/main)
 "uDE" = (
 /obj/structure/cable/yellow,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
@@ -87934,7 +87936,7 @@
 /obj/effect/turf_decal/edges/techfloor,
 /obj/structure/window/reinforced/spawner/directional/west,
 /turf/open/floor/iron/tech/grid,
-/area/station/engineering/supermatter)
+/area/station/engineering/main)
 "uHv" = (
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/plating,
@@ -88478,7 +88480,7 @@
 /turf/open/floor/iron/dark/textured_half{
 	dir = 1
 	},
-/area/station/engineering/supermatter)
+/area/station/engineering/main)
 "uNM" = (
 /obj/effect/turf_decal/alphabet/number_2,
 /turf/open/floor/engine,
@@ -88642,7 +88644,7 @@
 	name = "Gas to Cooling Loop"
 	},
 /turf/open/floor/iron/grid/steel,
-/area/station/engineering/supermatter)
+/area/station/engineering/main)
 "uPZ" = (
 /obj/effect/turf_decal/siding/yellow,
 /obj/structure/platform/warning/corner{
@@ -89848,7 +89850,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/grid/steel,
-/area/station/engineering/supermatter)
+/area/station/engineering/main)
 "veE" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
@@ -90278,7 +90280,7 @@
 /turf/open/floor/iron/dark/smooth_half{
 	dir = 1
 	},
-/area/station/engineering/supermatter)
+/area/station/engineering/main)
 "vkL" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
@@ -90615,7 +90617,7 @@
 "vov" = (
 /obj/effect/spawner/structure/window/reinforced/plasma/plastitanium,
 /turf/open/floor/plating/airless,
-/area/station/engineering/supermatter)
+/area/station/engineering/main)
 "voK" = (
 /obj/structure/chair/fancy/comfy{
 	dir = 8
@@ -90751,7 +90753,7 @@
 "vqJ" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
-/area/station/engineering/supermatter)
+/area/station/engineering/main)
 "vqS" = (
 /obj/effect/turf_decal/siding{
 	icon_state = "siding_corner";
@@ -90798,7 +90800,7 @@
 /obj/effect/mapping_helpers/make_non_slip,
 /obj/structure/tank_dispenser,
 /turf/open/floor/vault/rock,
-/area/station/engineering/supermatter)
+/area/station/engineering/main)
 "vrb" = (
 /obj/structure/curtain,
 /obj/machinery/door/firedoor,
@@ -91051,7 +91053,7 @@
 	},
 /obj/structure/cable/yellow,
 /turf/open/floor/iron/tech/grid,
-/area/station/engineering/supermatter)
+/area/station/engineering/main)
 "vus" = (
 /obj/effect/turf_decal/trimline/neutral/filled/warning{
 	dir = 1
@@ -91371,7 +91373,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron/grid/steel,
-/area/station/engineering/supermatter)
+/area/station/engineering/main)
 "vxs" = (
 /obj/effect/turf_decal/tile/neutral/opposingcorners,
 /obj/effect/turf_decal/siding/wideplating_new/dark{
@@ -92548,7 +92550,7 @@
 /obj/machinery/light/small/directional/south,
 /obj/machinery/status_display/evac/directional/south,
 /turf/open/floor/iron/grid/steel,
-/area/station/engineering/supermatter)
+/area/station/engineering/main)
 "vKF" = (
 /obj/machinery/door/airlock/research/glass{
 	name = "Robotics Lab"
@@ -92977,7 +92979,7 @@
 	pixel_y = 32
 	},
 /turf/open/floor/iron/grid/steel,
-/area/station/engineering/supermatter)
+/area/station/engineering/main)
 "vPN" = (
 /obj/structure/platform/gray{
 	dir = 1
@@ -93448,7 +93450,7 @@
 	pixel_x = -15
 	},
 /turf/open/floor/iron/grid/steel,
-/area/station/engineering/supermatter)
+/area/station/engineering/main)
 "vWb" = (
 /obj/structure/cable/yellow,
 /obj/machinery/door/poddoor/preopen{
@@ -93626,7 +93628,7 @@
 	},
 /obj/item/radio/intercom/directional/north,
 /turf/open/floor/iron/dark/smooth_large,
-/area/station/engineering/supermatter)
+/area/station/engineering/main)
 "vYh" = (
 /obj/machinery/meter,
 /obj/structure/cable,
@@ -93634,7 +93636,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/techmaint,
-/area/station/engineering/supermatter)
+/area/station/engineering/main)
 "vYi" = (
 /obj/structure/closet/secure_closet/personal/patient,
 /obj/machinery/button/door{
@@ -93910,13 +93912,13 @@
 	},
 /obj/machinery/atmospherics/pipe/bridge_pipe/scrubbers/visible,
 /turf/open/floor/iron/smooth,
-/area/station/engineering/supermatter)
+/area/station/engineering/main)
 "wcd" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/general/visible{
 	dir = 4
 	},
 /turf/open/floor/catwalk_floor/iron,
-/area/station/engineering/supermatter)
+/area/station/engineering/main)
 "wcD" = (
 /obj/effect/turf_decal/trimline/purple/filled/warning{
 	dir = 4
@@ -94631,7 +94633,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/smooth,
-/area/station/engineering/supermatter)
+/area/station/engineering/main)
 "wlR" = (
 /obj/effect/turf_decal/box,
 /obj/structure/chair{
@@ -94769,7 +94771,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron/smooth,
-/area/station/engineering/supermatter)
+/area/station/engineering/main)
 "wnw" = (
 /obj/structure/cable/yellow,
 /obj/effect/turf_decal/trimline/white/warning_offset,
@@ -94802,7 +94804,7 @@
 	},
 /obj/machinery/airalarm/directional/east,
 /turf/open/floor/iron/smooth,
-/area/station/engineering/supermatter)
+/area/station/engineering/main)
 "wog" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 1
@@ -95607,7 +95609,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/iron/techmaint,
-/area/station/engineering/supermatter)
+/area/station/engineering/main)
 "wxE" = (
 /obj/machinery/light/small/directional/south,
 /obj/effect/turf_decal/siding/wood{
@@ -95679,7 +95681,7 @@
 	dir = 9
 	},
 /turf/open/floor/vault/rock,
-/area/station/engineering/supermatter)
+/area/station/engineering/main)
 "wyz" = (
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
@@ -95775,7 +95777,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/iron/smooth_half,
-/area/station/engineering/supermatter)
+/area/station/engineering/main)
 "wzL" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 6
@@ -96366,7 +96368,7 @@
 	pixel_y = -32
 	},
 /turf/open/floor/iron/smooth,
-/area/station/engineering/supermatter)
+/area/station/engineering/main)
 "wGr" = (
 /obj/effect/turf_decal/siding/dark{
 	dir = 1
@@ -96450,7 +96452,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /obj/structure/cable/yellow,
 /turf/open/floor/iron/smooth,
-/area/station/engineering/supermatter)
+/area/station/engineering/main)
 "wHv" = (
 /obj/structure/cable/yellow,
 /obj/structure/disposalpipe/segment{
@@ -96717,7 +96719,7 @@
 	},
 /obj/machinery/meter,
 /turf/open/floor/iron/grid/steel,
-/area/station/engineering/supermatter)
+/area/station/engineering/main)
 "wLG" = (
 /obj/effect/turf_decal/edges/borderfloor{
 	dir = 4
@@ -96955,7 +96957,7 @@
 	pixel_y = -28
 	},
 /turf/open/floor/iron/dark/smooth_large,
-/area/station/engineering/supermatter)
+/area/station/engineering/main)
 "wOF" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 8
@@ -97233,7 +97235,7 @@
 	pixel_y = -16
 	},
 /turf/open/floor/iron/tech,
-/area/station/engineering/supermatter)
+/area/station/engineering/main)
 "wSj" = (
 /obj/effect/turf_decal/siding/blue,
 /obj/machinery/camera/directional/south,
@@ -98972,7 +98974,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/grid/steel,
-/area/station/engineering/supermatter)
+/area/station/engineering/main)
 "xlK" = (
 /obj/effect/turf_decal/tile/brown/opposingcorners,
 /obj/effect/turf_decal/tile/red/opposingcorners,
@@ -99495,7 +99497,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark/smooth_large,
-/area/station/engineering/supermatter)
+/area/station/engineering/main)
 "xrf" = (
 /obj/structure/chair/foldable,
 /obj/effect/turf_decal/siding/wood{
@@ -100132,7 +100134,7 @@
 /turf/open/floor/iron/dark/smooth_half{
 	dir = 1
 	},
-/area/station/engineering/supermatter)
+/area/station/engineering/main)
 "xAD" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/light/small/directional/south,
@@ -100174,7 +100176,7 @@
 /turf/open/floor/iron/dark/textured_half{
 	dir = 1
 	},
-/area/station/engineering/supermatter)
+/area/station/engineering/main)
 "xAV" = (
 /obj/structure/fluff/paper{
 	dir = 9
@@ -100426,7 +100428,7 @@
 /obj/structure/cable/yellow,
 /obj/structure/cable,
 /turf/open/floor/iron/smooth,
-/area/station/engineering/supermatter)
+/area/station/engineering/main)
 "xEy" = (
 /obj/machinery/recharge_station,
 /obj/effect/turf_decal/stripes/line{
@@ -100536,7 +100538,7 @@
 	},
 /obj/machinery/atmospherics/components/trinary/filter/flipped/critical,
 /turf/open/floor/iron/smooth,
-/area/station/engineering/supermatter)
+/area/station/engineering/main)
 "xFx" = (
 /obj/machinery/light/floor,
 /obj/structure/disposalpipe/segment{
@@ -100737,7 +100739,7 @@
 	req_access_txt = "10"
 	},
 /turf/open/floor/iron/grid/steel,
-/area/station/engineering/supermatter)
+/area/station/engineering/main)
 "xHS" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 5
@@ -101436,7 +101438,7 @@
 /obj/structure/cable/yellow,
 /obj/structure/cable,
 /turf/open/floor/iron/techmaint,
-/area/station/engineering/supermatter)
+/area/station/engineering/main)
 "xRv" = (
 /obj/effect/turf_decal/siding/dirt/corner{
 	dir = 8
@@ -101840,7 +101842,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/techmaint,
-/area/station/engineering/supermatter)
+/area/station/engineering/main)
 "xVU" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/firedoor,
@@ -102160,7 +102162,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron/smooth,
-/area/station/engineering/supermatter)
+/area/station/engineering/main)
 "xZY" = (
 /obj/effect/turf_decal/trimline/neutral/filled/warning,
 /obj/effect/turf_decal/trimline/neutral/warning,
@@ -102225,7 +102227,7 @@
 	},
 /obj/effect/turf_decal/tile/yellow/anticorner/contrasted,
 /turf/open/floor/iron/smooth,
-/area/station/engineering/supermatter)
+/area/station/engineering/main)
 "yaR" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
@@ -102332,7 +102334,7 @@
 	dir = 5
 	},
 /turf/open/floor/iron/smooth,
-/area/station/engineering/supermatter)
+/area/station/engineering/main)
 "ycc" = (
 /obj/effect/turf_decal/tile/neutral/opposingcorners,
 /obj/effect/turf_decal/siding/wideplating_new/corner{
@@ -102764,7 +102766,7 @@
 	color = "#74b366"
 	},
 /turf/open/floor/iron/tech/grid,
-/area/station/engineering/supermatter)
+/area/station/engineering/main)
 "yhL" = (
 /obj/structure/cable/yellow,
 /obj/machinery/door/airlock/engineering/glass{
@@ -133612,7 +133614,7 @@ ydd
 qeV
 hcO
 bmO
-gCo
+jOW
 bZL
 oyv
 iSy
@@ -133627,10 +133629,10 @@ xZW
 pPj
 rJL
 hDO
-gCo
-gCo
-gCo
-gCo
+jOW
+jOW
+jOW
+jOW
 mmm
 mmm
 fvO
@@ -133870,7 +133872,7 @@ uCt
 uLL
 uLL
 mvm
-jyE
+qpM
 pjy
 xEp
 nwP
@@ -133887,7 +133889,7 @@ ktU
 iER
 veC
 rDK
-gCo
+jOW
 dFS
 dFS
 hDf
@@ -134383,7 +134385,7 @@ sTQ
 nuE
 lmK
 sOD
-gCo
+jOW
 jYy
 aYh
 aYh
@@ -134398,10 +134400,10 @@ ipA
 pPj
 rCG
 lQw
-gCo
+jOW
 pVB
 uhi
-gCo
+jOW
 fvO
 hDf
 qjh
@@ -134645,7 +134647,7 @@ iZj
 dQJ
 dQJ
 dQJ
-gCo
+jOW
 urr
 fQP
 nUs
@@ -134655,10 +134657,10 @@ eyg
 eyg
 eyg
 gCo
-gCo
+jOW
 vPG
 eay
-gCo
+jOW
 fvO
 hDf
 liO
@@ -134915,7 +134917,7 @@ cMA
 dmK
 tKI
 vVZ
-aSU
+jyE
 fvO
 hDf
 qjh
@@ -135429,7 +135431,7 @@ aSU
 kwV
 tdY
 mXL
-aSU
+jyE
 hDf
 qjh
 qjh
@@ -135943,7 +135945,7 @@ aSU
 iDp
 xlx
 xHP
-aSU
+jyE
 hDf
 qjh
 qjh
@@ -136457,7 +136459,7 @@ cMA
 dmK
 rLA
 tbB
-aSU
+jyE
 fvO
 qjh
 hDf
@@ -136701,7 +136703,7 @@ iZj
 dQJ
 dQJ
 dQJ
-gCo
+jOW
 poH
 fvM
 hkL
@@ -136711,10 +136713,10 @@ eyg
 eyg
 eyg
 gCo
-gCo
+jOW
 wLE
 vKE
-gCo
+jOW
 fvO
 qjh
 sVR
@@ -136953,7 +136955,7 @@ pTW
 gHy
 vuu
 sOD
-gCo
+jOW
 rkE
 bZL
 bZL
@@ -136968,10 +136970,10 @@ wnv
 pPj
 rid
 wGh
-gCo
+jOW
 tcO
 uhi
-gCo
+jOW
 fvO
 qjh
 hDf
@@ -137485,7 +137487,7 @@ esU
 tlY
 kWs
 eNb
-gCo
+jOW
 dFS
 dFS
 hDf
@@ -137724,7 +137726,7 @@ nQc
 onW
 rBx
 bmO
-gCo
+jOW
 aLl
 aYh
 ipA
@@ -137739,10 +137741,10 @@ pPj
 pPj
 rCG
 yaO
-gCo
-gCo
-gCo
-gCo
+jOW
+jOW
+jOW
+jOW
 mmm
 mmm
 fvO
@@ -137987,9 +137989,9 @@ jex
 rPM
 frx
 jex
-gCo
+jOW
 djW
-gCo
+jOW
 oOq
 gsm
 uNA
@@ -138244,9 +138246,9 @@ usI
 nXm
 bbq
 qYQ
-gCo
+jOW
 iDE
-gCo
+jOW
 vXY
 eaJ
 sfA
@@ -138501,9 +138503,9 @@ rLM
 wSa
 tju
 yhC
-gCo
+jOW
 kXG
-gCo
+jOW
 trp
 xqV
 jNI
@@ -138758,9 +138760,9 @@ swE
 nXm
 hjT
 uHu
-gCo
+jOW
 bRU
-gCo
+jOW
 pdN
 sFi
 uAC
@@ -139011,13 +139013,13 @@ iGd
 iGd
 iGd
 iGd
-gCo
+jOW
 vqJ
 dyR
-gCo
-gCo
+jOW
+jOW
 kXG
-gCo
+jOW
 ugY
 tMD
 rbT
@@ -139272,9 +139274,9 @@ hDf
 hDf
 wbp
 hDf
-gCo
+jOW
 lKm
-gCo
+jOW
 oOq
 oOq
 oOq


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Second verse same as the first. The Supermatter area was applied to both the SM chamber and the wider surrounding room, meaning the air alarm by the SM would list a lot of scrubbers outside of the chamber. All I have done is reduce the SM area to just the chamber, and expanded the engine room area to emcompasse the surrounding space.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Closes #14496 

Should result in less confusion / scrubber setting errors for the unaware engineer.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

<img width="917" height="660" alt="image" src="https://github.com/user-attachments/assets/75464e10-9446-42ba-b2d8-65c5e23e9e1a" />

</details>

## Changelog
:cl:
fix: Fixed the CardStation Supermatter area being set to rooms around the SM chamber as well.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
