### PR TITLE
Bumps CI actions to shush Node.js warnings

### DIFF
--- a/.github/actions/restore_or_install_byond/action.yml
+++ b/.github/actions/restore_or_install_byond/action.yml
@@ -35,7 +35,7 @@ runs:
     # is cancelled, we already have a cache to restore from.
     - name: Restore BYOND cache
       id: restore_byond_cache
-      uses: actions/cache/restore@v4
+      uses: actions/cache/restore@v5
       with:
         path: ~/BYOND
         key: ${{ runner.os }}-byond-${{ env.BYOND_MAJOR }}-${{ env.BYOND_MINOR }}
@@ -45,7 +45,7 @@ runs:
       run: bash tools/ci/install_byond.sh
     - name: Save BYOND cache
       if: ${{ !steps.restore_byond_cache.outputs.cache-hit }}
-      uses: actions/cache/save@v4
+      uses: actions/cache/save@v5
       with:
         path: ~/BYOND
         key: ${{ steps.restore_byond_cache.outputs.cache-primary-key }}

--- a/.github/actions/restore_or_install_byond/action.yml
+++ b/.github/actions/restore_or_install_byond/action.yml
@@ -35,7 +35,7 @@ runs:
     # is cancelled, we already have a cache to restore from.
     - name: Restore BYOND cache
       id: restore_byond_cache
-      uses: actions/cache/restore@v5
+      uses: actions/cache/restore@v6
       with:
         path: ~/BYOND
         key: ${{ runner.os }}-byond-${{ env.BYOND_MAJOR }}-${{ env.BYOND_MINOR }}
@@ -45,7 +45,7 @@ runs:
       run: bash tools/ci/install_byond.sh
     - name: Save BYOND cache
       if: ${{ !steps.restore_byond_cache.outputs.cache-hit }}
-      uses: actions/cache/save@v5
+      uses: actions/cache/save@v6
       with:
         path: ~/BYOND
         key: ${{ steps.restore_byond_cache.outputs.cache-primary-key }}

--- a/.github/actions/setup_node/action.yml
+++ b/.github/actions/setup_node/action.yml
@@ -26,7 +26,7 @@ runs:
         source dependencies.sh
         echo "NODE_VERSION_REQUIRED=$NODE_VERSION_LTS" >> $GITHUB_ENV
     - name: Install Node
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v7
       with:
         node-version: ${{ env.NODE_VERSION_REQUIRED }}
         cache: ${{ fromJSON(inputs.restore-yarn-cache) && 'yarn' || '' }}

--- a/.github/workflows/autowiki.yml
+++ b/.github/workflows/autowiki.yml
@@ -20,7 +20,7 @@ jobs:
           echo "SECRETS_ENABLED=$SECRET_EXISTS" >> $GITHUB_OUTPUT
       - name: Checkout
         if: steps.secrets_set.outputs.SECRETS_ENABLED
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
       - name: Install BYOND
         if: steps.secrets_set.outputs.SECRETS_ENABLED
         uses: ./.github/actions/restore_or_install_byond

--- a/.github/workflows/collect_data.yml
+++ b/.github/workflows/collect_data.yml
@@ -27,7 +27,7 @@ jobs:
       required_build_versions: ${{ steps.setup_required_build_versions.outputs.required_build_versions }}
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
       - name: Find Maps
         id: map_finder
         run: |

--- a/.github/workflows/compare_screenshots.yml
+++ b/.github/workflows/compare_screenshots.yml
@@ -13,7 +13,7 @@ jobs:
         run: mkdir -p artifacts
       # If we ever add more artifacts, this is going to break, but it'll be obvious.
       - name: Download screenshot tests
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           path: artifacts
       - name: ls -R

--- a/.github/workflows/compare_screenshots.yml
+++ b/.github/workflows/compare_screenshots.yml
@@ -34,7 +34,7 @@ jobs:
           echo ${{ github.event.pull_request.number }} > artifacts/screenshot_comparisons/pull_request_number.txt
       - name: Upload bad screenshots
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: bad-screenshots
           path: artifacts/screenshot_comparisons

--- a/.github/workflows/compare_screenshots.yml
+++ b/.github/workflows/compare_screenshots.yml
@@ -8,7 +8,7 @@ jobs:
     timeout-minutes: 15
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Setup directory
         run: mkdir -p artifacts
       # If we ever add more artifacts, this is going to break, but it'll be obvious.

--- a/.github/workflows/compile_all_maps.yml
+++ b/.github/workflows/compile_all_maps.yml
@@ -14,7 +14,7 @@ jobs:
     timeout-minutes: 5
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Setup Node
         uses: ./.github/actions/setup_node
       - name: Restore BYOND from Cache
@@ -36,7 +36,7 @@ jobs:
     timeout-minutes: 5
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Setup Node
         uses: ./.github/actions/setup_node
       - name: Restore BYOND from Cache

--- a/.github/workflows/compile_all_maps.yml
+++ b/.github/workflows/compile_all_maps.yml
@@ -21,7 +21,6 @@ jobs:
         uses: ./.github/actions/restore_or_install_byond
       - name: Compile All Maps
         run: |
-          bash tools/ci/install_byond.sh
           source $HOME/BYOND/byond/bin/byondsetup
           tools/build/build --ci dm -DCIBUILDING -DCITESTING -DALL_MAPS
       - name: Check client Compatibility
@@ -43,6 +42,5 @@ jobs:
         uses: ./.github/actions/restore_or_install_byond
       - name: Compile All Maps
         run: |
-          bash tools/ci/install_byond.sh
           source $HOME/BYOND/byond/bin/byondsetup
           tools/build/build --ci dm -DCIBUILDING -DCITESTING -DALL_TEMPLATES

--- a/.github/workflows/compile_changelogs.yml
+++ b/.github/workflows/compile_changelogs.yml
@@ -11,11 +11,11 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v7
         with:
           fetch-depth: 25
       - name: Python setup
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v6
         with:
           python-version: "3.11"
       - name: Install depends

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -9,7 +9,7 @@ jobs:
   build:
     runs-on: ubuntu-24.04
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v7
     - name: Publish to Registry
       uses: elgohr/Publish-Docker-Github-Action@master
       with:

--- a/.github/workflows/make_changelogs.yml
+++ b/.github/workflows/make_changelogs.yml
@@ -11,11 +11,11 @@ jobs:
     if: "!contains(github.event.head_commit.message, '[ci skip]')"
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v7
         with:
           fetch-depth: 25
       - name: Python setup
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v6
         with:
           python-version: "3.11"
       - name: Install depends

--- a/.github/workflows/rerun_flaky_tests.yml
+++ b/.github/workflows/rerun_flaky_tests.yml
@@ -10,7 +10,7 @@ jobs:
     if: ${{ github.event.workflow_run.conclusion == 'failure' && github.event.workflow_run.run_attempt == 1 }}
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v7
     - name: Rerun flaky tests
       uses: actions/github-script@v6
       with:
@@ -22,7 +22,7 @@ jobs:
     if: ${{ github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.run_attempt == 2 }}
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v7
     - name: Report flaky tests
       uses: actions/github-script@v6
       with:

--- a/.github/workflows/run_integration_tests.yml
+++ b/.github/workflows/run_integration_tests.yml
@@ -35,7 +35,7 @@ jobs:
           major: ${{ inputs.major }}
           minor: ${{ inputs.minor }}
       - name: Download build outputs
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: build-artifact-${{ inputs.major || env.BYOND_MAJOR }}-${{ inputs.minor || env.BYOND_MINOR}}
           path: ./

--- a/.github/workflows/run_integration_tests.yml
+++ b/.github/workflows/run_integration_tests.yml
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Restore BYOND from Cache
         uses: ./.github/actions/restore_or_install_byond
         with:

--- a/.github/workflows/run_integration_tests.yml
+++ b/.github/workflows/run_integration_tests.yml
@@ -81,7 +81,7 @@ jobs:
           done
       - name: Upload screenshot tests
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: test_artifacts_${{ inputs.map }}_${{ inputs.major }}_${{ inputs.minor }}
           path: data/screenshots_new/

--- a/.github/workflows/run_linters.yml
+++ b/.github/workflows/run_linters.yml
@@ -9,9 +9,9 @@ jobs:
     timeout-minutes: 5
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Restore SpacemanDMM cache
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: ~/SpacemanDMM
           key: ${{ runner.os }}-spacemandmm-${{ hashFiles('dependencies.sh') }}
@@ -22,26 +22,26 @@ jobs:
         with:
           restore-yarn-cache: true
       - name: Restore Bootstrap cache
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: tools/bootstrap/.cache
           key: ${{ runner.os }}-bootstrap-${{ hashFiles('/tools/requirements.txt') }}
           restore-keys: |
             ${{ runner.os }}-bootstrap-
       - name: Restore Rust cache
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: ~/.cargo
           key: ${{ runner.os }}-rust-${{ hashFiles('/tools/ci/ci_dependencies.sh')}}
           restore-keys: |
             ${{ runner.os }}-rust-
       - name: Restore Cutter cache
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: tools/icon_cutter/cache
           key: ${{ runner.os }}-cutter-${{ hashFiles('dependencies.sh') }}
       - name: Python setup
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v6
         with:
           python-version: "3.11"
       - name: Setup .NET SDK
@@ -49,7 +49,7 @@ jobs:
         with:
           dotnet-version: 9.x
       - name: Install OpenDream
-        uses: robinraju/release-downloader@v1.12
+        uses: robinraju/release-downloader@v1.13
         with:
           repository: "OpenDreamProject/OpenDream"
           tag: "latest"

--- a/.github/workflows/setup_build_artifact.yml
+++ b/.github/workflows/setup_build_artifact.yml
@@ -35,7 +35,7 @@ jobs:
           bash tools/ci/copy_build_output.sh $OUTPUT_DIR
       - name: Upload artifact
         if: success()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: build-artifact-${{ inputs.major }}-${{ inputs.minor }}
           path: ${{ env.OUTPUT_DIR }}

--- a/.github/workflows/setup_build_artifact.yml
+++ b/.github/workflows/setup_build_artifact.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Setup Node
         uses: ./.github/actions/setup_node
       - name: Restore BYOND from Cache

--- a/.github/workflows/show_screenshot_test_results.yml
+++ b/.github/workflows/show_screenshot_test_results.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
       - name: Prepare module
         run: |
           # This is needed because node-fetch needs import and doesn't work with require :/

--- a/.github/workflows/test_windows.yml
+++ b/.github/workflows/test_windows.yml
@@ -13,7 +13,7 @@ jobs:
     timeout-minutes: 5
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Setup Node
         uses: ./.github/actions/setup_node
         with:

--- a/.github/workflows/update_tgs_dmapi.yml
+++ b/.github/workflows/update_tgs_dmapi.yml
@@ -11,7 +11,7 @@ jobs:
     name: Update the TGS DMAPI
     steps:
     - name: Clone
-      uses: actions/checkout@v2
+      uses: actions/checkout@v7
 
     - name: Branch
       run: |


### PR DESCRIPTION
## About The Pull Request

- `actions/cache/restore@v4` --> `actions/cache/restore@v6`
- `actions/cache/save@v4` --> `actions/cache/save@v6`
- `actions/checkout@v2` --> `actions/checkout@v7`
- `actions/checkout@v3` --> `actions/checkout@v7`
- `actions/checkout@v4` --> `actions/checkout@v7`
- `actions/checkout@v5` --> `actions/checkout@v7`
- `actions/download-artifact@v4` --> `actions/download-artifact@v8`
- `actions/setup-node@v4` --> `actions/setup-node@v7`
- `actions/setup-python@v4` --> `actions/setup-python@v6`
- `actions/upload-artifact@v4` --> `actions/upload-artifact@v7`
- `robinraju/release-downloader@v1.12` --> `robinraju/release-downloader@v1.13`

Also: in `compile_all_maps.yml` there were 2 `bash tools/ci/install_byond.sh` calls even though we do `actions/restore_or_install_byond` right above that which calls `install_byond.sh`, so I removed them

## Why It's Good For The Game

I'm tired of seeing "Node.js 20 is deprecated" warnings in the workflow

## Testing Photographs and Procedure

<img width="746" height="213" alt="image" src="https://github.com/user-attachments/assets/c714edfd-c310-4cdd-9f4a-439a9409def9" />