### PR TITLE
Fixes spaceproof directional window mapping helper breaking the entire game

### DIFF
--- a/code/modules/mapping/mapping_helpers.dm
+++ b/code/modules/mapping/mapping_helpers.dm
@@ -1022,7 +1022,7 @@ CREATION_TEST_IGNORE_SELF(/obj/effect/mapping_helpers/atom_injector)
 
 	// well, it's a bad idea to put a directional window here. Mapping failsafe process here.
 	if(unliable_atmos_blocking && (isspaceturf(my_turf) || isopenspace(my_turf)))
-		my_turf.place_on_top(list(/turf/open/floor/plating, /turf/open/floor/iron), flags = CHANGETURF_INHERIT_AIR)
+		my_turf.place_on_top(/turf/open/floor/plating, flags = CHANGETURF_INHERIT_AIR)
 		for(var/turf/each_turf in nearby_turfs)
 			if(isspaceturf(each_turf) || isopenspace(each_turf))
 				var/obj/d_glass = new window_type(my_turf)


### PR DESCRIPTION
## About The Pull Request

I don't really know what this mapping helper does, nor do I care, but it was calling `place_on_top()` with a list when that proc doesn't support a list in its args.

On round 56582 this runtimed very early and cascaded into thousands of other runtimes breaking the round which required a server restart to fix.

## Testing Photographs and Procedure

Sorry, I don't know what this mapping helper does so I don't know what proper testing evidence would be. The proc call has correct args though now so fingers crossed.

## Changelog
:cl:
fix: Fixed the spaceproof directional windows mapping helper sometimes breaking the entire game
/:cl: