### PR TITLE
Optimizes anomalies

### DIFF
--- a/code/__DEFINES/anomalies.dm
+++ b/code/__DEFINES/anomalies.dm
@@ -18,5 +18,5 @@
 #define ANOMALY_FLUX_EXPLOSIVE 1
 #define ANOMALY_FLUX_LOW_EXPLOSIVE 2
 
-/// Chance of anomalies moving every process tick
+/// Chance of anomalies moving every second
 #define ANOMALY_MOVECHANCE 45

--- a/code/__HELPERS/turfs.dm
+++ b/code/__HELPERS/turfs.dm
@@ -356,30 +356,35 @@ Turf and target are separate in case you want to teleport some distance from a t
 	if (length(turfs))
 		return pick(turfs)
 
-///Returns a random turf or turf list on the station, excludes dense turfs (like walls) and areas with valid_territory set to FALSE
+/**
+ * Returns a random turf or turf list on the station, excludes dense turfs (like walls) and areas with valid_territory set to FALSE
+ * This is an expensive proc. USE SPARINGLY PLEASE!
+ */
 /proc/get_safe_random_station_turfs(list/areas_to_pick_from = GLOB.the_station_areas, amount = 1)
-	var/list/picked_turfs = list()
-	var/list/turf_list = list()
-	for(var/area/A as anything in areas_to_pick_from)
-		turf_list += get_area_turfs(A)
-	while(turf_list.len && length(picked_turfs) < amount)
-		var/I = rand(1, length(turf_list))
-		var/turf/checked_turf = turf_list[I]
-		var/area/turf_area = get_area(checked_turf)
-		if(!checked_turf.density && (turf_area.area_flags & VALID_TERRITORY) && !isgroundlessturf(checked_turf))
-			var/clear = TRUE
-			for(var/obj/checked_object in checked_turf)
-				if(checked_object.density)
-					clear = FALSE
-					break
-			if(clear)
-				picked_turfs |= checked_turf
-			turf_list.Cut(I,I+1)
+	var/list/turf/all_station_turfs = list()
+	for(var/area/area_to_search as anything in areas_to_pick_from)
+		all_station_turfs += get_area_turfs(area_to_search)
+
+	var/list/turf/picked_turfs = list()
+	while(length(all_station_turfs) && length(picked_turfs) < amount)
+		var/turf/checked_turf = pick_n_take(all_station_turfs)
+
+		if(!checked_turf.density && !isgroundlessturf(checked_turf))
+			var/area/turf_area = get_area(checked_turf)
+			if(turf_area.area_flags & VALID_TERRITORY)
+				var/clear = TRUE
+				for(var/obj/checked_object in checked_turf)
+					if(checked_object.density)
+						clear = FALSE
+						break
+				if(clear)
+					picked_turfs += checked_turf
 		CHECK_TICK
-	if(!picked_turfs.len)
+
+	if(!length(picked_turfs))
 		return null
 	if(amount == 1)
-		return picked_turfs[1]
+		return pick(picked_turfs)
 	return picked_turfs
 
 /**

--- a/code/__HELPERS/turfs.dm
+++ b/code/__HELPERS/turfs.dm
@@ -363,22 +363,21 @@ Turf and target are separate in case you want to teleport some distance from a t
 /proc/get_safe_random_station_turfs(list/areas_to_pick_from = GLOB.the_station_areas, amount = 1)
 	var/list/turf/all_station_turfs = list()
 	for(var/area/area_to_search as anything in areas_to_pick_from)
-		all_station_turfs += get_area_turfs(area_to_search)
+		if(area_to_search.area_flags & VALID_TERRITORY)
+			all_station_turfs += get_area_turfs(area_to_search)
 
 	var/list/turf/picked_turfs = list()
 	while(length(all_station_turfs) && length(picked_turfs) < amount)
 		var/turf/checked_turf = pick_n_take(all_station_turfs)
 
 		if(!checked_turf.density && !isgroundlessturf(checked_turf))
-			var/area/turf_area = get_area(checked_turf)
-			if(turf_area.area_flags & VALID_TERRITORY)
-				var/clear = TRUE
-				for(var/obj/checked_object in checked_turf)
-					if(checked_object.density)
-						clear = FALSE
-						break
-				if(clear)
-					picked_turfs += checked_turf
+			var/clear = TRUE
+			for(var/obj/checked_object in checked_turf)
+				if(checked_object.density)
+					clear = FALSE
+					break
+			if(clear)
+				picked_turfs += checked_turf
 		CHECK_TICK
 
 	if(!length(picked_turfs))

--- a/code/game/objects/effects/anomalies/_anomalies.dm
+++ b/code/game/objects/effects/anomalies/_anomalies.dm
@@ -59,11 +59,6 @@ CREATION_TEST_IGNORE_SUBTYPES(/obj/effect/anomaly)
 		QDEL_NULL(anomaly_core)
 	return ..()
 
-/obj/effect/anomaly/Exited(atom/movable/gone, direction)
-	. = ..()
-	if(gone == anomaly_core)
-		anomaly_core = null
-
 /obj/effect/anomaly/analyzer_act(mob/living/user, obj/item/tool)
 	if(isnull(anomaly_core))
 		return
@@ -95,6 +90,7 @@ CREATION_TEST_IGNORE_SUBTYPES(/obj/effect/anomaly)
 	new /obj/effect/particle_effect/smoke/bad(loc)
 
 	anomaly_core.forceMove(drop_location())
+	anomaly_core = null
 	qdel(src)
 
 /**

--- a/code/game/objects/effects/anomalies/_anomalies.dm
+++ b/code/game/objects/effects/anomalies/_anomalies.dm
@@ -9,85 +9,131 @@
 	anchored = TRUE
 	light_range = 3
 
+	/// The anomaly core we drop
 	var/obj/item/assembly/signaler/anomaly/anomaly_core = /obj/item/assembly/signaler/anomaly
+	/// The area that we were spawned in
 	var/area/impact_area
-
-	var/lifespan = 990
+	/// The time we expire
 	var/death_time
-
-	var/countdown_colour
+	/// Our countdown timer
 	var/obj/effect/countdown/anomaly/countdown
 
 	/// Do we keep on living forever?
 	var/immortal = FALSE
-	///How many harvested pierced realities do we spawn on destruction
+	/// How many harvested pierced realities do we spawn on destruction. Only used by subtypes
 	var/max_spawned_faked = 2
 
 CREATION_TEST_IGNORE_SUBTYPES(/obj/effect/anomaly)
 
-/obj/effect/anomaly/Initialize(mapload, new_lifespan, spawned_fake_harvested)
+/obj/effect/anomaly/Initialize(mapload, life_span = 1.5 MINUTES, spawned_fake_harvested)
 	. = ..()
 
 	AddElement(/datum/element/point_of_interest)
 
 	START_PROCESSING(SSobj, src)
-	impact_area = get_area(src)
 
 	anomaly_core = new anomaly_core(src)
-	anomaly_core.name = "[name] core"
 	anomaly_core.code = rand(1,100)
 	anomaly_core.anomaly_type = type
-
 	var/frequency = rand(MIN_FREE_FREQ, MAX_FREE_FREQ)
 	if(ISMULTIPLE(frequency, 2))//signaller frequencies are always uneven!
 		frequency++
 	anomaly_core.set_frequency(frequency)
 
-	if(new_lifespan)
-		lifespan = new_lifespan
-	death_time = world.time + lifespan
+	death_time = world.time + life_span
 
 	if(spawned_fake_harvested)
 		max_spawned_faked = spawned_fake_harvested
 
+	impact_area = get_area(src)
+
 	if(immortal)
 		return // no countdown for forever anomalies
 	countdown = new(src)
-	if(countdown_colour)
-		countdown.color = countdown_colour
 	countdown.start()
 
+/obj/effect/anomaly/Destroy()
+	STOP_PROCESSING(SSobj, src)
+	QDEL_NULL(countdown)
+	if(!isnull(anomaly_core))
+		QDEL_NULL(anomaly_core)
+	return ..()
+
+/obj/effect/anomaly/Exited(atom/movable/gone, direction)
+	. = ..()
+	if(gone == anomaly_core)
+		anomaly_core = null
+
+/obj/effect/anomaly/analyzer_act(mob/living/user, obj/item/tool)
+	if(isnull(anomaly_core))
+		return
+	to_chat(user, span_notice("Analyzing... [src]'s unstable field is fluctuating along frequency [format_frequency(anomaly_core.frequency)], code [anomaly_core.code]."))
+	return TOOL_ACT_TOOLTYPE_SUCCESS
+
 /obj/effect/anomaly/process(delta_time)
-	anomalyEffect(delta_time)
+	anomaly_process(delta_time)
 	if(death_time < world.time && !immortal)
 		if(loc)
 			detonate()
 		qdel(src)
 
-/obj/effect/anomaly/Destroy()
-	STOP_PROCESSING(SSobj, src)
-	QDEL_NULL(countdown)
-	return ..()
+/obj/effect/anomaly/ex_act(severity, target)
+	if(severity == EXPLODE_DEVASTATE)
+		qdel(src)
 
-/obj/effect/anomaly/proc/anomalyEffect(delta_time)
+/// Called every process() tick. Do anomaly stuff here
+/obj/effect/anomaly/proc/anomaly_process(delta_time)
 	if(DT_PROB(ANOMALY_MOVECHANCE, delta_time))
-		step(src,pick(GLOB.alldirs))
+		step(src, pick(GLOB.alldirs))
 
+/// Called when the anomaly expires. Guaranteed to have a loc when called.
 /obj/effect/anomaly/proc/detonate()
 	return
 
-/obj/effect/anomaly/ex_act(severity, target)
-	if(severity == 1)
-		qdel(src)
-
-/obj/effect/anomaly/proc/anomalyNeutralize()
+/// Called when an anomaly neutralizer is used on this
+/obj/effect/anomaly/proc/neutralize()
 	new /obj/effect/particle_effect/smoke/bad(loc)
 
-	for(var/atom/movable/O in src)
-		O.forceMove(drop_location())
-
+	anomaly_core.forceMove(drop_location())
 	qdel(src)
 
-/obj/effect/anomaly/attackby(obj/item/I, mob/user, params)
-	if(I.tool_behaviour == TOOL_ANALYZER)
-		to_chat(user, span_notice("Analyzing... [src]'s unstable field is fluctuating along frequency [format_frequency(anomaly_core.frequency)], code [anomaly_core.code]."))
+/**
+ * Helper proc to spawn fake pierced realities centered around a turf or around the station
+ *
+ * Arguments:
+ * * centered_turf: The turf to center the influences around, if null, they will be spawned across the station
+ * * max_amount: A random amount of influences will be spawned to a maximum of this value
+ */
+/proc/generate_fake_pierced_realities(turf/center_turf, max_amount = 2)
+	if(max_amount <= 0)
+		return
+	var/to_spawn = rand(1, max_amount)
+
+	var/list/turf/possible_locations
+	if(!isnull(center_turf))
+		possible_locations = get_teleport_turfs(center = center_turf, precision = 5 * to_spawn)
+	else
+		possible_locations = get_safe_random_station_turfs(amount = to_spawn)
+
+	while(to_spawn > 0 && length(possible_locations))
+		// Regardless of if we spawn a pierced reality or not, we want to remove this turf from the pool.
+		// This is because if the turf is found to be invalid, we don't want future runs to loop over it.
+		var/turf/chosen_location = pick_n_take(possible_locations)
+
+		if(isspaceturf(chosen_location))
+			continue
+
+		// We don't want them close to each other - at least 1 tile of seperation
+		var/found_nearby_influence = FALSE
+		for(var/atom/nearby_thing as anything in range(1, chosen_location))
+			if(istype(nearby_thing, /obj/effect/heretic_influence) || istype(nearby_thing, /obj/effect/visible_heretic_influence))
+				found_nearby_influence = TRUE
+				break
+		if(found_nearby_influence)
+			continue
+
+		addtimer(CALLBACK(GLOBAL_PROC, GLOBAL_PROC_REF(_create_new_fake_reality), chosen_location), rand(0 SECONDS, 50 SECONDS))
+		to_spawn--
+
+/proc/_create_new_fake_reality(turf/location)
+	new /obj/effect/visible_heretic_influence(location)

--- a/code/game/objects/effects/anomalies/anomaly_bioscrambler.dm
+++ b/code/game/objects/effects/anomalies/anomaly_bioscrambler.dm
@@ -21,20 +21,22 @@
 	. = ..()
 	COOLDOWN_START(src, pulse_cooldown, pulse_interval) // give them time to react
 
-/obj/effect/anomaly/bioscrambler/anomalyEffect(delta_time)
+/obj/effect/anomaly/bioscrambler/anomaly_process(delta_time)
 	. = ..()
-
 	if(!COOLDOWN_FINISHED(src, pulse_cooldown))
 		return
 	COOLDOWN_START(src, pulse_cooldown, pulse_interval)
-
 	bioscrambler_pulse(src, range)
 
 /proc/bioscrambler_pulse(atom/owner, range = 5, ignore_owner = FALSE, message_admins = FALSE)
+	var/list/atom/nearby_things
+	if(ignore_owner)
+		nearby_things = orange(range, owner)
+	else
+		nearby_things = range(range, owner)
+
 	var/list/mob/living/carbon/affected = list()
-	for(var/mob/living/carbon/target in range(range, owner))
-		if(!ignore_owner && target == owner)
-			continue
+	for(var/mob/living/carbon/target in nearby_things)
 		// probability should linearly scale from no protection at 30 to guaranteed at 90 bio armor
 		var/protection_chance = (target.getarmor(type = BIO) - 30) * (100 / (90 - 30))
 		if(prob(protection_chance))
@@ -70,7 +72,7 @@
 		target.log_message("had their [picked_user_part.type] turned into [new_part.type] by a bioscrambling pulse from [owner].", LOG_ATTACK, color="red")
 
 	if(message_admins)
-		message_admins("[ADMIN_LOOKUPFLW(owner)] has caused a bioscrambler pulse affecting [english_list(affected)].")
+		message_admins("[ADMIN_LOOKUPFLW(owner)] has caused a bioscrambler pulse affecting: [english_list(affected)].")
 
 #undef ANOMALY_BIOSCRAMBLER_ZONES
 #undef ANOMALY_BIOSCRAMBLER_ZONE_CHEST

--- a/code/game/objects/effects/anomalies/anomaly_bleed.dm
+++ b/code/game/objects/effects/anomalies/anomaly_bleed.dm
@@ -5,7 +5,7 @@
 	anomaly_core = /obj/item/assembly/signaler/anomaly/blood
 	var/sucking = FALSE
 
-/obj/effect/anomaly/blood/anomalyEffect(delta_time)
+/obj/effect/anomaly/blood/anomaly_process(delta_time)
 	if (sucking)
 		return
 	..()

--- a/code/game/objects/effects/anomalies/anomaly_bluespace.dm
+++ b/code/game/objects/effects/anomalies/anomaly_bluespace.dm
@@ -6,12 +6,13 @@
 	max_spawned_faked = 4
 	anomaly_core = /obj/item/assembly/signaler/anomaly/bluespace
 
-/obj/effect/anomaly/bluespace/anomalyEffect()
-	..()
+/obj/effect/anomaly/bluespace/anomaly_process()
+	. = ..()
 	for(var/mob/living/M in hearers(1,src))
 		do_teleport(M, locate(M.x, M.y, M.z), 4, channel = TELEPORT_CHANNEL_BLUESPACE)
 
 /obj/effect/anomaly/bluespace/Bumped(atom/movable/AM)
+	. = ..()
 	if(isliving(AM))
 		do_teleport(AM, locate(AM.x, AM.y, AM.z), 8, channel = TELEPORT_CHANNEL_BLUESPACE)
 
@@ -72,5 +73,5 @@
 					sleep(20)
 					M.client.screen -= blueeffect
 					qdel(blueeffect)
-	var/turf/F = get_turf(src)
-	F.generate_fake_pierced_realities(FALSE, max_spawned_faked)
+
+	generate_fake_pierced_realities(max_amount = max_spawned_faked)

--- a/code/game/objects/effects/anomalies/anomaly_flux.dm
+++ b/code/game/objects/effects/anomalies/anomaly_flux.dm
@@ -3,8 +3,8 @@
 	icon_state = "flux"
 	density = TRUE
 	anomaly_core = /obj/item/assembly/signaler/anomaly/flux
-	var/canshock = FALSE
-	var/shockdamage = 20
+	var/can_shock = FALSE
+	var/shock_damage = 20
 	var/explosive = ANOMALY_FLUX_EXPLOSIVE
 
 CREATION_TEST_IGNORE_SUBTYPES(/obj/effect/anomaly/flux)
@@ -17,27 +17,27 @@ CREATION_TEST_IGNORE_SUBTYPES(/obj/effect/anomaly/flux)
 	)
 	AddElement(/datum/element/connect_loc, loc_connections)
 
-/obj/effect/anomaly/flux/anomalyEffect()
-	..()
-	canshock = TRUE
-	for(var/mob/living/M in get_turf(src))
-		mobShock(M)
-
-/obj/effect/anomaly/flux/proc/on_entered(datum/source, atom/movable/AM)
-	SIGNAL_HANDLER
-
-	mobShock(AM)
-
-/obj/effect/anomaly/flux/Bump(mob/living/M)
-	mobShock(M)
+/obj/effect/anomaly/flux/Bump(atom/bumped_atom)
+	shock_mob(bumped_atom)
 
 /obj/effect/anomaly/flux/Bumped(atom/movable/AM)
-	mobShock(AM)
+	shock_mob(AM)
 
-/obj/effect/anomaly/flux/proc/mobShock(mob/living/M)
-	if(canshock && istype(M))
-		canshock = FALSE
-		M.electrocute_act(shockdamage, name, flags = SHOCK_NOGLOVES)
+/obj/effect/anomaly/flux/anomaly_process()
+	. = ..()
+	can_shock = TRUE
+	for(var/mob/living/poor_soul in get_turf(src))
+		shock_mob(poor_soul)
+
+/obj/effect/anomaly/flux/proc/on_entered(datum/source, atom/movable/arrived, atom/old_loc, list/atom/old_locs)
+	SIGNAL_HANDLER
+	shock_mob(arrived)
+
+/obj/effect/anomaly/flux/proc/shock_mob(mob/living/mob_to_shock)
+	if(!can_shock || !istype(mob_to_shock))
+		return
+	can_shock = FALSE
+	mob_to_shock.electrocute_act(shock_damage, name, flags = SHOCK_NOGLOVES)
 
 /obj/effect/anomaly/flux/detonate()
 	switch(explosive)
@@ -47,5 +47,4 @@ CREATION_TEST_IGNORE_SUBTYPES(/obj/effect/anomaly/flux)
 			explosion(src, heavy_impact_range = 1, light_impact_range = 4, flash_range = 6)
 		if(ANOMALY_FLUX_NO_EXPLOSION)
 			new /obj/effect/particle_effect/sparks(loc)
-	var/turf/T = get_turf(src)
-	T.generate_fake_pierced_realities(max_spawned_faked)
+	generate_fake_pierced_realities(center_turf = get_turf(src), max_amount = max_spawned_faked)

--- a/code/game/objects/effects/anomalies/anomaly_gravity.dm
+++ b/code/game/objects/effects/anomalies/anomaly_gravity.dm
@@ -11,7 +11,7 @@
 	icon_state = "gravity"
 	density = FALSE
 	anomaly_core = /obj/item/assembly/signaler/anomaly/grav
-	var/boing = 0
+	var/boing = FALSE
 	///Warp effect holder for displacement filter to "pulse" the anomaly
 	var/atom/movable/warp_effect/warp
 
@@ -29,30 +29,46 @@ CREATION_TEST_IGNORE_SUBTYPES(/obj/effect/anomaly/grav)
 
 /obj/effect/anomaly/grav/Destroy()
 	vis_contents -= warp
-	qdel(warp)
-	warp = null
+	QDEL_NULL(warp)
 	return ..()
 
-/obj/effect/anomaly/grav/anomalyEffect(delta_time)
-	..()
-	boing = 1
-	for(var/obj/O in orange(4, src))
-		if(!O.anchored)
-			step_towards(O,src)
-	for(var/mob/living/M in get_turf(src))
-		gravShock(M)
-	for(var/mob/living/M in orange(4, get_turf(src)))
-		if(!M.mob_negates_gravity())
-			step_towards(M,src)
-	for(var/obj/O in get_turf(src))
-		if(!O.anchored)
-			if(isturf(O.loc))
-				var/turf/T = O.loc
-				if(T.underfloor_accessibility < UNDERFLOOR_INTERACTABLE && HAS_TRAIT(O, TRAIT_T_RAY_VISIBLE))
-					continue
-			var/mob/living/target = locate() in hearers(4,src)
-			if(target && !target.stat)
-				O.throw_at(target, 5, 10)
+/obj/effect/anomaly/grav/anomaly_process(delta_time)
+	. = ..()
+	boing = TRUE
+
+	var/list/mob/living/nearby_people
+	var/turf/our_turf = get_turf(src)
+	for(var/atom/thing_on_us as anything in our_turf)
+		if(isliving(thing_on_us))
+			grav_shock(thing_on_us)
+			continue
+
+		if(!isobj(thing_on_us))
+			continue
+		var/obj/obj_on_us = thing_on_us
+		if(obj_on_us.anchored)
+			continue
+
+		if(our_turf.underfloor_accessibility < UNDERFLOOR_INTERACTABLE && HAS_TRAIT(obj_on_us, TRAIT_T_RAY_VISIBLE))
+			continue
+
+		nearby_people ||= hearers(4, src)
+		var/mob/living/target = locate() in nearby_people
+		if(target?.stat == CONSCIOUS)
+			obj_on_us.throw_at(target, 5, 10)
+
+	for(var/atom/nearby_thing as anything in orange(4, src))
+		if(isobj(nearby_thing))
+			var/obj/nearby_obj = nearby_thing
+			if(nearby_obj.anchored)
+				continue
+		else if(isliving(nearby_thing))
+			var/mob/living/nearby_living = nearby_thing
+			if(nearby_living.mob_negates_gravity())
+				continue
+		else
+			continue
+		step_towards(nearby_thing, src)
 
 	//anomaly quickly contracts then slowly expands it's ring
 	animate(warp, time = delta_time*3, transform = matrix().Scale(0.5,0.5))
@@ -60,21 +76,21 @@ CREATION_TEST_IGNORE_SUBTYPES(/obj/effect/anomaly/grav)
 
 /obj/effect/anomaly/grav/proc/on_entered(datum/source, atom/movable/AM)
 	SIGNAL_HANDLER
-
-	gravShock(AM)
+	grav_shock(AM)
 
 /obj/effect/anomaly/grav/Bump(mob/A)
-	gravShock(A)
+	grav_shock(A)
 
 /obj/effect/anomaly/grav/Bumped(atom/movable/AM)
-	gravShock(AM)
+	grav_shock(AM)
 
-/obj/effect/anomaly/grav/proc/gravShock(mob/living/A)
-	if(boing && isliving(A) && !A.stat)
-		A.Paralyze(40)
-		var/atom/target = get_edge_target_turf(A, get_dir(src, get_step_away(A, src)))
-		A.throw_at(target, 5, 1)
-		boing = 0
+/obj/effect/anomaly/grav/proc/grav_shock(mob/living/mob_to_grav)
+	if(!boing || !istype(mob_to_grav) || mob_to_grav.stat != CONSCIOUS)
+		return
+	mob_to_grav.Paralyze(4 SECONDS)
+	var/atom/target = get_edge_target_turf(mob_to_grav, get_dir(src, get_step_away(mob_to_grav, src)))
+	mob_to_grav.throw_at(target, 5, 1)
+	boing = FALSE
 
 /obj/effect/anomaly/grav/high
 	var/datum/proximity_monitor/advanced/gravity/grav_field
@@ -90,4 +106,4 @@ CREATION_TEST_IGNORE_SUBTYPES(/obj/effect/anomaly/grav/high)
 
 /obj/effect/anomaly/grav/high/Destroy()
 	QDEL_NULL(grav_field)
-	. = ..()
+	return ..()

--- a/code/game/objects/effects/anomalies/anomaly_hallucination.dm
+++ b/code/game/objects/effects/anomalies/anomaly_hallucination.dm
@@ -14,21 +14,18 @@
 		span_warning("You are going insane!"),
 	)
 
-/obj/effect/anomaly/hallucination/anomalyEffect(delta_time)
+/obj/effect/anomaly/hallucination/anomaly_process(delta_time)
 	. = ..()
-
-	if(!COOLDOWN_FINISHED(src, pulse_cooldown))
+	var/turf/our_turf = get_turf(src)
+	if(!COOLDOWN_FINISHED(src, pulse_cooldown) || !istype(our_turf))
 		return
 	COOLDOWN_START(src, pulse_cooldown, pulse_interval)
 
-	if(!isturf(loc))
-		return
-
 	visible_hallucination_pulse(
-		center = get_turf(src),
+		center = our_turf,
 		radius = 5,
 		hallucination_duration = 50 SECONDS,
-		hallucination_max_duration = 300 SECONDS,
+		hallucination_max_duration = 5 MINUTES,
 		optional_messages = messages,
 	)
 
@@ -39,7 +36,7 @@
 		center = our_turf,
 		radius = 15,
 		hallucination_duration = 50 SECONDS,
-		hallucination_max_duration = 300 SECONDS,
+		hallucination_max_duration = 5 MINUTES,
 		optional_messages = messages,
 	)
-	our_turf.generate_fake_pierced_realities(max_spawned_faked)
+	generate_fake_pierced_realities(center_turf = our_turf, max_amount = max_spawned_faked)

--- a/code/game/objects/effects/anomalies/anomaly_insanitypulse.dm
+++ b/code/game/objects/effects/anomalies/anomaly_insanitypulse.dm
@@ -1,32 +1,27 @@
 /obj/effect/anomaly/insanity_pulse
 	name = "sanity disruption pulse anomaly"
 	icon_state = "insanity"
+	anomaly_core = /obj/item/assembly/signaler/anomaly/insanity
 
 	COOLDOWN_DECLARE(pulse_cooldown)
-	anomaly_core = /obj/item/assembly/signaler/anomaly/insanity
 	var/pulse_interval = 7 SECONDS
 
 	var/weak_pulse_power = 8
 	var/strong_pulse_power = 150
 
-/obj/effect/anomaly/insanity_pulse/anomalyEffect(delta_time)
+/obj/effect/anomaly/insanity_pulse/anomaly_process(delta_time)
 	. = ..()
