### PR TITLE
Fixes linters

### DIFF
--- a/.github/workflows/run_linters.yml
+++ b/.github/workflows/run_linters.yml
@@ -49,7 +49,7 @@ jobs:
         with:
           dotnet-version: 9.x
       - name: Install OpenDream
-        uses: robinraju/release-downloader@v1.12
+        uses: robinraju/release-downloader@v1.13
         with:
           repository: "OpenDreamProject/OpenDream"
           tag: "latest"
@@ -84,7 +84,7 @@ jobs:
         run: ~/dreamchecker 2>&1 | bash tools/ci/annotate_dm.sh
       - name: Run OpenDream
         if: steps.linter-setup.conclusion == 'success' && !cancelled()
-        run: ./DMCompiler_linux-x64/DMCompiler beestation.dme --suppress-unimplemented --define=CIBUILDING --version=515.1642 | bash tools/ci/annotate_od.sh
+        run: ./DMCompiler_linux-x64/DMCompiler beestation.dme --suppress-unimplemented --define=CIBUILDING | bash tools/ci/annotate_od.sh
       - name: Check for Map & Maplint File Edits
         id: map-filter
         uses: dorny/paths-filter@v4

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -586,7 +586,7 @@ GLOBAL_LIST_INIT(blacklisted_builds, list(
 			return FALSE
 		if (NAMEOF(src, antag_token_count_cached))
 			return FALSE
-		if (NAMEOF(src, authenticated))
+		if (UNLINT(NAMEOF(src, authenticate))) // OpenDream doesn't have support for this var I guess. It exists.
 			return FALSE
 		if (NAMEOF(src, logged_in))
 			log_admin_private("[key_name(usr)] attempted to auth bypass [key_name(src)] via client.logged_in")

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -586,7 +586,7 @@ GLOBAL_LIST_INIT(blacklisted_builds, list(
 			return FALSE
 		if (NAMEOF(src, antag_token_count_cached))
 			return FALSE
-		if (NAMEOF(src, authenticate))
+		if (NAMEOF(src, authenticated))
 			return FALSE
 		if (NAMEOF(src, logged_in))
 			log_admin_private("[key_name(usr)] attempted to auth bypass [key_name(src)] via client.logged_in")


### PR DESCRIPTION
## About The Pull Request

~~There was a typo in the `NAMEOF()` macro & OpenDream only just recently started checking for that (I assume).~~

~~I've also changed OpenDream to run on the latest "byond" version instead of 515 & bumped the downloader action thing's version.~~

I was spitballing. See the 2nd comment

## Testing Photographs and Procedure

1 sec

## Changelog
:cl:
server: fixed the github linters workflow
/:cl: