### PR TITLE
Berry New Smoking Withdrawal Timeline

### DIFF
--- a/code/modules/reagents/withdrawal/_addiction.dm
+++ b/code/modules/reagents/withdrawal/_addiction.dm
@@ -20,6 +20,8 @@
 	var/medium_withdrawal_moodlet = /datum/mood_event/withdrawal_medium
 	///moodlet for severe withdrawal
 	var/severe_withdrawal_moodlet = /datum/mood_event/withdrawal_severe
+	/// How fast withdrawal processes, 1 is normal, 0.5 is half, 2 would be double
+	var/withdrawal_cycle_multiplier = 1
 
 ///Called when you gain addiction points somehow. Takes a mind as argument and sees if you gained the addiction
 /datum/addiction/proc/on_gain_addiction_points(datum/mind/victim_mind)
@@ -105,7 +107,7 @@
 		if(3)
 			withdrawal_stage_3_process(affected_carbon, delta_time)
 
-	LAZYADDASSOC(affected_carbon.mind.active_addictions, type, 1 * delta_time) //Next cycle!
+	LAZYADDASSOC(affected_carbon.mind.active_addictions, type, withdrawal_cycle_multiplier * delta_time) //Next cycle!
 
 /// Called when addiction enters stage 1
 /datum/addiction/proc/withdrawal_enters_stage_1(mob/living/carbon/affected_carbon)

--- a/code/modules/reagents/withdrawal/generic_addictions.dm
+++ b/code/modules/reagents/withdrawal/generic_addictions.dm
@@ -275,6 +275,7 @@
 	name = "Nicotine"
 	addiction_relief_treshold = MIN_NICOTINE_ADDICTION_REAGENT_AMOUNT //much less because your intake is probably from ciggies
 	withdrawal_stage_messages = list("Feel like having a smoke...", "Getting antsy. Really need a smoke now.", "I can't take it! Need a smoke NOW!")
+	withdrawal_cycle_multiplier = 0.2
 
 	medium_withdrawal_moodlet = /datum/mood_event/nicotine_withdrawal_moderate
 	severe_withdrawal_moodlet = /datum/mood_event/nicotine_withdrawal_severe


### PR DESCRIPTION
## About The Pull Request

Addition used to use a static 1 multiplier when determining how quickly withdrawal effects should take which is probably fine if you're a bath salt smoking moth, hard drugs should probably have harsh withdrawl- **But** the smoker trait which players can take creates an addiction to nicotine, fine and a good quirk but withdrawl stages take place 60/120/180seconds after the chem leaves the body... this means a player who wants to be a smoker has to smoke every minute or suffer visual shakes

I honestly believe this is far too oppressive a time frame for a role play setting, so this PR introduces a withdrawal_cycle_multiplier, inhrently set to 1. So aside from Nicotine which has a custom multiplier everything else is left the same- Nicotine however is now 0.2x slower at about 300/600/900seconds <sub> ( or 5/10/15 minutes ) </sub>

## Why It's Good For The Game

The withdrawal from nicotine isnt the most oppressive, mood debuffs and jitters. But the jitters are very visually attention getting, its a big effect, and its on an unfair timeframe. Im not sure if this PR is the best way to handle this issue code wise, its a bit simple- but i truly believe giving players more time, atleast a reasonable amount to choose ***not*** to smoke isnt a bad thing if the quirk itself still remains present
Smoking can be cool, but always needing to smoke makes it a little less... 

## Testing Photographs and Procedure

_I am not recording a 5minute video just to watch a mood change, then another 5 for the jitters unless requested #sorrynotsorry_ 

## Changelog
:cl:
tweak: Nicotine withdrawal stages now start after 5/10/15minutes
/:cl: