### PR TITLE
Adds dog rotation

### DIFF
--- a/beestation.dme
+++ b/beestation.dme
@@ -3593,6 +3593,7 @@
 #include "code\modules\mob\living\basic\pets\dog\_dog.dm"
 #include "code\modules\mob\living\basic\pets\dog\corgi.dm"
 #include "code\modules\mob\living\basic\pets\dog\dog_subtypes.dm"
+#include "code\modules\mob\living\basic\pets\dog\security_dog.dm"
 #include "code\modules\mob\living\basic\pets\dog\strippable_items.dm"
 #include "code\modules\mob\living\basic\pets\gondolas\gondola.dm"
 #include "code\modules\mob\living\basic\pets\gondolas\gondolapod.dm"

--- a/code/datums/elements/pet_collar.dm
+++ b/code/datums/elements/pet_collar.dm
@@ -36,6 +36,11 @@
 		COMSIG_MOB_STATCHANGE,
 	))
 
+/// Named pets don't get overrided. Earn your keep, unique_pet.
+/datum/element/wears_collar/proc/is_renameable(mob/living/source)
+	var/mob/living/basic/pet/pet_source = source
+	return !istype(pet_source) || !pet_source.unique_pet
+
 /datum/element/wears_collar/proc/on_stat_change(mob/living/source)
 	SIGNAL_HANDLER
 
@@ -47,6 +52,8 @@
 
 	if(!istype(moved, /obj/item/clothing/neck/petcollar))
 		return
+	if(!is_renameable(source))
+		return
 	source.fully_replace_character_name(null, source::name)
 	if(collar_icon_state)
 		source.update_appearance()
@@ -55,6 +62,8 @@
 	SIGNAL_HANDLER
 
 	if(!istype(new_collar) || !new_collar.tagname)
+		return
+	if(!is_renameable(source))
 		return
 
 	source.fully_replace_character_name(null, "\proper [new_collar.tagname]")

--- a/code/game/objects/structures/beds_chairs/bed.dm
+++ b/code/game/objects/structures/beds_chairs/bed.dm
@@ -103,45 +103,56 @@
 	anchored = FALSE
 	buildstacktype = /obj/item/stack/sheet/wood
 	buildstackamount = 10
+	//Is this owned already or can we put a name on it
 	var/owned = FALSE
+	///flavor desc
+	var/claimed_desc = "Looks comfy."
 
 /obj/structure/bed/dogbed/ian
 	desc = "Ian's bed! Looks comfy."
 	name = "Ian's bed"
 	anchored = TRUE
+	owned = TRUE
 
 /obj/structure/bed/dogbed/cayenne
 	desc = "Seems kind of... fishy."
 	name = "Cayenne's bed"
 	anchored = TRUE
+	owned = TRUE
 
 /obj/structure/bed/dogbed/renault
 	desc = "Renault's bed! Looks comfy. A foxy person needs a foxy pet."
 	name = "Renault's bed"
 	anchored = TRUE
+	owned = TRUE
 
 /obj/structure/bed/dogbed/runtime
 	desc = "A comfy-looking cat bed. You can even strap your pet in, in case the gravity turns off."
 	name = "Runtime's bed"
 	anchored = TRUE
+	owned = TRUE
 
 /obj/structure/bed/dogbed/vector
 	desc = "Vector's bed! Wait... Do hamsters normally have beds...?"
 	name = "Vector's bed"
 	anchored = TRUE
+	owned = TRUE
 
+/// Owned by the security dog
 /obj/structure/bed/dogbed/tyson
-	desc = "Tyson's bed! It reeks of testosterone and motor oil."
-	name = "Tyson's bed"
+	desc = "The security dog's bed! It reeks of adrenaline and motor oil."
+	name = "security dog's bed"
 	anchored = TRUE
+	owned = TRUE
+	claimed_desc = "It reeks of adrenaline and motor oil."
 
 ///Used to set the owner of a dogbed, returns FALSE if called on an owned bed or an invalid one, TRUE if the possesion succeeds
-/obj/structure/bed/dogbed/proc/update_owner(mob/living/M)
-	if(owned || type != /obj/structure/bed/dogbed) //Only marked beds work, this is hacky but I'm a hacky man
+/obj/structure/bed/dogbed/proc/update_owner(mob/living/M, force = FALSE)
+	if(owned && !force)
 		return FALSE //Failed
 	owned = TRUE
 	name = "[M]'s bed"
-	desc = "[M]'s bed! Looks comfy."
+	desc = "[M]'s bed! [claimed_desc]"
 	return TRUE //Let any callers know that this bed is ours now
 
 /obj/structure/bed/dogbed/buckle_mob(mob/living/M, force, check_loc)

--- a/code/modules/mob/living/basic/pets/dog/dog_subtypes.dm
+++ b/code/modules/mob/living/basic/pets/dog/dog_subtypes.dm
@@ -33,14 +33,6 @@
 	collar_icon_state = "bullterrier"
 	held_state = "bullterrier"
 
-/mob/living/basic/pet/dog/bullterrier/tyson
-	name = "Tyson"
-	real_name = "Tyson"
-	gender = MALE
-	desc = "A sturdy bullterrier with a friendly but watchful demeanor. His intelligent eyes belies his trustworthiness, despite what a goofy face and frame might suggest."
-	gold_core_spawnable = NO_SPAWN
-	unique_pet = TRUE
-
 /mob/living/basic/pet/dog/corgi/capybara
 	name = "\improper capybara"
 	real_name = "capybara"

--- a/code/modules/mob/living/basic/pets/dog/security_dog.dm
+++ b/code/modules/mob/living/basic/pets/dog/security_dog.dm
@@ -49,10 +49,10 @@ GLOBAL_LIST_INIT(security_dog_female_names, list(
  * Typepath we can use to spawn. Technically doesn't even have to be a dog
  */
 GLOBAL_LIST_INIT(security_dog_breeds, list(
-	/mob/living/basic/pet/dog/bullterrier,
-	/mob/living/basic/pet/dog/pug,
-	/mob/living/basic/pet/dog/corgi,
-	/mob/living/basic/pet/dog/corgi/cardigan,
+	/mob/living/basic/pet/dog/bullterrier = 40,
+	/mob/living/basic/pet/dog/pug = 10,
+	/mob/living/basic/pet/dog/corgi = 25,
+	/mob/living/basic/pet/dog/corgi/cardigan = 25,
 ))
 
 /**
@@ -77,7 +77,7 @@ GLOBAL_LIST_INIT(security_dog_breeds, list(
 	return list(
 		"name" = pick(new_gender == FEMALE ? GLOB.security_dog_female_names : GLOB.security_dog_male_names),
 		"gender" = new_gender,
-		"breed" = pick(GLOB.security_dog_breeds),
+		"breed" = pick_weight(GLOB.security_dog_breeds),
 		"tenure" = 0,
 	)
 

--- a/code/modules/mob/living/basic/pets/dog/security_dog.dm
+++ b/code/modules/mob/living/basic/pets/dog/security_dog.dm
@@ -1,0 +1,211 @@
+/**
+ * Same idea as Ian, but without the puppy phase, and we put a new name on.
+ */
+
+#define SECURITY_DOG_MEMORY_FILE "data/npc_saves/security_dog.json"
+
+GLOBAL_LIST_INIT(security_dog_male_names, list(
+	"Ace",
+	"Bandit",
+	"Boomer", //The equivalent of calling your pet 'cheeseburger'
+	"Bruno",
+	"Diesel",
+	"Duke",
+	"Gunner",
+	"Hobbes",
+	"Hunk",
+	"Kaiser",
+	"Magnum",
+	"Nero",
+	"Ranger",
+	"Rex",
+	"Rocco",
+	"Titus",
+	//"Toddlerdestroyer" //Pitbull name, but for good dogs (noncanon)
+	"Tyson",
+	"Walder", //Walter but ASOIAF :)
+	"Walter",
+))
+
+GLOBAL_LIST_INIT(security_dog_female_names, list(
+	"Athena", //The coolest greek goddess, obv
+	"Freya",
+	"Juno",
+	"Lillith",
+	"Luna",
+	"Maple",
+	"Nyx",
+	"Princess", //Pitbull name, but canon
+	"Roxy",
+	"Sable",
+	"Scout", //Apparentely a girl's name
+	"Trixie",
+	"Valkyrie",
+	"Vega",
+))
+
+/**
+ * Typepath we can use to spawn. Technically doesn't even have to be a dog
+ */
+GLOBAL_LIST_INIT(security_dog_breeds, list(
+	/mob/living/basic/pet/dog/bullterrier,
+	/mob/living/basic/pet/dog/pug,
+	/mob/living/basic/pet/dog/corgi,
+	/mob/living/basic/pet/dog/corgi/cardigan,
+))
+
+/**
+ * Attempt to steal last shifts dog. (This is shitty Ian code)
+ */
+/proc/requisition_security_dog()
+	var/json_file = file(SECURITY_DOG_MEMORY_FILE)
+	if(fexists(json_file))
+		var/list/save_data = json_decode(rustg_file_read(json_file))
+		if(islist(save_data) && save_data["name"])
+			//Sanity check the breed still exists
+			var/saved_breed = text2path(save_data["breed"])
+			if(saved_breed in GLOB.security_dog_breeds)
+				return list(
+					"name" = save_data["name"],
+					"gender" = save_data["gender"] == FEMALE ? FEMALE : MALE,
+					"breed" = saved_breed,
+					"tenure" = isnum(save_data["tenure"]) ? save_data["tenure"] : 0,
+				)
+
+	var/new_gender = prob(50) ? MALE : FEMALE
+	return list(
+		"name" = pick(new_gender == FEMALE ? GLOB.security_dog_female_names : GLOB.security_dog_male_names),
+		"gender" = new_gender,
+		"breed" = pick(GLOB.security_dog_breeds),
+		"tenure" = 0,
+	)
+
+/datum/component/security_dog
+	///Breed name, grab from type
+	var/breed
+	///How many shifts this dog has survived
+	var/tenure = 0
+	///We make a callback if his ass survived to the end
+	var/datum/callback/survival_check
+	///Is your fate sealed?
+	var/memory_saved = FALSE
+
+/datum/component/security_dog/Initialize(dog_name, dog_gender, dog_tenure = 0)
+	. = ..()
+	if(!istype(parent, /mob/living/basic/pet/dog))
+		return COMPONENT_INCOMPATIBLE
+
+	tenure = dog_tenure
+	var/mob/living/basic/pet/dog/dog = parent
+	//Grab real_name before overwriting
+	breed = dog.real_name
+	dog.gender = dog_gender
+	dog.unique_pet = TRUE
+	dog.fully_replace_character_name(null, dog_name)
+
+	claim_dogbed(dog)
+
+	survival_check = CALLBACK(src, PROC_REF(check_survival))
+	SSticker.OnRoundend(survival_check)
+
+	RegisterSignal(parent, COMSIG_LIVING_DEATH, PROC_REF(on_death))
+	RegisterSignal(parent, COMSIG_LIVING_REVIVE, PROC_REF(on_revive))
+	RegisterSignal(parent, COMSIG_ATOM_EXAMINE, PROC_REF(on_examine))
+
+/datum/component/security_dog/Destroy(force)
+	LAZYREMOVE(SSticker.round_end_events, survival_check)
+	survival_check = null
+	return ..()
+
+/datum/component/security_dog/UnregisterFromParent()
+	UnregisterSignal(parent, list(COMSIG_LIVING_DEATH, COMSIG_LIVING_REVIVE, COMSIG_ATOM_EXAMINE))
+
+/**
+ * The dogbed is static, so we just overwrite it with the dogs name
+ */
+/datum/component/security_dog/proc/claim_dogbed(mob/living/dog)
+	var/area/dog_area = get_area(dog)
+	if(!dog_area)
+		return
+	for(var/turf/area_turf as anything in dog_area.get_turfs_by_zlevel(dog.z))
+		for(var/obj/structure/bed/dogbed/tyson/bed in area_turf)
+			bed.update_owner(dog, force = TRUE)
+			return
+
+/**
+ * The security posting is described here rather than baked into desc, because the corgi
+ * breeds reset their desc back to the type default every time their hat changes.
+ */
+/datum/component/security_dog/proc/on_examine(mob/living/source, mob/user, list/examine_list)
+	SIGNAL_HANDLER
+	examine_list += span_notice("[source.p_Theyre()] Security's [breed], and [source.p_they()] take[source.p_s()] the job a good deal more seriously than most of these knuckleheads.")
+	if(tenure)
+		examine_list += span_notice("[source.p_They()] [source.p_have()] held the posting for [tenure] shift[tenure == 1 ? "" : "s"] running.")
+
+/datum/component/security_dog/proc/on_death(mob/living/source, gibbed)
+	SIGNAL_HANDLER
+	write_memory(dead = TRUE)
+
+/datum/component/security_dog/proc/on_revive(mob/living/source)
+	SIGNAL_HANDLER
+	//Back on the roster, so let the roundend check save us again.
+	memory_saved = FALSE
+
+///Roundend check: if we're still standing, we keep the posting.
+/datum/component/security_dog/proc/check_survival()
+	var/mob/living/dog = parent
+	if(!dog.stat)
+		write_memory(dead = FALSE)
+
+///Records this dog for next shift. A dead dog leaves no save behind, which is what makes the randomiser spin.
+/datum/component/security_dog/proc/write_memory(dead)
+	var/mob/living/dog = parent
+	if(memory_saved || !dog.write_memory(dead))
+		return
+	memory_saved = TRUE
+
+	var/json_file = file(SECURITY_DOG_MEMORY_FILE)
+	fdel(json_file)
+	if(dead)
+		return
+
+	var/list/file_data = list(
+		"name" = dog.real_name,
+		"gender" = dog.gender,
+		"breed" = "[dog.type]",
+		"tenure" = tenure + 1,
+	)
+	WRITE_FILE(json_file, json_encode(file_data, JSON_PRETTY_PRINT))
+
+/**
+ * The dog. basically a map spawner we swap in at init for whatever breed/name got chosen
+ */
+/mob/living/basic/pet/dog/bullterrier/tyson
+	name = "Tyson"
+	real_name = "Tyson"
+	gender = MALE
+	desc = "A sturdy bull terrier with a friendly but watchful demeanour."
+	gold_core_spawnable = NO_SPAWN
+	unique_pet = TRUE
+
+/mob/living/basic/pet/dog/bullterrier/tyson/Initialize(mapload)
+	. = ..()
+	if(mapload)
+		return INITIALIZE_HINT_LATELOAD
+	report_for_duty()
+
+/mob/living/basic/pet/dog/bullterrier/tyson/LateInitialize()
+	. = ..()
+	report_for_duty()
+
+///Swaps mr hardcoded out
+/mob/living/basic/pet/dog/bullterrier/tyson/proc/report_for_duty()
+	var/turf/kennel = get_turf(src)
+	if(kennel)
+		var/list/on_duty = requisition_security_dog()
+		var/breed = on_duty["breed"]
+		var/mob/living/basic/pet/dog/dog = new breed(kennel)
+		dog.AddComponent(/datum/component/security_dog, on_duty["name"], on_duty["gender"], on_duty["tenure"])
+	qdel(src)
+
+#undef SECURITY_DOG_MEMORY_FILE

--- a/code/modules/mob/living/basic/pets/dog/security_dog.dm
+++ b/code/modules/mob/living/basic/pets/dog/security_dog.dm
@@ -25,6 +25,7 @@ GLOBAL_LIST_INIT(security_dog_male_names, list(
 	"Tyson",
 	"Walder", //Walter but ASOIAF :)
 	"Walter",
+	"Walther",
 ))
 
 GLOBAL_LIST_INIT(security_dog_female_names, list(


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Supersedes #14620 

Essentially, security dog memory works like Ian. 

It takes the dog on init in the brig, determines a gender, and randomly picks a name from a list for whichever gender is chosen. The dog can can also be renamed during the round.

This dog will persist between rounds until it dies (and is failed to be revived) same as Ian. Should it die, it will be made a different dog with a different basetype and name upon the beginning of the next round.

You can see how many rounds the dog lived upon examination of it.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Its more thematically interesting that each departmental pet has memory. 

Ian has memory. Poly has memory. Runtime has memory.

<img width="458" height="425" alt="image" src="https://github.com/user-attachments/assets/12ebeaef-cd03-43c1-973e-3f58b7e99c2e" />


<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

See above.

</details>

## Changelog
:cl:
add: adds memory system for the security dog. Picks from a list of names and basetypes. Keeping the dog alive for the round will ensure it passes into the next.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
