### PR TITLE
Cyborg Language Button Fix

### DIFF
--- a/code/__DEFINES/hud.dm
+++ b/code/__DEFINES/hud.dm
@@ -107,7 +107,7 @@
 #define ui_borg_store "CENTER+2:16,SOUTH:5"
 #define ui_borg_camera "CENTER+3:21,SOUTH:5"
 #define ui_borg_alerts "CENTER+4:21,SOUTH:5"
-#define ui_borg_language_menu "CENTER+4:19,SOUTH+1:6"
+#define ui_borg_language_menu "CENTER+5:21,SOUTH+1:6"
 #define ui_borg_navigate_menu "CENTER+4:19,SOUTH+1:6"
 
 //AI


### PR DESCRIPTION
## About The Pull Request

Unaware to me till moments ago, Cyborgs were encountering a bug overlapping their navigation button with the language button. Cyborgs were still able to access languages via IC tab Language Button, but lacked an action button. 

This PR moves the language button slightly, making it accessible again to cyborg players.

## Why It's Good For The Game

Bug fixes are good! 

Not only that but having an action button easily accessible is more intuitive to new players who might not search through the various tabs offered. 

## Testing Photographs and Procedure

<details>
<summary>Screenshots&Videos</summary>

# Live Cyborg UI
<img width="840" height="697" alt="Screenshot 2026-07-18 000219" src="https://github.com/user-attachments/assets/48c261b2-c604-476d-b052-e44c2da77ac5" />

---

## After Fix Upload
<img width="1072" height="542" alt="Screenshot 2026-07-17 235523" src="https://github.com/user-attachments/assets/53b06de7-08cd-434b-a9a7-94daf6e26e01" />


</details>

## Changelog
:cl:
fix: Moves Cyborg Language Action Button To Clickable Location
/:cl:
