### PR TITLE
Fix noose crafting menu warning spam

### DIFF
--- a/code/datums/components/crafting/crafting_lists/structures.dm
+++ b/code/datums/components/crafting/crafting_lists/structures.dm
@@ -243,6 +243,5 @@
 
 /datum/crafting_recipe/noose/check_requirements(mob/user, list/collected_requirements)
 	if(!(locate(/obj/structure/chair) in get_turf(user)))
-		to_chat(user, span_warning("You have to be standing on top of a chair to make a noose!"))
 		return FALSE
 	return ..()


### PR DESCRIPTION
## About The Pull Request

This removes the user-facing warning from the noose recipe's `check_requirements()` probe. The crafting UI calls this probe while refreshing recipe availability, so emitting chat feedback there caused the chair requirement warning to repeat every few seconds.

The chair requirement itself remains unchanged: crafting still returns `FALSE` unless the user is standing on a chair, and the normal parent requirement checks still run when that condition is met.

Fixes #14586

## Why It's Good For The Game

Opening the crafting menu with enough cable should not flood chat with a warning for a recipe the player did not attempt to craft. This keeps availability checks silent without making the noose craftable in invalid locations.

## Testing Photographs and Procedure

- `git diff --check`
- Focused source assertion confirming the noose recipe keeps the chair check, failure return, and parent requirement call while containing no `to_chat`/warning side effect
- Changed-file whitespace and indentation checks

Full BYOND compilation and in-game runtime validation were not run locally because the BYOND toolchain is unavailable in this environment; the repository CI is left to perform compilation and integration coverage.

No screenshots are applicable because this change removes repeated chat output and does not alter visual assets.

## Changelog
:cl:
fix: Opening the crafting menu no longer repeatedly warns about the noose chair requirement.
/:cl:
