### PR TITLE
Fixes OpenDream disabling BYOND authentication incorrectly

### DIFF
--- a/code/__DEFINES/client.dm
+++ b/code/__DEFINES/client.dm
@@ -12,7 +12,7 @@
 
 /// If BYOND's HTTP API currently responding?
 /// Set to false on the first request failure
-#if !defined(DISABLE_BYOND_AUTH) && !defined(OPENDREAM)
+#if !defined(DISABLE_BYOND_AUTH)
 GLOBAL_VAR_INIT(byond_http, TRUE)
 #else
 GLOBAL_VAR_INIT(byond_http, FALSE)

--- a/code/_compile_options.dm
+++ b/code/_compile_options.dm
@@ -180,9 +180,7 @@
 #endif
 
 #ifdef OPENDREAM
-#ifndef DISABLE_BYOND_AUTH
 #define DISABLE_BYOND_AUTH
-#endif
 #endif
 
 

--- a/code/_compile_options.dm
+++ b/code/_compile_options.dm
@@ -179,6 +179,12 @@
 #define CBT
 #endif
 
+#ifdef OPENDREAM
+#ifndef DISABLE_BYOND_AUTH
+#define DISABLE_BYOND_AUTH
+#endif
+#endif
+
 
 #if defined(OPENDREAM) && !defined(CIBUILDING)
 #warn You are building with OpenDream. Remember to build TGUI manually.


### PR DESCRIPTION
## About The Pull Request

In my previous PR #14450, I implemented OpenDream disabling BYOND auth in a way that was kinda hacky. No excuse, I'm just stupid. This correctly sets the compile flag.

## Why It's Good For The Game

If you want something done right, you do it yourself after you've done it yourself.