### PR TITLE
Berry Simple Monkey Sentience Helmet Change

### DIFF
--- a/code/modules/clothing/head/mind_monkey_helmet.dm
+++ b/code/modules/clothing/head/mind_monkey_helmet.dm
@@ -25,9 +25,9 @@
 	. = ..()
 	if(slot != ITEM_SLOT_HEAD)
 		return
-	var/mob/living/carbon/carbon_user = user
-	var/obj/item/organ/brain/brain = carbon_user?.get_organ_slot(ORGAN_SLOT_BRAIN)
-	if(!istype(brain, /obj/item/organ/brain/primate) || user.key)
+	if(!iscarbon(user))
+		return
+	if(!HAS_TRAIT(user, TRAIT_PRIMITIVE) || user.key)
 		to_chat(user, span_boldnotice("You feel a stabbing pain in the back of your head for a moment."))
 		playsound(src, 'sound/machines/buzz-sigh.ogg', 30, TRUE)
 		if(isliving(user)) //I don't know what normally would force us to check this, but it's worth checking

--- a/code/modules/clothing/head/mind_monkey_helmet.dm
+++ b/code/modules/clothing/head/mind_monkey_helmet.dm
@@ -25,7 +25,9 @@
 	. = ..()
 	if(slot != ITEM_SLOT_HEAD)
 		return
-	if(!ismonkey(user) || user.key)
+	var/mob/living/carbon/carbon_user = user
+	var/obj/item/organ/brain/brain = carbon_user?.get_organ_slot(ORGAN_SLOT_BRAIN)
+	if(!istype(brain, /obj/item/organ/brain/primate) || user.key)
 		to_chat(user, span_boldnotice("You feel a stabbing pain in the back of your head for a moment."))
 		playsound(src, 'sound/machines/buzz-sigh.ogg', 30, TRUE)
 		if(isliving(user)) //I don't know what normally would force us to check this, but it's worth checking
@@ -35,7 +37,7 @@
 		return
 	INVOKE_ASYNC(src, PROC_REF(poll), user)
 
-/obj/item/clothing/head/helmet/monkey_sentience_helmet/proc/poll(mob/living/carbon/monkey/user) //At this point, we can assume we're given a monkey, since this'll put them in the body anyways
+/obj/item/clothing/head/helmet/monkey_sentience_helmet/proc/poll(mob/living/carbon/user)
 	if (user.stat) //Checks if the monkey is dead.
 		playsound(src, 'sound/machines/buzz-sigh.ogg', 30, TRUE) //If so, buzz and do not poll ghosts
 		return

--- a/code/modules/mob/living/brain/brain_item.dm
+++ b/code/modules/mob/living/brain/brain_item.dm
@@ -318,7 +318,6 @@
 /obj/item/organ/brain/primate
 	name = "primate brain"
 	desc = "This wad of meat is small, but has enlaged occipital lobes for spotting bananas."
-	variant_traits_removed = list(TRAIT_ADVANCEDTOOLUSER)
 	variant_traits_added = list(TRAIT_PRIMITIVE)
 
 /obj/item/organ/brain/lizard

--- a/code/modules/mob/living/carbon/monkey/monkey.dm
+++ b/code/modules/mob/living/carbon/monkey/monkey.dm
@@ -96,7 +96,7 @@ CREATION_TEST_IGNORE_SUBTYPES(/mob/living/carbon/monkey)
 	internal_organs += new /obj/item/organ/appendix
 	internal_organs += new /obj/item/organ/lungs
 	internal_organs += new /obj/item/organ/heart
-	internal_organs += new /obj/item/organ/brain
+	internal_organs += new /obj/item/organ/brain/primate
 	internal_organs += new /obj/item/organ/tongue
 	internal_organs += new /obj/item/organ/eyes
 	internal_organs += new /obj/item/organ/ears


### PR DESCRIPTION
## About The Pull Request

Monkey Sentience Helmets!! An amazing object that when placed on a monkey, offers the body to ghosts

I've loved this idea since first encountering it, its an idea which feels like it embodies the core setting that the game exists in, granting life, sentience, for any reason- from making a monster, or a lab assistant to wanting to create a sentient monkey uprising.. But it was also very quick into experimenting with this helmet that its limitations are shown... The sentience helmet at its core functions by checking if the helmet is placed on a; a monkey, and a body without a player soul attached. If it passed the check it offers the body to ghosts
This PR changes that first requirement, it changes the restriction on monkey and makes it more true to how I interpret. This PR makes it so the helmet doesnt check for monkey mob type, but the primate brain organ- an organ which is now given to all monkeys <sub> ( not just genetic humans turned to monkeys ) </sub>

At its core this PR is designed to let players unleash their inner frankenstien, to create a monster, to give a creatue any organ, any limb, to take advantage of the monkey brain and create life- this might not ever be used, but I feel is a slightly more open, and usable interpretation of the items intended use that can help create interesting RP on station

Of note, the primate brain which was formerly only given to humans turned into monkeys, a brain which loses the advanced_tool_user trait is also changed- It no longer loses that trait, if monkeys dont lose it then a human turning into a monkey shouldnt lose it. This was mainly to not change monkey gameplay while still giving them the organ that seemed intended for them while letting the helmet function as normal when used on a monkey

## Why It's Good For The Game

A player giving sentience to a monkey is already a... _risky_ situation- The difference between a monkey mob, and a... brain organ holding mob surely isnt that big. And if the potential damage of this isnt impacted... then all that remains is the potential for RP, the potential for genetics to create interesting creatures, and for unique mobs to exist gets a little bit better.
And the better odds on having fun situations occur, the better odds on a good round overall :)

## Testing Photographs and Procedure

<details>
<summary>Screenshots&Videos</summary>

https://github.com/user-attachments/assets/116f8f0a-83fd-4dcc-939b-6389cfbc8e90



</details>

## Changelog
:cl:
add: Monkey Sentience Helmets now work on any mob with a primate brain and never a soul
tweak: Monkeys now spawn with the Primate brain organ
/:cl:
