### PR TITLE
Fixes vscode interpreting webpack bundling as an error

### DIFF
--- a/_maps/map_files/debug/runtimestation.dmm
+++ b/_maps/map_files/debug/runtimestation.dmm
@@ -1309,6 +1309,10 @@
 	},
 /turf/open/floor/iron,
 /area/station/security/brig)
+"oX" = (
+/obj/effect/landmark/blobstart,
+/turf/open/floor/iron,
+/area/station/commons/storage/primary)
 "pd" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -8138,7 +8142,7 @@ dD
 dJ
 dI
 dJ
-dJ
+oX
 dJ
 dJ
 dJ

--- a/_maps/map_files/debug/runtimestation.dmm
+++ b/_maps/map_files/debug/runtimestation.dmm
@@ -1309,10 +1309,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/security/brig)
-"oX" = (
-/obj/effect/landmark/blobstart,
-/turf/open/floor/iron,
-/area/station/commons/storage/primary)
 "pd" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -8142,7 +8138,7 @@ dD
 dJ
 dI
 dJ
-oX
+dJ
 dJ
 dJ
 dJ

--- a/tgui/webpack.config.js
+++ b/tgui/webpack.config.js
@@ -10,7 +10,7 @@ const ExtractCssPlugin = require('mini-css-extract-plugin');
 
 const createStats = (verbose) => ({
   assets: verbose,
-  builtAt: verbose,
+  builtAt: false,
   cached: false,
   children: false,
   chunks: false,


### PR DESCRIPTION
## About The Pull Request

> vscode is dumb as hell so it interprets the date and hour as a filename and the minute and second as a line/column number and goes ohh i guess there was an error during compilation better put it in the problems tab

Ripped from https://github.com/tgstation/tgstation/pull/97261

## Why It's Good For The Game

I want the problems part of my vscode to be filled with problems only! Rah!!!

## Testing Photographs and Procedure

Before:

<img width="547" height="93" alt="image" src="https://github.com/user-attachments/assets/46b0e9d7-96f3-4138-9f38-0e80086be2d3" />

After (with a clean build environment):

<img width="392" height="75" alt="image" src="https://github.com/user-attachments/assets/9996d56f-418c-4936-be59-307f1f3b531d" />

## Changelog
:cl: TealSeer
code: Fixed webpack bundling TGUI being interpreted as an error by vscode
/:cl:
