### PR TITLE
Fixes MD Berets

### DIFF
--- a/code/modules/clothing/head/jobs.dm
+++ b/code/modules/clothing/head/jobs.dm
@@ -501,7 +501,7 @@
 	icon_state = "beret_badge"
 	greyscale_config = /datum/greyscale_config/beret_badge
 	greyscale_config_worn = /datum/greyscale_config/beret_badge/worn
-	greyscale_colors = "#E1E1E1#EDCC6A"
+	greyscale_colors = "#E1E1E1#A3EAFF"
 	armor_type = /datum/armor/beret_med
 	flags_1 = NONE
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Changes the color of the medical beret's badge from yellow to a light blue.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

The intent of #12754 was to restore the original designs of the berets post-GAGS, and failed to do with the medical beret.  Due to a typo, it had the same coloration as the CE beret.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

The medical beret should match the rest of medbay's coloration.

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos


</summary>
<img width="136" height="140" alt="image" src="https://github.com/user-attachments/assets/8cd60ffe-e870-4870-8fff-cef60d403d62" />

</details>

## Changelog
:cl: h42
image: Changes the medical beret badge to blue from yellow.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