-
-	if(!COOLDOWN_FINISHED(src, pulse_cooldown))
+	var/turf/our_turf = get_turf(src)
+	if(!COOLDOWN_FINISHED(src, pulse_cooldown) || !istype(our_turf))
 		return
 	COOLDOWN_START(src, pulse_cooldown, pulse_interval)
 
-	var/turf/open/our_turf = get_turf(src)
-	if(!isturf(our_turf))
-		return
 	sends_insanity_pulse(our_turf, weak_pulse_power)
 
 /obj/effect/anomaly/insanity_pulse/detonate()
 	var/turf/open/our_turf = get_turf(src)
-	if(!isturf(our_turf))
-		return
 	sends_insanity_pulse(our_turf, strong_pulse_power)
-	our_turf.generate_fake_pierced_realities(max_spawned_faked)
+	generate_fake_pierced_realities(center_turf = our_turf, max_amount = max_spawned_faked)
 
 /// Sends the insanity pulses from center upto the impact size.
 /// * atom/center: where the pulse starts from.
@@ -47,7 +42,7 @@
 			break
 		var/datum/enumerator/turf_enumerator = get_dereferencing_enumerator(edge_turfs)
 		SSenumeration.tickcheck(turf_enumerator.foreach(CALLBACK(GLOBAL_PROC, GLOBAL_PROC_REF(_insanity_pulse_on_turf))))
-		sleep(1)
+		sleep(0.1 SECONDS)
 
 /proc/_insanity_pulse_on_turf(turf/target_turf)
 	if((!isspaceturf(target_turf) && isopenturf(target_turf)) || isopenspace(target_turf)) // you don't see what's comming...

--- a/code/game/objects/effects/anomalies/anomaly_pyro.dm
+++ b/code/game/objects/effects/anomalies/anomaly_pyro.dm
@@ -6,29 +6,22 @@
 	COOLDOWN_DECLARE(pulse_cooldown)
 	var/pulse_interval = 10 SECONDS
 
-/obj/effect/anomaly/pyro/anomalyEffect(delta_time)
+/obj/effect/anomaly/pyro/anomaly_process(delta_time)
 	. = ..()
-
-	if(!COOLDOWN_FINISHED(src, pulse_cooldown))
+	var/turf/our_turf = get_turf(src)
+	if(!COOLDOWN_FINISHED(src, pulse_cooldown) || !istype(our_turf))
 		return
 	COOLDOWN_START(src, pulse_cooldown, pulse_interval)
 
-	var/turf/open/our_turf = get_turf(src)
-	if(!isturf(our_turf))
-		return
 	our_turf.atmos_spawn_air("o2=5;plasma=5;TEMP=1000")
 
 /obj/effect/anomaly/pyro/detonate()
-	INVOKE_ASYNC(src, PROC_REF(makepyroslime))
-
-/obj/effect/anomaly/pyro/proc/makepyroslime()
-	var/turf/open/T = get_turf(src)
-	if(istype(T))
-		T.atmos_spawn_air("o2=500;plasma=500;TEMP=1000") //Make it hot and burny for the new slime
-		log_game("A pyroclastic anomaly has detonated at [loc].")
-		message_admins("A pyroclastic anomaly has detonated at [ADMIN_VERBOSEJMP(loc)].")
+	var/turf/open/our_turf = get_turf(src)
+	our_turf.atmos_spawn_air("o2=500;plasma=500;TEMP=1000") //Make it hot and burny for the new slime
+	log_game("A pyroclastic anomaly has detonated at [AREACOORD(loc)].")
+	message_admins("A pyroclastic anomaly has detonated at [ADMIN_VERBOSEJMP(loc)].")
 	var/new_colour = pick(SLIME_TYPE_ORANGE, SLIME_TYPE_RED)
-	var/mob/living/simple_animal/slime/S = new(T, new_colour)
+	var/mob/living/simple_animal/slime/S = new(our_turf, new_colour)
 	S.rabid = TRUE
 	S.amount_grown = SLIME_EVOLUTION_THRESHOLD
 	S.Evolve()

--- a/code/game/objects/effects/anomalies/anomaly_vortex.dm
+++ b/code/game/objects/effects/anomalies/anomaly_vortex.dm
@@ -1,36 +1,41 @@
-/obj/effect/anomaly/bhole
+/obj/effect/anomaly/vortex
 	name = "vortex anomaly"
 	icon_state = "vortex"
 	desc = "That's a nice station you have there. It'd be a shame if something happened to it."
 	anomaly_core = /obj/item/assembly/signaler/anomaly/vortex
 
-/obj/effect/anomaly/bhole/anomalyEffect()
-	..()
+/obj/effect/anomaly/vortex/anomaly_process()
+	. = ..()
 	if(!isturf(loc)) //blackhole cannot be contained inside anything. Weird stuff might happen
+		detonate()
 		qdel(src)
 		return
 
 	grav(rand(0,3), rand(2,3), 50, 25)
 
 	//Throwing stuff around!
-	for(var/obj/O in orange(2,src))
-		if(O == src)
-			return
-		if(!O.anchored)
-			var/mob/living/target = locate() in hearers(4,src)
-			if(target && !target.stat)
-				O.throw_at(target, 7, 5)
-		else
-			SSexplosions.med_mov_atom += O
+	var/list/mob/living/nearby_people
+	for(var/obj/nearby_obj in orange(2,src))
+		if(nearby_obj.anchored)
+			SSexplosions.med_mov_atom += nearby_obj
+			continue
 
-/obj/effect/anomaly/bhole/proc/grav(r, ex_act_force, pull_chance, turf_removal_chance)
+		nearby_people ||= hearers(4, src)
+		var/mob/living/target = locate() in nearby_people
+		if(target?.stat == CONSCIOUS)
+			nearby_obj.throw_at(target, 7, 5)
+
+/obj/effect/anomaly/vortex/detonate()
+	generate_fake_pierced_realities(center_turf = get_turf(src), max_amount = max_spawned_faked)
+
+/obj/effect/anomaly/vortex/proc/grav(r, ex_act_force, pull_chance, turf_removal_chance)
 	for(var/t = -r, t < r, t++)
 		affect_coord(x+t, y-r, ex_act_force, pull_chance, turf_removal_chance)
 		affect_coord(x-t, y+r, ex_act_force, pull_chance, turf_removal_chance)
 		affect_coord(x+r, y+t, ex_act_force, pull_chance, turf_removal_chance)
 		affect_coord(x-r, y-t, ex_act_force, pull_chance, turf_removal_chance)
 
-/obj/effect/anomaly/bhole/proc/affect_coord(x, y, ex_act_force, pull_chance, turf_removal_chance)
+/obj/effect/anomaly/vortex/proc/affect_coord(x, y, ex_act_force, pull_chance, turf_removal_chance)
 	//Get turf at coordinate
 	var/turf/T = locate(x, y, z)
 	if(isnull(T))
@@ -53,7 +58,7 @@
 			step_towards(M,src)
 
 	//Damaging the turf
-	if( T && prob(turf_removal_chance) )
+	if(prob(turf_removal_chance))
 		switch(ex_act_force)
 			if(EXPLODE_DEVASTATE)
 				SSexplosions.highturf += T
@@ -61,7 +66,3 @@
 				SSexplosions.medturf += T
 			if(EXPLODE_LIGHT)
 				SSexplosions.lowturf += T
-
-/obj/effect/anomaly/bhole/detonate()
-	var/turf/T = get_turf(src)
-	T.generate_fake_pierced_realities(max_spawned_faked)

--- a/code/game/objects/effects/countdown.dm
+++ b/code/game/objects/effects/countdown.dm
@@ -139,12 +139,11 @@
 	name = "anomaly countdown"
 
 /obj/effect/countdown/anomaly/get_value()
-	var/obj/effect/anomaly/A = attached_to
-	if(!istype(A))
+	var/obj/effect/anomaly/anomaly = attached_to
+	if(!istype(anomaly))
 		return
-	else
-		var/time_left = max(0, (A.death_time - world.time) / 10)
-		return round(time_left)
+	var/time_left = max(0, (anomaly.death_time - world.time) / 10)
+	return round(time_left)
 
 /obj/effect/countdown/hourglass
 	name = "hourglass countdown"

--- a/code/game/objects/items/devices/anomaly_neutralizer.dm
+++ b/code/game/objects/items/devices/anomaly_neutralizer.dm
@@ -27,7 +27,7 @@
 	if(istype(target, /obj/effect/anomaly))
 		var/obj/effect/anomaly/A = target
 		to_chat(user, span_notice("The circuitry of [src] fries from the strain of neutralizing [A]!"))
-		A.anomalyNeutralize()
+		A.neutralize()
 		qdel(src)
 
 /*

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -597,33 +597,6 @@ CREATION_TEST_IGNORE_SELF(/turf)
 /turf/proc/take_temperature(temp)
 	temperature += temp
 
-/turf/proc/generate_fake_pierced_realities(centered = TRUE, max_amount = 2)
-	if(max_amount <= 0)
-		return
-	var/to_spawn = pick(1, max_amount)
-	var/spawned = 0
-	var/location_sanity = 0
-	while(spawned < to_spawn && location_sanity < 100)
-		var/precision = pick(5, 15 * max_amount)
-		var/turf/chosen_location = get_safe_random_station_turfs()
-		if(!chosen_location)
-			location_sanity++
-			continue
-		if(centered)
-			chosen_location = get_teleport_turf(src, precision) //Using the random teleportation logic here to find a destination turf
-		// We don't want them close to each other - at least 1 tile of seperation
-		var/list/nearby_things = range(1, chosen_location)
-		var/obj/effect/heretic_influence/what_if_i_have_one = locate() in nearby_things
-		var/obj/effect/visible_heretic_influence/what_if_i_had_one_but_its_used = locate() in nearby_things
-		if(what_if_i_have_one || what_if_i_had_one_but_its_used || isspaceturf(chosen_location))
-			location_sanity++
-			continue
-		addtimer(CALLBACK(src, PROC_REF(create_new_fake_reality), chosen_location), rand(0, 500))
-		spawned++
-
-/turf/proc/create_new_fake_reality(turf/F)
-	new /obj/effect/visible_heretic_influence(F)
-
 /// Checks if the turf was blessed with holy water OR the area its in is Chapel
 /turf/proc/is_holy()
 	if(locate(/obj/effect/blessing) in src)

--- a/code/modules/assembly/signaler.dm
+++ b/code/modules/assembly/signaler.dm
@@ -200,8 +200,9 @@
 		return FALSE
 	if(suicider)
 		manual_suicide(suicider)
-	for(var/obj/effect/anomaly/A in get_turf(src))
-		A.anomalyNeutralize()
+	if(istype(loc, /obj/effect/anomaly))
+		var/obj/effect/anomaly/linked_anomaly = loc
+		linked_anomaly.neutralize()
 	return TRUE
 
 /obj/item/assembly/signaler/anomaly/manual_suicide(mob/living/carbon/user)
@@ -248,7 +249,7 @@
 	name = "\improper vortex anomaly core"
 	desc = "The neutralized core of a vortex anomaly. It won't sit still, as if some invisible force is acting on it. It'd probably be valuable for research."
 	icon_state = "vortex_core"
-	anomaly_type = /obj/effect/anomaly/bhole
+	anomaly_type = /obj/effect/anomaly/vortex
 	custom_price = 15000
 
 /obj/item/assembly/signaler/anomaly/bioscrambler

--- a/code/modules/events/anomaly_vortex.dm
+++ b/code/modules/events/anomaly_vortex.dm
@@ -9,7 +9,7 @@
 /datum/round_event/anomaly/anomaly_vortex
 	startWhen = 10
 	announceWhen = 3
-	anomaly_path = /obj/effect/anomaly/bhole
+	anomaly_path = /obj/effect/anomaly/vortex
 
 /datum/round_event/anomaly/anomaly_vortex/announce(fake)
 	priority_announce("Localized high-intensity vortex anomaly detected on long range scanners. Expected location: [impact_area.name]", "Anomaly Alert", SSstation.announcer.get_rand_alert_sound())

--- a/code/modules/events/wormholes.dm
+++ b/code/modules/events/wormholes.dm
@@ -38,8 +38,7 @@ GLOBAL_LIST_EMPTY(all_wormholes) // So we can pick wormholes to teleport to
 /datum/round_event/wormholes/end()
 	QDEL_LIST(wormholes)
 	wormholes = null
-	var/turf/T = get_random_station_turf()
-	T.generate_fake_pierced_realities(FALSE, 6)
+	generate_fake_pierced_realities(max_amount = 6)
 
 /obj/effect/portal/wormhole
 	name = "wormhole"

--- a/code/modules/power/supermatter/supermatter_extra_effects.dm
+++ b/code/modules/power/supermatter/supermatter_extra_effects.dm
@@ -174,7 +174,7 @@
 		if(ANOMALY_HALLUCINATION)
 			new /obj/effect/anomaly/hallucination(local_turf, has_changed_lifespan ? rand(15 SECONDS, 25 SECONDS) : null, FALSE)
 		if(ANOMALY_VORTEX)
-			new /obj/effect/anomaly/bhole(local_turf, 2 SECONDS, FALSE)
+			new /obj/effect/anomaly/vortex(local_turf, 2 SECONDS, FALSE)
 		if(ANOMALY_BIOSCRAMBLER)
 			new /obj/effect/anomaly/bioscrambler(local_turf, null, FALSE)
 


### PR DESCRIPTION
## About The Pull Request

OKAY, so: earlier today I was lurking on the main server, getting runtime & harddel info like I frequently do, and suddenly this horrible lag starts. After opening the profiler I see this horribleness:

<img width="606" height="133" alt="image" src="https://github.com/user-attachments/assets/25396095-cbb0-43e2-9520-7b9990e94496" />

After investigating the main offending proc, `generate_fake_pierced_realities()`, I quickly see the issue.

```dm
var/to_spawn = pick(1, max_amount)
var/spawned = 0
var/location_sanity = 0
while(spawned < to_spawn && location_sanity < 100)
	var/precision = pick(5, 15 * max_amount)
	var/turf/chosen_location = get_safe_random_station_turfs()
	if(!chosen_location)
		location_sanity++
		continue
	if(centered)
		chosen_location = get_teleport_turf(src, precision) //Using the random teleportation logic here to find a destination turf
	// We don't want them close to each other - at least 1 tile of seperation
	var/list/nearby_things = range(1, chosen_location)
	var/obj/effect/heretic_influence/what_if_i_have_one = locate() in nearby_things
	var/obj/effect/visible_heretic_influence/what_if_i_had_one_but_its_used = locate() in nearby_things
	if(what_if_i_have_one || what_if_i_had_one_but_its_used || isspaceturf(chosen_location))
		location_sanity++
		continue
	addtimer(CALLBACK(src, PROC_REF(create_new_fake_reality), chosen_location), rand(0, 500))
	spawned++
```

Instead of like a normal person, calling `get_safe_random_station_turfs()` once and storing what it returns, it was called every time the while loop... looped. This paired with the `isspaceturf()` check below meant that if `generate_fake_pierced_realities()` was called on a space turf, we would call both `get_safe_random_station_turfs()` & `get_teleport_turf()`, two very expensive procs, 100 times from a single `generate_fake_pierced_realities()` call.

In other words, for every `generate_fake_pierced_realities()` call (on a space turf), we were spending ~0.9 seconds of CPU time doing nothing.

Ok, the actual fix was to only call `get_safe_random_station_turfs()` once per `generate_fake_pierced_realities()` call. I also made it so we don't even call it if we're centered around a turf because, y'know, we just don't use the returned list if that's the case.


## Testing Photographs and Procedure

<details>
<summary>Screenshots&Videos</summary>

### Before:

https://github.com/user-attachments/assets/97c5a419-12af-4c71-b61c-9250147eb981

### After:

https://github.com/user-attachments/assets/8d31ec04-7f0f-4deb-af97-86fed773cff4

</details>

## Changelog
:cl:
fix: Anomalies no longer slow the game down to a crawl when detonating in space.
code: Anomaly code has been cleaned up 
/:cl: