### PR TITLE
Improves the maplint screening step

### DIFF
--- a/.github/workflows/run_linters.yml
+++ b/.github/workflows/run_linters.yml
@@ -89,16 +89,25 @@ jobs:
         id: map-filter
         uses: dorny/paths-filter@v4
         with:
+          list-files: shell
           filters: |
-            run_maps:
-              - '**.dmm'
+            tool_edits:
               - 'tools/maplint/**'
               - 'tools/mapmerge2/**'
+            map_edits:
+              - '**.dmm'
+
       - name: Run Map Checks
-        if: steps.linter-setup.conclusion == 'success' && !cancelled() && steps.map-filter.outputs.run_maps == 'true'
+        if: steps.linter-setup.conclusion == 'success' && !cancelled() && (steps.map-filter.outputs.tool_edits == 'true' || steps.map-filter.outputs.map_edits == 'true')
         run: |
-          tools/bootstrap/python -m mapmerge2.dmm_test
-          tools/bootstrap/python -m tools.maplint.source
+          if [ "${{ steps.map-filter.outputs.tool_edits }}" = "true" ]; then
+            MAPS=$(find . -type f -name "*.dmm")
+          else
+            MAPS="${{ steps.map-filter.outputs.map_edits_files }}"
+          fi
+
+          tools/bootstrap/python -m mapmerge2.dmm_test $MAPS
+          tools/bootstrap/python -m tools.maplint.source $MAPS
       - name: Check Cutter
         if: steps.linter-setup.conclusion == 'success' && !cancelled()
         run: tools/bootstrap/python -m tools.icon_cutter.check

--- a/tools/maplint/source/__main__.py
+++ b/tools/maplint/source/__main__.py
@@ -1,5 +1,6 @@
 import argparse
 import glob
+import os
 import pathlib
 import traceback
 import yaml
@@ -76,6 +77,8 @@ def main(args):
             any_failed = True
 
     for map_filename in (args.maps or glob.glob("_maps/**/*.dmm", recursive = True)):
+        if not os.path.isfile(map_filename) or not map_filename.endswith('.dmm'):
+            continue
         print(map_filename, end = " ")
 
         success = True

--- a/tools/mapmerge2/dmm.py
+++ b/tools/mapmerge2/dmm.py
@@ -193,7 +193,6 @@ def parse_map_atom(atom):
     vars = {}
 
     in_string = False
-    in_name = False
     escaping = False
     current_name = ''
     current = ''

--- a/tools/mapmerge2/dmm_test.py
+++ b/tools/mapmerge2/dmm_test.py
@@ -2,38 +2,48 @@ import os
 import sys
 from .dmm import *
 
+def _test_file(fullpath):
+    try:
+        DMM.from_file(fullpath)
+    except Exception:
+        print('Failed on:', fullpath)
+        raise
 
-def _self_test():
-    # test: can we load every DMM in the tree
-    count = 0
+def _get_all_dmm_files():
     for dirpath, dirnames, filenames in os.walk('.'):
         if '.git' in dirnames:
             dirnames.remove('.git')
         for filename in filenames:
             if filename.endswith('.dmm'):
-                fullpath = os.path.join(dirpath, filename)
-                try:
-                    DMM.from_file(fullpath)
-                except Exception:
-                    print('Failed on:', fullpath)
-                    raise
-                count += 1
+                yield os.path.join(dirpath, filename)
+
+def _run_test(file_paths=None):
+    count = 0
+
+    if not file_paths:
+        file_paths = _get_all_dmm_files()
+
+    for fullpath in file_paths:
+        if not os.path.isfile(fullpath):
+            continue
+
+        _test_file(fullpath)
+        count += 1
 
     print(f"{os.path.relpath(__file__)}: successfully parsed {count} .dmm files")
-
 
 def _usage():
     print(f"Usage:")
     print(f"    tools{os.sep}bootstrap{os.sep}python -m {__spec__.name}")
     exit(1)
 
-
 def _main():
-    if len(sys.argv) == 1:
-        return _self_test()
+    args = sys.argv[1:]
+    if '-help' in args:
+        _usage()
+        return
 
-    return _usage()
-
+    _run_test(args)
 
 if __name__ == '__main__':
     _main()


### PR DESCRIPTION
## About The Pull Request

The maplint now only runs on maps which have had changes applied to them. If either of the tooling scripts are edited in any which way, all maps are ran, like you would expect.

## Why It's Good For The Game

Linters should run ~20 seconds faster on mapping PRs now.

## Testing Photographs and Procedure

I did this on TG first and simulated the following scenarios:

- [maplints edited](https://github.com/tgstation/tgstation/actions/runs/30619001911/job/91121647210)
- [no mapping changes made](https://github.com/tgstation/tgstation/actions/runs/30618608191/job/91117635070)
- [`.dmm` edits only](https://github.com/tgstation/tgstation/actions/runs/30618818969/job/91118292293)

(See the _Run Map Checks_ step)

## Changelog
:cl:
server: maplints are now only ran on maps that have actually had changes made to them as apposed to all maps.
/:cl: