### PR TITLE
Science's Techweb & Nanite Fixes

### DIFF
--- a/code/datums/components/nanites.dm
+++ b/code/datums/components/nanites.dm
@@ -98,6 +98,7 @@
 /datum/component/nanites/Destroy()
 	STOP_PROCESSING(SSnanites, src)
 	QDEL_LIST(programs)
+	assigned_techweb = null
 	if(host_mob)
 		set_nanite_bar(TRUE)
 		host_mob.hud_set_nanite_indicator()

--- a/code/datums/components/nanites.dm
+++ b/code/datums/components/nanites.dm
@@ -25,9 +25,7 @@
 	nanite_volume = amount
 	cloud_id = cloud
 
-	assigned_techweb = locate(/datum/techweb/science) in SSresearch.techwebs // Default techweb we give points to
-	if(provided_techweb) // If someone uses a multitool with a server on it, we change where we give our points towards
-		assigned_techweb = provided_techweb
+	assigned_techweb = provided_techweb || (locate(/datum/techweb/science) in SSresearch.techwebs) // Default techweb we give points to
 
 	//Nanites without hosts are non-interactive through normal means
 	if(isliving(parent))
@@ -396,8 +394,7 @@
 	if(host_mob.stat == DEAD)
 		research_value *= 0.75
 
-	if(assigned_techweb)
-		assigned_techweb.add_point_list(list(TECHWEB_POINT_TYPE_NANITES = research_value))
+	assigned_techweb?.add_point_list(list(TECHWEB_POINT_TYPE_NANITES = research_value))
 
 /datum/component/nanites/proc/nanite_scan(datum/source, mob/user, full_scan)
 	SIGNAL_HANDLER

--- a/code/datums/components/nanites.dm
+++ b/code/datums/components/nanites.dm
@@ -16,13 +16,18 @@
 	var/start_time = 0 ///Timestamp to when the nanites were first inserted in the host
 	var/stealth = FALSE //if TRUE, does not appear on HUDs and health scans
 	var/diagnostics = TRUE //if TRUE, displays program list when scanned by nanite scanners
+	var/datum/techweb/assigned_techweb // The server/techweb nanites should give their points towards
 
-/datum/component/nanites/Initialize(amount = 100, cloud = 0)
+/datum/component/nanites/Initialize(amount = 100, cloud = 0, datum/techweb/provided_techweb = null)
 	if(!isliving(parent) && !istype(parent, /datum/nanite_cloud_backup))
 		return COMPONENT_INCOMPATIBLE
 
 	nanite_volume = amount
 	cloud_id = cloud
+
+	assigned_techweb = locate(/datum/techweb/science) in SSresearch.techwebs // Default techweb we give points to
+	if(provided_techweb) // If someone uses a multitool with a server on it, we change where we give our points towards
+		assigned_techweb = provided_techweb
 
 	//Nanites without hosts are non-interactive through normal means
 	if(isliving(parent))
@@ -109,8 +114,8 @@
 
 /datum/component/nanites/process(delta_time)
 	if(!IS_IN_STASIS(host_mob))
-		var/datum/techweb/science_web = locate(/datum/techweb/science) in SSresearch.techwebs
-		adjust_nanites(amount = (regen_rate + (science_web.researched_nodes[TECHWEB_NODE_NANITE_HARMONIC] ? HARMONIC_REGEN_BOOST : 0)) * delta_time)
+		var/harmonic_researched = assigned_techweb?.researched_nodes[TECHWEB_NODE_NANITE_HARMONIC]
+		adjust_nanites(amount = (regen_rate + (harmonic_researched ? HARMONIC_REGEN_BOOST : 0)) * delta_time)
 		add_research()
 		for(var/datum/nanite_program/program as anything in programs)
 			program.on_process()
@@ -391,8 +396,8 @@
 	if(host_mob.stat == DEAD)
 		research_value *= 0.75
 
-	var/datum/techweb/science_web = locate(/datum/techweb/science) in SSresearch.techwebs
-	science_web.add_point_list(list(TECHWEB_POINT_TYPE_NANITES = research_value))
+	if(assigned_techweb)
+		assigned_techweb.add_point_list(list(TECHWEB_POINT_TYPE_NANITES = research_value))
 
 /datum/component/nanites/proc/nanite_scan(datum/source, mob/user, full_scan)
 	SIGNAL_HANDLER
@@ -429,8 +434,8 @@
 
 	data["has_nanites"] = TRUE
 	data["nanite_volume"] = nanite_volume
-	var/datum/techweb/science_web = locate(/datum/techweb/science) in SSresearch.techwebs
-	data["regen_rate"] = regen_rate + (science_web.researched_nodes[TECHWEB_NODE_NANITE_HARMONIC] ? HARMONIC_REGEN_BOOST : 0)
+	var/has_harmonic_boost = assigned_techweb?.researched_nodes[TECHWEB_NODE_NANITE_HARMONIC]
+	data["regen_rate"] = regen_rate + (has_harmonic_boost ? HARMONIC_REGEN_BOOST : 0)
 	data["safety_threshold"] = safety_threshold
 	data["cloud_id"] = cloud_id
 	data["cloud_active"] = cloud_active

--- a/code/modules/research/nanites/nanite_chamber.dm
+++ b/code/modules/research/nanites/nanite_chamber.dm
@@ -49,7 +49,7 @@
 	if(in_range(user, src) || isobserver(user))
 		. += span_notice("The status display reads: Scanning module has been upgraded to level <b>[scan_level]</b>.")
 		. += span_notice("A <b>Multitool</b> can be used to change the research server")
-		. += span_notice("The linked techweb is <b>[assigned_techweb.id]</b>.")
+		. += span_notice("Active research destination: <b>[assigned_techweb.id]</b>.")
 
 /obj/machinery/nanite_chamber/proc/set_busy(status, message, working_icon)
 	busy = status

--- a/code/modules/research/nanites/nanite_chamber.dm
+++ b/code/modules/research/nanites/nanite_chamber.dm
@@ -20,10 +20,16 @@
 	var/busy_icon_state
 	var/busy_message
 	var/message_cooldown = 0
+	var/datum/techweb/assigned_techweb
 
 /obj/machinery/nanite_chamber/Initialize(mapload)
 	. = ..()
 	occupant_typecache = GLOB.typecache_living
+
+/obj/machinery/nanite_chamber/LateInitialize()
+	. = ..()
+	if(!assigned_techweb)
+		CONNECT_TO_RND_SERVER_ROUNDSTART(assigned_techweb, src)
 
 /obj/machinery/nanite_chamber/RefreshParts()
 	scan_level = 0
@@ -84,7 +90,7 @@
 	set_busy(FALSE)
 	if(!occupant)
 		return
-	occupant.AddComponent(/datum/component/nanites, 100 * nanite_coeff)
+	occupant.AddComponent(/datum/component/nanites, 100 * nanite_coeff, 0, assigned_techweb)
 
 /obj/machinery/nanite_chamber/proc/remove_nanites(datum/nanite_program/NP)
 	if(machine_stat & (NOPOWER|BROKEN))
@@ -217,3 +223,11 @@
 	if(close_machine(target))
 		log_combat(user, target, "inserted", null, "into [src].")
 	add_fingerprint(user)
+
+REGISTER_BUFFER_HANDLER(/obj/machinery/nanite_chamber)
+DEFINE_BUFFER_HANDLER(/obj/machinery/nanite_chamber)
+	if(istype(buffer, /datum/techweb))
+		balloon_alert(user, "Server assigned to nanite chamber.")
+		assigned_techweb = buffer
+		return COMPONENT_BUFFER_RECEIVED
+	return NONE

--- a/code/modules/research/nanites/nanite_chamber.dm
+++ b/code/modules/research/nanites/nanite_chamber.dm
@@ -48,6 +48,8 @@
 	. = ..()
 	if(in_range(user, src) || isobserver(user))
 		. += span_notice("The status display reads: Scanning module has been upgraded to level <b>[scan_level]</b>.")
+		. += span_notice("A <b>Multitool</b> can be used to change the research server")
+		. += span_notice("The linked techweb is <b>[assigned_techweb.id]</b>.")
 
 /obj/machinery/nanite_chamber/proc/set_busy(status, message, working_icon)
 	busy = status

--- a/code/modules/research/nanites/public_chamber.dm
+++ b/code/modules/research/nanites/public_chamber.dm
@@ -69,7 +69,7 @@
 	. = ..()
 	if(in_range(user, src) || isobserver(user))
 		. += span_notice("A <b>Multitool</b> can be used to change the research server")
-		. += span_notice("The linked techweb is <b>[assigned_techweb.id]</b>.")
+		. += span_notice("Active research destination: <b>[assigned_techweb.id]</b>.")
 
 /obj/machinery/public_nanite_chamber/proc/complete_injection(locked_state, mob/living/attacker)
 	//TODO MACHINE DING

--- a/code/modules/research/nanites/public_chamber.dm
+++ b/code/modules/research/nanites/public_chamber.dm
@@ -19,10 +19,16 @@
 	var/message_cooldown = 0
 	var/nanite_coeff = 1
 	var/speed_coeff = 1
+	var/datum/techweb/assigned_techweb
 
 /obj/machinery/public_nanite_chamber/Initialize(mapload)
 	. = ..()
 	occupant_typecache = GLOB.typecache_living
+
+/obj/machinery/public_nanite_chamber/LateInitialize()
+	. = ..()
+	if(!assigned_techweb)
+		CONNECT_TO_RND_SERVER_ROUNDSTART(assigned_techweb, src)
 
 /obj/machinery/public_nanite_chamber/RefreshParts()
 	nanite_coeff = 0
@@ -68,7 +74,7 @@
 	if(attacker)
 		occupant.investigate_log("was injected with nanites by [key_name(attacker)] using [src] at [AREACOORD(src)].", INVESTIGATE_NANITES)
 		log_combat(attacker, occupant, "injected", null, "with nanites via [src]")
-	occupant.AddComponent(/datum/component/nanites, 75 * nanite_coeff, cloud_id)
+	occupant.AddComponent(/datum/component/nanites, 75 * nanite_coeff, cloud_id, assigned_techweb)
 
 /obj/machinery/public_nanite_chamber/proc/change_cloud(mob/living/attacker)
 	if(machine_stat & (NOPOWER|BROKEN))
@@ -213,3 +219,11 @@
 	if(close_machine(target, user))
 		log_combat(user, target, "inserted", null, "into [src].")
 	add_fingerprint(user)
+
+REGISTER_BUFFER_HANDLER(/obj/machinery/public_nanite_chamber)
+DEFINE_BUFFER_HANDLER(/obj/machinery/public_nanite_chamber)
+	if(istype(buffer, /datum/techweb))
+		balloon_alert(user, "Server assigned to public nanite chamber.")
+		assigned_techweb = buffer
+		return COMPONENT_BUFFER_RECEIVED
+	return NONE

--- a/code/modules/research/nanites/public_chamber.dm
+++ b/code/modules/research/nanites/public_chamber.dm
@@ -65,6 +65,12 @@
 	addtimer(CALLBACK(src, PROC_REF(set_busy), TRUE, "[initial(icon_state)]_falling"), max(60 * speed_coeff, 25))
 	addtimer(CALLBACK(src, PROC_REF(complete_injection), locked_state, attacker), max(80 * speed_coeff, 30))
 
+/obj/machinery/public_nanite_chamber/examine(mob/user)
+	. = ..()
+	if(in_range(user, src) || isobserver(user))
+		. += span_notice("A <b>Multitool</b> can be used to change the research server")
+		. += span_notice("The linked techweb is <b>[assigned_techweb.id]</b>.")
+
 /obj/machinery/public_nanite_chamber/proc/complete_injection(locked_state, mob/living/attacker)
 	//TODO MACHINE DING
 	locked = locked_state

--- a/code/modules/research/techweb/_techweb.dm
+++ b/code/modules/research/techweb/_techweb.dm
@@ -27,7 +27,7 @@
 	var/list/custom_designs = list()
 	/// Already boosted nodes that can't be boosted again. node id = path of boost object.
 	var/list/boosted_nodes = list()
-	/// Hidden nodes. id = TRUE. Used for unhiding nodes when requirements are met by removing the entry of the node.
+	/// Hidden nodes. id = TRUE. Used for hiding nodes until an item unhides it, such as illegal technology
 	var/list/hidden_nodes = list()
 	/// List of items already deconstructed for research points, preventing infinite research point generation.
 	var/list/deconstructed_items = list()
@@ -349,8 +349,11 @@
 	researched_nodes -= node.id
 	available_nodes -= node.id
 	visible_nodes -= node.id
-	if(hidden_nodes[node.id]) //Hidden.
-		return
+	if(hidden_nodes[node.id])
+		if(node.unhide_from_prereqs && available) // Prerequisites are met, we can go ahead and unhide this node
+			hidden_nodes -= node.id
+		else
+			return
 	if(researched)
 		researched_nodes[node.id] = TRUE
 		for(var/id in node.design_ids - researched_designs)

--- a/code/modules/research/techweb/_techweb_node.dm
+++ b/code/modules/research/techweb/_techweb_node.dm
@@ -38,6 +38,8 @@
 	var/list/research_costs = list()
 	/// Whether or not this node should show on the wiki
 	var/show_on_wiki = TRUE
