### PR TITLE
Moves CI libcurl download to the download byond step

### DIFF
--- a/.github/actions/restore_or_install_byond/action.yml
+++ b/.github/actions/restore_or_install_byond/action.yml
@@ -29,6 +29,14 @@ runs:
         echo "BYOND_MAJOR=$BYOND_MAJOR" >> $GITHUB_ENV
         echo "BYOND_MINOR=$BYOND_MINOR" >> $GITHUB_ENV
 
+    - name: Install curl (Linux only)
+      if: runner.os != 'Windows'
+      shell: bash
+      run: |
+        sudo dpkg --add-architecture i386 && \
+        sudo apt-get update -qq && \
+        sudo apt-get install -y --no-install-recommends libcurl4t64:i386
+
     # The use of `actions/cache/restore` and `actions/cache/save` here is deliberate, as we want to
     # save the BYOND install to a cache as early as possible. If we used just `actions/cache`, it
     # would only attempt to save the cache at the end of a job. This ensures that if a workflow run

--- a/.github/actions/setup_node/action.yml
+++ b/.github/actions/setup_node/action.yml
@@ -13,13 +13,6 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: Install curl (Linux only)
-      if: runner.os != 'Windows'
-      shell: bash
-      run: |
-        sudo dpkg --add-architecture i386
-        sudo apt update || true
-        sudo apt install -o APT::Immediate-Configure=false curl:i386
     - name: Configure Node version
       shell: bash
       run: |


### PR DESCRIPTION
libcurl is for BYOND, not Node, so it shouldn't be in the Setup Node action.

Also includes some small improvements for the actual installation.