### PR TITLE
Revert Holofan Capacity Nerf From #11550

### DIFF
--- a/code/game/objects/items/holosign_creator.dm
+++ b/code/game/objects/items/holosign_creator.dm
@@ -209,7 +209,7 @@
 	icon_state = "signmaker_atmos"
 	holosign_type = /obj/structure/holosign/barrier/atmos
 	creation_time = 0
-	max_signs = 3
+	max_signs = 6
 	projectable_through = list(
 		/obj/machinery/door,
 		/obj/structure/mineral_door,


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

This PR reverts the change from #11550, raising holofan capacity back to the original values of 6

If you want to flag this as ided, fine. It's been a major annoyance for me, so I'm finally attempting the revert.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

During a plasmaflood, the firelocks may not drop until the entire area is saturated with plasma, leading to many firelocks with plasma underneath during clean up.

In addition, because the firelocks drop everywhere in the area, people end up spreading the plasma far and wide due to the ease of raising firelocks by hitting them now.

This leads to plasma and fire breaching many hallways or sets of firelocks. To keep the firelocks open, you have to put a holo lock on top, otherwise it automatically closes pretty quickly, leading to people continuously bashing the firelocks to move around in the affected area (to escape), spreading the plasma even further.

With the nerf to 3 barriers, you can only block a single hallway to get the plasma out from under firelocks. Having 6 allowed for you to have an egress path for civilians while still having one or two available to assist in the clean up. The nerf just required hololock juggling which is annoying and takes up additional storage space, and on an engi, that is at a premium.

I have never seen an actual holobarrier (in the original PR) be deployed in an emergency situation. It takes too much setup, requiring wiring and construction.

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

One line revert. 

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>

## Changelog
:cl:
balance: Holofan projectors now have a maxcapacity of 6
/:cl:
<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
