### PR TITLE
Removing Prisoner Ready-Up Requirements

### DIFF
--- a/code/modules/jobs/job_types/prisoner.dm
+++ b/code/modules/jobs/job_types/prisoner.dm
@@ -7,7 +7,6 @@
 	exp_requirements = 300
 	exp_type = EXP_TYPE_CREW
 	total_positions = 3
-	min_pop = MINPOP_JOB_LIMIT
 	supervisors = "your own conscience"
 	selection_color = "#dddddd"
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Simple PR, which only removed Prisoners from having the min-pop requirement to be played. At the moment, prisoner requires 9 ready ups or the role is locked for the entire round, regardless of amount of security ingame, or amount of people that join round later. 

I think that basing a role's availability on the amount of ready-ups, which rarely represents the true population of a round, is not great.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

I believe that players can be trusted to make their own decisions on whether playing a certain job/role would work for them based on the round's pop. This role absolutely can work on lowpop and so I find the restriction to be quite frustrating at the moment. 

I do not foresee there being any problems as a result of this limit being removed.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

<img width="1366" height="632" alt="image" src="https://github.com/user-attachments/assets/4ed7997a-cea5-4343-b2d9-03fe8e067e77" />

</details>

## Changelog
:cl:
tweak: Removed the minpop requirement to play the Prisoner role. It no longer requires 9 ready-ups at round start to be available.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
