### PR TITLE
APC improvements - Fix missing cell runtime error and add RPED support

### DIFF
--- a/code/modules/power/apc/apc_attack.dm
+++ b/code/modules/power/apc/apc_attack.dm
@@ -13,7 +13,7 @@
 				return
 			if(!user.transferItemToLoc(W, src))
 				return
-			cell = W
+			set_cell(W)
 			user.visible_message(\
 				"[user.name] has inserted the power cell to [src.name]!",\
 				span_notice("You insert the power cell."))
@@ -93,7 +93,7 @@
 				return
 			var/obj/item/stock_parts/cell/crap/empty/C = new(src)
 			C.forceMove(src)
-			cell = C
+			set_cell(C)
 			user.visible_message(span_notice("[user] fabricates a weak power cell and places it into [src]."), \
 			span_warning("Your [P.name] whirs with strain as you create a weak power cell and place it into [src]!"))
 			update_appearance()
@@ -239,9 +239,10 @@
 	if(opened && (!issilicon(user)))
 		if(cell)
 			user.visible_message("[user] removes \the [cell] from [src]!",span_notice("You remove \the [cell]."))
-			user.put_in_hands(cell)
-			cell.update_appearance()
-			src.cell = null
+			var/obj/item/stock_parts/cell/removed_cell = cell
+			set_cell(null)
+			user.put_in_hands(removed_cell)
+			removed_cell.update_appearance()
 			charging = APC_NOT_CHARGING
 			src.update_appearance()
 		return
@@ -259,6 +260,55 @@
 
 /obj/machinery/power/apc/blob_act(obj/structure/blob/B)
 	set_broken()
+
+/obj/machinery/power/apc/exchange_parts(mob/user, obj/item/storage/part_replacer/replacer_tool)
+	try_rped_swap(replacer_tool, user)
+	return TRUE
+
+/obj/machinery/power/apc/proc/try_rped_swap(obj/item/storage/part_replacer/replacer, mob/living/user)
+	var/is_bluespace = istype(replacer, /obj/item/storage/part_replacer/bluespace)
+
+	if(!opened && !is_bluespace)
+		to_chat(user, span_warning("You need to open [src]'s cover first!"))
+		return
+
+	if(machine_stat & MAINT)
+		to_chat(user, span_warning("There is no connector for a power cell!"))
+		return
+
+	if(replacer.works_from_distance)
+		to_chat(user, display_parts(user))
+
+	var/current_rating = cell?.rating || 0
+	var/obj/item/stock_parts/cell/best_cell
+
+	for(var/obj/item/stock_parts/cell/candidate in replacer)
+		if(candidate.rating <= current_rating)
+			continue
+		if(!best_cell || candidate.rating > best_cell.rating)
+			best_cell = candidate
+
+	if(!best_cell)
+		return
+
+	if(is_bluespace && (best_cell.rigged || best_cell.corrupted))
+		best_cell.charge = best_cell.maxcharge
+		best_cell.explode()
+		return
+
+	var/obj/item/stock_parts/cell/old_cell = cell
+	set_cell(best_cell)
+	best_cell.forceMove(src)
+	cell.update_appearance()
+
+	if(old_cell)
+		old_cell.forceMove(replacer)
+
+	charging = APC_NOT_CHARGING
+	update_appearance()
+
+	to_chat(user, span_notice("[capitalize("[old_cell || "empty slot"]")] replaced [best_cell]."))
+	replacer.play_rped_sound()
 
 /obj/machinery/power/apc/proc/can_use(mob/user, loud = 0) //used by attack_hand() and Topic()
 	if(IsAdminGhost(user))

--- a/code/modules/power/apc/apc_attack.dm
+++ b/code/modules/power/apc/apc_attack.dm
@@ -283,17 +283,21 @@
 	var/obj/item/stock_parts/cell/best_cell
 
 	for(var/obj/item/stock_parts/cell/candidate in replacer)
-		if(candidate.rating <= current_rating)
+		if(candidate.rating < current_rating)
+			continue
+		if(candidate.rating == current_rating)
 			continue
 		if(!best_cell || candidate.rating > best_cell.rating)
 			best_cell = candidate
+		else if(candidate.rating == best_cell.rating && candidate.charge > best_cell.charge)
+			best_cell = candidate // We choose the best one and the best one that is fully charged if there is one
 
 	if(!best_cell)
 		return
 
 	if(is_bluespace && (best_cell.rigged || best_cell.corrupted))
 		best_cell.charge = best_cell.maxcharge
-		best_cell.explode()
+		best_cell.explode() // bomba (reused from regular corrupted RPED exchange)
 		return
 
 	var/obj/item/stock_parts/cell/old_cell = cell
@@ -307,7 +311,7 @@
 	charging = APC_NOT_CHARGING
 	update_appearance()
 
-	to_chat(user, span_notice("[capitalize("[old_cell || "empty slot"]")] replaced [best_cell]."))
+	to_chat(user, span_notice("[capitalize("[old_cell || "empty slot"]")] replaced with [best_cell]."))
 	replacer.play_rped_sound()
 
 /obj/machinery/power/apc/proc/can_use(mob/user, loud = 0) //used by attack_hand() and Topic()

--- a/code/modules/power/apc/apc_attack.dm
+++ b/code/modules/power/apc/apc_attack.dm
@@ -283,9 +283,7 @@
 	var/obj/item/stock_parts/cell/best_cell
 
 	for(var/obj/item/stock_parts/cell/candidate in replacer)
-		if(candidate.rating < current_rating)
-			continue
-		if(candidate.rating == current_rating)
+		if(candidate.rating <= current_rating)
 			continue
 		if(!best_cell || candidate.rating > best_cell.rating)
 			best_cell = candidate

--- a/code/modules/power/apc/apc_main.dm
+++ b/code/modules/power/apc/apc_main.dm
@@ -203,6 +203,9 @@
 		QDEL_NULL(cell)
 	if(terminal)
 		disconnect_terminal()
+	if(cell)
+		component_parts -= cell
+		QDEL_NULL(cell)
 	return ..()
 
 /obj/machinery/power/apc/proc/assign_to_area(area/target_area = get_area(src))
@@ -246,7 +249,7 @@
 
 /obj/machinery/power/apc/handle_atom_del(atom/A)
 	if(A == cell)
-		cell = null
+		set_cell(null)
 		charging = APC_NOT_CHARGING
 		update_appearance()
 		updateUsrDialog()
@@ -254,14 +257,15 @@
 /obj/machinery/power/apc/Initialize(mapload)
 	. = ..()
 	alarm_manager = new(src)
+	component_parts = list()
 
 	if(!mapload)
 		return
 	has_electronics = APC_ELECTRONICS_SECURED
 	// is starting with a power cell installed, create it and set its charge level
 	if(cell_type)
-		cell = new cell_type
-		cell.charge = start_charge * cell.maxcharge / 100	// (convert percentage to actual value)
+		set_cell(new cell_type)
+		cell.charge = start_charge * cell.maxcharge / 100
 
 	var/area/our_area = loc.loc
 
@@ -414,6 +418,13 @@
 
 /obj/machinery/power/apc/proc/report()
 	return "[area.name] : [equipment]/[lighting]/[environ] ([lastused_equip+lastused_light+lastused_environ]) : [cell? cell.percent() : "N/C"] ([charging])"
+
+/obj/machinery/power/apc/proc/set_cell(obj/item/stock_parts/cell/new_cell)
+	if(cell)
+		component_parts -= cell
+	cell = new_cell
+	if(cell)
+		component_parts |= cell
 
 /// Used for unlocked apc helper, which unlocks the apc.
 /obj/machinery/power/apc/proc/unlock()
@@ -568,17 +579,21 @@
 		main_status = APC_NO_POWER
 
 	// The following math salad handles channel activation based on cell percent and if its charge plus surplus can meet the channels demand
-	// TODO: Not having it require cell
-	lighting = update_channel(lighting, light_power_req,
-		(cell.percent() > 95 && (surplus() + cell.charge - (environ_power_req + equip_power_req)) > light_power_req),
-		(environ_power_req + equip_power_req),
-		TRUE) // only lighting triggers alarms
+	if (cell)
+		lighting = update_channel(lighting, light_power_req,
+			(cell.percent() > 95 && (surplus() + cell.charge - (environ_power_req + equip_power_req)) > light_power_req),
+			(environ_power_req + equip_power_req),
+			TRUE) // only lighting triggers alarms
 
-	equipment = update_channel(equipment, equip_power_req,
-		(cell.percent() >= 15 && (surplus() + cell.charge - environ_power_req) > equip_power_req), environ_power_req, FALSE)
+		equipment = update_channel(equipment, equip_power_req,
+			(cell.percent() >= 15 && (surplus() + cell.charge - environ_power_req) > equip_power_req), environ_power_req, FALSE)
 
-	environ = update_channel(environ, environ_power_req,
-		(cell.percent() > 15 && (surplus() + cell.charge) > environ_power_req), 0, FALSE)
+		environ = update_channel(environ, environ_power_req,
+			(cell.percent() > 15 && (surplus() + cell.charge) > environ_power_req), 0, FALSE)
+	else
+		lighting = autoset(lighting, AUTOSET_FORCE_OFF)
+		equipment = autoset(equipment, AUTOSET_FORCE_OFF)
+		environ = autoset(environ, AUTOSET_FORCE_OFF)
 
 	if(cell && !shorted) //need to check to make sure the cell is still there since rigged cells can randomly explode after use().
 		var/surplus_used = min(surplus(), lastused_total)	//Here we're using the powernet to meet demand


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Recoup of https://github.com/BeeStation/BeeStation-Hornet/pull/13746

Taken from the original PR
Reducing unhandled errors is always good. Without this change, an APC with no cell was getting caught up every cycle when it went to recalculate which channels should be active because of how it was calling percent() on a null.

APCs stand out as something that should be RPED-compatible. They have a power cell which can be upgraded, and using an RPED makes this much easier while avoiding power net disruptions. This will allow engineers or scientists to make the station's powernet more durable with bigger backups in each APC.

## Why It's Good For The Game

Read above you doofus

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

https://github.com/user-attachments/assets/a78b031e-006e-48e9-b863-feb80071364d

https://github.com/user-attachments/assets/5042ce84-bd7f-48e6-8564-9a0c920de94c

</details>

## Changelog
:cl: Isaac, Schoolboy215
add: RPED can now interact with APC's to change their battery
fix: APC's wont throw runtimes whenever they have no cell installed
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
