### PR TITLE
Actually gets rid of all bad `Destroy()` calls this time.

### DIFF
--- a/code/modules/mining/lavaland/ash_flora.dm
+++ b/code/modules/mining/lavaland/ash_flora.dm
@@ -46,7 +46,7 @@
 			new harvest(get_turf(src))
 
 	if(destroy_on_harvest)
-		Destroy()
+		qdel(src)
 	icon_state = "[base_icon_state]p"
 	name = harvested_name
 	desc = harvested_desc

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -765,7 +765,6 @@
 		cell = null
 	// Call destroy() before deleting to ensure that the borg's brain stays connected
 	qdel(src)
-	qdel(src)
 
 /mob/living/silicon/robot/proc/notify_ai(notifytype, oldname, newname)
 	if(!connected_ai)

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -763,7 +763,6 @@
 	if (cell) //Sanity check.
 		cell.forceMove(T)
 		cell = null
-	// Call destroy() before deleting to ensure that the borg's brain stays connected
 	qdel(src)
 
 /mob/living/silicon/robot/proc/notify_ai(notifytype, oldname, newname)

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -764,7 +764,7 @@
 		cell.forceMove(T)
 		cell = null
 	// Call destroy() before deleting to ensure that the borg's brain stays connected
-	Destroy()
+	qdel(src)
 	qdel(src)
 
 /mob/living/silicon/robot/proc/notify_ai(notifytype, oldname, newname)

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/gutlunch.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/gutlunch.dm
@@ -126,4 +126,4 @@
 	L.setDir(dir)
 	L.Stun(20, ignore_canstun = TRUE)
 	visible_message(span_notice("[src] grows up into [L]."))
-	Destroy()
+	qdel(src)

--- a/code/modules/mob/living/simple_animal/hostile/retaliate/nymph.dm
+++ b/code/modules/mob/living/simple_animal/hostile/retaliate/nymph.dm
@@ -364,7 +364,7 @@
 	. = ..()
 	M.muck()
 	held_mob.adjustFireLoss(50)
-	Destroy()
+	qdel(src)
 
 /obj/item/mob_holder/nymph/release(display_messages = TRUE, delete_mob = FALSE)
 	on_head = FALSE

--- a/code/modules/power/rbmk/rbmk_procs.dm
+++ b/code/modules/power/rbmk/rbmk_procs.dm
@@ -526,7 +526,7 @@ Arguments:
 	var/obj/effect/nuclear_sludge_spawner/nuclear_sludge_spawner = new /obj/effect/nuclear_sludge_spawner(get_turf(src))
 	nuclear_sludge_spawner.range = 4 + min(25,floor(4 * max(1,(temperature-RBMK_TEMPERATURE_CRITICAL)/RBMK_TEMPERATURE_CRITICAL))) // scales by an extra 4 tile radius per 100% over maximum
 	nuclear_sludge_spawner.fire()
-	Destroy()
+	qdel(src)
 
 /obj/machinery/atmospherics/components/unary/rbmk/core/proc/blowout()
 	explosion(get_turf(src), GLOB.MAX_EX_DEVESTATION_RANGE, GLOB.MAX_EX_HEAVY_RANGE, GLOB.MAX_EX_LIGHT_RANGE, GLOB.MAX_EX_FLASH_RANGE)

--- a/code/modules/religion/sects/shadow_sect.dm
+++ b/code/modules/religion/sects/shadow_sect.dm
@@ -583,7 +583,7 @@
 			sect.active_obelisks += obelisk
 			sect.active_obelisks_number += 1
 			obelisk.set_light(sect.light_reach, sect.light_power, DARKNESS_INVERSE_COLOR)
-		Destroy()
+		qdel(src)
 	if(sect.grand_ritual_level == 2)
 		var/obj/structure/destructible/religion/shadow_obelisk/after_rit_1/after_rit_2/obelisk = new(our_turf)
 		sect.obelisks += obelisk
@@ -594,7 +594,7 @@
 			sect.active_obelisks += obelisk
 			sect.active_obelisks_number += 1
 			obelisk.set_light(sect.light_reach, sect.light_power, DARKNESS_INVERSE_COLOR)
-		Destroy()
+		qdel(src)
 	if(sect.grand_ritual_level == 3)
 		var/obj/structure/destructible/religion/shadow_obelisk/after_rit_1/after_rit_2/after_rit_3/obelisk = new(our_turf)
 		sect.obelisks += obelisk
@@ -606,7 +606,7 @@
 			sect.active_obelisks_number += 1
 			obelisk.set_light(sect.light_reach, sect.light_power, DARKNESS_INVERSE_COLOR)
 		obelisk.toggling_buckling_after_ritual_3()
-		Destroy()
+		qdel(src)
 
 // Grand rituals themselves
 

--- a/code/modules/surgery/organs/augments_chest.dm
+++ b/code/modules/surgery/organs/augments_chest.dm
@@ -105,7 +105,7 @@
 	if(prob(30/severity))
 		to_chat(owner, span_userdanger("You feel a sharp pain in your chest, your reviver implant seems to have shorted out!"))
 		owner.Knockdown((3 SECONDS))
-		Destroy()
+		qdel(src)
 
 /obj/item/organ/cyberimp/chest/reviver/syndicate
 	organ_flags = ORGAN_ROBOTIC | ORGAN_HIDDEN


### PR DESCRIPTION
## About The Pull Request

When reviewing #11816 I saw a bad `Destroy()` call for diona nymphs. A quick search and replace later fixed 6 other instances.

`	Destroy()` --> `	qdel(src)`

## Why It's Good For The Game

Calling `Destroy()` is not how you delete things.

## Testing Photographs and Procedure

I don't think this is deserving of testing evidence.

## Changelog
:cl:
code: Fixed the remaining improper `Destroy()` calls across the codebase
/:cl: