### PR TITLE
Fixes `get_announcement_system()` bug & null brain organ trait

### DIFF
--- a/code/game/machinery/announcement_system.dm
+++ b/code/game/machinery/announcement_system.dm
@@ -217,13 +217,19 @@
 	if (!length(announcement_systems))
 		return null
 	var/list/intact_aass = list()
+	var/turf/source_turf = get_turf(source)
 	for(var/obj/machinery/announcement_system/announce as anything in announcement_systems)
-		if(announce.is_operational && announce.has_supported_channels(channels) && is_valid_z_level(get_turf(announce), get_turf(source)))
-			if(aas_config_entry_type)
-				var/datum/aas_config_entry/entry = locate(aas_config_entry_type) in announce.config_entries
-				if(!entry || !entry.enabled)
-					continue
-			intact_aass += announce
+		if(source_turf && !is_valid_z_level(get_turf(announce), source_turf))
+			continue
+		if(!announce.is_operational)
+			continue
+		if(!announce.has_supported_channels(channels))
+			continue
+		if(aas_config_entry_type)
+			var/datum/aas_config_entry/entry = locate(aas_config_entry_type) in announce.config_entries
+			if(!entry || !entry.enabled)
+				continue
+		intact_aass += announce
 	return length(intact_aass) ? pick(intact_aass) : null
 
 /// Announces the provided message with the provided variables and config entry type. Only aas_config_entry_type and variables_map are mandatory. Other args are optional.

--- a/code/modules/mob/living/brain/brain_item.dm
+++ b/code/modules/mob/living/brain/brain_item.dm
@@ -49,7 +49,8 @@
 /obj/item/organ/brain/Initialize(mapload)
 	. = ..()
 	organ_traits.Remove(variant_traits_removed)
-	organ_traits |= variant_traits_added
+	if(variant_traits_added)
+		organ_traits |= variant_traits_added
 
 /obj/item/organ/brain/Insert(mob/living/carbon/brain_owner, special = FALSE, drop_if_replaced = TRUE, no_id_transfer = FALSE, pref_load = FALSE)
 	. = ..()


### PR DESCRIPTION
## About The Pull Request

`get_announcement_system()` would cause a runtime if `source` was null because `is_valid_z_level()` expects an instance to be passed into the args

People had null traits which was a little confusing to me. After a little bit of digging I found out it was caused by the following code: `organ_traits |= variant_traits_added`. If `variant_traits_added` was null, which it is in the majority of cases, we add a null element to `organ_traits` causing the null trait.

## Why It's Good For The Game

Bug fixes

## Testing Photographs and Procedure

<img width="306" height="351" alt="image" src="https://github.com/user-attachments/assets/ed8ee549-7934-4c09-8171-9c47a7b7a383" />

<img width="765" height="482" alt="image" src="https://github.com/user-attachments/assets/1987a3aa-e785-4ae4-ab34-a6c117f4510e" />

## Changelog
:cl:
fix: Fixed a runtime when an AAS announcement was made in some situations
fix: Fixed brains giving people null traits
/:cl: