### PR TITLE
Revert "Fixes OpenDream disabling BYOND authentication incorrectly"

### DIFF
--- a/code/__DEFINES/client.dm
+++ b/code/__DEFINES/client.dm
@@ -12,7 +12,7 @@
 
 /// If BYOND's HTTP API currently responding?
 /// Set to false on the first request failure
-#if !defined(DISABLE_BYOND_AUTH)
+#if !defined(DISABLE_BYOND_AUTH) && !defined(OPENDREAM)
 GLOBAL_VAR_INIT(byond_http, TRUE)
 #else
 GLOBAL_VAR_INIT(byond_http, FALSE)

--- a/code/_compile_options.dm
+++ b/code/_compile_options.dm
@@ -179,10 +179,6 @@
 #define CBT
 #endif
 
-#ifdef OPENDREAM
-#define DISABLE_BYOND_AUTH
-#endif
-
 
 #if defined(OPENDREAM) && !defined(CIBUILDING)
 #warn You are building with OpenDream. Remember to build TGUI manually.


### PR DESCRIPTION
Reverts BeeStation/BeeStation-Hornet#14513

This isn't how you're supposed to do this