+	/// Does this node automatically unhide itself if all prerequisites are met? such as sticky tape
+	var/unhide_from_prereqs = FALSE
 	/**
 	 * If set, the researched node will be announced on these channels by an announcement system
 	 * with 'announce_research_node' set to TRUE when researched by the station.

--- a/code/modules/research/techweb/nodes/alien_nodes.dm
+++ b/code/modules/research/techweb/nodes/alien_nodes.dm
@@ -150,6 +150,7 @@ ABDUCTOR_SUBTYPE_UNLOCKS(/datum/techweb_node/alien_surgery)
 	)
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = TECHWEB_TIER_5_POINTS)
 	hidden = TRUE
+	unhide_from_prereqs = TRUE
 	announce_channels = list(RADIO_CHANNEL_ENGINEERING, RADIO_CHANNEL_SCIENCE)
 
 ABDUCTOR_SUBTYPE_UNLOCKS(/datum/techweb_node/nullspacebreaching)

--- a/code/modules/research/techweb/nodes/mech_nodes.dm
+++ b/code/modules/research/techweb/nodes/mech_nodes.dm
@@ -127,6 +127,7 @@
 	design_ids = list("mech_laser")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = TECHWEB_TIER_1_POINTS)
 	hidden = TRUE
+	unhide_from_prereqs = TRUE
 
 /datum/techweb_node/mech_laser_heavy
 	id = TECHWEB_NODE_MECH_LASER_HEAVY
@@ -137,6 +138,7 @@
 	design_ids = list("mech_laser_heavy")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = TECHWEB_TIER_1_POINTS)
 	hidden = TRUE
+	unhide_from_prereqs = TRUE
 
 /datum/techweb_node/mech_disabler
 	id = TECHWEB_NODE_MECH_DISABLER
@@ -147,6 +149,7 @@
 	design_ids = list("mech_disabler")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = TECHWEB_TIER_1_POINTS)
 	hidden = TRUE
+	unhide_from_prereqs = TRUE
 
 /datum/techweb_node/mech_grenade_launcher
 	id = TECHWEB_NODE_MECH_GRENADE_LAUNCHER

--- a/code/modules/research/techweb/nodes/nanite_nodes.dm
+++ b/code/modules/research/techweb/nodes/nanite_nodes.dm
@@ -204,6 +204,7 @@
 	)
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = TECHWEB_TIER_1_POINTS, TECHWEB_POINT_TYPE_NANITES = TECHWEB_TIER_5_POINTS)
 	hidden = TRUE
+	unhide_from_prereqs = TRUE
 
 /datum/techweb_node/nanite_hazard
 	id = TECHWEB_NODE_NANITE_HAZARD
@@ -218,3 +219,4 @@
 	)
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = TECHWEB_TIER_2_POINTS, TECHWEB_POINT_TYPE_NANITES = TECHWEB_TIER_5_POINTS)
 	hidden = TRUE
+	unhide_from_prereqs = TRUE

--- a/code/modules/research/techweb/nodes/syndicate_nodes.dm
+++ b/code/modules/research/techweb/nodes/syndicate_nodes.dm
@@ -43,6 +43,7 @@
 	design_ids = list("desynchronizer")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = TECHWEB_TIER_1_POINTS)
 	hidden = TRUE
+	unhide_from_prereqs = TRUE
 
 /datum/techweb_node/sticky_basic
 	id = TECHWEB_NODE_STICKY_BASIC
@@ -53,6 +54,7 @@
 	design_ids = list("sticky_tape")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = TECHWEB_TIER_1_POINTS)
 	hidden = TRUE
+	unhide_from_prereqs = TRUE
 
 /datum/techweb_node/sticky_advanced
 	id = TECHWEB_NODE_STICKY_ADVANCED
@@ -66,3 +68,4 @@
 	)
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = TECHWEB_TIER_2_POINTS)
 	hidden = TRUE
+	unhide_from_prereqs = TRUE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Some techwebs were completely hidden, since HIDDEN  is really misleading, all it makes is the node completely hidden until an external force unhides it

I added 	var/unhide_from_prereqs = FALSE, as the name implies all it makes is a HIDDEN TRUE node automatically unhide itself if all prerequisites are researched

Someone asked how to get nanite research on Charlie Servers, you can now use a multitool with the server buffer on it to change where nanite research points are given to, by default it's the Science's RnD

## Why It's Good For The Game

Bugs bad, also it locked some strong crew-side tools by making them always hidden

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>


Nodes unhidden after illegal tech and prerequisites are unlocked
<img width="1206" height="638" alt="image" src="https://github.com/user-attachments/assets/156e44d9-58f5-43a9-a10b-26713ce542d5" />


Linking Nanite chambers with a server buffer multitool
<img width="1913" height="999" alt="image" src="https://github.com/user-attachments/assets/8462e19a-1a8c-4be6-ace6-3f3952fe6e33" />


Research being given to the buffered server
<img width="1919" height="1079" alt="image" src="https://github.com/user-attachments/assets/4223b125-4545-428b-bdd7-6cbf6bf10b12" />

Examine on chambers

<img width="672" height="120" alt="image" src="https://github.com/user-attachments/assets/16031c59-d355-45bf-b876-44bc35340d73" />



</details>

## Changelog
:cl:
fix: Some RnD nodes aren't fully hidden forever, now they can be researched if it's prerequisites are also researched
fix: Nanite Chambers will now give the research to the server they're linked to
add: You can link nanite chambers using a multitool with a server buffer on it, it'll change where nanite research is given to
add: You can examine nanite chambers and it'll tell you what server it's linked to and a hint how you can change that 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
