### PR TITLE
Rad & Card  Tcomms Map Fixes

### DIFF
--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_syndicate_base1.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_syndicate_base1.dmm
@@ -1042,9 +1042,6 @@
 /turf/open/floor/plating,
 /area/ruin/syndicate_lava_base/cargo)
 "is" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
 /obj/machinery/turretid{
 	ailock = 1;
 	control_area = "/area/ruin/syndicate_lava_base";
@@ -1057,7 +1054,7 @@
 	req_access_txt = "150"
 	},
 /turf/open/floor/circuit/red,
-/area/ruin/syndicate_lava_base/engineering)
+/area/ruin/syndicate_lava_base)
 "iz" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
@@ -1125,10 +1122,6 @@
 	},
 /turf/open/floor/iron,
 /area/ruin/syndicate_lava_base/medbay)
-"jc" = (
-/obj/machinery/light/small,
-/turf/open/floor/circuit/red,
-/area/ruin/syndicate_lava_base/engineering)
 "jm" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
@@ -1693,6 +1686,7 @@
 /obj/structure/sign/warning/explosives/alt{
 	pixel_x = 32
 	},
+/obj/machinery/light/small/directional/east,
 /turf/open/floor/circuit/red,
 /area/ruin/syndicate_lava_base/engineering)
 "pR" = (
@@ -6873,7 +6867,7 @@ XA
 QW
 is
 iK
-jc
+iJ
 QW
 Nv
 LB

--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_syndicate_base2.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_syndicate_base2.dmm
@@ -1469,14 +1469,6 @@
 /obj/effect/turf_decal/siding/dark,
 /obj/effect/turf_decal/trimline/dark_red,
 /obj/machinery/light/small/directional/east,
-/obj/machinery/turretid{
-	ailock = 1;
-	control_area = "/area/ruin/syndicate_lava_base/virology";
-	name = "Base turret controls";
-	req_access = null;
-	req_access_txt = "150";
-	pixel_x = 30
-	},
 /turf/open/floor/iron/dark,
 /area/ruin/syndicate_lava_base/bridge)
 "nb" = (
@@ -1900,8 +1892,15 @@
 "rS" = (
 /obj/structure/table/reinforced,
 /obj/structure/window/reinforced/spawner/directional/west,
+/obj/machinery/turretid{
+	ailock = 1;
+	control_area = "/area/ruin/syndicate_lava_base/virology";
+	name = "Base turret controls";
+	req_access = null;
+	req_access_txt = "150"
+	},
 /turf/open/floor/iron/dark,
-/area/ruin/syndicate_lava_base/bridge)
+/area/ruin/syndicate_lava_base/virology)
 "sa" = (
 /obj/structure/cable/yellow,
 /obj/machinery/firealarm/directional/west,

--- a/_maps/map_files/CardinalStation/CardinalStation.dmm
+++ b/_maps/map_files/CardinalStation/CardinalStation.dmm
@@ -1632,8 +1632,7 @@
 	},
 /obj/effect/turf_decal/edges/techfloor,
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 5;
-	hide = 0
+	dir = 5
 	},
 /turf/open/floor/iron/techmaint{
 	initial_gas_mix = "n2=100;TEMP=80"
@@ -2158,8 +2157,7 @@
 /obj/structure/extinguisher_cabinet/directional/east,
 /obj/structure/cable/yellow,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 1;
-	hide = 0
+	dir = 1
 	},
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/captain/private)
@@ -5621,9 +5619,6 @@
 /area/station/security/courtroom)
 "bqO" = (
 /obj/machinery/telecomms/hub/preset,
-/obj/machinery/atmospherics/pipe/smart/simple/general/hidden{
-	dir = 1
-	},
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/station/tcommsat/server)
 "bqP" = (
@@ -5687,9 +5682,8 @@
 /obj/effect/turf_decal/tile/monorust,
 /obj/effect/turf_decal/guideline/guideline_in_alt/darkblue,
 /obj/effect/landmark/xeno_spawn,
-/obj/machinery/atmospherics/pipe/smart/simple/general/hidden{
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /turf/open/floor/iron/large{
 	initial_gas_mix = "n2=100;TEMP=80"
 	},
@@ -6089,6 +6083,9 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/alphabet/letter_m/quarter{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 1
 	},
 /turf/open/floor/iron/dark/smooth_corner{
@@ -7248,11 +7245,6 @@
 /area/station/engineering/storage_shared)
 "bLI" = (
 /obj/structure/cable/yellow,
-/obj/machinery/portable_atmospherics/canister/plasma,
-/obj/effect/mapping_helpers/atmos_auto_connect,
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 8
-	},
 /turf/open/floor/circuit/green/telecomms/mainframe,
 /area/station/science/server)
 "bLN" = (
@@ -10205,7 +10197,9 @@
 	dir = 4
 	},
 /obj/structure/cable/yellow,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
+/obj/machinery/atmospherics/pipe/heat_exchanging/manifold{
+	dir = 4
+	},
 /turf/open/floor/iron/techmaint{
 	initial_gas_mix = "n2=100;TEMP=80"
 	},
@@ -16560,6 +16554,9 @@
 /obj/effect/turf_decal/tile/monorust,
 /obj/effect/mapping_helpers/make_non_slip,
 /obj/effect/turf_decal/tile/dark/fourcorners,
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /turf/open/floor/iron/large{
 	initial_gas_mix = "n2=100;TEMP=80"
 	},
@@ -19389,6 +19386,9 @@
 	},
 /obj/effect/turf_decal/tile/dark/fourcorners,
 /obj/effect/turf_decal/tile/monorust,
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /turf/open/floor/iron/large{
 	initial_gas_mix = "n2=100;TEMP=80"
 	},
@@ -21012,6 +21012,9 @@
 "eWG" = (
 /obj/machinery/telecomms/server/presets/common,
 /obj/effect/turf_decal/bot_white,
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 6
+	},
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/station/tcommsat/server)
 "eWK" = (
@@ -22864,6 +22867,9 @@
 /obj/effect/turf_decal/siding/wideplating_new/dark/corner,
 /obj/effect/landmark/event_spawn,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/general/hidden{
+	dir = 6
+	},
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/tcommsat/computer)
 "ftR" = (
@@ -23354,6 +23360,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/station/tcommsat/server)
 "fAl" = (
@@ -23368,11 +23375,13 @@
 /obj/effect/turf_decal/guideline/guideline_in/darkblue{
 	dir = 5
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/general/hidden{
-	dir = 5
-	},
 /obj/effect/turf_decal/siding/wideplating_new/dark/corner,
 /obj/structure/cable/yellow,
+/obj/machinery/atmospherics/pipe/heat_exchanging/junction{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /turf/open/floor/iron/large{
 	initial_gas_mix = "n2=100;TEMP=80"
 	},
@@ -24210,6 +24219,9 @@
 	dir = 4
 	},
 /obj/structure/cable/yellow,
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /turf/open/floor/iron/large{
 	initial_gas_mix = "n2=100;TEMP=80"
 	},
@@ -24544,9 +24556,6 @@
 /obj/effect/turf_decal/siding/wideplating_new/dark/corner{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/general/hidden{
-	dir = 8
-	},
 /obj/machinery/door/window/brigdoor/westleft{
 	name = "Telecomms Server Room";
 	req_one_access_txt = "19; 61"
@@ -24560,6 +24569,11 @@
 	},
 /obj/structure/cable,
 /obj/structure/cable/yellow,
+/obj/machinery/atmospherics/pipe/smart/simple/general/hidden{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /turf/open/floor/iron/dark/textured_half{
 	dir = 1
 	},
@@ -27837,6 +27851,7 @@
 "gCF" = (
 /obj/machinery/telecomms/receiver/preset_right,
 /obj/effect/turf_decal/stripes/line,
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/station/tcommsat/server)
 "gCI" = (
@@ -30249,6 +30264,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/station/tcommsat/server)
 "hfY" = (
@@ -30989,6 +31005,9 @@
 "hqA" = (
 /obj/machinery/telecomms/server/presets/command,
 /obj/effect/turf_decal/bot_white,
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 10
+	},
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/station/tcommsat/server)
 "hqG" = (
@@ -33683,10 +33702,9 @@
 	},
 /obj/effect/landmark/blobstart,
 /obj/machinery/holopad,
-/obj/machinery/atmospherics/pipe/smart/manifold/general/hidden{
-	dir = 8
-	},
 /obj/structure/cable/yellow,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /turf/open/floor/iron/large{
 	initial_gas_mix = "n2=100;TEMP=80"
 	},
@@ -33732,6 +33750,9 @@
 "hVZ" = (
 /obj/machinery/telecomms/bus/preset_three,
 /obj/effect/turf_decal/bot_white,
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 4
+	},
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/station/tcommsat/server)
 "hWb" = (
@@ -34701,8 +34722,9 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/structure/table_frame,
-/obj/structure/fluff/fans,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 1
+	},
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/station/tcommsat/server)
 "iir" = (
@@ -35417,10 +35439,9 @@
 /obj/machinery/atmospherics/pipe/smart/simple/general/hidden{
 	dir = 8
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 4
-	},
 /obj/structure/cable/yellow,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /turf/open/floor/iron/dark/textured_large,
 /area/station/tcommsat/computer)
 "iqH" = (
@@ -35597,7 +35618,6 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 4
 	},
-/obj/item/toy/figure/engineer,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter)
 "irW" = (
@@ -38514,6 +38534,9 @@
 	dir = 5
 	},
 /obj/structure/cable/yellow,
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /turf/open/floor/iron/large{
 	initial_gas_mix = "n2=100;TEMP=80"
 	},
@@ -39964,6 +39987,8 @@
 	dir = 8
 	},
 /obj/structure/cable/yellow,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /turf/open/floor/iron/dark/textured_large,
 /area/station/tcommsat/computer)
 "jrc" = (
@@ -41761,6 +41786,9 @@
 /obj/effect/turf_decal/guideline/guideline_in/darkblue{
 	dir = 10
 	},
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /turf/open/floor/iron/large{
 	initial_gas_mix = "n2=100;TEMP=80"
 	},
@@ -48302,15 +48330,13 @@
 /obj/effect/turf_decal/siding/thinplating_new/dark{
 	dir = 8
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	external_pressure_bound = 140;
-	name = "server vent";
-	pressure_checks = 0
-	},
 /obj/effect/turf_decal/tile/dark/fourcorners,
 /obj/effect/turf_decal/tile/monorust,
 /obj/effect/mapping_helpers/make_non_slip,
 /obj/effect/turf_decal/guideline/guideline_in/darkblue{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 4
 	},
 /turf/open/floor/iron/large{
@@ -49294,12 +49320,12 @@
 	dir = 10
 	},
 /obj/effect/turf_decal/tile/neutral/opposingcorners,
-/obj/structure/reagent_dispensers/water_cooler,
 /obj/machinery/power/apc/auto_name/directional/west,
 /obj/structure/cable/yellow,
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden{
-	dir = 6
+/obj/machinery/atmospherics/pipe/smart/manifold/cyan/hidden{
+	dir = 8
 	},
+/obj/structure/reagent_dispensers/water_cooler,
 /turf/open/floor/iron/tech,
 /area/station/science/server)
 "lBM" = (
@@ -49387,6 +49413,9 @@
 "lDc" = (
 /obj/machinery/telecomms/bus/preset_two,
 /obj/effect/turf_decal/bot_white,
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 4
+	},
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/station/tcommsat/server)
 "lDd" = (
@@ -51624,6 +51653,9 @@
 "men" = (
 /obj/machinery/telecomms/server/presets/supply,
 /obj/effect/turf_decal/bot_white,
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 5
+	},
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/station/tcommsat/server)
 "met" = (
@@ -52062,6 +52094,9 @@
 "mkl" = (
 /obj/machinery/telecomms/processor/preset_four,
 /obj/effect/turf_decal/bot_white,
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 4
+	},
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/station/tcommsat/server)
 "mkt" = (
@@ -54167,8 +54202,8 @@
 	dir = 4
 	},
 /obj/structure/cable/yellow,
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden{
-	dir = 8
+/obj/machinery/atmospherics/pipe/heat_exchanging/junction{
+	dir = 4
 	},
 /turf/open/floor/iron/dark,
 /area/station/science/server)
@@ -55115,9 +55150,6 @@
 /area/station/science/lobby)
 "mTu" = (
 /obj/effect/turf_decal/siding/wideplating_new/dark/corner,
-/obj/machinery/atmospherics/pipe/smart/simple/general/hidden{
-	dir = 10
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /obj/effect/turf_decal/siding/wideplating_new/dark/corner{
 	dir = 4
@@ -55125,6 +55157,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/effect/landmark/navigate_destination,
 /obj/structure/cable/yellow,
+/obj/machinery/atmospherics/pipe/smart/manifold/general/hidden{
+	dir = 4
+	},
 /turf/open/floor/iron/dark/textured_large,
 /area/station/tcommsat/computer)
 "mTv" = (
@@ -57384,6 +57419,8 @@
 	},
 /obj/effect/turf_decal/tile/dark/fourcorners,
 /obj/effect/turf_decal/tile/monorust,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /turf/open/floor/iron/large{
 	initial_gas_mix = "n2=100;TEMP=80"
 	},
@@ -60453,6 +60490,7 @@
 "ohy" = (
 /obj/machinery/telecomms/broadcaster/preset_right,
 /obj/effect/turf_decal/stripes/line,
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/station/tcommsat/server)
 "ohE" = (
@@ -60943,11 +60981,13 @@
 /obj/effect/turf_decal/siding/wideplating_new/dark{
 	dir = 6
 	},
-/obj/item/kirbyplants{
-	icon_state = "plant-22";
-	pixel_y = 8
-	},
 /obj/structure/railing/perspective/black,
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 8;
+	name = "output gas connector port"
+	},
+/obj/machinery/portable_atmospherics/canister/plasma,
+/obj/effect/mapping_helpers/atmos_auto_connect,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/tcommsat/computer)
 "onW" = (
@@ -63066,7 +63106,6 @@
 /obj/effect/turf_decal/tile/dark/fourcorners,
 /obj/effect/turf_decal/tile/monorust,
 /obj/effect/mapping_helpers/make_non_slip,
-/obj/machinery/atmospherics/pipe/smart/simple/general/hidden,
 /turf/open/floor/iron/large{
 	initial_gas_mix = "n2=100;TEMP=80"
 	},
@@ -64393,14 +64432,12 @@
 /obj/effect/turf_decal/siding/thinplating_new/dark{
 	dir = 8
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/siphon/on{
-	dir = 1;
-	external_pressure_bound = 120;
-	name = "server vent"
-	},
 /obj/effect/turf_decal/tile/dark/fourcorners,
 /obj/effect/turf_decal/tile/monorust,
 /obj/effect/mapping_helpers/make_non_slip,
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 4
+	},
 /turf/open/floor/iron/large{
 	initial_gas_mix = "n2=100;TEMP=80"
 	},
@@ -68075,6 +68112,7 @@
 "pZw" = (
 /obj/machinery/telecomms/server/presets/medical,
 /obj/effect/turf_decal/bot_white,
+/obj/machinery/atmospherics/pipe/heat_exchanging/manifold,
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/station/tcommsat/server)
 "pZB" = (
@@ -68477,8 +68515,7 @@
 /obj/effect/turf_decal/edges/techfloor,
 /obj/machinery/light/small/directional/east,
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 4;
-	hide = 0
+	dir = 4
 	},
 /turf/open/floor/iron/techmaint{
 	initial_gas_mix = "n2=100;TEMP=80"
@@ -68518,6 +68555,10 @@
 	pixel_y = 9
 	},
 /obj/structure/cable/yellow,
+/obj/item/toy/figure/engineer{
+	pixel_y = -8;
+	pixel_x = -9
+	},
 /turf/open/floor/iron/tech/grid,
 /area/station/engineering/storage)
 "qeI" = (
@@ -69223,9 +69264,7 @@
 /obj/effect/turf_decal/siding/dark{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/heat_exchanging/junction{
-	hide = 0
-	},
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
 /turf/open/floor/iron/techmaint{
 	initial_gas_mix = "n2=100;TEMP=80"
 	},
@@ -69260,8 +69299,7 @@
 	},
 /obj/machinery/light/small/directional/east,
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 4;
-	hide = 0
+	dir = 4
 	},
 /turf/open/floor/iron/techmaint{
 	initial_gas_mix = "n2=100;TEMP=80"
@@ -75245,6 +75283,9 @@
 "rIi" = (
 /obj/machinery/telecomms/processor/preset_one,
 /obj/effect/turf_decal/bot_white,
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 4
+	},
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/station/tcommsat/server)
 "rIl" = (
@@ -82845,8 +82886,7 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 6;
-	hide = 0
+	dir = 6
 	},
 /turf/open/floor/iron/techmaint{
 	initial_gas_mix = "n2=100;TEMP=80"
@@ -83267,17 +83307,14 @@
 /turf/open/floor/iron/techmaint,
 /area/station/maintenance/department/bridge)
 "tDx" = (
-/obj/effect/turf_decal/siding/dark{
-	dir = 4
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/heat_exchanging/junction{
-	dir = 1;
-	hide = 0
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 1
 	},
-/turf/open/floor/iron/techmaint{
-	initial_gas_mix = "n2=100;TEMP=80"
-	},
-/area/station/science/server)
+/turf/open/floor/circuit/telecomms/mainframe,
+/area/station/tcommsat/server)
 "tDy" = (
 /turf/closed/wall,
 /area/station/maintenance/solars/starboard/aft)
@@ -88002,8 +88039,7 @@
 /area/station/maintenance/department/cargo)
 "uJB" = (
 /obj/effect/turf_decal/stripes/line,
-/obj/structure/table_frame,
-/obj/structure/fluff/fans,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/station/tcommsat/server)
 "uJC" = (
@@ -91556,8 +91592,9 @@
 /obj/effect/turf_decal/guideline/guideline_in/darkblue{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/general/hidden,
 /obj/structure/cable/yellow,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /turf/open/floor/iron/large{
 	initial_gas_mix = "n2=100;TEMP=80"
 	},
@@ -91638,7 +91675,6 @@
 /obj/effect/turf_decal/guideline/guideline_in/darkblue{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/general/hidden,
 /turf/open/floor/iron/large{
 	initial_gas_mix = "n2=100;TEMP=80"
 	},
@@ -91893,6 +91929,9 @@
 	},
 /obj/machinery/airalarm/directional/west,
 /obj/machinery/light/small/directional/west,
+/obj/machinery/portable_atmospherics/canister/plasma,
+/obj/effect/mapping_helpers/atmos_auto_connect,
+/obj/machinery/atmospherics/components/unary/portables_connector/visible,
 /turf/open/floor/iron/tech,
 /area/station/science/server)
 "vEk" = (
@@ -93262,22 +93301,9 @@
 /turf/open/floor/iron/dark,
 /area/station/science/xenobiology)
 "vUp" = (
-/obj/effect/turf_decal/siding/thinplating_new/dark,
-/obj/effect/turf_decal/siding/thinplating_new/dark{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/dark/fourcorners,
-/obj/effect/turf_decal/tile/monorust,
-/obj/effect/turf_decal/guideline/guideline_in/darkblue{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/general/hidden{
-	dir = 8
-	},
-/obj/structure/cable/yellow,
-/turf/open/floor/iron/large{
-	initial_gas_mix = "n2=100;TEMP=80"
-	},
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
+/turf/open/floor/circuit/telecomms/mainframe,
 /area/station/tcommsat/server)
 "vUt" = (
 /obj/structure/chair{
@@ -94549,6 +94575,8 @@
 /obj/effect/turf_decal/tile/dark/fourcorners,
 /obj/effect/turf_decal/tile/monorust,
 /obj/effect/turf_decal/guideline/guideline_in/darkblue,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /turf/open/floor/iron/large{
 	initial_gas_mix = "n2=100;TEMP=80"
 	},
@@ -96681,10 +96709,10 @@
 /obj/effect/turf_decal/guideline/guideline_in/darkblue{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/general/hidden{
-	dir = 8
-	},
 /obj/structure/cable/yellow,
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /turf/open/floor/iron/large{
 	initial_gas_mix = "n2=100;TEMP=80"
 	},
@@ -97915,11 +97943,10 @@
 /obj/effect/turf_decal/guideline/guideline_in_alt/darkblue{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/general/hidden{
-	dir = 10
-	},
 /obj/machinery/light_switch/directional/east,
 /obj/structure/cable/yellow,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /turf/open/floor/iron/large{
 	initial_gas_mix = "n2=100;TEMP=80"
 	},
@@ -99460,6 +99487,8 @@
 	dir = 1
 	},
 /obj/structure/cable/yellow,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /turf/open/floor/iron/large{
 	initial_gas_mix = "n2=100;TEMP=80"
 	},
@@ -128664,7 +128693,7 @@ gDA
 mlI
 gVa
 txI
-tDx
+qnL
 cvt
 qnL
 atK
@@ -130780,7 +130809,7 @@ fvO
 erD
 opx
 mkl
-uJB
+vUp
 wkM
 cEc
 xqM
@@ -131297,8 +131326,8 @@ hVZ
 uJB
 ntF
 nwn
-vUp
-iim
+xqM
+tDx
 rIi
 sxe
 erD

--- a/_maps/map_files/RadStation/RadStation.dmm
+++ b/_maps/map_files/RadStation/RadStation.dmm
@@ -3187,6 +3187,7 @@
 /obj/effect/turf_decal/box,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
 /turf/open/floor/engine{
 	initial_gas_mix = "n2=100;TEMP=80";
 	name = "mainframe floor"
@@ -4037,6 +4038,9 @@
 	dir = 10
 	},
 /obj/machinery/telecomms/processor/preset_two,
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 6
+	},
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/station/tcommsat/server)
 "byW" = (
@@ -5030,6 +5034,7 @@
 	dir = 8
 	},
 /obj/machinery/firealarm/directional/west,
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
 /turf/open/floor/engine{
 	initial_gas_mix = "n2=100;TEMP=80";
 	name = "mainframe floor"
@@ -10469,7 +10474,6 @@
 	dir = 5
 	},
 /obj/machinery/telecomms/server/presets/security,
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
 /turf/open/floor/circuit/green/telecomms/mainframe,
 /area/station/tcommsat/server)
 "dXa" = (
@@ -10865,8 +10869,8 @@
 "edU" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/ntnet_relay,
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 4
+/obj/machinery/atmospherics/pipe/heat_exchanging/manifold{
+	dir = 1
 	},
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/station/tcommsat/server)
@@ -11230,7 +11234,6 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
 /turf/open/floor/circuit/green/telecomms/mainframe,
 /area/station/tcommsat/server)
 "ekT" = (
@@ -11705,7 +11708,7 @@
 	density = 0
 	},
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 10
+	dir = 4
 	},
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/station/tcommsat/server)
@@ -12013,7 +12016,6 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
 /turf/open/floor/circuit/green/telecomms/mainframe,
 /area/station/tcommsat/server)
 "eyy" = (
@@ -12134,7 +12136,6 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
 /turf/open/floor/engine{
 	initial_gas_mix = "n2=100;TEMP=80";
 	name = "mainframe floor"
@@ -14648,6 +14649,7 @@
 /obj/machinery/atmospherics/pipe/heat_exchanging/junction{
 	dir = 1
 	},
+/obj/structure/fans/tiny,
 /turf/open/floor/engine{
 	initial_gas_mix = "n2=100;TEMP=80";
 	name = "mainframe floor"
@@ -14721,7 +14723,7 @@
 /area/station/commons/vacant_room/office)
 "fxd" = (
 /obj/structure/sign/poster/random,
-/turf/closed/wall,
+/turf/closed/wall/r_wall,
 /area/station/tcommsat/server)
 "fxE" = (
 /obj/structure/cable/yellow,
@@ -15514,7 +15516,7 @@
 /turf/open/floor/plating,
 /area/station/cargo/sorting)
 "fNX" = (
-/turf/closed/wall,
+/turf/closed/wall/r_wall,
 /area/station/tcommsat/server)
 "fNY" = (
 /obj/structure/sign/warning/no_smoking/circle,
@@ -16297,6 +16299,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
 /turf/open/floor/circuit/green/telecomms/mainframe,
 /area/station/tcommsat/server)
 "gkj" = (
@@ -16663,7 +16666,7 @@
 	pixel_y = 32
 	},
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 6
+	dir = 4
 	},
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/station/tcommsat/server)
@@ -18540,7 +18543,6 @@
 	dir = 9
 	},
 /obj/machinery/telecomms/server/presets/science,
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
 /turf/open/floor/circuit/green/telecomms/mainframe,
 /area/station/tcommsat/server)
 "heM" = (
@@ -19823,7 +19825,6 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
 /turf/open/floor/circuit/green/telecomms/mainframe,
 /area/station/tcommsat/server)
 "hDL" = (
@@ -20602,6 +20603,9 @@
 	dir = 8
 	},
 /obj/machinery/telecomms/message_server/preset,
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 5
+	},
 /turf/open/floor/circuit/green/telecomms/mainframe,
 /area/station/tcommsat/server)
 "hUh" = (
@@ -21087,6 +21091,7 @@
 	dir = 4
 	},
 /obj/machinery/telecomms/bus/preset_four,
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
 /turf/open/floor/circuit/green/telecomms/mainframe,
 /area/station/tcommsat/server)
 "idd" = (
@@ -27375,6 +27380,7 @@
 	dir = 5
 	},
 /obj/machinery/telecomms/server/presets/medical,
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
 /turf/open/floor/circuit/green/telecomms/mainframe,
 /area/station/tcommsat/server)
 "kyb" = (
@@ -29135,6 +29141,7 @@
 	pixel_x = -28
 	},
 /obj/machinery/telecomms/bus/preset_one,
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
 /turf/open/floor/circuit/green/telecomms/mainframe,
 /area/station/tcommsat/server)
 "ldT" = (
@@ -29853,6 +29860,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
 /turf/open/floor/circuit/green/telecomms/mainframe,
 /area/station/tcommsat/server)
 "ltY" = (
@@ -31053,6 +31061,9 @@
 /obj/machinery/telecomms/processor/preset_four,
 /obj/machinery/status_display/ai{
 	pixel_y = 32
+	},
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 10
 	},
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/station/tcommsat/server)
@@ -33236,6 +33247,9 @@
 	dir = 8
 	},
 /obj/machinery/telecomms/hub/preset,
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 9
+	},
 /turf/open/floor/circuit/green/telecomms/mainframe,
 /area/station/tcommsat/server)
 "mDl" = (
@@ -33593,7 +33607,7 @@
 /area/station/engineering/atmos)
 "mJt" = (
 /obj/machinery/status_display/evac,
-/turf/closed/wall,
+/turf/closed/wall/r_wall,
 /area/station/command/heads_quarters/hop)
 "mJA" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
@@ -34265,6 +34279,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
 /turf/open/floor/circuit/green/telecomms/mainframe,
 /area/station/tcommsat/server)
 "mXc" = (
@@ -34954,6 +34969,7 @@
 "nku" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/east,
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
 /turf/open/floor/engine{
 	initial_gas_mix = "n2=100;TEMP=80";
 	name = "mainframe floor"
@@ -37287,9 +37303,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/science/shuttledock)
-"nYG" = (
-/turf/closed/wall,
-/area/station/tcommsat/computer)
 "nYI" = (
 /obj/structure/chair/fancy/sofa/old/right{
 	color = "#742925";
@@ -37819,6 +37832,7 @@
 	dir = 9
 	},
 /obj/machinery/telecomms/server/presets/command,
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
 /turf/open/floor/circuit/green/telecomms/mainframe,
 /area/station/tcommsat/server)
 "ojz" = (
@@ -44640,6 +44654,7 @@
 "qNX" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
 /turf/open/floor/engine{
 	initial_gas_mix = "n2=100;TEMP=80";
 	name = "mainframe floor"
@@ -52185,6 +52200,7 @@
 /obj/effect/landmark/xeno_spawn,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
 /turf/open/floor/engine{
 	initial_gas_mix = "n2=100;TEMP=80";
 	name = "mainframe floor"
@@ -53340,6 +53356,7 @@
 	dir = 4
 	},
 /obj/machinery/camera/directional/east,
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
 /turf/open/floor/engine{
 	initial_gas_mix = "n2=100;TEMP=80";
 	name = "mainframe floor"
@@ -53757,9 +53774,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/heat_exchanging/manifold,
 /turf/open/floor/engine{
 	initial_gas_mix = "n2=100;TEMP=80";
 	name = "mainframe floor"
@@ -58237,7 +58252,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 5
+	dir = 4
 	},
 /turf/open/floor/engine{
 	initial_gas_mix = "n2=100;TEMP=80";
@@ -58445,6 +58460,7 @@
 /obj/effect/landmark/blobstart,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
 /turf/open/floor/engine{
 	initial_gas_mix = "n2=100;TEMP=80";
 	name = "mainframe floor"
@@ -58960,7 +58976,6 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
 /turf/open/floor/circuit/green/telecomms/mainframe,
 /area/station/tcommsat/server)
 "wpx" = (
@@ -61035,7 +61050,6 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
 /turf/open/floor/circuit/green/telecomms/mainframe,
 /area/station/tcommsat/server)
 "xdw" = (
@@ -62371,7 +62385,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/heat_exchanging/manifold{
-	dir = 4
+	dir = 1
 	},
 /turf/open/floor/engine{
 	initial_gas_mix = "n2=100;TEMP=80";
@@ -97336,7 +97350,7 @@ ivq
 vih
 nbp
 tvE
-hqR
+tkT
 fNX
 fNX
 fNX
@@ -97346,10 +97360,10 @@ fxd
 fNX
 fNX
 fNX
-nYG
+aIl
 snQ
-nYG
-nYG
+aIl
+aIl
 kmj
 kmj
 eMv
@@ -97595,7 +97609,7 @@ paG
 saF
 mJt
 byE
-jHP
+bvt
 ojk
 ltX
 bRR
@@ -97606,7 +97620,7 @@ kbA
 foV
 xXS
 stF
-nYG
+aIl
 gSJ
 bkZ
 mDM
@@ -97850,12 +97864,12 @@ hqR
 jDT
 tOT
 hqR
-hqR
+tkT
 gsn
-bvt
+jHP
 dWZ
 hDH
-bvt
+jHP
 gNj
 eyw
 waP
@@ -97863,7 +97877,7 @@ kbA
 bmU
 vqI
 dCx
-nYG
+aIl
 grd
 juc
 diW
@@ -98107,7 +98121,7 @@ wrM
 xfX
 mcO
 oCs
-hqR
+tkT
 edU
 bhE
 qNX
@@ -98120,7 +98134,7 @@ kbA
 uAH
 obE
 qxn
-nYG
+aIl
 tZg
 dyf
 ccU
@@ -98369,7 +98383,7 @@ ety
 eAT
 heq
 wpv
-bvt
+jHP
 ekK
 xdu
 xCz
@@ -98377,7 +98391,7 @@ fvz
 mno
 uyu
 unb
-nYG
+aIl
 dyf
 aMY
 jhm
@@ -98621,7 +98635,7 @@ nAF
 tiD
 npa
 sRV
-hqR
+tkT
 lPz
 nku
 kxR
@@ -98634,7 +98648,7 @@ kbA
 iEP
 vDD
 nVD
-nYG
+aIl
 ccU
 cYa
 tZg
@@ -98878,7 +98892,7 @@ uha
 kkC
 qpL
 pVZ
-hqR
+tkT
 fNX
 fNX
 fNX
@@ -98888,9 +98902,9 @@ fNX
 fNX
 fNX
 fNX
-nYG
-nYG
-nYG
+aIl
+aIl
+aIl
 aIl
 wdW
 wdW
@@ -99135,7 +99149,7 @@ tkT
 hqR
 igU
 krG
-hqR
+tkT
 bHh
 jiE
 myA


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes a few issues with telecommunications heating up in Radstation and Cardstation due to insufficient Heat Exchanging Pipes, and in Cardstation's situation, due to not having Heat Exchanging at all

## Why It's Good For The Game

Things need to work properly

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

<img width="473" height="682" alt="image" src="https://github.com/user-attachments/assets/8a11ef9e-d6c3-4d81-8d04-29f045b2b8d7" />

<img width="1656" height="871" alt="image" src="https://github.com/user-attachments/assets/ed5a6708-fc9b-433d-87c3-e034e0164850" />

<img width="416" height="384" alt="image" src="https://github.com/user-attachments/assets/0a8b46c9-9363-4304-9d2a-fc92b886d93f" />

<img width="224" height="416" alt="image" src="https://github.com/user-attachments/assets/f9612543-0d08-4b40-9376-02017aff56b4" />

<img width="256" height="224" alt="image" src="https://github.com/user-attachments/assets/33b8b74c-d43e-4a06-a530-0ed35fdb2e62" />


</details>

## Changelog
:cl: Isaac
fix: Radstation telecommunications HE should cover the entire room
fix: Radstation Telecommunications is now encased in reinforced walls instead of regular walls
fix: Cardstation Telecommunications now has HE
fix: Cardstation R&D Server no longer has the plasma canister alongside the servers
fix: Moves some areas around in both syndicate lavaland bases so the turrets can actually be turned off by their turret control
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
