### PR TITLE
Uses built-in BYOND `isnan()` & `isinf()`

### DIFF
--- a/code/__DEFINES/is_helpers.dm
+++ b/code/__DEFINES/is_helpers.dm
@@ -304,9 +304,6 @@ GLOBAL_LIST_INIT(book_types, typecacheof(list(
 
 #define isProbablyWallMounted(O) (O.pixel_x > 20 || O.pixel_x < -20 || O.pixel_y > 20 || O.pixel_y < -20)
 
-/// NaN isn't a number, damn it. Infinity is a problem too.
-#define isnum_safe(x) IS_FINITE(x)
-
 #define iscash(A) (istype(A, /obj/item/coin) || istype(A, /obj/item/stack/spacecash) || istype(A, /obj/item/holochip))
 
 // Jobs

--- a/code/__DEFINES/is_helpers.dm
+++ b/code/__DEFINES/is_helpers.dm
@@ -302,15 +302,10 @@ GLOBAL_LIST_INIT(book_types, typecacheof(list(
 	/obj/item/storage/book,
 )))
 
-/// isnum() returns TRUE for NaN. Also, NaN != NaN. Checkmate, BYOND.
-#define isnan(x) ( (x) != (x) )
-
-#define isinf(x) (isnum((x)) && (((x) == SYSTEM_TYPE_INFINITY) || ((x) == -SYSTEM_TYPE_INFINITY)))
-
 #define isProbablyWallMounted(O) (O.pixel_x > 20 || O.pixel_x < -20 || O.pixel_y > 20 || O.pixel_y < -20)
 
 /// NaN isn't a number, damn it. Infinity is a problem too.
-#define isnum_safe(x) ( isnum((x)) && !isnan((x)) && !isinf((x)) )
+#define isnum_safe(x) IS_FINITE(x)
 
 #define iscash(A) (istype(A, /obj/item/coin) || istype(A, /obj/item/stack/spacecash) || istype(A, /obj/item/holochip))
 

--- a/code/__DEFINES/maths.dm
+++ b/code/__DEFINES/maths.dm
@@ -126,7 +126,7 @@
 
 /// Finds the shortest angle that angle A has to change to get to angle B. Aka, whether to move clock or counterclockwise.
 /proc/closer_angle_difference(a, b)
-	if(!isnum_safe(a) || !isnum_safe(b))
+	if(!IS_FINITE(a) || !IS_FINITE(b))
 		return
 	a = SIMPLIFY_DEGREES(a)
 	b = SIMPLIFY_DEGREES(b)

--- a/code/__DEFINES/maths.dm
+++ b/code/__DEFINES/maths.dm
@@ -1,12 +1,5 @@
-// Remove these once we have Byond implementation.
-#define ISNAN(a) (a!=a)
-#define ISINF(a) (!ISNAN(a) && ISNAN(a-a))
-#define IS_INF_OR_NAN(a) (ISNAN(a-a))
-
-#define IS_FINITE__UNSAFE(a) (a-a==a-a)
+#define IS_FINITE__UNSAFE(a) (!isinf(a) && !isnan(a))
 #define IS_FINITE(a) (isnum(a) && IS_FINITE__UNSAFE(a))
-
-// Aight dont remove the rest
 
 // Credits to Nickr5 for the useful procs I've taken from his library resource.
 // This file is quadruple wrapped for your pleasure
@@ -16,7 +9,6 @@
 
 #define PI 3.1416
 #define INFINITY 1e31	//closer then enough
-#define SYSTEM_TYPE_INFINITY 1.#INF //only for isinf check
 
 #define SHORT_REAL_LIMIT 16777216
 
@@ -107,7 +99,7 @@
 	. = list()
 	var/d		= b*b - 4 * a * c
 	var/bottom  = 2 * a
-	if(d < 0 || IS_INF_OR_NAN(d) || IS_INF_OR_NAN(bottom))
+	if(d < 0 || !IS_FINITE__UNSAFE(d) || !IS_FINITE__UNSAFE(bottom))
 		return
 	var/root = sqrt(d)
 	. += (-b + root) / bottom

--- a/code/__DEFINES/vv.dm
+++ b/code/__DEFINES/vv.dm
@@ -35,7 +35,7 @@
 #define VV_BIG_SIZED_LIST_THRESHOLD 50
 
 //#define IS_VALID_ASSOC_KEY(V) (istext(V) || ispath(V) || isdatum(V) || islist(V))
-#define IS_VALID_ASSOC_KEY(V) (!isnum_safe(V))		//hhmmm..
+#define IS_VALID_ASSOC_KEY(V) (!IS_FINITE(V))		//hhmmm..
 
 //General helpers
 #define VV_HREF_TARGET_INTERNAL(target, href_key) "?_src_=vars;[HrefToken()];[href_key]=TRUE;[VV_HK_TARGET]=[REF(target)]"

--- a/code/__HELPERS/_lists.dm
+++ b/code/__HELPERS/_lists.dm
@@ -40,7 +40,7 @@
 ///Returns the key of the submitted item in the list
 #define LAZYFIND(L, V) L ? L.Find(V) : 0
 ///returns L[I] if L exists and I is a valid index of L, runtimes if L is not a list
-#define LAZYACCESS(L, I) (L ? (isnum_safe(I) ? (I > 0 && I <= length(L) ? L[I] : null) : L[I]) : null)
+#define LAZYACCESS(L, I) (L ? (IS_FINITE(I) ? (I > 0 && I <= length(L) ? L[I] : null) : L[I]) : null)
 ///Sets the item K to the value V, if the list is null it will initialize it
 #define LAZYSET(L, K, V) if(!L) { L = list(); } L[K] = V;
 ///Sets the length of a lazylist
@@ -585,7 +585,7 @@
 	var/temp = inserted_list.Copy()
 	inserted_list.len = 0
 	for(var/key in temp)
-		if (isnum_safe(key))
+		if (IS_FINITE(key))
 			inserted_list |= key
 		else
 			inserted_list[key] = temp[key]
@@ -773,7 +773,7 @@
 	. = inserted_list.Copy()
 	for(var/i in 1 to inserted_list.len)
 		var/key = .[i]
-		if(isnum_safe(key))
+		if(IS_FINITE(key))
 			// numbers cannot ever be associative keys
 			continue
 		var/value = .[key]
@@ -792,7 +792,7 @@
 	var/copied_list = inserted_list.Copy()
 	. = copied_list
 	for(var/key_or_value in inserted_list)
-		if(isnum_safe(key_or_value) || !inserted_list[key_or_value])
+		if(IS_FINITE(key_or_value) || !inserted_list[key_or_value])
 			continue
 		var/value = inserted_list[key_or_value]
 		var/new_value = value

--- a/code/__HELPERS/sanitize_values.dm
+++ b/code/__HELPERS/sanitize_values.dm
@@ -1,7 +1,7 @@
 //general stuff
 /// Return `number` if it is in the range `min to max`, otherwise `default`
 /proc/sanitize_integer(number, min=0, max=INFINITY, default=0)
-	if(isnum_safe(number))
+	if(IS_FINITE(number))
 		number = round(number)
 		if(min <= number && number <= max)
 			return number
@@ -9,7 +9,7 @@
 
 /// Return `float` if it is in the range `min to max`, otherwise `default`
 /proc/sanitize_float(number, min=0, max=1, accuracy=0.1, default=0)
-	if(isnum_safe(number))
+	if(IS_FINITE(number))
 		number = round(number, accuracy)
 		if(round(min, accuracy) <= number && number <= round(max, accuracy))
 			return number

--- a/code/__HELPERS/text.dm
+++ b/code/__HELPERS/text.dm
@@ -911,7 +911,7 @@ GLOBAL_LIST_INIT(alphabet, list("a","b","c","d","e","f","g","h","i","j","k","l",
 
 /// Replacement for the \th macro when you want the whole word output as text (first instead of 1st)
 /proc/thtotext(number)
-	if(!isnum_safe(number))
+	if(!IS_FINITE(number))
 		return
 	switch(number)
 		if(1)

--- a/code/__HELPERS/time.dm
+++ b/code/__HELPERS/time.dm
@@ -20,7 +20,7 @@
 	return time2text(station_time(wtime), format, NO_TIMEZONE)
 
 /proc/station_time_debug(force_set)
-	if(isnum_safe(force_set))
+	if(IS_FINITE(force_set))
 		SSticker.gametime_offset = force_set
 		return
 	SSticker.gametime_offset = rand(0, 24 HOURS)		//hours in day * minutes in hour * seconds in minute * deciseconds in second
@@ -31,7 +31,7 @@
 
 /// Returns 1 if it is the selected month and day
 /proc/isDay(month, day)
-	if(isnum_safe(month) && isnum_safe(day))
+	if(IS_FINITE(month) && IS_FINITE(day))
 		var/MM = text2num(time2text(world.timeofday, "MM")) // get the current month
 		var/DD = text2num(time2text(world.timeofday, "DD")) // get the current day
 		if(month == MM && day == DD)

--- a/code/__HELPERS/view.dm
+++ b/code/__HELPERS/view.dm
@@ -1,7 +1,7 @@
 /proc/getviewsize(view, extra_x = 0, extra_y = 0)
 	var/viewX
 	var/viewY
-	if(isnum_safe(view))
+	if(IS_FINITE(view))
 		var/totalviewrange = (view < 0 ? -1 : 1) + 2 * view
 		viewX = totalviewrange + extra_x
 		viewY = totalviewrange + extra_y
@@ -25,7 +25,7 @@
 /proc/get_zoomed_view(view, zoom_amt)
 	var/viewX
 	var/viewY
-	if(isnum_safe(view))
+	if(IS_FINITE(view))
 		return view + zoom_amt
 	else
 		var/list/viewrangelist = splittext(view,"x")

--- a/code/controllers/subsystem/blackbox.dm
+++ b/code/controllers/subsystem/blackbox.dm
@@ -232,7 +232,7 @@ Versioning
 						"gun_fired" = 2)
 */
 /datum/controller/subsystem/blackbox/proc/record_feedback(key_type, key, increment, data, overwrite)
-	if(sealed || !key_type || !istext(key) || !isnum_safe(increment || !data) || CONFIG_GET(flag/limited_feedback))
+	if(sealed || !key_type || !istext(key) || !IS_FINITE(increment || !data) || CONFIG_GET(flag/limited_feedback))
 		return
 	var/datum/feedback_variable/FV = find_feedback_datum(key, key_type)
 	switch(key_type)

--- a/code/controllers/subsystem/persistence/recent_modes.dm
+++ b/code/controllers/subsystem/persistence/recent_modes.dm
@@ -31,7 +31,7 @@
 
 /datum/controller/subsystem/persistence/proc/get_rounds_since_execution(datum/dynamic_ruleset/gamemode/gamemode)
 	var/located = gamemode_data["[gamemode.type]"]
-	if (!isnum_safe(located))
+	if (!IS_FINITE(located))
 		return 0
 	return located
 

--- a/code/controllers/subsystem/weather.dm
+++ b/code/controllers/subsystem/weather.dm
@@ -57,7 +57,7 @@ SUBSYSTEM_DEF(weather)
 
 	if (isnull(z_levels))
 		z_levels = SSmapping.levels_by_trait(initial(weather_datum_type.target_trait))
-	else if (isnum_safe(z_levels))
+	else if (IS_FINITE(z_levels))
 		z_levels = list(z_levels)
 	else if (!islist(z_levels))
 		CRASH("run_weather called with invalid z_levels: [z_levels || "null"]")

--- a/code/datums/map_config.dm
+++ b/code/datums/map_config.dm
@@ -154,14 +154,14 @@
 		return
 
 	var/temp = json["space_ruin_levels"]
-	if (isnum_safe(temp))
+	if (IS_FINITE(temp))
 		space_ruin_levels = temp
 	else if (!isnull(temp))
 		log_world("map_config space_ruin_levels is not a number!")
 		return
 
 	temp = json["space_empty_levels"]
-	if (isnum_safe(temp))
+	if (IS_FINITE(temp))
 		space_empty_levels = temp
 	else if (!isnull(temp))
 		log_world("map_config space_empty_levels is not a number!")

--- a/code/datums/outfit.dm
+++ b/code/datums/outfit.dm
@@ -228,7 +228,7 @@
 		if(backpack_contents)
 			for(var/path in backpack_contents)
 				var/number = backpack_contents[path]
-				if(!isnum_safe(number))//Default to 1
+				if(!IS_FINITE(number))//Default to 1
 					number = 1
 				for(var/i in 1 to number)
 					EQUIP_OUTFIT_ITEM(path, ITEM_SLOT_BACKPACK)

--- a/code/datums/status_effects/buffs.dm
+++ b/code/datums/status_effects/buffs.dm
@@ -48,7 +48,7 @@
 
 /datum/status_effect/cyborg_power_regen/on_creation(mob/living/new_owner, new_power_per_tick)
 	. = ..()
-	if(. && isnum_safe(new_power_per_tick))
+	if(. && IS_FINITE(new_power_per_tick))
 		power_to_give = new_power_per_tick
 
 /atom/movable/screen/alert/status_effect/power_regen

--- a/code/datums/status_effects/debuffs/debuffs.dm
+++ b/code/datums/status_effects/debuffs/debuffs.dm
@@ -11,7 +11,7 @@
 	var/needs_update_stat = FALSE
 
 /datum/status_effect/incapacitating/on_creation(mob/living/new_owner, set_duration)
-	if(isnum_safe(set_duration))
+	if(IS_FINITE(set_duration))
 		duration = set_duration
 	. = ..()
 	if(. && (needs_update_stat || issilicon(owner)))

--- a/code/datums/wires/_wires.dm
+++ b/code/datums/wires/_wires.dm
@@ -110,7 +110,8 @@
 	ui_update()
 
 /datum/wires/proc/repair()
-	cut_wires.Cut()
+	for(var/wire in cut_wires)
+		cut(wire) // I KNOW I KNOW OK
 	ui_update()
 
 /datum/wires/proc/get_wire(color)

--- a/code/game/machinery/computer/dna_console.dm
+++ b/code/game/machinery/computer/dna_console.dm
@@ -46,7 +46,7 @@
 	do { \
 		var/_L = FLOOR(##new_length, 5 SECONDS); \
 		var/_CT = src.to_index##_timeout; \
-		if(!isnum_safe(_CT) || _CT <= 0) { \
+		if(!IS_FINITE(_CT) || _CT <= 0) { \
 			src.cd_index##_cooldown = 0; \
 			src.to_index##_timeout = _L; \
 			break; \
@@ -55,7 +55,7 @@
 		} \
 		src.to_index##_timeout = _L; \
 		var/_CD = src.cd_index##_cooldown; \
-		if(!isnum_safe(_CD) || world.time >= _CD) { \
+		if(!IS_FINITE(_CD) || world.time >= _CD) { \
 			break; \
 		} \
 		src.cd_index##_cooldown = FLOOR(_L * FLOOR((_CD - world.time) / _CT, 0.05), 1 SECONDS); \

--- a/code/game/machinery/computer/prisoner/gulag_teleporter.dm
+++ b/code/game/machinery/computer/prisoner/gulag_teleporter.dm
@@ -93,7 +93,7 @@
 			return TRUE
 		if("set_goal")
 			var/new_goal = text2num(params["value"])
-			if(!isnum_safe(new_goal) || !contained_id)
+			if(!IS_FINITE(new_goal) || !contained_id)
 				return
 			if(!new_goal)
 				new_goal = default_goal

--- a/code/game/machinery/porta_turret/portable_turret.dm
+++ b/code/game/machinery/porta_turret/portable_turret.dm
@@ -238,6 +238,7 @@
 		reqpower = gun_properties["reqpower"]
 
 	update_icon()
+	return gun_properties
 
 ///destroys reference to stored_gun to prevent hard deletions
 /obj/machinery/porta_turret/proc/null_gun()

--- a/code/game/machinery/syndicatebomb.dm
+++ b/code/game/machinery/syndicatebomb.dm
@@ -320,7 +320,8 @@
 	if(adminlog)
 		message_admins(adminlog)
 		log_game(adminlog)
-	qdel(loc)
+	if(isobj(loc))
+		qdel(loc)
 	qdel(src)
 
 // the machine's defusal is mostly done from the wires code, this is here if you want the core itself to do anything.

--- a/code/game/objects/effects/spawners/gibspawner.dm
+++ b/code/game/objects/effects/spawners/gibspawner.dm
@@ -24,7 +24,7 @@ CREATION_TEST_IGNORE_SUBTYPES(/obj/effect/gibspawner)
 
 	var/obj/effect/decal/cleanable/blood/gib = null
 
-	if(sound_to_play && isnum_safe(sound_vol))
+	if(sound_to_play && IS_FINITE(sound_vol))
 		playsound(src, sound_to_play, sound_vol, TRUE)
 
 	if(sparks)

--- a/code/game/objects/effects/temporary_visuals/cult.dm
+++ b/code/game/objects/effects/temporary_visuals/cult.dm
@@ -75,7 +75,7 @@
 CREATION_TEST_IGNORE_SUBTYPES(/obj/effect/temp_visual/cult/rune_spawn)
 
 /obj/effect/temp_visual/cult/rune_spawn/Initialize(mapload, set_duration, set_color)
-	if(isnum_safe(set_duration))
+	if(IS_FINITE(set_duration))
 		duration = set_duration
 	if(set_color)
 		add_atom_colour(set_color, FIXED_COLOUR_PRIORITY)

--- a/code/game/objects/items/devices/sound_synth.dm
+++ b/code/game/objects/items/devices/sound_synth.dm
@@ -128,7 +128,7 @@
 		var/list/sound_name = sound_filenames[sound.file]
 		if(sound_name)
 			// Just in case something goes fucky wucky, don't cache a bad result.
-			if(!isnum_safe(sound.len) || sound.len <= 0)
+			if(!IS_FINITE(sound.len) || sound.len <= 0)
 				continue
 			var/sound_len = ceil(sound.len * 10)
 			sound_lengths[sound_name] = sound_len

--- a/code/modules/admin/ipintel.dm
+++ b/code/modules/admin/ipintel.dm
@@ -97,7 +97,7 @@
 		if (response)
 			if (response["status"] == "success")
 				var/intelnum = text2num(response["result"])
-				if (isnum_safe(intelnum))
+				if (IS_FINITE(intelnum))
 					return text2num(response["result"])
 				else
 					ipintel_handle_error("Bad intel from server: [response["result"]].", ip, retryed)

--- a/code/modules/admin/player_panel.dm
+++ b/code/modules/admin/player_panel.dm
@@ -156,7 +156,7 @@
 	data["players"] = players
 	data["selected_ckey"] = selected_ckey
 	data["search_text"] = search_text
-	data["update_interval"] = isnum_safe(update_interval) ? update_interval : 5
+	data["update_interval"] = IS_FINITE(update_interval) ? update_interval : 5
 	return data
 
 /datum/admin_player_panel/ui_act(action, params)

--- a/code/modules/admin/sql_message_system.dm
+++ b/code/modules/admin/sql_message_system.dm
@@ -501,7 +501,7 @@
 			var/alphatext = ""
 			var/nsd = CONFIG_GET(number/note_stale_days)
 			var/nfd = CONFIG_GET(number/note_fresh_days)
-			if (agegate && type == "note" && isnum_safe(nsd) && isnum_safe(nfd) && nsd > nfd)
+			if (agegate && type == "note" && IS_FINITE(nsd) && IS_FINITE(nfd) && nsd > nfd)
 				var/alpha = clamp(100 - (age - nfd) * (85 / (nsd - nfd)), 15, 100)
 				if (alpha < 100)
 					if (alpha <= 15)

--- a/code/modules/admin/verbs/SDQL2/SDQL_2.dm
+++ b/code/modules/admin/verbs/SDQL2/SDQL_2.dm
@@ -357,7 +357,7 @@ GLOBAL_LIST_INIT(sdql2_queries, GLOB.sdql2_queries || list())
 			output += "[key]"
 
 		//print the value
-		var/is_value = (!isnum_safe(key) && !isnull(input[key]))
+		var/is_value = (!IS_FINITE(key) && !isnull(input[key]))
 		if(is_value)
 			var/value = input[key]
 			if(islist(value))
@@ -731,7 +731,7 @@ GLOBAL_LIST_INIT(sdql2_queries, GLOB.sdql2_queries || list())
 				text_list += ", "
 			first = FALSE
 			SDQL_print(x, text_list)
-			if (!isnull(x) && !isnum_safe(x) && L[x] != null)
+			if (!isnull(x) && !IS_FINITE(x) && L[x] != null)
 				text_list += " -> "
 				SDQL_print(L[L[x]])
 		text_list += "]<br>"
@@ -874,7 +874,7 @@ GLOBAL_LIST_INIT(sdql2_queries, GLOB.sdql2_queries || list())
 	else if(expression[i] == "null")
 		val = null
 
-	else if(isnum_safe(expression[i]))
+	else if(IS_FINITE(expression[i]))
 		val = expression[i]
 
 	else if(ispath(expression[i]))
@@ -970,7 +970,7 @@ GLOBAL_LIST_INIT(sdql2_queries, GLOB.sdql2_queries || list())
 		else
 			to_chat(usr, "[spaces][item]")
 
-		if(!isnum_safe(item) && query_tree[item])
+		if(!IS_FINITE(item) && query_tree[item])
 
 			if(istype(query_tree[item], /list))
 				to_chat(usr, "[spaces][whitespace](")
@@ -1061,7 +1061,7 @@ GLOBAL_LIST_INIT(sdql2_queries, GLOB.sdql2_queries || list())
 		else if(expression[start + 1] == "\[" && islist(v))
 			var/list/L = v
 			var/index = query.SDQL_expression(source, expression[start + 2])
-			if(isnum_safe(index) && (!ISINTEGER(index) || L.len < index))
+			if(IS_FINITE(index) && (!ISINTEGER(index) || L.len < index))
 				to_chat(usr, span_danger("Invalid list index: [index]"))
 				return null
 			return L[index]

--- a/code/modules/admin/verbs/SDQL2/SDQL_2_parser.dm
+++ b/code/modules/admin/verbs/SDQL2/SDQL_2_parser.dm
@@ -605,11 +605,11 @@
 		node += "null"
 		i++
 
-	else if(LOWER_TEXT(copytext(token(i), 1, 3)) == "0x" && isnum_safe(hex2num(copytext(token(i), 3))))//3 == length("0x") + 1
+	else if(LOWER_TEXT(copytext(token(i), 1, 3)) == "0x" && IS_FINITE(hex2num(copytext(token(i), 3))))//3 == length("0x") + 1
 		node += hex2num(copytext(token(i), 3))
 		i++
 
-	else if(isnum_safe(text2num(token(i))))
+	else if(IS_FINITE(text2num(token(i))))
 		node += text2num(token(i))
 		i++
 

--- a/code/modules/admin/verbs/mapping.dm
+++ b/code/modules/admin/verbs/mapping.dm
@@ -233,7 +233,7 @@ GLOBAL_LIST_EMPTY(dirty_vars)
 	var/num_level = text2num(level)
 	if(!num_level)
 		return
-	if(!isnum_safe(num_level))
+	if(!IS_FINITE(num_level))
 		return
 
 	var/type_text = capped_input(src, "Which type path?","Path?")

--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -1001,7 +1001,7 @@ Traitors and the like can also be revived with the previous role mostly intact.
 
 	var/turf/T = get_turf(mob)
 	var/z_level = input("Z-Level to target?", "Z-Level", T?.z) as num|null
-	if(!isnum_safe(z_level))
+	if(!IS_FINITE(z_level))
 		return
 
 	SSweather.run_weather(weather_type, z_level)

--- a/code/modules/admin/verbs/spawnobjasmob.dm
+++ b/code/modules/admin/verbs/spawnobjasmob.dm
@@ -61,7 +61,7 @@
 				basemob.access_card = new newaccess
 
 		if (mainsettings["maxhealth"]["value"])
-			if (!isnum_safe(mainsettings["maxhealth"]["value"]))
+			if (!IS_FINITE(mainsettings["maxhealth"]["value"]))
 				mainsettings["maxhealth"]["value"] = text2num(mainsettings["maxhealth"]["value"])
 			if (mainsettings["maxhealth"]["value"] > 0)
 				basemob.maxHealth = basemob.maxHealth =  mainsettings["maxhealth"]["value"]

--- a/code/modules/admin/view_variables/modify_variables.dm
+++ b/code/modules/admin/view_variables/modify_variables.dm
@@ -125,7 +125,7 @@ GLOBAL_PROTECT(VVpixelmovement)
 	for (var/i in 1 to L.len)
 		var/key = L[i]
 		var/value
-		if (is_normal_list && !isnum_safe(key))
+		if (is_normal_list && !IS_FINITE(key))
 			value = L[key]
 		if (value == null)
 			value = "null"

--- a/code/modules/antagonists/_common/antag_datum.dm
+++ b/code/modules/antagonists/_common/antag_datum.dm
@@ -93,7 +93,8 @@ GLOBAL_LIST(admin_antag_list)
 
 /datum/antagonist/Destroy()
 	GLOB.active_antagonists -= src
-	GLOB.antag_prototypes -= src // Removing that just in case
+	if(length(GLOB.antag_prototypes))
+		GLOB.antag_prototypes -= src // Removing that just in case
 	if(owner)
 		LAZYREMOVE(owner.antag_datums, src)
 	QDEL_NULL(team_hud_ref)

--- a/code/modules/antagonists/vampire/powers/presence/entrance.dm
+++ b/code/modules/antagonists/vampire/powers/presence/entrance.dm
@@ -62,7 +62,7 @@
 	alert_type = /atom/movable/screen/alert/status_effect/entranced
 
 /datum/status_effect/entranced/on_creation(mob/living/new_owner, set_duration)
-	if(isnum_safe(set_duration))
+	if(IS_FINITE(set_duration))
 		duration = set_duration
 	return ..()
 

--- a/code/modules/antagonists/vampire/powers/presence/summon.dm
+++ b/code/modules/antagonists/vampire/powers/presence/summon.dm
@@ -81,7 +81,7 @@
 	var/step_delay = 0.6 SECONDS
 
 /datum/status_effect/summoned/on_creation(mob/living/new_owner, set_duration, mob/living/vampire)
-	if(isnum_safe(set_duration))
+	if(IS_FINITE(set_duration))
 		duration = set_duration
 	source_vampire = vampire
 	return ..()

--- a/code/modules/atmospherics/gasmixtures/gas_mixture.dm
+++ b/code/modules/atmospherics/gasmixtures/gas_mixture.dm
@@ -657,7 +657,7 @@ GLOBAL_LIST_INIT(gaslist_cache, init_gaslist_cache())
 /// Do mind that the numbers can get very big and might hit BYOND's single point float limit.
 /datum/gas_mixture/proc/gas_pressure_quadratic(a, b, c, lower_limit, upper_limit)
 	var/solution
-	if(!IS_INF_OR_NAN(a) && !IS_INF_OR_NAN(b) && !IS_INF_OR_NAN(c))
+	if(IS_FINITE(a) && IS_FINITE(b) && IS_FINITE(c))
 		solution = max(SolveQuadratic(a, b, c))
 		if(solution > lower_limit && solution < upper_limit) //SolveQuadratic can return empty lists so be careful here
 			return solution
@@ -668,7 +668,7 @@ GLOBAL_LIST_INIT(gaslist_cache, init_gaslist_cache())
 /// We use the slope of an approximate value to get closer to the root of a given equation.
 /datum/gas_mixture/proc/gas_pressure_approximate(a, b, c, lower_limit, upper_limit)
 	var/solution
-	if(!IS_INF_OR_NAN(a) && !IS_INF_OR_NAN(b) && !IS_INF_OR_NAN(c))
+	if(IS_FINITE(a) && IS_FINITE(b) && IS_FINITE(c))
 		// We start at the extrema of the equation, added by a number.
 		// This way we will hopefully always converge on the positive root, while starting at a reasonable number.
 		solution = (-b / (2 * a)) + 200

--- a/code/modules/awaymissions/corpse.dm
+++ b/code/modules/awaymissions/corpse.dm
@@ -204,7 +204,7 @@ CREATION_TEST_IGNORE_SELF(/obj/effect/mob_spawn)
 		var/static/list/slots = list("uniform", "r_hand", "l_hand", "suit", "shoes", "gloves", "ears", "glasses", "mask", "head", "belt", "r_pocket", "l_pocket", "back", "id", "neck", "backpack_contents", "suit_store")
 		for(var/slot in slots)
 			var/T = vars[slot]
-			if(!isnum_safe(T))
+			if(!IS_FINITE(T))
 				outfit.vars[slot] = T
 		H.equipOutfit(outfit)
 		if(disable_pda)

--- a/code/modules/cargo/centcom_podlauncher.dm
+++ b/code/modules/cargo/centcom_podlauncher.dm
@@ -293,7 +293,7 @@
 					boomInput.Add(input("Enter the [expNames[i]] range of the explosion. WARNING: This ignores the bomb cap!", "[expNames[i]] Range",  0) as null|num)
 					if (isnull(boomInput[i]))
 						return
-					if (!isnum_safe(boomInput[i])) //If the user doesn't input a number, set that specific explosion value to zero
+					if (!IS_FINITE(boomInput[i])) //If the user doesn't input a number, set that specific explosion value to zero
 						alert(usr, "That wasn't a number! Value set to default (zero) instead.")
 						boomInput = 0
 				explosionChoice = 1
@@ -315,7 +315,7 @@
 				var/damageInput = input("Enter the amount of brute damage dealt by getting hit","How much damage to deal",  0) as null|num
 				if (isnull(damageInput))
 					return
-				if (!isnum_safe(damageInput)) //Sanitize the input for damage to deal.s
+				if (!IS_FINITE(damageInput)) //Sanitize the input for damage to deal.s
 					alert(usr, "That wasn't a number! Value set to default (zero) instead.")
 					damageInput = 0
 				damageChoice = 1

--- a/code/modules/chatter/chatter.dm
+++ b/code/modules/chatter/chatter.dm
@@ -27,7 +27,7 @@
 					sleep(6)
 				continue
 
-			if(isnum_safe(item))
+			if(IS_FINITE(item))
 				var/length = min(item, 10)
 				if (length == 0)
 					// "verbalise" long spaces

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -135,7 +135,7 @@ GLOBAL_LIST_INIT(blacklisted_builds, list(
 	if(href_list["seeker_port"])
 		winshow(src, "login", FALSE) // make sure this thing is hidden
 		var/port_num = text2num(href_list["seeker_port"])
-		if(isnum_safe(port_num))
+		if(IS_FINITE(port_num))
 			seeker_port = port_num
 		if(!logged_in) // the login handler is ready now
 			src?.send_saved_session_token()

--- a/code/modules/client/login/client_login.dm
+++ b/code/modules/client/login/client_login.dm
@@ -234,15 +234,15 @@
 		if(QDELETED(src))
 			return FALSE
 		// The following is only relevant to BYOND accounts.
-		if (isnum_safe(cached_player_age) && cached_player_age == -1) //first connection
+		if (IS_FINITE(cached_player_age) && cached_player_age == -1) //first connection
 			player_age = 0
 		var/nnpa = CONFIG_GET(number/notify_new_player_age)
-		if (isnum_safe(cached_player_age) && cached_player_age == -1) //first connection
+		if (IS_FINITE(cached_player_age) && cached_player_age == -1) //first connection
 			if (nnpa >= 0)
 				message_admins("New user: [key_name_admin(src)] is connecting here for the first time.")
 				if (CONFIG_GET(flag/irc_first_connection_alert))
 					send2tgs_adminless_only("New-user", "[key_name(src)] is connecting for the first time!")
-		else if (isnum_safe(cached_player_age) && cached_player_age < nnpa)
+		else if (IS_FINITE(cached_player_age) && cached_player_age < nnpa)
 			message_admins("New user: [key_name_admin(src)] just connected with an age of [cached_player_age] day[(player_age==1?"":"s")]")
 #ifndef DISABLE_BYOND_AUTH
 		if(!src.key_is_external)

--- a/code/modules/client/login/external_login_methods.dm
+++ b/code/modules/client/login/external_login_methods.dm
@@ -15,7 +15,7 @@
 	if(!istext(link))
 		return null
 	var/port_data = ""
-	if(isnum_safe(seeker_port))
+	if(IS_FINITE(seeker_port))
 		port_data = "&seeker_port=[seeker_port]"
 	return "[link]?ip=[url_encode(ip)]&nonce=[session_creation_nonce][port_data]"
 

--- a/code/modules/client/login/sessions.dm
+++ b/code/modules/client/login/sessions.dm
@@ -345,7 +345,7 @@
 	if(is_localhost())
 		ip = "127.0.0.1"
 	var/seeker_port_in = src.seeker_port
-	if(!isnum_safe(seeker_port_in) || seeker_port_in < 1024 || seeker_port_in > 65535)
+	if(!IS_FINITE(seeker_port_in) || seeker_port_in < 1024 || seeker_port_in > 65535)
 		seeker_port_in = null
 	var/my_nonce = add_session_creation_nonce()
 	if(!istext(my_nonce) || !length(my_nonce))
@@ -366,7 +366,7 @@
 	if(!SSdbcore.Connect())
 		return null
 	var/seeker_port_in = src.seeker_port
-	if(!isnum_safe(seeker_port_in) || seeker_port_in < 1024 || seeker_port_in > 65535)
+	if(!IS_FINITE(seeker_port_in) || seeker_port_in < 1024 || seeker_port_in > 65535)
 		seeker_port_in = null
 	// sufficiently entropic, unguessable string unique to this user's current connection
 	var/hashtext = "[rustg_csprng_chacha20(RUSTG_RNG_FORMAT_HEX, 32)][ckey][ip][world.realtime][computer_id][GLOB.round_id]"

--- a/code/modules/clothing/outfits/vv_outfit.dm
+++ b/code/modules/clothing/outfits/vv_outfit.dm
@@ -60,7 +60,7 @@
 			if(vval == initial(I.vars[varname]))
 				continue
 			//Only text/numbers and icons variables to make it less weirdness prone.
-			if(!istext(vval) && !isnum_safe(vval) && !isicon(vval))
+			if(!istext(vval) && !IS_FINITE(vval) && !isicon(vval))
 				continue
 			vedits[varname] = I.vars[varname]
 		return vedits
@@ -159,7 +159,7 @@
 		var/list/vedits = vv_values[slot]
 		var/list/stripped_edits = list()
 		for(var/edit in vedits)
-			if(istext(vedits[edit]) || isnum_safe(vedits[edit]) || isnull(vedits[edit]))
+			if(istext(vedits[edit]) || IS_FINITE(vedits[edit]) || isnull(vedits[edit]))
 				stripped_edits[edit] = vedits[edit]
 		if(stripped_edits.len)
 			stripped_vv[slot] = stripped_edits

--- a/code/modules/food_and_drinks/kitchen_machinery/oven.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/oven.dm
@@ -160,7 +160,9 @@
 	return TRUE
 
 /obj/machinery/oven/proc/update_baking_audio()
-	if(!open && used_tray?.contents.len)
+	if(!oven_loop)
+		return
+	if(!open && length(used_tray?.contents))
 		oven_loop.start()
 	else
 		oven_loop.stop()

--- a/code/modules/holoparasite/holoparasite_builder.dm
+++ b/code/modules/holoparasite/holoparasite_builder.dm
@@ -34,13 +34,13 @@
 	theme = get_holoparasite_theme(_theme)
 	if(!istype(theme))
 		CRASH("Holoparasite builder created without valid theme!")
-	if(isnum_safe(_max_points))
+	if(IS_FINITE(_max_points))
 		max_points = max(round(_max_points), 1)
 	points = max_points
-	if(isnum_safe(_max_level))
+	if(IS_FINITE(_max_level))
 		max_level = max(round(_max_level), 1)
 	saved_stats.max_level = max_level
-	if(isnum_safe(_uses))
+	if(IS_FINITE(_uses))
 		uses = max(round(_uses), 1)
 	debug_mode = _debug_mode
 	accent_color = pick(GLOB.color_list_rainbow)
@@ -172,7 +172,7 @@
 		if("set:stat")
 			var/stat = params["stat"]
 			var/value = params["level"]
-			if(!istext(stat) || !length(stat) || !isnum_safe(value))
+			if(!istext(stat) || !length(stat) || !IS_FINITE(value))
 				return
 			var/level = clamp(round(value), 1, max_level)
 			switch(stat)
@@ -283,7 +283,7 @@
 	if(!path || !ispath(path, base_path))
 		return FALSE
 	var/datum/holoparasite_ability/ability = GLOB.holoparasite_abilities[path]
-	if(!istype(ability) || !isnum_safe(ability.cost)) // null cost means this ability is NOT obtainable through normal means.
+	if(!istype(ability) || !IS_FINITE(ability.cost)) // null cost means this ability is NOT obtainable through normal means.
 		return FALSE
 /**
  * Checks the validity of the name of the holoparasite, returning the reason if it's invalid, or "valid" if it is in fact valid.
@@ -488,7 +488,7 @@ CREATION_TEST_IGNORE_SUBTYPES(/obj/item/holoparasite_creator)
 /obj/item/holoparasite_creator/vv_edit_var(var_name, var_value)
 	switch(var_name)
 		if(NAMEOF(src, debug_mode))
-			if(!isnum_safe(var_value))
+			if(!IS_FINITE(var_value))
 				return FALSE
 			builder.debug_mode = var_value
 			builder.datum_flags |= DF_VAR_EDITED
@@ -496,7 +496,7 @@ CREATION_TEST_IGNORE_SUBTYPES(/obj/item/holoparasite_creator)
 			datum_flags |= DF_VAR_EDITED
 			return TRUE
 		if(NAMEOF(src, max_points))
-			if(!isnum_safe(var_value) || var_value < 1)
+			if(!IS_FINITE(var_value) || var_value < 1)
 				return FALSE
 			var/new_max_points = round(var_value)
 			builder.max_points = new_max_points
@@ -505,7 +505,7 @@ CREATION_TEST_IGNORE_SUBTYPES(/obj/item/holoparasite_creator)
 			datum_flags |= DF_VAR_EDITED
 			return TRUE
 		if(NAMEOF(src, max_level))
-			if(!isnum_safe(var_value) || var_value < 1)
+			if(!IS_FINITE(var_value) || var_value < 1)
 				return FALSE
 			var/new_max_level = round(var_value)
 			builder.max_level = new_max_level
@@ -525,7 +525,7 @@ CREATION_TEST_IGNORE_SUBTYPES(/obj/item/holoparasite_creator)
 			datum_flags |= DF_VAR_EDITED
 			return TRUE
 		if(NAMEOF(src, uses))
-			if(!isnum_safe(var_value) || var_value < 0)
+			if(!IS_FINITE(var_value) || var_value < 0)
 				return FALSE
 			var/new_uses = round(var_value)
 			builder.uses = new_uses

--- a/code/modules/holoparasite/holoparasite_stats.dm
+++ b/code/modules/holoparasite/holoparasite_stats.dm
@@ -237,7 +237,7 @@
 		return FALSE
 	switch(var_name)
 		if(NAMEOF(src, damage), NAMEOF(src, defense), NAMEOF(src, speed), NAMEOF(src, potential), NAMEOF(src, range))
-			if(!isnum_safe(var_value))
+			if(!IS_FINITE(var_value))
 				message_admins("[ADMIN_LOOKUPFLW(usr)] attempted to set an invalid stat ([var_value]) for the holoparasite stats of [ADMIN_LOOKUPFLW(last_holopara)].")
 				log_admin("[key_name_admin(usr)] attempted to set an invalid stat ([var_value]) for the holoparasite stats of [key_name_admin(last_holopara)].")
 				return FALSE

--- a/code/modules/jobs/job_exp.dm
+++ b/code/modules/jobs/job_exp.dm
@@ -162,7 +162,7 @@ GLOBAL_PROTECT(exp_to_update)
 		return -1
 	if(!SSdbcore.Connect())
 		return -1
-	if (!isnum_safe(minutes))
+	if (!IS_FINITE(minutes))
 		return -1
 
 	var/list/play_records = list()
@@ -192,7 +192,7 @@ GLOBAL_PROTECT(exp_to_update)
 		var/jvalue = play_records[jtype]
 		if (!jvalue)
 			continue
-		if (!isnum_safe(jvalue))
+		if (!IS_FINITE(jvalue))
 			CRASH("invalid job value [jtype]:[jvalue]")
 		LAZYINITLIST(GLOB.exp_to_update)
 		GLOB.exp_to_update.Add(list(list(

--- a/code/modules/jobs/job_types/_job.dm
+++ b/code/modules/jobs/job_types/_job.dm
@@ -562,7 +562,7 @@
 		return 0
 	if(!SSdbcore.Connect())
 		return 0 //Without a database connection we can't get a player's age so we'll assume they're old enough for all jobs
-	if(!isnum_safe(minimal_player_age))
+	if(!IS_FINITE(minimal_player_age))
 		return 0
 
 	return max(0, minimal_player_age - C.player_age)

--- a/code/modules/library/lib_machines.dm
+++ b/code/modules/library/lib_machines.dm
@@ -498,7 +498,7 @@ GLOBAL_LIST(cachedbooks) // List of our cached book datums
 		else
 			var/orderid = input("Enter your order:") as num|null
 			if(orderid)
-				if(isnum_safe(orderid) && ISINTEGER(orderid))
+				if(IS_FINITE(orderid) && ISINTEGER(orderid))
 					href_list["targetid"] = num2text(orderid)
 
 	if(href_list["targetid"])

--- a/code/modules/library/random_books.dm
+++ b/code/modules/library/random_books.dm
@@ -32,7 +32,7 @@
 
 /obj/structure/bookcase/random/Initialize(mapload)
 	. = ..()
-	if(books_to_load && isnum_safe(books_to_load))
+	if(books_to_load && IS_FINITE(books_to_load))
 		books_to_load += pick(-1,-1,0,1,1)
 	if(books_to_load && prob(15)) // as long as the bookshelf is not meant to be empty, it has a small chance of having manuscript
 		new /obj/item/book/manuscript(src)
@@ -40,7 +40,7 @@
 
 /proc/create_random_books(amount, location, fail_loud = FALSE, category = null, obj/item/book/existing_book)
 	. = list()
-	if(!isnum_safe(amount) || amount<1)
+	if(!IS_FINITE(amount) || amount<1)
 		return
 	if (!SSdbcore.Connect())
 		if(existing_book && (fail_loud || prob(5)))

--- a/code/modules/mapexporting/mapexporter.dm
+++ b/code/modules/mapexporting/mapexporter.dm
@@ -161,7 +161,7 @@ GLOBAL_LIST_INIT(save_file_chars, list(
 			value = sanitize_simple(value, list("{"="", "}"="", "\""="", ";"="", ","=""))
 		else if(isicon(value) || isfile(value))
 			symbol = "'"
-		else if(!(isnum_safe(value) || ispath(value)))
+		else if(!(IS_FINITE(value) || ispath(value)))
 			continue
 		//Prevent symbols from being because otherwise you can name something [";},/obj/item/gun/energy/laser/instakill{name="da epic gun] and spawn yourself an instakill gun.
 		data_to_add += "[V] = [symbol][value][symbol]"

--- a/code/modules/mapping/preloader.dm
+++ b/code/modules/mapping/preloader.dm
@@ -24,7 +24,7 @@ GLOBAL_LIST_INIT(_preloader_path, null)
 			value = deep_copy_list(value)
 		#ifdef TESTING
 		if(what.vars[attribute] == value)
-			var/message = "<font color=green>[what.type]</font> at [AREACOORD(what)] - <b>VAR:</b> <font color=red>[attribute] = [isnull(value) ? "null" : (isnum_safe(value) ? value : "\"[value]\"")]</font>"
+			var/message = "<font color=green>[what.type]</font> at [AREACOORD(what)] - <b>VAR:</b> <font color=red>[attribute] = [isnull(value) ? "null" : (IS_FINITE(value) ? value : "\"[value]\"")]</font>"
 			log_mapping("DIRTY VAR: [message]")
 			GLOB.dirty_vars += message
 		#endif

--- a/code/modules/mapping/reader.dm
+++ b/code/modules/mapping/reader.dm
@@ -960,7 +960,7 @@ GLOBAL_LIST_EMPTY(map_model_default)
 		if(!left_constant) // damn newlines man. Exists to provide behavior consistency with the above loop. not a major cost becuase this path is cold
 			continue
 
-		if(equal_position && !isnum_safe(left_constant))
+		if(equal_position && !IS_FINITE(left_constant))
 			// Associative var, so do the association.
 			// Note that numbers cannot be keys - the RHS is dropped if so.
 			var/trim_right = TRIM_TEXT(copytext(text, equal_position + length(text[equal_position]), position))
@@ -972,7 +972,7 @@ GLOBAL_LIST_EMPTY(map_model_default)
 /datum/parsed_map/proc/parse_constant(text)
 	// number
 	var/num = text2num(text)
-	if(isnum_safe(num))
+	if(IS_FINITE(num))
 		return num
 
 	// string

--- a/code/modules/mapping/space_management/traits.dm
+++ b/code/modules/mapping/space_management/traits.dm
@@ -1,6 +1,6 @@
 /// Look up levels[z].traits[trait]
 /datum/controller/subsystem/mapping/proc/level_trait(z, trait)
-	if (!isnum_safe(z) || z < 1)
+	if (!IS_FINITE(z) || z < 1)
 		return null
 	if (z_list)
 		if (z > z_list.len)

--- a/code/modules/mob/dead/new_player/new_player.dm
+++ b/code/modules/mob/dead/new_player/new_player.dm
@@ -289,7 +289,7 @@
 	if(!job.has_space())
 		if(job.title == JOB_NAME_ASSISTANT)
 			//Newbies can always be assistants
-			if(isnum_safe(client.player_age) && client.player_age <= 14)
+			if(IS_FINITE(client.player_age) && client.player_age <= 14)
 				return JOB_AVAILABLE
 			// If there are other jobs that this user can select, then the assistant is unavailable
 			// If the user has no other choices, then we will display the assistant

--- a/code/modules/mob/living/carbon/emote.dm
+++ b/code/modules/mob/living/carbon/emote.dm
@@ -152,7 +152,7 @@
 
 /datum/emote/living/carbon/sign/select_param(mob/user, params)
 	. = ..()
-	if(!isnum_safe(text2num(params)))
+	if(!IS_FINITE(text2num(params)))
 		return message
 
 /datum/emote/living/carbon/sign/signal

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/colossus.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/colossus.dm
@@ -245,7 +245,7 @@ Difficulty: Very Hard
 		sleep(1)
 
 /mob/living/simple_animal/hostile/megafauna/colossus/proc/shoot_projectile(turf/marker, set_angle)
-	if(!isnum_safe(set_angle) && (!marker || marker == loc))
+	if(!IS_FINITE(set_angle) && (!marker || marker == loc))
 		return
 	var/turf/startloc = get_turf(src)
 	var/obj/projectile/P = new /obj/projectile/colossus(startloc)
@@ -267,7 +267,7 @@ Difficulty: Very Hard
 	playsound(src, 'sound/magic/clockwork/invoke_general.ogg', 200, 1, 2)
 	newtonian_move(get_dir(target_turf, src))
 	var/angle_to_target = get_angle(src, target_turf)
-	if(isnum_safe(set_angle))
+	if(IS_FINITE(set_angle))
 		angle_to_target = set_angle
 	var/static/list/colossus_shotgun_shot_angles = list(12.5, 7.5, 2.5, -2.5, -7.5, -12.5)
 	for(var/i in colossus_shotgun_shot_angles)

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -691,7 +691,7 @@
 		process_hit(get_turf(direct_target), direct_target)
 		if(QDELETED(src))
 			return
-	if(isnum_safe(angle))
+	if(IS_FINITE(angle))
 		set_angle(angle)
 	if(spread)
 		set_angle(Angle + ((rand() - 0.5) * spread))

--- a/code/modules/reagents/chemistry/holder.dm
+++ b/code/modules/reagents/chemistry/holder.dm
@@ -765,7 +765,7 @@
 		stack_trace("invalid reagent passed to add reagent [reagent]")
 		return FALSE
 
-	if(!isnum_safe(amount) || !amount)
+	if(!IS_FINITE(amount) || !amount)
 		return FALSE
 
 	// Prevents small amount problems, as well as zero and below zero amounts.
@@ -956,7 +956,7 @@
 		stack_trace("invalid reagent path passed to remove all type [reagent_type]")
 		return FALSE
 
-	if(!isnum_safe(amount))
+	if(!IS_FINITE(amount))
 		return 1
 	var/list/cached_reagents = reagent_list
 	var/has_removed_reagent = 0

--- a/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
@@ -75,8 +75,8 @@
 
 /datum/reagent/toxin/plasma/on_mob_life(mob/living/carbon/affected_mob, delta_time, times_fired)
 	. = ..()
-	if(holder.has_reagent(/datum/reagent/medicine/epinephrine))
-		holder.remove_reagent(/datum/reagent/medicine/epinephrine, 2 * REM * delta_time)
+	if(affected_mob.reagents.has_reagent(/datum/reagent/medicine/epinephrine))
+		affected_mob.reagents.remove_reagent(/datum/reagent/medicine/epinephrine, 2 * REM * delta_time)
 	affected_mob.adjustPlasma(20 * REM * delta_time)
 
 /datum/reagent/toxin/plasma/expose_turf(turf/exposed_turf, volume)
@@ -84,7 +84,7 @@
 	if(!istype(exposed_turf))
 		return
 
-	exposed_turf.atmos_spawn_air("[GAS_PLASMA]=[volume];[TURF_TEMPERATURE(holder ? holder.chem_temp : T20C)]")
+	exposed_turf.atmos_spawn_air("[GAS_PLASMA]=[volume];[TURF_TEMPERATURE(holder?.chem_temp || T20C)]")
 
 /datum/reagent/toxin/plasma/expose_mob(mob/living/exposed_mob, method = TOUCH, reac_volume)//Splashing people with plasma is stronger than fuel!
 	. = ..()
@@ -103,8 +103,8 @@
 
 /datum/reagent/toxin/hot_ice/on_mob_life(mob/living/carbon/affected_mob, delta_time, times_fired)
 	. = ..()
-	if(holder.has_reagent(/datum/reagent/medicine/epinephrine))
-		holder.remove_reagent(/datum/reagent/medicine/epinephrine, 2 * REM * delta_time)
+	if(affected_mob.reagents.has_reagent(/datum/reagent/medicine/epinephrine))
+		affected_mob.reagents.remove_reagent(/datum/reagent/medicine/epinephrine, 2 * REM * delta_time)
 
 	affected_mob.adjustPlasma(20 * REM * delta_time)
 	affected_mob.adjust_bodytemperature(-7 * TEMPERATURE_DAMAGE_COEFFICIENT * REM * delta_time, affected_mob.get_body_temp_normal())
@@ -493,8 +493,8 @@
 /datum/reagent/toxin/formaldehyde/on_mob_life(mob/living/carbon/affected_mob, delta_time, times_fired)
 	. = ..()
 	if(DT_PROB(2.5, delta_time))
-		holder.add_reagent(/datum/reagent/toxin/histamine, pick(5,15))
-		holder.remove_reagent(/datum/reagent/toxin/formaldehyde, 1.2)
+		affected_mob.reagents.add_reagent(/datum/reagent/toxin/histamine, pick(5,15))
+		affected_mob.reagents.remove_reagent(/datum/reagent/toxin/formaldehyde, 1.2)
 
 /datum/reagent/toxin/venom
 	name = "Venom"
@@ -512,8 +512,8 @@
 		. = UPDATE_MOB_HEALTH
 
 	if(DT_PROB(8, delta_time))
-		holder.add_reagent(/datum/reagent/toxin/histamine, pick(5,10))
-		holder.remove_reagent(/datum/reagent/toxin/venom, 1.1)
+		affected_mob.reagents.add_reagent(/datum/reagent/toxin/histamine, pick(5,10))
+		affected_mob.reagents.remove_reagent(/datum/reagent/toxin/venom, 1.1)
 
 //Very similar to heparin, but causes toxin damage instead of brute
 /datum/reagent/toxin/apidvenom
@@ -553,7 +553,7 @@
 		affected_mob.Paralyze(3 SECONDS * REM * delta_time, 0)
 		toxpwr += 0.1 //The venom gets stronger until completely purged.
 
-	if(holder.has_reagent(/datum/reagent/medicine/calomel) || holder.has_reagent(/datum/reagent/medicine/pen_acid) || holder.has_reagent(/datum/reagent/medicine/charcoal) || holder.has_reagent(/datum/reagent/medicine/carthatoline))
+	if(affected_mob.reagents.has_reagent(/datum/reagent/medicine/calomel) || affected_mob.reagents.has_reagent(/datum/reagent/medicine/pen_acid) || affected_mob.reagents.has_reagent(/datum/reagent/medicine/charcoal) || affected_mob.reagents.has_reagent(/datum/reagent/medicine/carthatoline))
 		current_cycle += 5 // Prevents using purgatives while in combat
 
 	if(affected_mob.getStaminaLoss() <= 70) //Will never stamcrit
@@ -634,8 +634,8 @@
 		. = UPDATE_MOB_HEALTH
 
 	if(DT_PROB(1.5, delta_time))
-		holder.add_reagent(/datum/reagent/toxin/histamine, rand(1, 3))
-		holder.remove_reagent(/datum/reagent/toxin/itching_powder, 1.2)
+		affected_mob.reagents.add_reagent(/datum/reagent/toxin/histamine, rand(1, 3))
+		affected_mob.reagents.remove_reagent(/datum/reagent/toxin/itching_powder, 1.2)
 		return
 	else
 		return ..() || .
@@ -786,11 +786,11 @@
 	. = ..()
 	if(current_cycle >= 11 && DT_PROB(min(30, current_cycle), delta_time))
 		affected_mob.vomit(10, prob(10), prob(50), rand(0, 4), TRUE, prob(30))
-		for(var/datum/reagent/toxin/toxin in holder.reagent_list)
+		for(var/datum/reagent/toxin/toxin in affected_mob.reagents.reagent_list)
 			if(toxin == src)
 				continue
 
-			holder.remove_reagent(toxin.type, 1)
+			affected_mob.reagents.remove_reagent(toxin.type, 1)
 
 /datum/reagent/toxin/spewium/overdose_process(mob/living/carbon/affected_mob, delta_time, times_fired)
 	. = ..()
@@ -872,11 +872,11 @@
 /datum/reagent/toxin/anacea/on_mob_life(mob/living/carbon/affected_mob, delta_time, times_fired)
 	. = ..()
 	var/remove_amt = 5
-	if(holder.has_reagent(/datum/reagent/medicine/calomel) || holder.has_reagent(/datum/reagent/medicine/pen_acid))
+	if(affected_mob.reagents.has_reagent(/datum/reagent/medicine/calomel) || affected_mob.reagents.has_reagent(/datum/reagent/medicine/pen_acid))
 		remove_amt = 0.5
 
-	for(var/datum/reagent/medicine/medicine in holder.reagent_list)
-		holder.remove_reagent(medicine.type, remove_amt * REM * delta_time)
+	for(var/datum/reagent/medicine/medicine in affected_mob.reagents.reagent_list)
+		affected_mob.reagents.remove_reagent(medicine.type, remove_amt * REM * delta_time)
 
 //ACID
 
@@ -948,13 +948,14 @@
 
 /datum/reagent/toxin/delayed/on_mob_life(mob/living/carbon/affected_mob, delta_time, times_fired)
 	. = ..()
-	if(current_cycle > delay)
-		if(holder)
-			holder.remove_reagent(type, actual_metaboliztion_rate * affected_mob.metabolism_efficiency * delta_time)
-		if(affected_mob.adjustToxLoss(actual_toxpwr * REM * delta_time, updating_health = FALSE, required_biotype = affected_biotype))
-			. = UPDATE_MOB_HEALTH
-		if(DT_PROB(5, delta_time))
-			affected_mob.Paralyze(20)
+	if(current_cycle <= delay)
+		return
+	if(holder)
+		affected_mob.reagents.remove_reagent(type, actual_metaboliztion_rate * affected_mob.metabolism_efficiency * delta_time)
+	if(affected_mob.adjustToxLoss(actual_toxpwr * REM * delta_time, updating_health = FALSE, required_biotype = affected_biotype))
+		. = UPDATE_MOB_HEALTH
+	if(DT_PROB(5, delta_time))
+		affected_mob.Paralyze(2 SECONDS)
 
 /datum/reagent/toxin/mimesbane
 	name = "Mime's Bane"

--- a/code/modules/reagents/reagent_containers.dm
+++ b/code/modules/reagents/reagent_containers.dm
@@ -46,7 +46,7 @@ CREATION_TEST_IGNORE_SUBTYPES(/obj/item/reagent_containers)
 
 /obj/item/reagent_containers/Initialize(mapload, vol)
 	. = ..()
-	if(isnum_safe(vol) && vol > 0)
+	if(IS_FINITE(vol) && vol > 0)
 		volume = vol
 	create_reagents(volume, reagent_flags)
 	if(spawned_disease)

--- a/code/modules/recycling/disposal/pipe_sorting.dm
+++ b/code/modules/recycling/disposal/pipe_sorting.dm
@@ -47,7 +47,7 @@
 	. = ..()
 	// Generate a list of soring tags.
 	if(sortType)
-		if(isnum_safe(sortType))
+		if(IS_FINITE(sortType))
 			sortTypes |= sortType
 		else if(istext(sortType))
 			var/list/sorts = splittext(sortType,";")

--- a/code/modules/research/nanites/extra_settings/number.dm
+++ b/code/modules/research/nanites/extra_settings/number.dm
@@ -14,7 +14,7 @@
 /datum/nanite_extra_setting/number/set_value(value)
 	if(istext(value))
 		value = text2num(value)
-	if(!isnum_safe(value))
+	if(!IS_FINITE(value))
 		return
 	src.value = clamp(value, min, max)
 

--- a/code/modules/tooltip/tooltip.dm
+++ b/code/modules/tooltip/tooltip.dm
@@ -50,7 +50,7 @@ Notes:
 
 
 /datum/tooltip/proc/show(atom/movable/thing, params = null, title = null, content = null, theme = "default", special = "none")
-	if (!thing || !params || (!title && !content) || !owner || !isnum_safe(ICON_SIZE_ALL))
+	if (!thing || !params || (!title && !content) || !owner || !IS_FINITE(ICON_SIZE_ALL))
 		return 0
 	if (!init)
 		//Initialize some vars

--- a/code/modules/unit_tests/component_tests.dm
+++ b/code/modules/unit_tests/component_tests.dm
@@ -3,7 +3,7 @@
 	var/list/bad_dts = list()
 	for(var/t in typesof(/datum/component))
 		var/datum/component/comp = t
-		if(!isnum_safe(initial(comp.dupe_mode)))
+		if(!IS_FINITE(initial(comp.dupe_mode)))
 			bad_dms += t
 		var/dupe_type = initial(comp.dupe_type)
 		if(dupe_type && !ispath(dupe_type))

--- a/code/modules/unit_tests/techweb_sanity.dm
+++ b/code/modules/unit_tests/techweb_sanity.dm
@@ -83,7 +83,7 @@
 			var/list/points = TN.required_items_to_unlock[p]
 			if(islist(points))
 				for(var/i in points)
-					if(!isnum_safe(points[i]))
+					if(!IS_FINITE(points[i]))
 						TEST_FAIL("[TN] has invalid required item: [points[i]] is not a valid number.")
 						continue
 					if(!points_types[i])


### PR DESCRIPTION
## About The Pull Request

```dm
// Remove these once we have Byond implementation.
#define ISNAN(a) (a!=a)
#define ISINF(a) (!ISNAN(a) && ISNAN(a-a))
#define IS_INF_OR_NAN(a) (ISNAN(a-a))

#define IS_FINITE__UNSAFE(a) (a-a==a-a)
#define IS_FINITE(a) (isnum(a) && IS_FINITE__UNSAFE(a))
```

We got both `isinf()` and `isnan()` in 515. I think it's time to use them.

Both `IS_FINITE()` and `isnum_safe()` did the same thing, so I just removed the `isnum_safe()` macro and replaced all of its occurrences with `IS_FINITE()`.

## Why It's Good For The Game

These will be faster since they compile down to individual instructions instead of the arithmetic we did before. That being said, performance is not why I'm doing this- the motivation behind this PR is the fact that it's insane to **not** use the BYOND built-ins.

## Testing Photographs and Procedure

<img width="506" height="702" alt="image" src="https://github.com/user-attachments/assets/e989c1bd-86c3-42fd-bf20-3e0491f132bd" />

## Changelog
:cl:
code: isnum_safe() has been removed since it was logically identical to IS_FINITE()
code: Replaced our isnan() and isinf() overrides with the BYOND built-in procs.
/:cl: