### PR TITLE
Fixes cut down posters being impossible to hang back up

### DIFF
--- a/code/game/objects/effects/posters/poster.dm
+++ b/code/game/objects/effects/posters/poster.dm
@@ -180,7 +180,7 @@ CREATION_TEST_IGNORE_SUBTYPES(/obj/item/poster)
 	var/obj/item/poster/rolled_poster = new poster_item_type(loc, src)
 	if(!user?.put_in_hands(rolled_poster))
 		forceMove(rolled_poster)
-	qdel(src)
+	src.forceMove(rolled_poster)
 	return rolled_poster
 
 // Various possible posters follow


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes #14584. 
Turns out, the original poster structure gets qdelled for some reason after spawning the item, and so when you apply the rolled up poster back, you are putting a null on the wall.

## Why It's Good For The Game

~~Bugs bad~~ I like posters
<details>
<summary>This PR is NOT a result of my poster obsession, that I do not have.</summary>
<img width="1191" height="890" alt="зображення" src="https://github.com/user-attachments/assets/e21918bd-a945-4ace-bda2-38a551cf6449" />
</details>


## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

Hoster hanging
<img width="667" height="944" alt="зображення" src="https://github.com/user-attachments/assets/f158cc0d-c67d-4d95-b7c2-ea4b6b1dd4c3" />

Poster cut down
<img width="563" height="958" alt="зображення" src="https://github.com/user-attachments/assets/b59c9a30-a88e-44c2-a8be-ff39330ccce2" />

Poster hanging again
<img width="669" height="1001" alt="зображення" src="https://github.com/user-attachments/assets/95a85ab3-fe50-4b17-af8e-aa2d2288db53" />


</details>

## Changelog
:cl:
fix: Posters can be once again cut down and put back up.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
