### PR TITLE
Fixes a nearly 5 year old supercruise hard del

### DIFF
--- a/code/controllers/subsystem/processing/orbits.dm
+++ b/code/controllers/subsystem/processing/orbits.dm
@@ -65,7 +65,8 @@ PROCESSING_SUBSYSTEM_DEF(orbits)
 	assoc_shuttles |= SSorbits.assoc_shuttles
 	interdicted_shuttles |= SSorbits.interdicted_shuttles
 	research_disks |= SSorbits.research_disks
-	if(!islist(runnable_events)) runnable_events = list()
+	if(!islist(runnable_events))
+		runnable_events = list()
 	runnable_events |= SSorbits.runnable_events
 
 	station_instance = SSorbits.station_instance
@@ -83,7 +84,6 @@ PROCESSING_SUBSYSTEM_DEF(orbits)
 	for(var/datum/thing in SSorbits.processing)
 		STOP_PROCESSING(SSorbits, thing)
 		START_PROCESSING(src, thing)
-
 
 /datum/controller/subsystem/processing/orbits/proc/setup_event_list()
 	runnable_events = list()

--- a/code/game/machinery/_machinery.dm
+++ b/code/game/machinery/_machinery.dm
@@ -663,7 +663,7 @@
 	update_last_used(user)
 	. = ..()
 
-/obj/machinery/ui_act(action, params)
+/obj/machinery/ui_act(action, list/params, datum/tgui/ui, datum/ui_state/state)
 	add_fingerprint(usr)
 	update_last_used(usr)
 	if(isliving(usr) && in_range(src, usr))

--- a/code/modules/shuttle/custom_shuttle.dm
+++ b/code/modules/shuttle/custom_shuttle.dm
@@ -5,7 +5,6 @@
 	icon_screen = "shuttle"
 	icon_keyboard = "tech_key"
 	light_color = LIGHT_COLOR_CYAN
-	req_access = list( )
 	possible_destinations = "whiteship_home"
 
 	var/datum/weakref/designator_ref = null

--- a/code/modules/shuttle/super_cruise/orbital_map_components/orbital_objects/shuttle.dm
+++ b/code/modules/shuttle/super_cruise/orbital_map_components/orbital_objects/shuttle.dm
@@ -53,7 +53,7 @@
 	stealth = TRUE
 
 /datum/orbital_object/shuttle/Destroy()
-	var/z_level = port?.z
+	var/z_level = port?.virtual_z
 	port = null
 	can_dock_with = null
 	docking_target = null

--- a/code/modules/shuttle/super_cruise/shuttle_components/shuttle_console.dm
+++ b/code/modules/shuttle/super_cruise/shuttle_components/shuttle_console.dm
@@ -36,7 +36,7 @@ GLOBAL_VAR_INIT(shuttle_docking_jammed, FALSE)
 
 CREATION_TEST_IGNORE_SUBTYPES(/obj/machinery/computer/shuttle_flight)
 
-/obj/machinery/computer/shuttle_flight/Initialize(mapload, obj/item/circuitboard/C)
+/obj/machinery/computer/shuttle_flight/Initialize(mapload)
 	. = ..()
 	valid_docks = params2list(possible_destinations)
 	if(shuttleId)
@@ -87,9 +87,6 @@ CREATION_TEST_IGNORE_SUBTYPES(/obj/machinery/computer/shuttle_flight)
 			else
 				to_chat(usr, span_notice("Unable to comply."))
 
-/obj/machinery/computer/shuttle_flight/ui_state(mob/user)
-	return GLOB.default_state
-
 /obj/machinery/computer/shuttle_flight/ui_interact(mob/user, datum/tgui/ui)
 	. = ..()
 	if(!allowed(user) && !isobserver(user))
@@ -104,7 +101,6 @@ CREATION_TEST_IGNORE_SUBTYPES(/obj/machinery/computer/shuttle_flight)
 		ui = new(user, src, "OrbitalMap")
 		ui.open()
 	SSorbits.open_orbital_maps |= ui
-	ui.set_autoupdate(FALSE)
 
 /obj/machinery/computer/shuttle_flight/ui_close(mob/user, datum/tgui/tgui)
 	. = ..()
@@ -205,9 +201,8 @@ CREATION_TEST_IGNORE_SUBTYPES(/obj/machinery/computer/shuttle_flight)
 						))
 	return data
 
-/obj/machinery/computer/shuttle_flight/ui_act(action, params)
+/obj/machinery/computer/shuttle_flight/ui_act(action, list/params, datum/tgui/ui, datum/ui_state/state)
 	. = ..()
-
 	if(.)
 		return
 

--- a/code/modules/shuttle/super_cruise/shuttle_components/shuttle_console.dm
+++ b/code/modules/shuttle/super_cruise/shuttle_components/shuttle_console.dm
@@ -49,7 +49,7 @@ CREATION_TEST_IGNORE_SUBTYPES(/obj/machinery/computer/shuttle_flight)
 	. = ..()
 	if(LAZYLEN(open_uis))
 		SSorbits.open_orbital_maps -= open_uis
-	shuttleObject = null
+	set_linked_shuttle(null)
 	//De-link the port
 	if(my_port)
 		my_port.delete_after = TRUE
@@ -70,8 +70,10 @@ CREATION_TEST_IGNORE_SUBTYPES(/obj/machinery/computer/shuttle_flight)
 	. = ..()
 
 	//Check to see if the shuttleObject was launched by another console.
-	if(QDELETED(shuttleObject) && SSorbits.assoc_shuttles.Find(shuttleId))
-		shuttleObject = SSorbits.assoc_shuttles[shuttleId]
+	if(isnull(shuttleObject) && SSorbits.assoc_shuttles.Find(shuttleId))
+		var/datum/orbital_object/new_shuttle = SSorbits.assoc_shuttles[shuttleId]
+		if(new_shuttle)
+			set_linked_shuttle(new_shuttle)
 
 	if(recall_docking_port_id && shuttleObject?.docking_target && shuttleObject.shuttleTarget == shuttleObject.docking_target && shuttleObject.controlling_computer == src)
 		//We are at destination, dock.
@@ -246,7 +248,7 @@ CREATION_TEST_IGNORE_SUBTYPES(/obj/machinery/computer/shuttle_flight)
 									return
 							if(shuttleObject.shuttleTarget == z_linked && shuttleObject.controlling_computer == src)
 								return
-							shuttleObject = SSorbits.assoc_shuttles[shuttleId]
+							set_linked_shuttle(SSorbits.assoc_shuttles[shuttleId])
 							shuttleObject.shuttleTarget = z_linked
 							shuttleObject.autopilot = TRUE
 							shuttleObject.controlling_computer = src
@@ -451,9 +453,9 @@ CREATION_TEST_IGNORE_SUBTYPES(/obj/machinery/computer/shuttle_flight)
 		return
 	if(SSorbits.assoc_shuttles.Find(shuttleId))
 		say("Shuttle is controlled from another location, updating telemetry.")
-		shuttleObject = SSorbits.assoc_shuttles[shuttleId]
+		set_linked_shuttle(SSorbits.assoc_shuttles[shuttleId])
 		return shuttleObject
-	shuttleObject = mobile_port.enter_supercruise()
+	set_linked_shuttle(mobile_port.enter_supercruise())
 	if(!shuttleObject)
 		say("Failed to enter supercruise due to an unknown error.")
 		return
@@ -546,3 +548,15 @@ CREATION_TEST_IGNORE_SUBTYPES(/obj/machinery/computer/shuttle_flight)
 	if(istype(circuit_board) && circuit_board.hacked)
 		return TRUE
 	return ..()
+
+/obj/machinery/computer/shuttle_flight/proc/set_linked_shuttle(datum/orbital_object/shuttle/new_shuttle)
+	if(!isnull(shuttleObject))
+		UnregisterSignal(shuttleObject, COMSIG_QDELETING)
+	shuttleObject = new_shuttle
+	if(!isnull(shuttleObject))
+		RegisterSignal(shuttleObject, COMSIG_QDELETING, PROC_REF(on_shuttle_deleted))
+
+/obj/machinery/computer/shuttle_flight/proc/on_shuttle_deleted(datum/source)
+	SIGNAL_HANDLER
+	UnregisterSignal(shuttleObject, COMSIG_QDELETING)
+	shuttleObject = null

--- a/code/modules/shuttle/super_cruise/shuttle_components/shuttle_console.dm
+++ b/code/modules/shuttle/super_cruise/shuttle_components/shuttle_console.dm
@@ -70,7 +70,7 @@ CREATION_TEST_IGNORE_SUBTYPES(/obj/machinery/computer/shuttle_flight)
 	. = ..()
 
 	//Check to see if the shuttleObject was launched by another console.
-	if(isnull(shuttleObject) && SSorbits.assoc_shuttles.Find(shuttleId))
+	if(isnull(shuttleObject))
 		var/datum/orbital_object/new_shuttle = SSorbits.assoc_shuttles[shuttleId]
 		if(new_shuttle)
 			set_linked_shuttle(new_shuttle)


### PR DESCRIPTION
## About The Pull Request

Every round I check harddels I see shuttle objects and it's so annoying. For the longest time It wasn't super high on my list of priorities since it didn't use as much CPU time compared to other harddels, but now, thank God, that has changed.

The other changes are me fixing bad proc args & replacing empty `req_access` lists with null

## Testing Photographs and Procedure

https://github.com/user-attachments/assets/aa291640-2860-49a4-97eb-02837e8bd381

## Changelog
:cl:
fix: Fixed shuttles hard deleting when exiting supercruise
/:cl: