### PR TITLE
Dragon Nerf?

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/space_dragon.dm
+++ b/code/modules/mob/living/simple_animal/hostile/space_dragon.dm
@@ -320,7 +320,7 @@
 		if(L in hit_list)
 			continue
 		hit_list += L
-		L.adjustFireLoss(30)
+		L.apply_damage(30,BURN,blocked = L.run_armor_check(attack_flag = FIRE))
 		to_chat(L, span_userdanger("You're hit by [src]'s fire breath!"))
 	// deals damage to mechs
 	for(var/obj/vehicle/sealed/mecha/M in T.contents)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Dragon is stupidly common in lowpop, and the stupid high burn damage it's breath has is being shown
Let's make it respect armor instead of dealing a flat damage amount

Maximum amount of FIRE resistance will be dealing 9 damage, instead of 30 


## Why It's Good For The Game

It's a balance PR, some people hate it, some dont

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

<img width="822" height="410" alt="image" src="https://github.com/user-attachments/assets/8b271770-762f-4291-ab63-969b1e462779" />

<img width="431" height="332" alt="image" src="https://github.com/user-attachments/assets/fb040d56-0a4b-4efd-808d-f829140d6718" />

<img width="454" height="315" alt="image" src="https://github.com/user-attachments/assets/db8069ab-67e5-40e7-a1b0-127080be1034" />

</details>

## Changelog
:cl:
fix: Space Dragon's Fire Breath respects FIRE armor
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
