### PR TITLE
Bans `instance:variable` syntax

### DIFF
--- a/code/__DEFINES/ref.dm
+++ b/code/__DEFINES/ref.dm
@@ -1,16 +1,16 @@
 /// INTERNAL USE ONLY - byond doesn't like undef block defines on older versions
-#define CACHED_REF(datum) (datum:cached_ref ||= "\ref[datum]")
+#define CACHED_REF(datum) (datum.cached_ref ||= text_ref(datum))
 
 /// Takes a datum as input, returns its ref string, or a cached version of it
 /// This allows us to cache \ref creation, which ensures it'll only ever happen once per datum, saving string tree time
 /// It is slightly less optimal then a []'d datum, but the cost is massively outweighed by the potential savings
 /// It will only work for datums mind, for datum reasons
 /// : because of the embedded typecheck
-#define FAST_REF(datum) (isdatum(datum) ? CACHED_REF(datum) : "\ref[datum]")
+#define FAST_REF(datum) (isdatum(datum) ? CACHED_REF(datum) : text_ref(datum))
 
 /// FAST_REF but with 512 tag support
 /// Retrieves the \ref string (aka [0xd3adb33f]) of a given datum, or its tag if DF_USE_TAG is set
-/// Broken REF define if you ever want it: #define REF(datum) (isdatum(datum) ? ((datum:datum_flags & DF_USE_TAG) && datum:tag ? "[datum:tag]" : CACHED_REF(datum)) : "\ref[datum]")
+/// Broken REF define if you ever want it: #define REF(datum) (isdatum(datum) ? ((datum.datum_flags & DF_USE_TAG) && datum.tag ? "[datum.tag]" : CACHED_REF(datum)) : text_ref(datum))
 /proc/REF(input)
 	if(istype(input, /datum))
 		var/datum/thing = input
@@ -22,4 +22,4 @@
 			else
 				return "\[[url_encode(thing.tag)]\]"
 		return CACHED_REF(thing)
-	return "\ref[input]"
+	return text_ref(input)

--- a/code/__HELPERS/icons.dm
+++ b/code/__HELPERS/icons.dm
@@ -924,7 +924,7 @@ GLOBAL_LIST_EMPTY(friendly_animal_types)
 	if(isicon(icon) && isfile(icon))
 		//icons compiled in from 'icons/path/to/dmi_file.dmi' at compile time are weird and arent really /icon objects,
 		///but they pass both isicon() and isfile() checks. theyre the easiest case since stringifying them gives us the path we want
-		var/icon_ref = FAST_REF(icon)
+		var/icon_ref = text_ref(icon)
 		var/locate_icon_string = "[locate(icon_ref)]"
 
 		icon_path = locate_icon_string
@@ -935,7 +935,7 @@ GLOBAL_LIST_EMPTY(friendly_animal_types)
 		// the rsc reference returned by fcopy_rsc() will be stringifiable to "icons/path/to/dmi_file.dmi"
 		var/rsc_ref = fcopy_rsc(icon)
 
-		var/icon_ref = FAST_REF(rsc_ref)
+		var/icon_ref = text_ref(rsc_ref)
 
 		var/icon_path_string = "[locate(icon_ref)]"
 
@@ -945,7 +945,7 @@ GLOBAL_LIST_EMPTY(friendly_animal_types)
 		var/rsc_ref = fcopy_rsc(icon)
 		//if its the text path of an existing dmi file, the rsc reference returned by fcopy_rsc() will be stringifiable to a dmi path
 
-		var/rsc_ref_ref = FAST_REF(rsc_ref)
+		var/rsc_ref_ref = text_ref(rsc_ref)
 		var/rsc_ref_string = "[locate(rsc_ref_ref)]"
 
 		icon_path = rsc_ref_string

--- a/code/game/objects/structures/crates_lockers/wall_closets.dm
+++ b/code/game/objects/structures/crates_lockers/wall_closets.dm
@@ -52,7 +52,7 @@
 			for(var/image in current_item.overlays)
 				var/image/current_overlay = image
 				if(current_overlay.plane != LIGHTING_PLANE && current_overlay.plane != EMISSIVE_PLANE || current_item.greyscale_colors || current_item.greyscale_config || current_item.color) //i HATE this "list of shit that breaks" but i have no idea how to solve this any other way
-					list_item["image"] = FAST_REF(current_item.appearance)
+					list_item["image"] = text_ref(current_item.appearance)
 					usr << output(current_item, "push_appearance_placeholder_id")
 					break
 			if(!list_item["image"])

--- a/tools/ci/od_lints.dm
+++ b/tools/ci/od_lints.dm
@@ -56,3 +56,4 @@
 #pragma AssignmentInConditional error
 #pragma PickWeightedSyntax disabled
 #pragma AmbiguousInOrder error
+#pragma RuntimeSearchOperator error


### PR DESCRIPTION
## About The Pull Request

Copy&Pasting bacon's words:

> a:b syntax can massively increase compile times, I had ~5-6 calls inside of a define that was called ~400 times, which increased compilation times by 2 minutes. With some very, very rough maths that means each a:b call is something like 50ms of compile time, which when inside a define that is used a lot can really increase the compilation times.

closes #11864

## Testing Photographs and Procedure



## Changelog
:cl:
code: The instance:variable syntax has been banned
/:cl: