### PR TITLE
Prevent "accidentally" banning admins without "Applies to admins" checkbox

### DIFF
--- a/code/modules/admin/sql_ban_system.dm
+++ b/code/modules/admin/sql_ban_system.dm
@@ -279,6 +279,7 @@
 	data["duration"] = duration
 	data["can_supress"] = can_supress
 	data["applies_to_admins"] = applies_to_admins
+	data["target_is_admin"] = key ? is_admin(ckey(key)) : FALSE
 	data["reason"] = reason
 	data["force_cryo_after"] = force_cryo_after
 	data["ban_type"] = ban_type
@@ -386,6 +387,8 @@
 		error_state += "Use last connection was ticked, but neither IP nor CID was."
 	if(applies_to_admins && redact)
 		error_state += "Admin bans can not be suppressed."
+	if(player_key && !applies_to_admins && is_admin(ckey(player_key)))
+		error_state += "[player_key] is an admin. You must tick \"Applies to admins\" to ban them."
 	if(!duration)
 		error_state += "No duration was provided."
 	if(!reason)

--- a/tgui/packages/tgui/interfaces/BanningPanel.jsx
+++ b/tgui/packages/tgui/interfaces/BanningPanel.jsx
@@ -9,6 +9,7 @@ import {
   Flex,
   Input,
   LabeledList,
+  NoticeBox,
   NumberInput,
   Section,
   Stack,
@@ -29,6 +30,7 @@ export const BanningPanel = (props) => {
     cid_enabled,
     cid,
     applies_to_admins,
+    target_is_admin,
     can_supress,
     suppressed,
     duration_type,
@@ -47,6 +49,7 @@ export const BanningPanel = (props) => {
   const hasValidIp = ip_enabled && ip && ip.trim() !== '';
   const hasValidCid = cid_enabled && cid && cid.trim() !== '';
   const canSubmit = hasValidKey || hasValidIp || hasValidCid;
+  const blockedAdminBan = !!target_is_admin && !applies_to_admins;
 
   return (
     <Window
@@ -57,6 +60,12 @@ export const BanningPanel = (props) => {
       resizable
     >
       <Window.Content>
+        {blockedAdminBan && (
+          <NoticeBox danger style={{ whiteSpace: 'normal' }}>
+            This CKEY belongs to an ADMIN. You may not ban another admin unless
+            you tick &quot;Applies to admins&quot;.
+          </NoticeBox>
+        )}
         <Section title="Player Information">
           <Stack>
             <Flex direction="column">
@@ -246,8 +255,14 @@ export const BanningPanel = (props) => {
           content="Submit"
           onClick={() => act('submit_ban')}
           // Disabled if no key OR no IP OR no CID. Look at the checkbox too so some wiseguy doesn't fuck it up by inputting then unchecking either
-          disabled={!canSubmit}
-          tooltip={!canSubmit ? 'CKEY/IP/CID is required' : null}
+          disabled={!canSubmit || blockedAdminBan}
+          tooltip={
+            blockedAdminBan
+              ? 'Tick "Applies to admins" to ban an admin'
+              : !canSubmit
+                ? 'CKEY/IP/CID is required'
+                : null
+          }
           m={0.5}
           width={7}
           height={2}


### PR DESCRIPTION
## About The Pull Request

Adds a CKEY based interface safeguard to the banning panel that prevents an admin from being banned
unless "Applies to admins" is checked.

## Why It's Good For The Game
~~Moderators won't ban me again~~
QOL change I guess.


## Testing Photographs and Procedure


https://github.com/user-attachments/assets/dfbf9204-6e81-405f-b0ce-b80f42da09a2



## Changelog
:cl:
admin: The banning panel now blocks banning other admin unless "Applies to admins" is ticked.
/:cl: