### PR TITLE
Fixes Pointing Bringing Up Point Text Box

### DIFF
--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -482,7 +482,7 @@
 	return
 
 /mob/proc/ShiftMiddleClickOn(atom/A, params)
-	src.pointed(A, params)
+	src._pointed(A, params)
 	return
 
 /atom/proc/CtrlShiftClick(mob/user)


### PR DESCRIPTION
## About The Pull Request

There bee a bug on our station! Apparently as a ghost atleast, pointing will result in a menu like this being brought up:

<img width="520" height="241" alt="image" src="https://github.com/user-attachments/assets/7b129330-752f-4e7b-b1fa-c801eeff9026" />

Rather then our beautiful arrows... 

This PR fixes that- It changes the shift middle click ( point hotkey ) to **not** use the pointed verb as that brings up the undesirable dialogue. Instead, the _pointed *proc* is called to point at atoms.

## Why It's Good For The Game

Not only was that menu UGLY, but entirely unneeded- I didnt even both seeing how well it worked because at its core pointing is a simple action, that appreciates being done quickly... something this menu is lacking in. So not only is it a bug fix, which are always good but it gets rid of a bad feature and replaces it with a good one.

## Testing Photographs and Procedure

<details>
<summary>Screenshots&Videos</summary>

https://github.com/user-attachments/assets/c4a91ede-5fff-4283-acc9-5f56033fbf92

</details>

## Changelog
:cl:
fix: Fixes pointing. Shift+Middleclick now points again instead of bringing up a text input dialogue
/:cl:

