### PR TITLE
Fixes United budget on explo and asclepius rod

### DIFF
--- a/_maps/map_files/RadStation/RadStation.dmm
+++ b/_maps/map_files/RadStation/RadStation.dmm
@@ -19687,6 +19687,7 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 5
 	},
+/obj/machinery/keycard_auth/directional/north,
 /turf/open/floor/carpet/purple,
 /area/station/command/heads_quarters/rd)
 "hCb" = (
@@ -61348,6 +61349,8 @@
 /obj/structure/disposalpipe/sorting/mail/destination/research{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/station/science/research)
 "xij" = (

--- a/code/datums/status_effects/buffs.dm
+++ b/code/datums/status_effects/buffs.dm
@@ -367,6 +367,7 @@
 /datum/status_effect/hippocratic_oath/on_apply()
 	//Makes the user passive, it's in their oath not to harm!
 	owner.add_traits(list(TRAIT_PACIFISM, TRAIT_MEDICAL_HUD), TRAIT_STATUS_EFFECT(id))
+	return TRUE
 
 /datum/status_effect/hippocratic_oath/on_remove()
 	owner.remove_traits(list(TRAIT_PACIFISM, TRAIT_MEDICAL_HUD), TRAIT_STATUS_EFFECT(id))

--- a/code/modules/shuttle/super_cruise/orbital_poi_generator/_orbital_objective.dm
+++ b/code/modules/shuttle/super_cruise/orbital_poi_generator/_orbital_objective.dm
@@ -16,7 +16,7 @@
 	station_name = new_station_name()
 
 	if(!istype(bound_bank_account))
-		bound_bank_account = SSeconomy.get_budget_account(bound_bank_account)
+		bound_bank_account = SSeconomy.get_budget_account(bound_bank_account, force = TRUE)
 
 /datum/orbital_objective/proc/on_assign(obj/machinery/computer/objective/objective_computer)
 	return


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Smaller fixes

1 - United budget completely breaks exploration vendor points, placing force = true, forces it to not use united budget and work normally

2- Asclepius rod wasn't working because it was returning null and never properly applied the effect onto the player

3- RD's office in radstation didn't have a card reader, adds it

4- Missing pipe in science Radstation's

## Why It's Good For The Game

Bugs bad

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

<img width="160" height="160" alt="image" src="https://github.com/user-attachments/assets/aba28583-a9bb-4236-a693-d4c254e1ad38" />

<img width="192" height="160" alt="image" src="https://github.com/user-attachments/assets/98fc6212-ec3c-4e96-8e66-44437e285b4b" />

After completing a mission with united budget active
<img width="513" height="774" alt="image" src="https://github.com/user-attachments/assets/73459f19-0b9f-4d32-9f1d-fc50cacd3d77" />

<img width="821" height="641" alt="image" src="https://github.com/user-attachments/assets/59eff8a4-cff0-46e8-b5f4-52029927ce0f" />

Rod working

<img width="1623" height="719" alt="image" src="https://github.com/user-attachments/assets/e18e59f9-8ec9-4a93-9a9e-20fe3c13f691" />



</details>

## Changelog
:cl:
add: Missing Pipes in Radstation's Science and Auth Keycard Device in RD's office
fix:  United Budget Station trait no longer breaks exploration vendor points
fix: Asclepius rod works again
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
