### PR TITLE
Fixes escape pods being unlocked roundstart. Adds ways to open them anyway.

### DIFF
--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -7937,15 +7937,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
 /turf/open/floor/engine,
 /area/station/engineering/main)
-"diR" = (
-/obj/machinery/door/airlock/external{
-	name = "Escape Pod Three"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
-	cycle_id = "escape-pod-3"
-	},
-/turf/open/floor/plating,
-/area/misc/space)
 "diX" = (
 /obj/structure/cable/yellow,
 /obj/effect/turf_decal/siding/white{
@@ -61611,9 +61602,6 @@
 	},
 /turf/open/floor/wood,
 /area/station/command/corporate_showroom)
-"vnM" = (
-/turf/closed/wall,
-/area/misc/space)
 "vnS" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
 /obj/structure/cable/yellow,
@@ -107483,9 +107471,9 @@ feE
 feE
 feE
 vUJ
-vnM
-diR
-vnM
+vUJ
+jsR
+vUJ
 vUJ
 hHk
 tFu
@@ -111376,7 +111364,7 @@ pdM
 mhL
 pmq
 aHM
-doC
+sJP
 sJP
 moi
 gYt
@@ -111633,7 +111621,7 @@ sug
 sug
 imP
 lKw
-doC
+sJP
 nsT
 rjj
 xQw
@@ -111890,7 +111878,7 @@ fQU
 knC
 diz
 ubd
-doC
+sJP
 kyU
 vPj
 vPj
@@ -112147,7 +112135,7 @@ nMP
 hRi
 qdj
 ubd
-doC
+sJP
 fok
 tgA
 cIk
@@ -112404,7 +112392,7 @@ dtX
 dtX
 qdj
 rXJ
-doC
+sJP
 xpa
 qgp
 gbi

--- a/_maps/shuttles/mining/mining_rad.dmm
+++ b/_maps/shuttles/mining/mining_rad.dmm
@@ -49,10 +49,6 @@
 /turf/open/floor/iron/tech/grid,
 /area/shuttle/mining)
 "z" = (
-/obj/item/storage/pod{
-	pixel_x = -25;
-	unlocked = 1
-	},
 /obj/structure/closet/crate/miningcar{
 	pixel_x = 1;
 	pixel_y = 2
@@ -60,6 +56,9 @@
 /obj/machinery/camera/directional/west,
 /obj/structure/window/reinforced/spawner/directional/north,
 /obj/effect/turf_decal/loading_area,
+/obj/item/storage/pod/unlocked{
+	pixel_x = -25
+	},
 /turf/open/floor/iron/tech/grid,
 /area/shuttle/mining)
 "C" = (

--- a/_maps/shuttles/mining/mining_tiny.dmm
+++ b/_maps/shuttles/mining/mining_tiny.dmm
@@ -19,10 +19,6 @@
 	},
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/item/storage/pod{
-	pixel_x = -26;
-	unlocked = 1
-	},
 /obj/effect/turf_decal/loading_area{
 	dir = 4
 	},
@@ -86,6 +82,9 @@
 	},
 /obj/machinery/light{
 	dir = 8
+	},
+/obj/item/storage/pod/unlocked{
+	pixel_x = -25
 	},
 /turf/open/floor/iron/tech/grid,
 /area/shuttle/mining)

--- a/code/modules/shuttle/emergency.dm
+++ b/code/modules/shuttle/emergency.dm
@@ -723,7 +723,13 @@
 	density = FALSE
 	icon = 'icons/obj/storage/storage.dmi'
 	icon_state = "safe"
-	var/unlocked = FALSE
+	var/icon_sparking = "safespark"
+	var/icon_opened = "safe0"
+
+/obj/item/storage/pod/Initialize(mapload)
+	. = ..()
+	atom_storage.locked = TRUE
+	RegisterSignal(SSsecurity_level, COMSIG_SECURITY_LEVEL_CHANGED, PROC_REF(alert_unlock))
 
 /obj/item/storage/pod/PopulateContents()
 	new /obj/item/clothing/head/helmet/space/orange(src)
@@ -756,12 +762,36 @@
 	if(!can_interact(user))
 		return
 
+/obj/item/storage/pod/emp_act(severity)
+	. = ..()
+	add_overlay(icon_sparking)	//coincidence?
+	unlock()
+
+/obj/item/storage/pod/on_emag(mob/user)
+	. = ..()
+	add_overlay(icon_sparking)	//or sabotage?
+	unlock()
+
+/obj/item/storage/pod/proc/unlock()
+	atom_storage.locked = FALSE
+	UnregisterSignal(SSsecurity_level, COMSIG_SECURITY_LEVEL_CHANGED)
+
+/obj/item/storage/pod/proc/alert_unlock(datum/source, new_level)
+	SIGNAL_HANDLER
+
+	if(new_level >= SEC_LEVEL_RED)	//"oh, too bad you already launched, red alert is over, so no gear for you!"
+		add_overlay(icon_opened)
+		unlock()
+
 /obj/item/storage/pod/can_interact(mob/user)
 	if(!..())
 		return FALSE
-	if(SSsecurity_level.get_current_level_as_number() >= SEC_LEVEL_RED || unlocked)
+	if(!atom_storage.locked)
 		return TRUE
-	to_chat(user, "The storage unit will only unlock during a Red or Delta security alert.")
+	if(obj_flags & EMAGGED)
+		return FALSE
+	to_chat(user, "The storage unit will only unlock during a Red, Black, or Delta security alert.")
+	balloon_alert(user, "The storage unit will only unlock during a Red, Black, or Delta security alert.")
 
 /obj/docking_port/mobile/emergency/backup
 	name = "backup shuttle"

--- a/code/modules/shuttle/emergency.dm
+++ b/code/modules/shuttle/emergency.dm
@@ -797,7 +797,7 @@
 		return TRUE
 	if(obj_flags & EMAGGED)
 		return FALSE
-	to_chat(user, "The storage unit will only unlock during a Red, Black, or Delta security alert.")
+	to_chat(user, span_warning("The storage unit will only unlock during a Red, Black, or Delta security alert."))
 	balloon_alert(user, "The storage unit will only unlock during a Red, Black, or Delta security alert.")
 
 /obj/docking_port/mobile/emergency/backup

--- a/code/modules/shuttle/emergency.dm
+++ b/code/modules/shuttle/emergency.dm
@@ -723,13 +723,20 @@
 	density = FALSE
 	icon = 'icons/obj/storage/storage.dmi'
 	icon_state = "safe"
+	var/must_be_locked = TRUE
 	var/icon_sparking = "safespark"
 	var/icon_opened = "safe0"
 
+/obj/item/storage/pod/unlocked
+	must_be_locked = FALSE
+
 /obj/item/storage/pod/Initialize(mapload)
 	. = ..()
-	atom_storage.locked = TRUE
-	RegisterSignal(SSsecurity_level, COMSIG_SECURITY_LEVEL_CHANGED, PROC_REF(alert_unlock))
+	if(must_be_locked == TRUE)
+		atom_storage.locked = TRUE
+		RegisterSignal(SSsecurity_level, COMSIG_SECURITY_LEVEL_CHANGED, PROC_REF(alert_unlock))
+	else
+		add_overlay(icon_opened)
 
 /obj/item/storage/pod/PopulateContents()
 	new /obj/item/clothing/head/helmet/space/orange(src)

--- a/code/modules/shuttle/emergency.dm
+++ b/code/modules/shuttle/emergency.dm
@@ -798,7 +798,6 @@
 	if(obj_flags & EMAGGED)
 		return FALSE
 	to_chat(user, span_warning("The storage unit will only unlock during a Red, Black, or Delta security alert."))
-	balloon_alert(user, "The storage unit will only unlock during a Red, Black, or Delta security alert.")
 
 /obj/docking_port/mobile/emergency/backup
 	name = "backup shuttle"

--- a/code/modules/shuttle/on_move.dm
+++ b/code/modules/shuttle/on_move.dm
@@ -310,16 +310,6 @@ All ShuttleMove procs go here
 		GLOB.deliverybeacons += src
 		GLOB.deliverybeacontags += location
 
-/************************************Item move procs************************************/
-
-/obj/item/storage/pod/afterShuttleMove(turf/oldT, list/movement_force, shuttle_dir, shuttle_preferred_direction, move_dir, rotation)
-	. = ..()
-	// If the pod was launched, the storage will always open. The CentCom check
-	// ignores the movement of the shuttle from the staging area on CentCom to
-	// the station as it is loaded in.
-	if (oldT && !is_centcom_level(oldT.z))
-		unlocked = TRUE
-
 /************************************Mob move procs************************************/
 
 /mob/onShuttleMove(turf/newT, turf/oldT, list/movement_force, move_dir, obj/docking_port/stationary/old_dock, obj/docking_port/mobile/moving_dock, list/obj/docking_port/mobile/towed_shuttles)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
The emergency suit storage has been broken unlocked since 2019! That was 7 years ago!

This PR fixes the issue by removing the code that unlocked the safes the moment they were spawned in. The safes will now unlock on Red Alert and higher, however, they will not lock when the alert is lowered. The safes can also be emagged and EMPed open.

This PR also fixes some mapping issues on Metastation:
- Dorms pod airlock now correctly belongs to the dorms area, instead of being unpowered in space.
- A thin stripe of wall in Engineering incorrectly had engie security outpost area from before it got moved.

## Why It's Good For The Game
Bugs are bad, 'mkay?

Now why the changes.

There is no clean way to tie safe opening to pod launch at this moment. If I make them close on Red Alert dropping, then, people who did launch in a pod will be stuck with no gear. Or someone might empty the safe, make a stash inside, and then it is locked down, with just a single convoluted way to open it again.

Emag and EMP:
Thing is, I have almost never seen people steal from these safes. And the only thing worth stealing other than for the looks, is the shelter capsule, which is usually too big to use on the station anyway. So if you, as a player, are so inclined to rob the emergency trash storage for some reason, and got EMP to do it - who am I to stop you? There are less shit versions of all the stuff you might find inside if you just bother making a loop around the station.

Map changes:
Bugs are bad, aight?


## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

Safe refuses to open on Green alert.
<img width="901" height="1066" alt="зображення" src="https://github.com/user-attachments/assets/63bf1392-ab07-49e0-abdb-05af96a44b6c" />

Safe opens and emits sparks after hit with ion.
<img width="890" height="1016" alt="зображення" src="https://github.com/user-attachments/assets/3c76ab0b-40d2-4d5f-bc47-9381b975e085" />

Safe opens and emits sparks after emagged.
<img width="878" height="945" alt="зображення" src="https://github.com/user-attachments/assets/11b7d338-a7cb-4ac8-ae8f-7b6196eab7bf" />

Safe is opened on Red alert.
<img width="859" height="517" alt="зображення" src="https://github.com/user-attachments/assets/161719f2-cd25-4eaf-a8ba-544d5a894215" />

Mapped-in opened safes are open.
<img width="923" height="894" alt="зображення" src="https://github.com/user-attachments/assets/3becba03-fe0c-40fd-8b9b-e354cd12c3e6" />


</details>

## Changelog
:cl:
fix: Pod emergency suit storage safes are now correctly locked roundstart.
tweak: Pod emergency suit storage safes can now be opened by EMP or Emag.
tweak: Pod emergency suit storage safes will open on Red alert or higher, but will not lock once alert is lowered.
map: Fixed Metastation dorms pod airlock being unpowered.
map: Fixed Metastation engineering wall belonging to the incorrect area.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
