### PR TITLE
Solar Panel Examination

### DIFF
--- a/code/modules/power/solar.dm
+++ b/code/modules/power/solar.dm
@@ -258,6 +258,10 @@ CREATION_TEST_IGNORE_SUBTYPES(/obj/machinery/power/solar)
 	if(control)
 		control.gen += sgen
 
+/obj/machinery/power/solar/examine(mob/user)
+	.=..()
+	. += span_notice("\The [src]'s panels are composed of [material_type.name], giving it a power coefficient of [span_bold("[power_tier]")]")
+
 //Bit of a hack but this whole type is a hack
 /obj/machinery/power/solar/fake/Initialize(mapload, obj/item/solar_assembly/S)
 	. = ..()

--- a/code/modules/power/solar.dm
+++ b/code/modules/power/solar.dm
@@ -260,7 +260,8 @@ CREATION_TEST_IGNORE_SUBTYPES(/obj/machinery/power/solar)
 
 /obj/machinery/power/solar/examine(mob/user)
 	.=..()
-	. += span_notice("\The [src]'s panels are composed of [material_type.name], giving it a power coefficient of [span_bold("[power_tier]")]")
+	. += span_notice("\The [src]'s panels are composed of [material_type.name], giving it a power coefficient of [span_bold("[power_tier]")] ([span_italics("[SOLAR_GEN_RATE * power_tier]w maximum output")])")
+	. =+ span_notice("\The [src]'s panels could be <b>pried</b> out.")
 
 //Bit of a hack but this whole type is a hack
 /obj/machinery/power/solar/fake/Initialize(mapload, obj/item/solar_assembly/S)

--- a/code/modules/power/solar.dm
+++ b/code/modules/power/solar.dm
@@ -261,7 +261,7 @@ CREATION_TEST_IGNORE_SUBTYPES(/obj/machinery/power/solar)
 /obj/machinery/power/solar/examine(mob/user)
 	.=..()
 	. += span_notice("\The [src]'s panels are composed of [material_type.name], giving it a power coefficient of [span_bold("[power_tier]")] ([span_italics("[SOLAR_GEN_RATE * power_tier]w maximum output")])")
-	. =+ span_notice("\The [src]'s panels could be <b>pried</b> out.")
+	. += span_notice("\The [src]'s panels could be <b>pried</b> out.")
 
 //Bit of a hack but this whole type is a hack
 /obj/machinery/power/solar/fake/Initialize(mapload, obj/item/solar_assembly/S)

--- a/code/modules/power/solar.dm
+++ b/code/modules/power/solar.dm
@@ -260,8 +260,12 @@ CREATION_TEST_IGNORE_SUBTYPES(/obj/machinery/power/solar)
 
 /obj/machinery/power/solar/examine(mob/user)
 	.=..()
-	. += span_notice("\The [src]'s panels are composed of [material_type.name], giving it a power coefficient of [span_bold("[power_tier]")] ([span_italics("[SOLAR_GEN_RATE * power_tier]w maximum output")])")
 	. += span_notice("\The [src]'s panels could be <b>pried</b> out.")
+
+	if(!in_range(user, src) && !isobserver(user))
+		return
+
+	. += span_notice("\The [src]'s panels are composed of [material_type.name], giving it a power coefficient of [span_bold("[power_tier]")] ([span_italics("[SOLAR_GEN_RATE * power_tier]w maximum output")])")
 
 //Bit of a hack but this whole type is a hack
 /obj/machinery/power/solar/fake/Initialize(mapload, obj/item/solar_assembly/S)


### PR DESCRIPTION
## About The Pull Request
Adds an examine for solars to tell you their power coefficient, their panel type, and that you should use a crowbar to remove their panels

## Why It's Good For The Game
I wasn't even aware you could change the solar panels to upgrade their coefficiencies. This helps explain to the player that this is a mechanic

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

<img width="786" height="117" alt="image" src="https://github.com/user-attachments/assets/37df789d-1cfd-496a-8691-2eef8c99d528" />
<img width="785" height="121" alt="image" src="https://github.com/user-attachments/assets/a75847d0-58e1-4dba-b012-68c8663765f4" />

</details>

## Changelog
:cl:
tweak: You can now examine solar panels to infer their power multiplier coefficient, their maximum output, their glass type, and what tools to use on them
/:cl:

