### PR TITLE
Fixes SSticker ticking 25% too quicky

### DIFF
--- a/code/controllers/master.dm
+++ b/code/controllers/master.dm
@@ -282,11 +282,11 @@ GLOBAL_REAL(Master, /datum/controller/master) = new
 	// Topological sorting algorithm end
 
 	if(length(subsystems) != length(sorted_subsystems))
-		var/list/circular_dependency = subsystems.Copy() - sorted_subsystems
+		var/list/circular_dependency = subsystems - sorted_subsystems
 		var/list/debug_msg = list()
 		var/list/usr_msg = list()
 		for(var/datum/controller/subsystem/subsystem as anything in circular_dependency)
-			usr_msg += "[subsystem.name]"
+			usr_msg += subsystem.name
 
 		var/list/datum/controller/subsystem/nodes = list(circular_dependency[1])
 		var/list/loop = list()
@@ -494,9 +494,18 @@ GLOBAL_REAL(Master, /datum/controller/master) = new
 		if ((SS.ss_flags & (SS_TICKER|SS_BACKGROUND)) == SS_TICKER)
 			tickersubsystems += SS
 			// Timer subsystems aren't allowed to bunch up, so we offset them a bit
-			timer += world.tick_lag * rand(0, 1)
+			timer += TICKS2DS(rand(0, 1))
 			SS.next_fire = timer
 			continue
+
+		// Now, we have to set starting next_fires for all our new non ticker kids
+		if(SS.init_stage == init_stage - 1 && (SS.runlevels & current_runlevel))
+			// Give em a random offset so things don't clump up too bad
+			var/delay = SS.wait
+			if(SS.ss_flags & SS_TICKER)
+				delay = TICKS2DS(delay)
+			// Gotta convert to ticks cause rand needs integers
+			SS.next_fire = world.time + TICKS2DS(rand(0, DS2TICKS(min(delay, 2 SECONDS))))
 
 		var/ss_runlevels = SS.runlevels
 		var/added_to_any = FALSE
@@ -595,7 +604,11 @@ GLOBAL_REAL(Master, /datum/controller/master) = new
 					//we only want to offset it if it's new and also behind
 					if(SS.next_fire > world.time || (SS in old_subsystems))
 						continue
-					SS.next_fire = world.time + world.tick_lag * rand(0, DS2TICKS(min(SS.wait, 2 SECONDS)))
+					// If they're new, give em a random offset so things don't clump up too bad
+					var/delay = SS.wait
+					if(SS.ss_flags & SS_TICKER)
+						delay = TICKS2DS(delay)
+					SS.next_fire = world.time + TICKS2DS(rand(0, DS2TICKS(min(delay, 2 SECONDS))))
 
 			subsystems_to_check = current_runlevel_subsystems
 		else
@@ -693,6 +706,8 @@ GLOBAL_REAL(Master, /datum/controller/master) = new
 		if (SS_flags & SS_NO_FIRE)
 			subsystemstocheck -= SS
 			continue
+		// If we're keeping timing and running behind,
+		// fire at most 25% faster then normal to try and make up the gap without spamming
 		if ((SS_flags & (SS_TICKER|SS_KEEP_TIMING)) == SS_KEEP_TIMING && SS.last_fire + (SS.wait * 0.75) > world.time)
 			continue
 		if (SS.postponed_fires >= 1)

--- a/config/config.txt
+++ b/config/config.txt
@@ -46,7 +46,7 @@ STATIONNAME Space Station 13
 #HUB
 
 ## Lobby time: This is the amount of time between rounds that players have to setup their characters and be ready.
-LOBBY_COUNTDOWN 300
+LOBBY_COUNTDOWN 210
 
 ## Round End Time: This is the amount of time after the round ends that players have to murder death kill each other.
 ROUND_END_COUNTDOWN 90


### PR DESCRIPTION
## About The Pull Request

Port of:
- https://github.com/tgstation/tgstation/pull/93802

<details>
<summary>Lemon's explanation</summary>

> Ok so this explanation is gonna suck a bit I'm sorry. I was sittin in coderbus and flleeppyy mentioned this problem where SSticker counted down to roundstart significantly faster then it should.

> I poked on tg, and saw the same behavior. I did further poking, and realized that despite wait being 20ds, the actual delay between fires was 15ds.

> I'll spare you the rest of the story, it turned out that SSticker's next_fire was set to 0 at the start instead of world.time, so when we did the KEEP_TIMING thing of incrementing next_fire by wait, we were pretty much always going to be trying to fire on the very next tick.

> This was prevented by the existing sanity check which limits how fast KEEP_TIMING subsystems are allowed to try and recover their tick locked nature, reducing it to 15ds instead of 1ds delay.

> The actual problem here was next_fire not being set properly, which is normally handled by a block in the while(1) block that checks to see if the run level has changed. Unfortunately if you have the starting run level, this never happens.

> This impacts EXACTLY SSticker, and nothing else. For now at least.

> Solution is to write similar code in Loop's setup block, which brings SSticker's roundstart timer back into parity with real life. This has the nice side effect of achieving the randomized starting delays we want for subsystems, to prevent clumping. See discussion on https://github.com/tgstation/tgstation/pull/71730 for more on that.

> I'm going straight off the dome on this one. Didn't wanna bug mto about it if I feel comfortable and all.

> Please note, this does mean the roundstart lobby time is slower now, it's accurate but it's slower. Might need config changes idk.

> I also added some code that checks to see if the subsystem we're randomizing is a ticker or not, I'm kind of dubious on the "wait is actually TICKS for ONLY TICKER" thing but I'm not comfortable enough to change that yet.

</details>


## Why It's Good For The Game

One less lie in this world

## Testing Photographs and Procedure

<img width="622" height="235" alt="image" src="https://github.com/user-attachments/assets/2400fd41-4e66-4c82-9f62-bbed7c08fab8" />

<img width="635" height="238" alt="image" src="https://github.com/user-attachments/assets/bf5848a3-e455-4a2d-a20a-d67b6b2c0403" />

(The small differences in time is because I am not an elite gamer with <1ms click times)

## Changelog
:cl:
fix: Fixed the pre-round timer moving 25% faster than it should've been
config: Alongside the above fix, the pre-round timer has been reduced to 3.5 minutes to stay (mostly) accurate to the previous actual time
/:cl: