### PR TITLE
Minor Fixes - Missing map stuff, swarmer fixes

### DIFF
--- a/_maps/RandomRuins/LavaRuins/lavaland_biodome_beach.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_biodome_beach.dmm
@@ -225,7 +225,7 @@
 /turf/open/floor/plating/beach/sand,
 /area/ruin/powered/beach)
 "aW" = (
-/obj/structure/chair/stool,
+/obj/structure/chair/stool/directional/north,
 /obj/effect/turf_decal/stripes/asteroid/line{
 	dir = 1
 	},

--- a/_maps/_basemap.dm
+++ b/_maps/_basemap.dm
@@ -1,8 +1,8 @@
 // #define LOWMEMORYMODE //uncomment this to load centcom and runtime station and thats it.
-#define QUICKSTART // uncomment this to start the round immidiately when ready and automatically spawn players with debug outfit
+// #define QUICKSTART // uncomment this to start the round immidiately when ready and automatically spawn players with debug outfit
 
 // uncomment this for a map you need to use
-#define FORCE_MAP "boxstation"
+// #define FORCE_MAP "boxstation"
 // #define FORCE_MAP "cardinalstation"
 // #define FORCE_MAP "metastation"
 // #define FORCE_MAP "deltastation"

--- a/_maps/_basemap.dm
+++ b/_maps/_basemap.dm
@@ -1,8 +1,8 @@
 // #define LOWMEMORYMODE //uncomment this to load centcom and runtime station and thats it.
-// #define QUICKSTART // uncomment this to start the round immidiately when ready and automatically spawn players with debug outfit
+#define QUICKSTART // uncomment this to start the round immidiately when ready and automatically spawn players with debug outfit
 
 // uncomment this for a map you need to use
-// #define FORCE_MAP "boxstation"
+#define FORCE_MAP "boxstation"
 // #define FORCE_MAP "cardinalstation"
 // #define FORCE_MAP "metastation"
 // #define FORCE_MAP "deltastation"

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -6887,6 +6887,9 @@
 	id = "kitchencounter";
 	name = "Kitchen Shutters"
 	},
+/obj/structure/desk_bell/wired/service{
+	pixel_x = 6
+	},
 /turf/open/floor/iron/cafeteria,
 /area/station/service/kitchen)
 "cOm" = (

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -5844,16 +5844,6 @@
 /obj/effect/mapping_helpers/airlock/access/all/engineering/general,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter)
-"ctv" = (
-/obj/effect/turf_decal/tile/purple/opposingcorners,
-/obj/structure/sign/poster/contraband/clown{
-	pixel_y = -32
-	},
-/obj/effect/turf_decal/tile/random/opposingcorners{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/station/service/theater/backstage)
 "ctG" = (
 /obj/machinery/camera/directional/south{
 	c_tag = "Port Primary Hallway - Starboard"
@@ -17632,13 +17622,6 @@
 /obj/structure/cable/yellow,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/command)
-"gAH" = (
-/obj/item/cigbutt{
-	pixel_y = -11;
-	pixel_x = -3
-	},
-/turf/closed/wall,
-/area/station/security/detectives_office)
 "gAW" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable/yellow,
@@ -30919,6 +30902,7 @@
 /area/station/maintenance/starboard)
 "laP" = (
 /obj/structure/fluff/hedge/opaque,
+/obj/machinery/light_switch/directional/north,
 /turf/open/floor/carpet/red,
 /area/station/service/bar)
 "laQ" = (
@@ -66087,7 +66071,6 @@
 	dir = 8
 	},
 /obj/item/food/baguette,
-/obj/machinery/light_switch/directional/east,
 /turf/open/floor/iron/white,
 /area/station/service/theater/backstage)
 "wTS" = (
@@ -101085,7 +101068,7 @@ fBT
 vVi
 kan
 xZU
-gAH
+xZU
 hqf
 vPU
 voS
@@ -103424,7 +103407,7 @@ pTw
 bNO
 rco
 lSS
-ctv
+vHY
 pTw
 laP
 rlf

--- a/_maps/map_files/RadStation/RadStation.dmm
+++ b/_maps/map_files/RadStation/RadStation.dmm
@@ -16605,10 +16605,10 @@
 /area/station/service/hydroponics)
 "gry" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/chair/stool/directional/west,
 /obj/effect/turf_decal/siding/wood{
 	dir = 10
 	},
+/obj/structure/chair/stool/directional/east,
 /turf/open/floor/carpet/blue,
 /area/station/service/cafeteria)
 "grz" = (
@@ -16891,10 +16891,10 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/storage/tech)
 "gyl" = (
-/obj/structure/chair/stool/directional/west,
 /obj/effect/turf_decal/siding/wood{
 	dir = 9
 	},
+/obj/structure/chair/stool/directional/east,
 /turf/open/floor/carpet/blue,
 /area/station/service/cafeteria)
 "gyC" = (

--- a/_maps/map_files/RadStation/RadStation.dmm
+++ b/_maps/map_files/RadStation/RadStation.dmm
@@ -19687,6 +19687,7 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 5
 	},
+/obj/machinery/keycard_auth/directional/north,
 /turf/open/floor/carpet/purple,
 /area/station/command/heads_quarters/rd)
 "hCb" = (

--- a/code/__DEFINES/antagonists.dm
+++ b/code/__DEFINES/antagonists.dm
@@ -267,3 +267,7 @@ GLOBAL_LIST_INIT(ai_employers, list(
 
 /// Is this item available for the toxin directive?
 #define STEAL_DIRECTIVE_TOXIN (1 << 0)
+
+// Swarmers
+// ------------------------------------
+#define SWARMER_SHELL_COST 20

--- a/code/modules/antagonists/swarmer/swarmer.dm
+++ b/code/modules/antagonists/swarmer/swarmer.dm
@@ -1,3 +1,5 @@
+#define SWARMER_SHELL_COST 20
+
 ////Deactivated swarmer shell////
 /obj/item/deactivated_swarmer
 	name = "deactivated swarmer"
@@ -169,7 +171,7 @@
 	return FALSE //would logically be TRUE, but we don't want AI swarmers eating player spawn chances.
 
 /obj/effect/mob_spawn/swarmer/IntegrateAmount()
-	return 20
+	return SWARMER_SHELL_COST
 
 /turf/closed/indestructible/swarmer_act()
 	return FALSE
@@ -346,6 +348,10 @@
 	to_chat(S, span_warning("This bluespace source will be important to us later. Aborting."))
 	return FALSE
 
+/obj/machinery/computer/communications/swarmer_act(mob/living/simple_animal/hostile/swarmer/S)
+	to_chat(S, span_warning("This console should be preserved, its communication technology will be useful to our masters in the future. Aborting."))
+	return FALSE
+
 /turf/closed/wall/swarmer_act(mob/living/simple_animal/hostile/swarmer/S)
 	var/isonshuttle = istype(loc, /area/shuttle)
 	for(var/turf/T as anything in RANGE_TURFS(1, src))
@@ -404,7 +410,7 @@
 	return ..()
 
 /obj/item/deactivated_swarmer/IntegrateAmount()
-	return 20
+	return SWARMER_SHELL_COST
 
 /obj/machinery/hydroponics/soil/swarmer_act(mob/living/simple_animal/hostile/swarmer/S)
 	to_chat(S, span_warning("This object does not contain enough materials to work with."))
@@ -687,7 +693,7 @@
 	set category = "Swarmer"
 	set desc = "Creates a shell for a new swarmer. Swarmers will self activate."
 	to_chat(src, span_info("We are attempting to replicate ourselves. We will need to stand still until the process is complete."))
-	if(resources < 20)
+	if(resources < SWARMER_SHELL_COST)
 		to_chat(src, span_warning("We do not have the resources for this!"))
 		return
 	if(!isturf(loc))
@@ -695,7 +701,7 @@
 		return
 	if(do_after(src, 10 SECONDS))
 		var/createtype = SwarmerTypeToCreate()
-		if(createtype && Fabricate(createtype, 20))
+		if(createtype && Fabricate(createtype, SWARMER_SHELL_COST))
 			playsound(loc,'sound/items/poster_being_created.ogg',50, 1, -1)
 
 

--- a/code/modules/antagonists/swarmer/swarmer.dm
+++ b/code/modules/antagonists/swarmer/swarmer.dm
@@ -1,4 +1,3 @@
-
 ////Deactivated swarmer shell////
 /obj/item/deactivated_swarmer
 	name = "deactivated swarmer"

--- a/code/modules/antagonists/swarmer/swarmer.dm
+++ b/code/modules/antagonists/swarmer/swarmer.dm
@@ -322,6 +322,14 @@
 	to_chat(S, span_warning("An inhospitable area may be created as a result of destroying this object. Aborting."))
 	return FALSE
 
+/obj/machinery/airalarm/swarmer_act(mob/living/simple_animal/hostile/swarmer/S)
+	to_chat(S, span_warning("An inhospitable area may be created as a result of destroying this object. Aborting."))
+	return FALSE
+
+/obj/structure/reflector/swarmer_act(mob/living/simple_animal/hostile/swarmer/S)
+	to_chat(S, span_warning("An inhospitable area may be created as a result of destroying this object. Aborting."))
+	return FALSE
+
 /obj/machinery/telecomms/swarmer_act(mob/living/simple_animal/hostile/swarmer/S)
 	to_chat(S, span_warning("This communications relay should be preserved, it will be a useful resource to our masters in the future. Aborting."))
 	return FALSE
@@ -396,7 +404,7 @@
 	return ..()
 
 /obj/item/deactivated_swarmer/IntegrateAmount()
-	return 50
+	return 20
 
 /obj/machinery/hydroponics/soil/swarmer_act(mob/living/simple_animal/hostile/swarmer/S)
 	to_chat(S, span_warning("This object does not contain enough materials to work with."))

--- a/code/modules/antagonists/swarmer/swarmer.dm
+++ b/code/modules/antagonists/swarmer/swarmer.dm
@@ -1,4 +1,3 @@
-#define SWARMER_SHELL_COST 20
 
 ////Deactivated swarmer shell////
 /obj/item/deactivated_swarmer


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

- Fixes a few mistakes on some maps. Think I may have been over-eager to rotate every stool earlier. Meta's seating area didn't have a light switch, and its kitchen didn't have a bell. 
- Fixes a couple of issues with swarmers. Deactivated swarmer resource amount was never changed from the old figure, so you got way too much resources from eating it. Same fix as in #12536, basically. I also don't think swarmers should be allowed to eat air alarms, or reflectors.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Map fixes are nice. It is good to prevent any station harm that an over-eager swarmer can cause. 
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

<img width="531" height="35" alt="image" src="https://github.com/user-attachments/assets/332b154a-d1a3-4e76-9d7d-07039c5729c1" />
trying to eat an air alarm
<img width="508" height="81" alt="image" src="https://github.com/user-attachments/assets/cd5d5185-5313-40f6-af9d-1747958e003d" />
before eating
<img width="498" height="97" alt="image" src="https://github.com/user-attachments/assets/d2d92091-9c64-4955-86f9-343174bf43e0" />
after eating 
<img width="1006" height="362" alt="image" src="https://github.com/user-attachments/assets/8c7f5d78-66a5-4a5f-ab70-203e6ee56025" />
trying to eat a reflector

</details>

## Changelog
:cl:
fix: Fixed a few mapping mistakes on Meta and Rad.
fix: Fixes deactivated swarmer shells being worth 50 resources, rather than the 20 used to create them.
tweak: Swarmers are no longer able to eat Air Alarms, Reflectors, or the Communications Console.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
