### PR TITLE
Adjusts keyloop to only call try_face when an actual direction is inputted. Additionally, fixes pipes.

### DIFF
--- a/code/game/objects/effects/particles/smoke.dm
+++ b/code/game/objects/effects/particles/smoke.dm
@@ -61,3 +61,6 @@
 	scale = 0.75
 	spawning = 1
 	friction = 0.75
+
+/particles/smoke/cig/pipe
+	position = list(-6, 4, 0)

--- a/code/game/objects/items/cigs_lighters.dm
+++ b/code/game/objects/items/cigs_lighters.dm
@@ -540,7 +540,7 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 
 /obj/item/cigarette/proc/make_cig_smoke()
 	cig_smoke = new(src, /particles/smoke/cig)
-	cig_smoke.particles?.scale *= 1.5
+	cig_smoke.particles.scale *= 1.5
 	return cig_smoke
 
 // Cigarette brands.
@@ -825,7 +825,7 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 
 /obj/item/cigarette/pipe/make_cig_smoke()
 	cig_smoke = new(src, /particles/smoke/cig/pipe)
-	cig_smoke.particles?.scale *= 1.5
+	cig_smoke.particles.scale *= 1.5
 	return cig_smoke
 
 /obj/item/cigarette/pipe/cobpipe

--- a/code/game/objects/items/cigs_lighters.dm
+++ b/code/game/objects/items/cigs_lighters.dm
@@ -823,11 +823,16 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 		return
 	return ..()
 
+/obj/item/cigarette/pipe/make_cig_smoke()
+	cig_smoke = new(src, /particles/smoke/cig/pipe)
+	cig_smoke.particles?.scale *= 1.5
+	return cig_smoke
+
 /obj/item/cigarette/pipe/cobpipe
 	name = "corn cob pipe"
 	desc = "A nicotine delivery system popularized by folksy backwoodsmen and kept popular in the modern age and beyond by space hipsters. Can be loaded with objects."
 	icon_state = "cobpipeoff"
-	icon_on = "cobpipeff"  //Note - these are in masks.dmi
+	icon_on = "cobpipeoff"  //Note - these are in masks.dmi
 	icon_off = "cobpipeoff"
 	inhand_icon_on = null
 	inhand_icon_off = null

--- a/code/modules/keybindings/bindings_atom.dm
+++ b/code/modules/keybindings/bindings_atom.dm
@@ -19,7 +19,7 @@
 		movement_dir = turn(movement_dir, -dir2angle(user.dir)) //By doing this we ensure that our input direction is offset by the client (camera) direction
 
 	//turn without moving while using the movement lock key, unless something wants to ignore it and move anyway
-	if(user?.movement_locked && !(SEND_SIGNAL(src, COMSIG_MOVABLE_KEYBIND_FACE_DIR, movement_dir) & COMSIG_IGNORE_MOVEMENT_LOCK))
+	if(movement_dir != NONE && user?.movement_locked && !(SEND_SIGNAL(src, COMSIG_MOVABLE_KEYBIND_FACE_DIR, movement_dir) & COMSIG_IGNORE_MOVEMENT_LOCK))
 		try_face(movement_dir)
 	else
 		user.Move(get_step(src, movement_dir), movement_dir)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

The biggest change here is adding a check before try_face in the keyloop to only actually call try_face if a movement key AND the movement lock key are pressed. This prevents try_face calling setDir with a NONE value, which messed up cigarette smoke effect offsets.

## Why It's Good For The Game

Bug fix good. It makes more sense (at least to me) to only attempt to change direction when you are actually going to change direction.

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

https://github.com/user-attachments/assets/6a5469d3-53ed-4fe1-8816-7465bc51c7e8

</details>

## Changelog
:cl:
fix: Prevented try_face from being called when it shouldn't be.
fix: Fixed a missing cob pipe sprite and adjusted the smoke particle offsets for the items.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
