### PR TITLE
Fixes being unable to examine emitters to ascertain their stats

### DIFF
--- a/code/modules/power/singularity/emitter.dm
+++ b/code/modules/power/singularity/emitter.dm
@@ -114,7 +114,7 @@
 	else
 		. += span_info("It's not anchored to the floor. You can secure it in place with a <b>wrench</b>.")
 
-	if(!in_range(user, src) || !isobserver(user))
+	if(!in_range(user, src) && !isobserver(user))
 		return
 
 	if(!active)


### PR DESCRIPTION
## About The Pull Request

While I was looking at the code for Emitters wondering what the upgrades did, I found that there was in fact an examine to tell you the statistics for Emitters.
It was accidentally gated away during a refactor, that made it so that only observers could see them. #9989 

## Why It's Good For The Game

Now you can see that upgrading the emitters' internal components does make for great improvements

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots of it working again</summary>

<img width="751" height="278" alt="image" src="https://github.com/user-attachments/assets/b949d372-7f19-4914-b19c-8adac4a7b3d4" />

</details>

## Changelog
:cl:
fix: You can now examine emitters again to ascertain their stats, and whether or not they're wired/powered properly.
/:cl: