### PR TITLE
Adds stasis bed ripples & fixes oxygen candle capitalization

### DIFF
--- a/code/datums/status_effects/debuffs/debuffs.dm
+++ b/code/datums/status_effects/debuffs/debuffs.dm
@@ -202,12 +202,17 @@
 	if(!.)
 		return
 	owner.add_traits(list(TRAIT_IMMOBILIZED, TRAIT_HANDS_BLOCKED), TRAIT_STATUS_EFFECT(id))
+	owner.add_filter("stasis_status_ripple", 2, list("type" = "ripple", "flags" = WAVE_BOUNDED, "radius" = 0, "size" = 2))
+	var/filter = owner.get_filter("stasis_status_ripple")
+	animate(filter, radius = 0, time = 0.2 SECONDS, size = 2, easing = JUMP_EASING, loop = -1, flags = ANIMATION_PARALLEL)
+	animate(radius = 32, time = 1.5 SECONDS, size = 0)
 
 /datum/status_effect/grouped/stasis/tick(seconds_between_ticks)
 	update_time_of_death()
 
 /datum/status_effect/grouped/stasis/on_remove()
 	owner.remove_traits(list(TRAIT_IMMOBILIZED, TRAIT_HANDS_BLOCKED), TRAIT_STATUS_EFFECT(id))
+	owner.remove_filter("stasis_status_ripple")
 	update_time_of_death()
 	owner.update_incapacitated()
 	SEND_SIGNAL(owner, COMSIG_LIVING_EXIT_STASIS)

--- a/code/game/objects/items/devices/oxycandle.dm
+++ b/code/game/objects/items/devices/oxycandle.dm
@@ -1,5 +1,5 @@
 /obj/item/flashlight/oxycandle
-	name = "Oxygen Candle"
+	name = "oxygen candle"
 	desc = "A standard Nakamura Engineering branded emergency oxygen candle. There are instructions on the side that read: 'Remove lid with provided key, strike key on striker surface, insert lit key into designated marked receptacle, wait 5 minutes or until the candle cools'."
 	w_class = WEIGHT_CLASS_MEDIUM
 	slot_flags = null


### PR DESCRIPTION
## About The Pull Request

Adds a ripple effect for people in stasis and removes the improper capitalization from oxygen candles.

Attributions:

- https://github.com/tgstation/tgstation/pull/54609
- https://github.com/tgstation/tgstation/pull/67403

## Why It's Good For The Game

More flavor

## Testing Photographs and Procedure

https://github.com/user-attachments/assets/026d0036-4fee-4cf5-a6c3-ed88da71e906

## Changelog
:cl: mrmanlikesbt, Timberpoes, GoldenAlpharex
add: Added a ripple effect to people in stasis 
spellcheck: Removed improper capitalization for oxygen candles
/:cl: