### PR TITLE
Fixes being unable to craft the voice modulator mask

### DIFF
--- a/code/datums/components/crafting/crafting_lists/tailoring/clothing.dm
+++ b/code/datums/components/crafting/crafting_lists/tailoring/clothing.dm
@@ -74,7 +74,7 @@
 	time = 4 SECONDS
 	tool_behaviors = list(TOOL_SCREWDRIVER, TOOL_MULTITOOL)
 	reqs = list(
-		/obj/item/clothing/mask/gas/old = 1,
+		/obj/item/clothing/mask/gas = 1,
 		/obj/item/assembly/voice = 1,
 		/obj/item/stack/cable_coil = 5
 	)


### PR DESCRIPTION


<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Says what it does on the tin 

Fixes #14459

## Why It's Good For The Game

Why not

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

<img width="137" height="13" alt="image" src="https://github.com/user-attachments/assets/8e422c05-861b-4d13-b3bf-05af9ee58a1b" />

</details>

## Changelog
:cl: Geatish
fix: You can now craft the voice modulator mask again, now with both the old and new mask
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
