### PR TITLE
Xenobiology: Back to Baseline

### DIFF
--- a/code/__DEFINES/is_helpers.dm
+++ b/code/__DEFINES/is_helpers.dm
@@ -104,6 +104,7 @@ GLOBAL_LIST_INIT(turfs_without_ground, typecacheof(list(
 #define isslimeperson(A) (is_species(A, /datum/species/oozeling/slime))
 #define isluminescent(A) (is_species(A, /datum/species/oozeling/luminescent))
 #define isstargazer(A) (is_species(A, /datum/species/oozeling/stargazer))
+#define isjellyperson(A) (isslimeperson(A) || isluminescent(A) || isstargazer(A)) //Every special snowflake slime/ooze/jelly whatever. Basically everyone EXCEPT oozelings
 #define isoozeling(A) (is_species(A, /datum/species/oozeling))
 #define iszombie(A) (is_species(A, /datum/species/zombie))
 #define isskeleton(A) (is_species(A, /datum/species/skeleton))

--- a/code/datums/diseases/transformation.dm
+++ b/code/datums/diseases/transformation.dm
@@ -201,13 +201,14 @@
 
 	switch(stage)
 		if(1)
-			if(ishuman(affected_mob) && affected_mob.dna)
-				if(affected_mob.dna.species.id == "slime" || affected_mob.dna.species.id == "stargazer" || affected_mob.dna.species.id == "lum")
+			if(ishuman(affected_mob))
+				var/mob/living/carbon/human/human = affected_mob
+				if(isjellyperson(human))
 					stage = 5
 		if(3)
 			if(ishuman(affected_mob))
 				var/mob/living/carbon/human/human = affected_mob
-				if(human.dna.species.id != "slime" && affected_mob.dna.species.id != "stargazer" && affected_mob.dna.species.id != "lum")
+				if(!ismonkey(human) && !isjellyperson(human))
 					human.set_species(/datum/species/oozeling/slime)
 
 /datum/disease/transformation/corgi

--- a/code/datums/diseases/transformation.dm
+++ b/code/datums/diseases/transformation.dm
@@ -201,10 +201,8 @@
 
 	switch(stage)
 		if(1)
-			if(ishuman(affected_mob))
-				var/mob/living/carbon/human/human = affected_mob
-				if(isjellyperson(human))
-					stage = 5
+			if(isjellyperson(affected_mob))
+				stage = 5
 		if(3)
 			if(ishuman(affected_mob))
 				var/mob/living/carbon/human/human = affected_mob

--- a/code/datums/storage/subtypes/extract_inventory.dm
+++ b/code/datums/storage/subtypes/extract_inventory.dm
@@ -27,9 +27,6 @@
 
 	if(parent_slime_extract.contents.len >= max_slots)
 		QDEL_LIST(parent_slime_extract.contents)
-		if(GLOB.total_slimes >= CONFIG_GET(number/max_slimes))
-			to_chat(user, span_warning("The extract jiggles, and fails to produce a slime..."))
-			return
 		createExtracts(user)
 
 /datum/storage/extract_inventory/proc/createExtracts(mob/user)
@@ -37,7 +34,9 @@
 	if(!parent_slime_extract)
 		return
 
+	var/cores = rand(1,4)
 	playsound(parent_slime_extract, 'sound/effects/splat.ogg', 40, TRUE)
 	parent_slime_extract.last_produce = world.time
-	to_chat(user, span_notice("[parent_slime_extract] briefly swells to a massive size, and expels a baby slime!"))
-	new /mob/living/simple_animal/slime(parent_slime_extract.drop_location(), parent_slime_extract.colour)
+	to_chat(user, span_notice("[parent_slime_extract] briefly swells to a massive size, and expels [cores] extract[cores > 1 ? "s":""]!"))
+	for(var/i in 1 to cores)
+		new parent_slime_extract.extract_type(parent_slime_extract.drop_location())

--- a/code/modules/research/xenobiology/crossbreeding/_status_effects.dm
+++ b/code/modules/research/xenobiology/crossbreeding/_status_effects.dm
@@ -446,49 +446,34 @@
 //////////////////STABILIZED EXTRACTS//////////////////
 ///////////////////////////////////////////////////////
 
-/atom/movable/screen/alert/status_effect/stabilized
-	name = "Stabilized"
-	icon_state = "template"
-
 /datum/status_effect/stabilized //The base stabilized extract effect, has no effect of its' own.
 	id = "stabilizedbase"
 	duration = STATUS_EFFECT_PERMANENT
-	alert_type = /atom/movable/screen/alert/status_effect/stabilized
-	status_type = STATUS_EFFECT_REPLACE
+	alert_type = null
 	/// Item which provides this buff
 	var/obj/item/slimecross/stabilized/linked_extract
 	/// Colour of the extract providing the buff
 	var/colour = "null"
 
-/datum/status_effect/stabilized/proc/link_extract(obj/item/slimecross/stabilized/linked_extract)
-	src.linked_extract = linked_extract
-	if (linked_extract && linked_alert)
-		linked_alert.name = linked_extract.name
-		linked_alert.desc = linked_extract.desc
-		linked_alert.add_overlay(linked_extract)
-
 /datum/status_effect/stabilized/on_creation(mob/living/new_owner, obj/item/slimecross/stabilized/linked_extract)
-	src.link_extract(linked_extract)
+	src.linked_extract = linked_extract
 	return ..()
 
-/datum/status_effect/stabilized/tick(seconds_between_ticks)
-	if (duration != STATUS_EFFECT_PERMANENT)
-		return ..()
+/datum/status_effect/stabilized/tick()
 	if(isnull(linked_extract))
-		duration = world.time + 15 SECONDS
-		START_PROCESSING(SSfastprocess, src)
-		return ..()
+		qdel(src)
+		return
 	if(linked_extract.get_held_mob() == owner)
 		return
 	owner.balloon_alert(owner, "[colour] extract faded!")
 	if(!QDELETED(linked_extract))
 		linked_extract.linked_effect = null
 		START_PROCESSING(SSobj,linked_extract)
-	duration = world.time + 15 SECONDS
-	START_PROCESSING(SSfastprocess, src)
+	qdel(src)
 
 /datum/status_effect/stabilized/null //This shouldn't ever happen, but just in case.
 	id = "stabilizednull"
+
 
 //Stabilized effects start below.
 /datum/status_effect/stabilized/grey

--- a/code/modules/research/xenobiology/crossbreeding/reproductive.dm
+++ b/code/modules/research/xenobiology/crossbreeding/reproductive.dm
@@ -8,10 +8,11 @@ Reproductive extracts:
 	desc = "It pulses with a strange hunger."
 	icon_state = "reproductive"
 	effect = "reproductive"
-	effect_desc = "When fed monkey cubes it produces a baby slime. Bio bag compatible as well."
+	effect_desc = "When fed monkey cubes it produces more extracts. Bio bag compatible as well."
 	layer = LOW_ITEM_LAYER
+	var/extract_type = /obj/item/slime_extract
 	var/last_produce = 0
-	var/cooldown = 30 SECONDS
+	var/cooldown = 3 SECONDS
 	var/feed_amount = 3
 	var/static/list/typecache_to_take
 
@@ -60,67 +61,89 @@ Reproductive extracts:
 		to_chat(user, span_notice("The [src] rejects the Monkey Cube!")) //in case it fails to insert for whatever reason you get feedback
 
 /obj/item/slimecross/reproductive/grey
+	extract_type = /obj/item/slime_extract/grey
 	colour = SLIME_TYPE_GREY
 
 /obj/item/slimecross/reproductive/orange
+	extract_type = /obj/item/slime_extract/orange
 	colour = SLIME_TYPE_ORANGE
 
 /obj/item/slimecross/reproductive/purple
+	extract_type = /obj/item/slime_extract/purple
 	colour = SLIME_TYPE_PURPLE
 
 /obj/item/slimecross/reproductive/blue
+	extract_type = /obj/item/slime_extract/blue
 	colour = SLIME_TYPE_BLUE
 
 /obj/item/slimecross/reproductive/metal
+	extract_type = /obj/item/slime_extract/metal
 	colour = SLIME_TYPE_METAL
 
 /obj/item/slimecross/reproductive/yellow
+	extract_type = /obj/item/slime_extract/yellow
 	colour = SLIME_TYPE_YELLOW
 
 /obj/item/slimecross/reproductive/darkpurple
+	extract_type = /obj/item/slime_extract/darkpurple
 	colour = SLIME_TYPE_DARK_PURPLE
 
 /obj/item/slimecross/reproductive/darkblue
+	extract_type = /obj/item/slime_extract/darkblue
 	colour = SLIME_TYPE_DARK_BLUE
 
 /obj/item/slimecross/reproductive/silver
+	extract_type = /obj/item/slime_extract/silver
 	colour = SLIME_TYPE_SILVER
 
 /obj/item/slimecross/reproductive/bluespace
+	extract_type = /obj/item/slime_extract/bluespace
 	colour = SLIME_TYPE_BLUESPACE
 
 /obj/item/slimecross/reproductive/sepia
+	extract_type = /obj/item/slime_extract/sepia
 	colour = SLIME_TYPE_SEPIA
 
 /obj/item/slimecross/reproductive/cerulean
+	extract_type = /obj/item/slime_extract/cerulean
 	colour = SLIME_TYPE_CERULEAN
 
 /obj/item/slimecross/reproductive/pyrite
+	extract_type = /obj/item/slime_extract/pyrite
 	colour = SLIME_TYPE_PYRITE
 
 /obj/item/slimecross/reproductive/red
+	extract_type = /obj/item/slime_extract/red
 	colour = SLIME_TYPE_RED
 
 /obj/item/slimecross/reproductive/green
+	extract_type = /obj/item/slime_extract/green
 	colour = SLIME_TYPE_GREEN
 
 /obj/item/slimecross/reproductive/pink
+	extract_type = /obj/item/slime_extract/pink
 	colour = SLIME_TYPE_PINK
 
 /obj/item/slimecross/reproductive/gold
+	extract_type = /obj/item/slime_extract/gold
 	colour = SLIME_TYPE_GOLD
 
 /obj/item/slimecross/reproductive/oil
+	extract_type = /obj/item/slime_extract/oil
 	colour = SLIME_TYPE_OIL
 
 /obj/item/slimecross/reproductive/black
+	extract_type = /obj/item/slime_extract/black
 	colour = SLIME_TYPE_BLACK
 
 /obj/item/slimecross/reproductive/lightpink
+	extract_type = /obj/item/slime_extract/lightpink
 	colour = SLIME_TYPE_LIGHT_PINK
 
 /obj/item/slimecross/reproductive/adamantine
+	extract_type = /obj/item/slime_extract/adamantine
 	colour = SLIME_TYPE_ADAMANTINE
 
 /obj/item/slimecross/reproductive/rainbow
+	extract_type = /obj/item/slime_extract/rainbow
 	colour = SLIME_TYPE_RAINBOW

--- a/code/modules/research/xenobiology/crossbreeding/stabilized.dm
+++ b/code/modules/research/xenobiology/crossbreeding/stabilized.dm
@@ -50,16 +50,9 @@ Stabilized extracts:
 			continue
 		effectpath = effect
 		break
-	var/datum/status_effect/stabilized/current_effect = holder.has_status_effect(effectpath)
-	if(!current_effect)
-		// No effect exists, apply it
-		holder.apply_status_effect(effectpath, src)
-		return PROCESS_KILL
-	else if(current_effect.duration != STATUS_EFFECT_PERMANENT)
-		// Effect exists but is temporary (fading), refresh it to permanent
-		holder.apply_status_effect(effectpath, src)
-		return PROCESS_KILL
-	// Effect already exists and is permanent, stop processing
+	if (holder.has_status_effect(effectpath))
+		return
+	holder.apply_status_effect(effectpath, src)
 	return PROCESS_KILL
 
 //Colors and subtypes:

--- a/code/modules/research/xenobiology/crossbreeding/stabilized.dm
+++ b/code/modules/research/xenobiology/crossbreeding/stabilized.dm
@@ -47,14 +47,9 @@ Stabilized extracts:
 	var/static/list/effects = subtypesof(/datum/status_effect/stabilized)
 	for(var/datum/status_effect/stabilized/effect as anything in effects)
 		if(initial(effect.colour) != colour)
-			//Does the holder already have a different stabilized effect?
-			if(holder.has_status_effect(effect))
-				holder.visible_message("[src] dissolves as you pick it up, overpowered by the [effect.colour] extract you already have!")
-				qdel(src)
-				return PROCESS_KILL
 			continue
 		effectpath = effect
-
+		break
 	var/datum/status_effect/stabilized/current_effect = holder.has_status_effect(effectpath)
 	if(!current_effect)
 		// No effect exists, apply it
@@ -64,9 +59,8 @@ Stabilized extracts:
 		// Effect exists but is temporary (fading), refresh it to permanent
 		holder.apply_status_effect(effectpath, src)
 		return PROCESS_KILL
-
-	// Effect exists and is permanent, do nothing or the extract will break because it relies on the status effect to start processing again.
-	// Users will not carry two of the same extract for long, so do not kill processing here.
+	// Effect already exists and is permanent, stop processing
+	return PROCESS_KILL
 
 //Colors and subtypes:
 /obj/item/slimecross/stabilized/grey


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

closes #14530 

reverts #5989 
reverts #12716 (reverted everything except the title.)
reverts #13418 

This PR brings xenobio balance to around what it was in 2021-2022. (minus #6299, which was a good exploit fix)

In particular, reverting these 3 prs.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

I don't really do balance PRs. I consider them radioactive, but I have felt strongly about this for a long enough time and my window to do something about it has opened with what I feel will be not much pushback.

---

All the individuals involved are no longer active in contributing, so I feel open to say these changes are no longer (if they ever were) good for the game, much less in our current state.

1. The first of which I recall went months with the author not really caring to wiki the changes. I eventually did it for them. It likely did have some application to higher pop days when golden was still around, but we are well past that, as well as the people who minmaxed for that type of thing not really being part of the playerbase anymore. 
Personally, I do not know anyone who finds the current situation particularly interesting. This department has always somewhat suffered with slimes just being... honestly boring as hell compared to the expectation of being an actual *slime rancher*. 

Reproductive Extracts are of no obstacle to experienced minmaxers, only those of less talent. They have been a shortcut at times in the past, however from the reverse position, it mitigates the xenobiologist simply hoarding extracts. I prefer the risk of xenobio being overused to newer players not being able to complete it in a normal shift at all. 


2. The second/third of which are intertwined due to cascading issues revolving around how the "timer" system was implemented. For some reason, extracts weren't sufficiently tested to see if they still functioned when juggling multiple, and the 3rd PR doubled down by making extracts arbitrarily qdel themselves in inventory with no warning. Existing issues from the 2nd pr are still existing (cerulean extracts spawning infinite clones), and the 3rd PR has no basis for existence without out it, so I am taking both. I cannot say I've ever seen someone abuse lightpinks the way the 2nd pr claimed. The speed changes remain.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

https://github.com/user-attachments/assets/f3c72b0c-11f0-4df8-a68c-f050099ad707

https://github.com/user-attachments/assets/2225b5ad-26d0-4cad-b50d-04de45fb2ca6

https://github.com/user-attachments/assets/da4944de-3529-4813-be4c-265c4aa271bf

</details>



## Changelog
:cl:
add: 2022 Reproductive extract behavior has been reimplemented. They now output the given slime's colored extracts when fed monkey cubes. Reproductive extract cooldown has been reduced to the same value as before.
balance: mobs are no longer limited to holding one stabilized extract
balance: stabilized extracts now removed and gain their effect immediately upon holding/dropping.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
