### PR TITLE
Askwalker Bonfire Typepath, Interrogation Telescreen and Spike Head Bug Fixes !

### DIFF
--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_ash_walker1.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_ash_walker1.dmm
@@ -838,8 +838,8 @@
 /turf/open/lava/smooth/lava_land_surface,
 /area/ruin/unpowered/ash_walkers)
 "IE" = (
-/obj/structure/bonfire/dense/askwalker,
 /obj/structure/stone_tile/center,
+/obj/structure/bonfire/dense/ashwalker,
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/ruin/unpowered/ash_walkers)
 "Ji" = (

--- a/code/game/area/areas/station.dm
+++ b/code/game/area/areas/station.dm
@@ -1365,6 +1365,7 @@
 /area/station/security/interrogation
 	name = "\improper Interrogation Room"
 	icon_state = "interrogation"
+	camera_networks = list(CAMERA_NETWORK_INTERROGATION)
 	sound_environment = SOUND_AREA_SMALL_ENCLOSED
 
 /area/station/security/interrogation/Exited(atom/movable/a, atom/oldloc)

--- a/code/game/objects/structures/bonfire.dm
+++ b/code/game/objects/structures/bonfire.dm
@@ -32,7 +32,7 @@
 /obj/structure/bonfire/dense
 	density = TRUE
 
-/obj/structure/bonfire/dense/askwalker
+/obj/structure/bonfire/dense/ashwalker
 	needs_oxygen = FALSE
 
 /obj/structure/bonfire/prelit/Initialize(mapload)

--- a/code/game/objects/structures/headpike.dm
+++ b/code/game/objects/structures/headpike.dm
@@ -41,11 +41,10 @@
 /obj/structure/headpike/update_icon()
 	..()
 	var/obj/item/bodypart/head/H = locate() in contents
-	var/mutable_appearance/MA = new()
 	if(H)
-		MA.copy_overlays(H)
+		var/mutable_appearance/MA = new(H)
 		MA.pixel_y = 12
-		add_overlay(H)
+		add_overlay(MA)
 
 /obj/structure/headpike/attack_hand(mob/user, list/modifiers)
 	. = ..()


### PR DESCRIPTION
## About The Pull Request

This PR does **three** really small things, so small that unless asked id rather not bother publishing into seperate PR's. Without further ado the changes are;
- The bonfire used by ashwalkers uses the path : /obj/structure/bonfire/dense/as**k**walker, its changed to as**h**walker in this PR
- Area's can be assigned camera networks, camera's in that area will register as apart of the network, which can be displayed on Telescreens. The interrogation room used by Security had no network assigned to it despite the network and screens already existing. This PR just re adds the network to the area, making interrogation telescreens display cameras inside of interrogation rooms again!
- **The Big One!** : Heads on spears was BROKEN, i mean look at this!

<img width="92" height="97" alt="Screenshot 2026-08-10 122233" src="https://github.com/user-attachments/assets/14ae7d87-a047-485e-85d3-be71e84d6725" />

the code already existed for spiked heads to use the mutated appearance of the head used in crafting, but wasn't being utilized till changed again hopefully in this pr....

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure

<details>
<summary>Putting a head on a spike!</summary>


https://github.com/user-attachments/assets/ea875d11-2335-4e6f-bd75-1fb718734391

</details>

<details>
<summary>Interrogation Camera Working</summary>


<img width="1312" height="891" alt="Screenshot 2026-08-10 131650" src="https://github.com/user-attachments/assets/2a55f0fc-89e0-423c-855b-f3282dfea7d7" />


</details>

## Changelog
:cl:
fix: Putting a head on a spike now properly displays the head used.
fix: Interrogation telescreens are now working again
/:cl:

