### PR TITLE
Stat panel tank timer

### DIFF
--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -94,8 +94,15 @@
 		tab_data["Tank Pressure"] = GENERATE_STAT_TEXT("[return_pressure]")
 		tab_data["Distribution Pressure"] = GENERATE_STAT_TEXT("[target_tank.distribute_pressure]")
 		var/moles_per_breath = (clamp(return_pressure, 0, target_tank.distribute_pressure)* BREATH_VOLUME/(R_IDEAL_GAS_EQUATION*target_tank.air_contents.temperature)) //worrying amount of math for the status tab
-		var/breaths_left = target_tank_air.total_moles() / QUANTIZE(moles_per_breath)
-		tab_data["Approximate tank time remaining"] = GENERATE_STAT_TEXT("[round(breaths_left * 2)]s") //As of time of writing, mob subsystem *should* fire every 2 seconds, but in testing it was more like every 5, but I can not find a solid variable as for WHY
+		var/breaths_left = 0
+		if(moles_per_breath > 0)
+			breaths_left = target_tank_air.total_moles() / QUANTIZE(moles_per_breath)
+		tab_data["Approximate tank time remaining"] = GENERATE_STAT_TEXT("[round(breaths_left * 2*4)]s")
+		/* As of time of writing, mob subsystem *should* fire every 2 seconds, and every breath *should* be every 4 ticks,
+		but it is depending on lung damage and heart damage
+		While we could add checks to account for that, this is essentially just a digital readout from an oxygen tank, so it shouldn't be
+		used to also gauge your internal organ condition
+		*/
 	if(istype(wear_suit, /obj/item/clothing/suit/space))
 		var/obj/item/clothing/suit/space/S = wear_suit
 		tab_data["Thermal Regulator"] = GENERATE_STAT_TEXT("[S.thermal_on ? "on" : "off"]")

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -89,9 +89,13 @@
 	var/obj/item/tank/target_tank = internal || external
 	if(target_tank)
 		var/datum/gas_mixture/target_tank_air = target_tank.return_air()
+		var/return_pressure = target_tank_air.return_pressure()
 		tab_data["Internal Atmosphere Info"] = GENERATE_STAT_TEXT("[target_tank.name]")
-		tab_data["Tank Pressure"] = GENERATE_STAT_TEXT("[target_tank_air.return_pressure()]")
+		tab_data["Tank Pressure"] = GENERATE_STAT_TEXT("[return_pressure]")
 		tab_data["Distribution Pressure"] = GENERATE_STAT_TEXT("[target_tank.distribute_pressure]")
+		var/moles_per_breath = (clamp(return_pressure, 0, target_tank.distribute_pressure)* BREATH_VOLUME/(R_IDEAL_GAS_EQUATION*target_tank.air_contents.temperature)) //worrying amount of math for the status tab
+		var/breaths_left = target_tank_air.total_moles() / QUANTIZE(moles_per_breath)
+		tab_data["Approximate tank time remaining"] = GENERATE_STAT_TEXT("[round(breaths_left * 2)]s") //As of time of writing, mob subsystem *should* fire every 2 seconds, but in testing it was more like every 5, but I can not find a solid variable as for WHY
 	if(istype(wear_suit, /obj/item/clothing/suit/space))
 		var/obj/item/clothing/suit/space/S = wear_suit
 		tab_data["Thermal Regulator"] = GENERATE_STAT_TEXT("[S.thermal_on ? "on" : "off"]")


### PR DESCRIPTION
## About The Pull Request

Adds a timer to the stat panel for you to be able to judge how long you have left with your oxygen tank.

## Why It's Good For The Game

This may seem like an 'im ded' change, as I've been caught lacking a few times with my oxygen tanks, and figured while you could try to infer how long is left on your tank, having a timer makes it that much easier.

## Testing Photographs and Procedure
<details>
<summary>Screenshots&Videos</summary>

Test one: Timer works
<img width="414" height="99" alt="image" src="https://github.com/user-attachments/assets/8454473b-2419-4ec4-9500-2e555bee8ad3" />

Test two: Adjusting output pressure changes the timer appropriately
<img width="356" height="102" alt="image" src="https://github.com/user-attachments/assets/01975254-0c8f-4dc3-94e3-a8533431eb6a" />
<img width="336" height="109" alt="image" src="https://github.com/user-attachments/assets/c520455a-04b7-4de1-9f8c-ac93139b6d4b" />

Test three: Extremes. 0 air, unlimited air
<img width="308" height="106" alt="image" src="https://github.com/user-attachments/assets/3e84be96-0196-4092-8cb3-6e57d68ad8d2" />
<img width="384" height="98" alt="image" src="https://github.com/user-attachments/assets/e44cd0a4-6e1b-4ab8-b7bc-030779c3f95b" />

</details>

## Changelog
:cl:
add: Adds a timer to the stat page to tell you approximately how long you have left on your breathing apparatus
/:cl:
