### PR TITLE
Chem Dispenser User Feedback

### DIFF
--- a/code/game/machinery/_machinery.dm
+++ b/code/game/machinery/_machinery.dm
@@ -82,6 +82,16 @@
  *
  *  process_atmos()
  *     Called by the 'air subsystem' once per atmos tick for each machine that is listed in its 'atmos_machines' list.
+ *
+ *Helpers:
+ *	is_powered()
+ *		Returns true if the machine_stat for NOPOWER is inactive,
+ *
+ *	is_broken()
+ *		Returns true if the machine_stat for BROKEN is active,
+ *
+ * 	is_maintenance_mode()
+ *		Returns true if the machine_stat for MAINT is active,
  * Compiled by Aygar
  */
 
@@ -574,6 +584,16 @@
 ///Called when the value of `is_operational` changes, so we can react to it.
 /obj/machinery/proc/on_set_is_operational(old_value)
 	return
+
+/obj/machinery/proc/is_powered()
+	return !(machine_stat & NOPOWER)
+
+/obj/machinery/proc/is_broken()
+	return machine_stat & BROKEN
+
+/obj/machinery/proc/is_maintenance_mode()
+	return machine_stat & MAINT
+
 
 /obj/machinery/can_interact(mob/user)
 	var/silicon = issilicon(user)

--- a/code/game/machinery/_machinery.dm
+++ b/code/game/machinery/_machinery.dm
@@ -83,15 +83,6 @@
  *  process_atmos()
  *     Called by the 'air subsystem' once per atmos tick for each machine that is listed in its 'atmos_machines' list.
  *
- *Helpers:
- *	is_powered()
- *		Returns true if the machine_stat for NOPOWER is inactive,
- *
- *	is_broken()
- *		Returns true if the machine_stat for BROKEN is active,
- *
- * 	is_maintenance_mode()
- *		Returns true if the machine_stat for MAINT is active,
  * Compiled by Aygar
  */
 
@@ -584,16 +575,6 @@
 ///Called when the value of `is_operational` changes, so we can react to it.
 /obj/machinery/proc/on_set_is_operational(old_value)
 	return
-
-/obj/machinery/proc/is_powered()
-	return !(machine_stat & NOPOWER)
-
-/obj/machinery/proc/is_broken()
-	return machine_stat & BROKEN
-
-/obj/machinery/proc/is_maintenance_mode()
-	return machine_stat & MAINT
-
 
 /obj/machinery/can_interact(mob/user)
 	var/silicon = issilicon(user)

--- a/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
@@ -292,11 +292,11 @@
 			. = TRUE
 
 	if(!is_operational)
-		if(is_broken())
+		if(machine_stat & BROKEN)
 			to_chat(usr, span_warning("\The [src] is broken."))
-		if(!is_powered())
+		if(machine_stat & NOPOWER)
 			to_chat(usr, span_warning("\The [src] is not currently powered."))
-		if(is_maintenance_mode())
+		if(machine_stat & MAINT)
 			to_chat(usr, span_warning("\The [src]'s maintenance panel is open."))
 		return
 

--- a/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
@@ -292,8 +292,12 @@
 			. = TRUE
 
 	if(!is_operational)
-		if(panel_open)
-			to_chat(usr, span_warning("You're unable to operate \the [src] whilst its maintenance panel is open."))
+		if(is_broken())
+			to_chat(usr, span_warning("\The [src] is broken."))
+		if(!is_powered())
+			to_chat(usr, span_warning("\The [src] is not currently powered."))
+		if(is_maintenance_mode())
+			to_chat(usr, span_warning("\The [src]'s maintenance panel is open."))
 		return
 
 	switch(action)

--- a/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
@@ -292,6 +292,8 @@
 			. = TRUE
 
 	if(!is_operational)
+		if(panel_open)
+			to_chat(usr, span_warning("You're unable to operate \the [src] whilst its maintenance panel is open."))
 		return
 
 	switch(action)


### PR DESCRIPTION
## About The Pull Request
After some wrestling with the booze dispensers in cargo in a previous round, I figured some 'you are dumb' user feedback was necessary, as the soda and booze dispensers lack an overlay for when they have their maintenance panels open. The alternative being silent failure and worry that something was bugged.

During testing, hit some edge cases where the UI was still open but the dispenser wasn't dispensing. Realised the machine had no power yet the UI was still accessible, so presumed it was intentional so covered those edge cases too.

I figured that implementing helper functions would be more reasonable to maintain than direct bitflag comparisons, but opted not to implement them across the entire machine network to keep the PR atomic to its intended goal. I can remove them if needs be.

## Why It's Good For The Game
Gives feedback to the user as to why their dispenser isn't dispensing

## Testing Photographs and Procedure
<details>
<summary>Screenshots&Videos</summary>

<img width="568" height="694" alt="image" src="https://github.com/user-attachments/assets/53ee384e-3d47-48df-88a7-154f365bc5b0" />

Did try to test for broken, but the dispensers deconstruct when shot enough, so... no luck there.

</details>

## Changelog
:cl:
tweak: Dispensers, such as Chemical, Booze, Soda, and Mutagen Dispensers, now tell you when they can not be operated due to their maintenance panel being open.
/:cl:

