### PR TITLE
Explorer Nuclear Decommission fix

### DIFF
--- a/code/controllers/subsystem/processing/orbits.dm
+++ b/code/controllers/subsystem/processing/orbits.dm
@@ -163,6 +163,18 @@ PROCESSING_SUBSYSTEM_DEF(orbits)
 	possible_objectives += objective
 	update_objective_computers()
 
+//Just gives one of each objective for debug purposes
+/datum/controller/subsystem/processing/orbits/proc/create_objectives()
+	for (var/type in list(/datum/orbital_objective/recover_blackbox,
+		/datum/orbital_objective/nuclear_bomb,
+		/datum/orbital_objective/assassination,
+		/datum/orbital_objective/artifact,
+		/datum/orbital_objective/vip_recovery))
+		var/datum/orbital_objective/objective = new type()
+		objective.generate_payout()
+		possible_objectives += objective
+	update_objective_computers()
+
 /datum/controller/subsystem/processing/orbits/proc/assign_objective(objective_computer, datum/orbital_objective/objective)
 	if(!possible_objectives.Find(objective))
 		return "Selected objective is no longer available or has been claimed already."

--- a/code/modules/shuttle/super_cruise/orbital_poi_generator/objective_types/nuke_ruin.dm
+++ b/code/modules/shuttle/super_cruise/orbital_poi_generator/objective_types/nuke_ruin.dm
@@ -16,17 +16,17 @@
 /datum/orbital_objective/nuclear_bomb/get_text()
 	. = "Outpost [station_name] requires immediate decomissioning to prevent infomation from being \
 		leaked to the space press. Retrieve the nuclear authentication disk from the outpost and detonate it \
-		with the provided nuclear bomb which will be delivered to you, via this objectives computer."
+		with the provided nuclear bomb which will be delivered to your home station's bridge. \
+		Note: If the bridge is not available, the nuclear device will be rerouted to your objective computer."
 	if(linked_beacon)
 		. += " The station is located at the beacon marked [linked_beacon.name]. Good luck."
 
 /datum/orbital_objective/nuclear_bomb/on_assign(obj/machinery/computer/objective/objective_computer)
-	var/obj/structure/closet/supplypod/centcompod/toLaunch = new()
-	nuclear_bomb = new /obj/machinery/nuclearbomb/decomission()
-	nuclear_bomb.forceMove(toLaunch)
-	var/turf/T = get_turf(objective_computer)
-	new /obj/effect/pod_landingzone(T, toLaunch)
-
+	var/area/A = GLOB.areas_by_type[/area/station/command/bridge]
+	var/turf/open/T = locate() in shuffle(A.contents)
+	if(!T)
+		T = get_turf(objective_computer) //Backup, in case the bridge doesn't exist
+	nuclear_bomb = new /obj/machinery/nuclearbomb/decomission(T)
 
 /datum/orbital_objective/nuclear_bomb/check_failed()
 	if((!QDELETED(nuclear_bomb) && !QDELETED(nuclear_disk) && !QDELETED(linked_beacon)) || !generated)
@@ -54,6 +54,7 @@
 GLOBAL_LIST_EMPTY(decomission_bombs)
 
 /obj/machinery/nuclearbomb/decomission
+	name = "nuclear fission station-scuttler explosive"
 	desc = "A nuclear bomb for destroying stations. Uses an old version of the nuclear authentication disk."
 	proper_bomb = FALSE
 	var/datum/orbital_objective/nuclear_bomb/linked_objective

--- a/code/modules/shuttle/super_cruise/orbital_poi_generator/objective_types/nuke_ruin.dm
+++ b/code/modules/shuttle/super_cruise/orbital_poi_generator/objective_types/nuke_ruin.dm
@@ -16,7 +16,7 @@
 /datum/orbital_objective/nuclear_bomb/get_text()
 	. = "Outpost [station_name] requires immediate decomissioning to prevent infomation from being \
 		leaked to the space press. Retrieve the nuclear authentication disk from the outpost and detonate it \
-		with the provided nuclear bomb which will be delivered to your exploration preparation area."
+		with the provided nuclear bomb which will be delivered to you, via this objectives computer."
 	if(linked_beacon)
 		. += " The station is located at the beacon marked [linked_beacon.name]. Good luck."
 

--- a/code/modules/shuttle/super_cruise/orbital_poi_generator/objective_types/nuke_ruin.dm
+++ b/code/modules/shuttle/super_cruise/orbital_poi_generator/objective_types/nuke_ruin.dm
@@ -16,14 +16,17 @@
 /datum/orbital_objective/nuclear_bomb/get_text()
 	. = "Outpost [station_name] requires immediate decomissioning to prevent infomation from being \
 		leaked to the space press. Retrieve the nuclear authentication disk from the outpost and detonate it \
-		with the provided nuclear bomb which will be delivered to the bridge."
+		with the provided nuclear bomb which will be delivered to your exploration preparation area."
 	if(linked_beacon)
 		. += " The station is located at the beacon marked [linked_beacon.name]. Good luck."
 
 /datum/orbital_objective/nuclear_bomb/on_assign(obj/machinery/computer/objective/objective_computer)
-	var/area/A = GLOB.areas_by_type[/area/station/command]
-	var/turf/open/T = locate() in shuffle(A.contents)
-	nuclear_bomb = new /obj/machinery/nuclearbomb/decomission(T)
+	var/obj/structure/closet/supplypod/centcompod/toLaunch = new()
+	nuclear_bomb = new /obj/machinery/nuclearbomb/decomission()
+	nuclear_bomb.forceMove(toLaunch)
+	var/turf/T = get_turf(objective_computer)
+	new /obj/effect/pod_landingzone(T, toLaunch)
+
 
 /datum/orbital_objective/nuclear_bomb/check_failed()
 	if((!QDELETED(nuclear_bomb) && !QDELETED(nuclear_disk) && !QDELETED(linked_beacon)) || !generated)


### PR DESCRIPTION
## About The Pull Request

Makes the explorer nuclear decommission explosive guaranteed, by just dropping it on the objective computer, making use of the central command pods similar to the plush spawn beacons, rather than attempting to spawn it in an area that may not be on the station.


## Why It's Good For The Game
Previously, the nuke presumably wasn't spawning. Tested this on three different stations as a player on the server (so, unable to observe and confirm if they'd spawned anywhere), but going by the explorer objective overlay, it wasn't being spawned on the station z-level.

## Testing Photographs and Procedure
<details>
<summary>Screenshots&Videos</summary>

<img width="507" height="497" alt="image" src="https://github.com/user-attachments/assets/9b710621-9f19-44c3-93cf-cc6510ae4dba" />


</details>

## Changelog
:cl:
fix: The Explorer Nuclear Decommission objective now just drops the nuke on the mission console, rather than accidentally nullspacing it trying to aim for the bridge
/:cl:
