### PR TITLE
Raises minimum player requirement for most antags to 6. Raises minimum player requirement for spiders (10), midround heretic (14), midround wizard (20).

### DIFF
--- a/code/controllers/subsystem/dynamic/dynamic_rulesets.dm
+++ b/code/controllers/subsystem/dynamic/dynamic_rulesets.dm
@@ -15,7 +15,7 @@
 	/// How many points this ruleset costs to run.
 	var/points_cost = 7
 	/// The minimum amount of players that have to be connected for this ruleset to run
-	var/minimum_players_required = 0
+	var/minimum_players_required = 6
 	/// The amount of people drafted by this ruleset.
 	var/drafted_players_amount = 1
 	/// The role preference used for this ruleset

--- a/code/controllers/subsystem/dynamic/dynamic_rulesets_gamemode.dm
+++ b/code/controllers/subsystem/dynamic/dynamic_rulesets_gamemode.dm
@@ -6,9 +6,6 @@
 	// Sorry, but if you are going to be THE antagonist, you can't be leaving the station and making
 	// the round boring for everyone else.
 	protected_roles = list(JOB_NAME_SECURITYOFFICER, JOB_NAME_DETECTIVE, JOB_NAME_WARDEN, JOB_NAME_HEADOFSECURITY, JOB_NAME_CAPTAIN, JOB_NAME_SHAFTMINER, JOB_NAME_EXPLORATIONCREW)
-	/// Default minimum players required so that there is some mystery involved.
-	/// Disabled for now, since traitor works fine on 0 pop
-	minimum_players_required = 3
 	/// The number of rounds that it takes before this gamemode reaches full weight after it has been executed.
 	/// The first round after execution will use a weight of 1 (still possible but rare).
 	/// A value of 1 means that it will instantly recover

--- a/code/controllers/subsystem/dynamic/dynamic_rulesets_midround.dm
+++ b/code/controllers/subsystem/dynamic/dynamic_rulesets_midround.dm
@@ -34,6 +34,7 @@
 	points_cost = 40
 	weight = 2
 	ruleset_flags = CANNOT_REPEAT | NO_TRANSFER_RULESET
+	minimum_players_required = 6
 
 /datum/dynamic_ruleset/midround/pirates/allowed(require_drafted = TRUE)
 	if(!SSmapping.empty_space)

--- a/code/controllers/subsystem/dynamic/dynamic_rulesets_midround.dm
+++ b/code/controllers/subsystem/dynamic/dynamic_rulesets_midround.dm
@@ -34,7 +34,6 @@
 	points_cost = 40
 	weight = 2
 	ruleset_flags = CANNOT_REPEAT | NO_TRANSFER_RULESET
-	minimum_players_required = 6
 
 /datum/dynamic_ruleset/midround/pirates/allowed(require_drafted = TRUE)
 	if(!SSmapping.empty_space)

--- a/code/controllers/subsystem/dynamic/dynamic_rulesets_midround_ghost.dm
+++ b/code/controllers/subsystem/dynamic/dynamic_rulesets_midround_ghost.dm
@@ -342,7 +342,6 @@
 	antag_datum = /datum/antagonist/ninja
 	points_cost = 40
 	weight = 4
-	minimum_players_required = 6
 
 /datum/dynamic_ruleset/midround/ghost/ninja/get_poll_icon()
 	return /obj/item/energy_katana
@@ -366,7 +365,6 @@
 	antag_datum = /datum/antagonist/nightmare
 	points_cost = 40
 	weight = 4
-	minimum_players_required = 6
 
 /datum/dynamic_ruleset/midround/ghost/nightmare/get_poll_icon()
 	return /obj/item/light_eater
@@ -399,7 +397,6 @@
 	points_cost = 30
 	weight = 4
 	use_spawn_locations = FALSE
-	minimum_players_required = 6
 
 	var/has_made_leader = FALSE
 	var/datum/team/abductor_team/team
@@ -431,7 +428,6 @@
 	points_cost = 30
 	weight = 4
 	use_spawn_locations = FALSE
-	minimum_players_required = 6
 
 	var/datum/team/abductor_team/team
 
@@ -456,7 +452,6 @@
 	antag_datum = /datum/antagonist/revenant
 	points_cost = 30
 	weight = 4
-	minimum_players_required = 6
 
 /datum/dynamic_ruleset/midround/ghost/revenant/get_poll_icon()
 	return /mob/living/simple_animal/revenant
@@ -555,7 +550,6 @@
 	antag_datum = /datum/antagonist/swarmer
 	points_cost = 40
 	weight = 4
-	minimum_players_required = 6
 
 	var/announce_probability = 25
 
@@ -590,7 +584,6 @@
 	antag_datum = /datum/antagonist/morph
 	points_cost = 30
 	weight = 4
-	minimum_players_required = 6
 
 /datum/dynamic_ruleset/midround/ghost/morph/get_poll_icon()
 	return /mob/living/simple_animal/hostile/morph
@@ -618,7 +611,6 @@
 	antag_datum = /datum/antagonist/prisoner
 	points_cost = 30
 	weight = 4
-	minimum_players_required = 6
 
 /datum/dynamic_ruleset/midround/ghost/prisoners/get_poll_icon()
 	return /obj/item/card/id/prisoner
@@ -658,7 +650,6 @@
 	antag_datum = /datum/antagonist/fugitive
 	points_cost = 30
 	weight = 4
-	minimum_players_required = 6
 
 /datum/dynamic_ruleset/midround/ghost/fugitives/get_poll_icon()
 	return /obj/item/clothing/mask/gas/tiki_mask

--- a/code/controllers/subsystem/dynamic/dynamic_rulesets_midround_ghost.dm
+++ b/code/controllers/subsystem/dynamic/dynamic_rulesets_midround_ghost.dm
@@ -249,7 +249,7 @@
 	severity = DYNAMIC_MIDROUND_HEAVY
 	antag_datum = /datum/antagonist/blob
 	points_cost = 50
-	minimum_players_required = 13
+	minimum_players_required = 20
 	weight = 4
 	use_spawn_locations = FALSE
 
@@ -316,7 +316,7 @@
 	antag_datum = /datum/antagonist/space_dragon
 	points_cost = 40
 	weight = 4
-	minimum_players_required = 10
+	minimum_players_required = 20
 
 /datum/dynamic_ruleset/midround/ghost/space_dragon/get_poll_icon()
 	return /mob/living/simple_animal/hostile/space_dragon

--- a/code/controllers/subsystem/dynamic/dynamic_rulesets_midround_ghost.dm
+++ b/code/controllers/subsystem/dynamic/dynamic_rulesets_midround_ghost.dm
@@ -188,6 +188,7 @@
 	antag_datum = /datum/antagonist/wizard
 	points_cost = 50
 	weight = 4
+	minimum_players_required = 20
 
 /datum/dynamic_ruleset/midround/ghost/wizard/get_poll_icon()
 	return /obj/item/clothing/head/wizard
@@ -341,6 +342,7 @@
 	antag_datum = /datum/antagonist/ninja
 	points_cost = 40
 	weight = 4
+	minimum_players_required = 6
 
 /datum/dynamic_ruleset/midround/ghost/ninja/get_poll_icon()
 	return /obj/item/energy_katana
@@ -364,6 +366,7 @@
 	antag_datum = /datum/antagonist/nightmare
 	points_cost = 40
 	weight = 4
+	minimum_players_required = 6
 
 /datum/dynamic_ruleset/midround/ghost/nightmare/get_poll_icon()
 	return /obj/item/light_eater
@@ -396,6 +399,7 @@
 	points_cost = 30
 	weight = 4
 	use_spawn_locations = FALSE
+	minimum_players_required = 6
 
 	var/has_made_leader = FALSE
 	var/datum/team/abductor_team/team
@@ -427,6 +431,7 @@
 	points_cost = 30
 	weight = 4
 	use_spawn_locations = FALSE
+	minimum_players_required = 6
 
 	var/datum/team/abductor_team/team
 
@@ -451,6 +456,7 @@
 	antag_datum = /datum/antagonist/revenant
 	points_cost = 30
 	weight = 4
+	minimum_players_required = 6
 
 /datum/dynamic_ruleset/midround/ghost/revenant/get_poll_icon()
 	return /mob/living/simple_animal/revenant
@@ -493,6 +499,7 @@
 	drafted_players_amount = 2
 	points_cost = 40
 	weight = 4
+	minimum_players_required = 10
 
 	var/datum/team/spiders/team
 
@@ -548,6 +555,7 @@
 	antag_datum = /datum/antagonist/swarmer
 	points_cost = 40
 	weight = 4
+	minimum_players_required = 6
 
 	var/announce_probability = 25
 
@@ -582,6 +590,7 @@
 	antag_datum = /datum/antagonist/morph
 	points_cost = 30
 	weight = 4
+	minimum_players_required = 6
 
 /datum/dynamic_ruleset/midround/ghost/morph/get_poll_icon()
 	return /mob/living/simple_animal/hostile/morph
@@ -609,6 +618,7 @@
 	antag_datum = /datum/antagonist/prisoner
 	points_cost = 30
 	weight = 4
+	minimum_players_required = 6
 
 /datum/dynamic_ruleset/midround/ghost/prisoners/get_poll_icon()
 	return /obj/item/card/id/prisoner
@@ -648,6 +658,7 @@
 	antag_datum = /datum/antagonist/fugitive
 	points_cost = 30
 	weight = 4
+	minimum_players_required = 6
 
 /datum/dynamic_ruleset/midround/ghost/fugitives/get_poll_icon()
 	return /obj/item/clothing/mask/gas/tiki_mask

--- a/code/controllers/subsystem/dynamic/dynamic_rulesets_midround_living.dm
+++ b/code/controllers/subsystem/dynamic/dynamic_rulesets_midround_living.dm
@@ -113,6 +113,7 @@
 	antag_datum = /datum/antagonist/heretic
 	weight = 7
 	points_cost = 30
+	minimum_players_required = 14
 
 /datum/dynamic_ruleset/midround/living/heretic/get_poll_icon()
 	return /obj/item/codex_cicatrix


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Raises the minimum players for all antags to 6, with the exception of:
- Spiders, to 10
- Midround Heretic, to 14 (same as roundstart counterpart already)
- Midround Wizard, to 20 (same as roundstart counterpart already)
- Dragon, to 20
- Blob, to 20

Antags with an existing minimum player requirement higher than 6 remain unchanged.


<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

At deadpop, antags are in a difficult position. The conflict caused by antags at super low-pop has a more harmful effect on the round's quality, since they are designed around there being sufficient crew to face them. Roles like Wizard should be rare due to how powerful they are, rather than showing up several times a week when there are only a few players in-game. 

I believe this will promote higher quality rounds that don't turn away players due to them being forced to face threats that are balanced around there being more players online. 

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>

## Changelog
:cl:
tweak: The base minimum player requirement for antags is now 6.
tweak: Spiders now have a minimum player requirement of 10.
tweak: Wizard midround, Dragon, and Blob now have a minimum player requirement of 20.
fix: Fixed the heretic midround not having a minimum player requirement, resulting in them being unable to complete objectives due to lack of targets (It is now 14, same as their roundstart counterpart)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
