### PR TITLE
The Bureaucratic Error event can no longer remove job openings

### DIFF
--- a/code/modules/events/bureaucratic_error.dm
+++ b/code/modules/events/bureaucratic_error.dm
@@ -24,5 +24,4 @@
 		for(var/datum/job/current as anything in jobs)
 			if(!current.allow_bureaucratic_error)
 				continue
-			var/ran = rand(-2,4)
-			current.total_positions = max(current.total_positions + ran, 0)
+			current.total_positions += rand(0, 4)

--- a/code/modules/events/bureaucratic_error.dm
+++ b/code/modules/events/bureaucratic_error.dm
@@ -24,4 +24,4 @@
 		for(var/datum/job/current as anything in jobs)
 			if(!current.allow_bureaucratic_error)
 				continue
-			current.total_positions += rand(0, 4)
+			current.total_positions += rand(0, 3)


### PR DESCRIPTION
## About The Pull Request

See title

## Why It's Good For The Game

This happens frequently enough that people think it is a bug. We should not remove job openings as part of a random event- disallowing people from playing the roles they want is not a good idea. I cannot think of a situation where it would be any more interesting to remove job openings than it would be to just add them. 

## Testing Photographs and Procedure

It's a two line PR

## Changelog
:cl:
tweak: The Bureaucratic Error event can no longer remove job openings
/:cl: