### PR TITLE
Midround Blood Cult

### DIFF
--- a/code/controllers/subsystem/dynamic/dynamic_rulesets_midround_living.dm
+++ b/code/controllers/subsystem/dynamic/dynamic_rulesets_midround_living.dm
@@ -64,7 +64,7 @@
 	return ..()
 
 /datum/dynamic_ruleset/midround/living/bloodcultist
-	name = "Blood Cultist (Midround)"
+	name = "Blood Cultists"
 	severity = DYNAMIC_MIDROUND_HEAVY
 	role_preference = /datum/role_preference/midround/bloodcultist
 	antag_datum = /datum/antagonist/cult

--- a/code/controllers/subsystem/dynamic/dynamic_rulesets_midround_living.dm
+++ b/code/controllers/subsystem/dynamic/dynamic_rulesets_midround_living.dm
@@ -64,17 +64,27 @@
 	return ..()
 
 /datum/dynamic_ruleset/midround/living/bloodcultist
-	name = "Blood Cultists"
+	name = "Blood Cultist" // Yes, blood cultist as in (1) singular cultist
 	severity = DYNAMIC_MIDROUND_HEAVY
 	role_preference = /datum/role_preference/midround/bloodcultist
 	antag_datum = /datum/antagonist/cult
-	drafted_players_amount = 3
+	drafted_players_amount = 1
 	weight = 4
-	points_cost = 40
+	points_cost = 35
 	minimum_players_required = 25
 
 /datum/dynamic_ruleset/midround/living/bloodcultist/get_poll_icon()
 	return /obj/item/melee/cultblade/dagger
+
+/datum/dynamic_ruleset/midround/living/bloodcultist/execute()
+	. = ..()
+	if(. != DYNAMIC_EXECUTE_SUCCESS)
+		return .
+	for(var/mob/chosen_candidate in chosen_candidates)
+		var/datum/antagonist/cult/Candidate = chosen_candidate.mind?.has_antag_datum(/datum/antagonist/cult)
+		if(Candidate)
+			Candidate.rune_power = 2 // They count as 2 towards runes, so they have less issue getting the cult going alone
+	return .
 
 //////////////////////////////////////////////
 //                                          //

--- a/code/controllers/subsystem/dynamic/dynamic_rulesets_midround_living.dm
+++ b/code/controllers/subsystem/dynamic/dynamic_rulesets_midround_living.dm
@@ -81,7 +81,7 @@
 	if(. != DYNAMIC_EXECUTE_SUCCESS)
 		return .
 	for(var/mob/chosen_candidate in chosen_candidates)
-		var/datum/antagonist/cult/Candidate = chosen_candidate.mind?.has_antag_datum(/datum/antagonist/cult)
+		var/datum/antagonist/cult/Candidate = IS_CULTIST(chosen_candidate)
 		if(Candidate)
 			Candidate.rune_power = 2 // They count as 2 towards runes, so they have less issue getting the cult going alone
 	return .

--- a/code/controllers/subsystem/dynamic/dynamic_rulesets_midround_living.dm
+++ b/code/controllers/subsystem/dynamic/dynamic_rulesets_midround_living.dm
@@ -63,6 +63,19 @@
 		chosen_candidate.mind.special_role = antag_datum.banning_key
 	return ..()
 
+/datum/dynamic_ruleset/midround/living/bloodcultist
+	name = "Blood Cultist (Midround)"
+	severity = DYNAMIC_MIDROUND_HEAVY
+	role_preference = /datum/role_preference/midround/bloodcultist
+	antag_datum = /datum/antagonist/cult
+	drafted_players_amount = 3
+	weight = 4
+	points_cost = 40
+	minimum_players_required = 25
+
+/datum/dynamic_ruleset/midround/living/bloodcultist/get_poll_icon()
+	return /obj/item/melee/cultblade/dagger
+
 //////////////////////////////////////////////
 //                                          //
 //         VALUE DRIFTED AI (MEDIUM)        //

--- a/code/modules/antagonists/cult/cult.dm
+++ b/code/modules/antagonists/cult/cult.dm
@@ -15,6 +15,7 @@
 	var/ignore_implant = FALSE
 	var/give_equipment = FALSE
 	var/datum/team/cult/cult_team
+	var/rune_power = 1 // How many cultists does this cult member count as for things such as runes?
 
 
 /datum/antagonist/cult/get_team()

--- a/code/modules/antagonists/cult/runes.dm
+++ b/code/modules/antagonists/cult/runes.dm
@@ -43,6 +43,17 @@ GLOBAL_LIST_EMPTY(wall_runes)
 		return FALSE //can't convert machines, shielded, braindead, or ratvar's dogs
 	return TRUE
 
+/proc/get_rune_power(list/invokers)
+	var/total = 0
+	for(var/atom/movable/invoker in invokers)
+		if(isliving(invoker))
+			var/mob/living/living_invoker = invoker
+			var/datum/antagonist/cult/cultist_datum = living_invoker.mind?.has_antag_datum(/datum/antagonist/cult)
+			total += cultist_datum ? cultist_datum.rune_power : 1
+		else
+			total += 1
+	return total
+
 /*
 
 This file contains runes.
@@ -127,10 +138,11 @@ CREATION_TEST_IGNORE_SUBTYPES(/obj/effect/rune)
 		to_chat(user, span_warning("You aren't able to understand the words of [src]."))
 		return
 	var/list/invokers = can_invoke(user)
-	if(length(invokers) >= req_cultists)
+	var/power = get_rune_power(invokers)
+	if(power >= req_cultists)
 		invoke(invokers)
 	else
-		to_chat(user, span_danger("You need [req_cultists - length(invokers)] more adjacent cultists to use this rune in such a manner."))
+		to_chat(user, span_danger("You need [req_cultists - power] more adjacent cultists to use this rune in such a manner."))
 		fail_invoke()
 
 /obj/effect/rune/attack_animal(mob/living/simple_animal/M)
@@ -288,7 +300,7 @@ CREATION_TEST_IGNORE_SUBTYPES(/obj/effect/rune/malformed)
 	rune_in_use = FALSE
 
 /obj/effect/rune/convert/proc/do_convert(mob/living/convertee, list/invokers)
-	if(length(invokers) < 2)
+	if(get_rune_power(invokers) < 2)
 		for(var/M in invokers)
 			to_chat(M, span_danger("You need at least two invokers to convert [convertee]!"))
 		log_game("Offer rune failed - tried conversion with one invoker")
@@ -331,7 +343,7 @@ CREATION_TEST_IGNORE_SUBTYPES(/obj/effect/rune/malformed)
 		return FALSE
 
 	var/big_sac = FALSE
-	if((((ishuman(sacrificial) || iscyborg(sacrificial)) && sacrificial.stat != DEAD) || C.cult_team.is_sacrifice_target(sacrificial.mind)) && length(invokers) < 3)
+	if((((ishuman(sacrificial) || iscyborg(sacrificial)) && sacrificial.stat != DEAD) || C.cult_team.is_sacrifice_target(sacrificial.mind)) && get_rune_power(invokers) < 3)
 		for(var/M in invokers)
 			to_chat(M, span_cultitalic("[sacrificial] is too greatly linked to the world! You need three acolytes!"))
 		log_game("Offer rune failed - not enough acolytes and target is living or sac target")

--- a/code/modules/antagonists/role_preference/role_midrounds.dm
+++ b/code/modules/antagonists/role_preference/role_midrounds.dm
@@ -7,6 +7,14 @@
 	antag_datum = /datum/antagonist/traitor
 	use_icon = /datum/role_preference/roundstart/traitor
 
+/datum/role_preference/midround/bloodcultist
+	name = "Blood Cultist (Midround)"
+	description = "Nar'Sie has called upon you, and you have answered. \
+	Join your fellow cultists, convert the crew, sacrifice those who oppose \
+	the Geometer of Blood, and complete the ritual to summon Nar'Sie."
+	antag_datum = /datum/antagonist/cult
+	use_icon = /datum/role_preference/roundstart/blood_cultist
+
 /datum/role_preference/midround/heretic
 	name = "Fanatic Revelation"
 	description = "Find hidden influences and sacrifice crew members to gain magical \


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Turns Blood Cultist into a Midround aswell, not just being a roundstart antag

## Why It's Good For The Game

People are getting bored of most of the midround antags being dragon + nukie at higher pops, this places another antag into that pool so we can get some variety

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

<img width="1333" height="665" alt="image" src="https://github.com/user-attachments/assets/d9352b44-967d-4af6-a7ae-f329b58ab5dd" />

<img width="1309" height="735" alt="image" src="https://github.com/user-attachments/assets/929e8c64-d365-4212-8d11-1ab61ab474b3" />

<img width="582" height="621" alt="image" src="https://github.com/user-attachments/assets/c3fd814c-f2fb-438f-b18a-6674daca48ce" />


Pref Working

</details>

## Changelog
:cl:
add: Blood Cult can now be rolled as a midround living poll, you are however alone
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
