### PR TITLE
Minor Map Changes - Stools, Cameras, PAI Cards

### DIFF
--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -12868,6 +12868,10 @@
 /obj/structure/desk_bell/wired/medical{
 	pixel_x = -7
 	},
+/obj/item/pai_card{
+	pixel_x = 7;
+	pixel_y = 1
+	},
 /turf/open/floor/iron,
 /area/station/medical/medbay/lobby)
 "fzX" = (
@@ -26801,6 +26805,7 @@
 /area/station/engineering/gravity_generator)
 "lmR" = (
 /obj/structure/table/wood,
+/obj/item/pai_card,
 /turf/open/floor/carpet/green,
 /area/station/commons/dorms)
 "lng" = (
@@ -41329,11 +41334,9 @@
 /turf/open/floor/noslip/white,
 /area/station/commons/toilet/locker)
 "rjn" = (
-/obj/structure/chair/stool/directional/south{
-	dir = 1
-	},
-/obj/effect/landmark/start/janitor,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/stool/directional/north,
+/obj/effect/landmark/start/janitor,
 /turf/open/floor/iron/half{
 	dir = 1
 	},

--- a/_maps/map_files/CardinalStation/CardinalStation.dmm
+++ b/_maps/map_files/CardinalStation/CardinalStation.dmm
@@ -17706,9 +17706,7 @@
 /turf/open/floor/mineral/plastitanium,
 /area/station/maintenance/club)
 "ekV" = (
-/obj/structure/chair/stool/directional/south{
-	dir = 1
-	},
+/obj/structure/chair/stool/directional/north,
 /obj/effect/landmark/event_spawn,
 /obj/effect/landmark/start/assistant,
 /turf/open/floor/carpet,
@@ -40903,9 +40901,7 @@
 /turf/open/floor/wood/big,
 /area/station/service/hydroponics)
 "jCY" = (
-/obj/structure/chair/stool/directional/west{
-	dir = 4
-	},
+/obj/structure/chair/stool/directional/east,
 /obj/machinery/power/terminal{
 	dir = 8
 	},
@@ -55466,6 +55462,7 @@
 /area/station/command/heads_quarters/cmo)
 "mWS" = (
 /obj/effect/turf_decal/tile/yellow/half/contrasted,
+/obj/structure/chair/stool/directional/south,
 /turf/open/floor/iron/smooth,
 /area/station/maintenance/solars/port/fore)
 "mWT" = (
@@ -69164,8 +69161,8 @@
 /area/station/maintenance/department/crew_quarters/bar)
 "qmG" = (
 /obj/structure/table/wood,
-/obj/item/plate{
-	pixel_y = 3
+/obj/item/pai_card{
+	pixel_x = -5
 	},
 /turf/open/floor/wood/big,
 /area/station/service/kitchen)
@@ -70396,9 +70393,7 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/cargo)
 "qzT" = (
-/obj/structure/chair/stool/directional/south{
-	dir = 1
-	},
+/obj/structure/chair/stool/directional/north,
 /obj/effect/landmark/start/assistant,
 /turf/open/floor/carpet,
 /area/station/commons/dorms)
@@ -72621,6 +72616,7 @@
 /obj/effect/turf_decal/siding/yellow{
 	dir = 6
 	},
+/obj/item/pai_card,
 /turf/open/floor/carpet/black,
 /area/station/commons/vacant_room/office)
 "rbb" = (
@@ -91468,9 +91464,6 @@
 /turf/open/floor/iron/dark,
 /area/station/hallway/secondary/service)
 "vyu" = (
-/obj/structure/chair/stool/directional/north{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/structure/cable,
 /obj/structure/cable/yellow,

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -12318,7 +12318,7 @@
 /area/station/science/storage)
 "eyA" = (
 /obj/structure/cable/yellow,
-/obj/structure/chair/stool/directional/west,
+/obj/structure/chair/stool/directional/east,
 /obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
 /turf/open/floor/iron,
 /area/station/commons/locker)
@@ -13189,7 +13189,7 @@
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/aft)
 "eMA" = (
-/obj/structure/chair/stool/directional/west,
+/obj/structure/chair/stool/directional/east,
 /obj/effect/turf_decal/tile/red/opposingcorners,
 /obj/effect/turf_decal/tile/yellow/opposingcorners{
 	dir = 1
@@ -26659,6 +26659,11 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/science/misc_lab/range)
+"iLC" = (
+/obj/structure/chair/stool/directional/east,
+/obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
+/turf/open/floor/iron,
+/area/station/commons/fitness/recreation)
 "iLX" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -26907,9 +26912,7 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/command)
 "iPU" = (
-/obj/structure/chair/stool/directional/west{
-	dir = 4
-	},
+/obj/structure/chair/stool/directional/east,
 /obj/item/radio/intercom{
 	desc = "Talk through this. It looks like it has been modified to not broadcast.";
 	name = "Prison Intercom (General)";
@@ -36361,7 +36364,7 @@
 /turf/open/floor/iron,
 /area/station/maintenance/starboard/aft)
 "lzh" = (
-/obj/structure/chair/stool/directional/south,
+/obj/structure/chair/stool/directional/north,
 /obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
 /turf/open/floor/iron,
 /area/station/commons/locker)
@@ -66667,7 +66670,7 @@
 /area/station/commons/storage/primary)
 "uHv" = (
 /obj/effect/landmark/start/assistant,
-/obj/structure/chair/stool/directional/west,
+/obj/structure/chair/stool/directional/east,
 /obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
 /turf/open/floor/iron,
 /area/station/commons/locker)
@@ -132268,12 +132271,12 @@ vEX
 vEX
 vEX
 thi
-qSP
-qSP
+iLC
+iLC
 icU
 eFG
-qSP
-qSP
+iLC
+iLC
 pLA
 elG
 pgb

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -790,7 +790,7 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
 "ary" = (
-/obj/structure/chair/stool/directional/south,
+/obj/structure/chair/stool/directional/north,
 /turf/open/floor/iron/cafeteria{
 	dir = 5
 	},
@@ -7758,7 +7758,7 @@
 /obj/machinery/airalarm/directional/south{
 	pixel_y = -22
 	},
-/obj/structure/chair/stool/directional/west,
+/obj/structure/chair/stool/directional/east,
 /obj/effect/landmark/start/exploration,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -22395,13 +22395,8 @@
 	dir = 6
 	},
 /obj/structure/table,
-/obj/item/paper_bin{
-	pixel_x = -3;
-	pixel_y = 7
-	},
-/obj/item/pen{
-	pixel_x = -3
-	},
+/obj/item/paper_bin,
+/obj/item/pen,
 /turf/open/floor/prison,
 /area/station/security/prison)
 "ilZ" = (
@@ -30446,7 +30441,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 8
 	},
-/obj/structure/chair/stool/directional/west,
+/obj/structure/chair/stool/directional/east,
 /turf/open/floor/iron,
 /area/station/command/gateway)
 "kSa" = (
@@ -49954,7 +49949,7 @@
 /obj/machinery/newscaster{
 	pixel_x = -30
 	},
-/obj/structure/chair/stool/directional/south,
+/obj/structure/chair/stool/directional/north,
 /turf/open/floor/iron/cafeteria{
 	dir = 5
 	},
@@ -62312,7 +62307,7 @@
 /turf/open/floor/wood,
 /area/station/service/hydroponics/garden)
 "vyG" = (
-/obj/structure/chair/stool/directional/west,
+/obj/structure/chair/stool/directional/east,
 /obj/effect/landmark/start/scientist,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8

--- a/_maps/map_files/RadStation/RadStation.dmm
+++ b/_maps/map_files/RadStation/RadStation.dmm
@@ -11521,6 +11521,7 @@
 	pixel_y = 5
 	},
 /obj/item/soap/nanotrasen,
+/obj/effect/spawner/random/decoration/glowstick/lit,
 /turf/open/floor/wood,
 /area/station/maintenance/central)
 "eqc" = (
@@ -25525,11 +25526,9 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/machinery/camera/directional/north{
-	c_tag = "Teleporter Room"
-	},
 /obj/structure/table/wood,
 /obj/machinery/computer/libraryconsole/bookmanagement,
+/obj/machinery/camera/directional/north,
 /turf/open/floor/carpet/royalblack,
 /area/station/service/library)
 "jOx" = (
@@ -45664,9 +45663,7 @@
 /obj/machinery/light{
 	light_color = "#7AC3FF"
 	},
-/obj/machinery/camera/directional/south{
-	c_tag = "Captain's Quarters"
-	},
+/obj/machinery/camera/directional/south,
 /turf/open/floor/carpet/royalblack,
 /area/station/service/library)
 "rfH" = (
@@ -46522,7 +46519,7 @@
 	pixel_x = 9;
 	pixel_y = 6
 	},
-/obj/effect/spawner/random/decoration/glowstick/lit,
+/obj/item/gun/ballistic/revolver/russian,
 /turf/open/floor/wood,
 /area/station/maintenance/central)
 "rzU" = (
@@ -54576,6 +54573,7 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
 	},
+/obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/wood,
 /area/station/maintenance/central)
 "uAL" = (

--- a/_maps/map_files/RadStation/RadStation.dmm
+++ b/_maps/map_files/RadStation/RadStation.dmm
@@ -12123,9 +12123,7 @@
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
 	dir = 8
 	},
-/obj/machinery/camera/directional/south{
-	c_tag = "Captain's Quarters"
-	},
+/obj/machinery/camera/directional/south,
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "eAI" = (
@@ -23343,9 +23341,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/machinery/camera/directional/north{
-	c_tag = "Teleporter Room"
-	},
+/obj/machinery/camera/directional/north,
 /turf/open/floor/iron/white,
 /area/station/service/kitchen)
 "jaN" = (
@@ -24632,9 +24628,6 @@
 /turf/open/floor/wood,
 /area/station/commons/dorms)
 "jxx" = (
-/obj/machinery/camera/directional/north{
-	c_tag = "Teleporter Room"
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -24653,6 +24646,7 @@
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
 	dir = 4
 	},
+/obj/machinery/camera/directional/north,
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "jxD" = (
@@ -29478,9 +29472,7 @@
 /area/station/science/robotics)
 "lkZ" = (
 /obj/structure/chair,
-/obj/machinery/camera/directional/north{
-	c_tag = "Teleporter Room"
-	},
+/obj/machinery/camera/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/hallway/secondary/exit/departure_lounge)
 "lla" = (
@@ -43488,7 +43480,7 @@
 "qum" = (
 /obj/machinery/button/door{
 	id = "commissarydoor1";
-	name = "Cabin 2 Privacy Lock";
+	name = "Vacant Commissary Door Control";
 	normaldoorcontrol = 1;
 	pixel_y = -31;
 	specialfunctions = 4


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Mostly minor details, like usual.
- I feel like every time I log in there are 10 more backward stools. This time I believe I searched and eradicated them all on the major maps.
- A few cameras on radstation had the wrong tag, so there were several "Teleporter Room" cameras located in the library, kitchen, and departures,  as well as a Captain's Quarters camera in a hallway. They should show under the area name now :)
- I added a couple of pAI cards on Box and Card. Makes the pAI role a bit more visible and easier to ping users for activation (since they're more likely to walk past a card now).
- Fixed a wrongly named door lock in rad's vacant commissary
- Added a russian revolver to radstation because I think it's neat
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Stools being right way is good. pAI cards being more visible are nice. Cameras being named correctly is pretty sweet. Russian Revolver is funny.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

<img width="831" height="691" alt="image" src="https://github.com/user-attachments/assets/0c144e61-a5a1-44e9-a9d0-cb79c7dda9f6" />
<img width="708" height="187" alt="image" src="https://github.com/user-attachments/assets/bffddcf0-e62b-408f-8854-35a27d1015e3" />

</details>

## Changelog
:cl:
fix: Fixed some more stools being in the wrong directions on various maps.
fix: Fixed a few cameras and a door control being incorrectly named on Radstation.
add: Added some additional pAI cards on Box and Cardinal.
add: Added a Russian Revolver to Radstation.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
