### PR TITLE
Kilostation - Some fixes, enabling prisoner.

### DIFF
--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -637,7 +637,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
-/turf/open/floor/plating,
+/turf/open/floor/iron,
 /area/station/commons/dorms)
 "apb" = (
 /obj/docking_port/stationary{

--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -209,6 +209,12 @@
 	},
 /turf/open/floor/plating/airless,
 /area/misc/space/nearstation)
+"aeN" = (
+/obj/effect/turf_decal/tile/red/fourcorners/contrasted,
+/obj/structure/cable/yellow,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/prison,
+/area/station/security/prison)
 "afQ" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -464,6 +470,11 @@
 /obj/structure/barricade/wooden/crude,
 /turf/open/floor/plating,
 /area/station/maintenance/port)
+"amZ" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/prison,
+/area/station/security/prison)
 "anT" = (
 /obj/structure/table,
 /obj/item/paper_bin{
@@ -7728,6 +7739,12 @@
 	broken = 1
 	},
 /area/station/maintenance/starboard)
+"dgx" = (
+/obj/structure/chair/fancy/sofa/old/left{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/station/security/prison)
 "dgz" = (
 /obj/machinery/atmospherics/pipe/smart/simple/green/visible,
 /obj/machinery/button/door{
@@ -8032,11 +8049,6 @@
 	initial_gas_mix = "o2=14;n2=23;TEMP=300"
 	},
 /area/docking/arrival)
-"dmK" = (
-/obj/effect/turf_decal/tile/red/fourcorners/contrasted,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/prison,
-/area/station/security/prison)
 "dmQ" = (
 /obj/machinery/light_switch{
 	pixel_y = -24
@@ -9102,12 +9114,6 @@
 /obj/structure/cable/yellow,
 /turf/open/floor/iron/techmaint,
 /area/station/security/prison/safe)
-"dDZ" = (
-/obj/structure/chair/fancy/sofa/old/left{
-	dir = 8
-	},
-/turf/open/floor/wood,
-/area/station/security/prison)
 "dEj" = (
 /obj/effect/turf_decal/tile/red/half/contrasted,
 /turf/open/floor/iron/showroomfloor,
@@ -10618,6 +10624,14 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
 /turf/open/floor/iron/dark,
 /area/station/service/chapel)
+"eee" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/caution,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/techmaint,
+/area/station/security/prison)
 "eem" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -11314,13 +11328,6 @@
 /obj/effect/turf_decal/stripes/closeup,
 /turf/open/floor/iron/dark,
 /area/station/security/courtroom)
-"erX" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/prison,
-/area/station/security/prison)
 "esg" = (
 /obj/structure/grille,
 /obj/effect/decal/cleanable/dirt,
@@ -15935,10 +15942,9 @@
 /turf/open/floor/iron/dark,
 /area/station/service/chapel/office)
 "fMh" = (
-/obj/structure/chair/fancy/sofa/old/right{
-	dir = 4
+/obj/structure/chair/fancy/sofa/old/left{
+	dir = 8
 	},
-/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood,
 /area/station/security/prison)
 "fMn" = (
@@ -17219,11 +17225,10 @@
 /turf/open/floor/iron/dark,
 /area/station/security/warden)
 "giK" = (
-/obj/structure/chair/fancy/sofa/old{
-	dir = 8
-	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/wood,
+/turf/open/floor/prison,
 /area/station/security/prison)
 "giN" = (
 /obj/effect/decal/cleanable/dirt,
@@ -17858,6 +17863,12 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/commons/vacant_room/commissary)
+"gtJ" = (
+/obj/structure/chair/fancy/sofa/old{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/station/security/prison)
 "gtL" = (
 /obj/machinery/door/poddoor,
 /turf/open/floor/plating/airless{
@@ -17964,11 +17975,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/security/courtroom)
-"gvJ" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/prison,
-/area/station/security/prison)
 "gvK" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating{
@@ -18058,11 +18064,6 @@
 /obj/effect/spawner/random/maintenance,
 /turf/open/floor/carpet/green,
 /area/station/cargo/warehouse)
-"gwT" = (
-/obj/effect/turf_decal/siding/wood,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/wood,
-/area/station/security/prison)
 "gwU" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/rack,
@@ -18226,13 +18227,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/security/brig)
-"gAc" = (
-/obj/structure/chair/fancy/sofa/old/right{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/wood,
-/area/station/security/prison)
 "gAh" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/grille/broken,
@@ -18579,12 +18573,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/cargo/storage)
-"gGd" = (
-/obj/structure/chair/fancy/sofa/old/left{
-	dir = 4
-	},
-/turf/open/floor/wood,
-/area/station/security/prison)
 "gGe" = (
 /obj/effect/turf_decal/tile/yellow/half/contrasted,
 /obj/effect/turf_decal/tile/blue,
@@ -24703,12 +24691,6 @@
 /obj/effect/landmark/navigate_destination,
 /turf/open/floor/iron/showroomfloor,
 /area/station/security/office)
-"iKG" = (
-/obj/structure/chair/fancy/sofa/old{
-	dir = 4
-	},
-/turf/open/floor/wood,
-/area/station/security/prison)
 "iKO" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
@@ -25574,13 +25556,6 @@
 /obj/effect/turf_decal/tile/neutral/opposingcorners,
 /turf/open/floor/iron/dark,
 /area/station/service/library)
-"jbI" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/prison,
-/area/station/security/prison)
 "jce" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/engineering{
@@ -28778,6 +28753,13 @@
 	},
 /turf/open/floor/iron/showroomfloor,
 /area/station/service/kitchen)
+"kcD" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/prison,
+/area/station/security/prison)
 "kcJ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
@@ -28793,12 +28775,6 @@
 /obj/item/pickaxe,
 /turf/open/floor/plating/asteroid/airless,
 /area/misc/space/nearstation)
-"kdD" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/prison,
-/area/station/security/prison)
 "kdG" = (
 /obj/effect/decal/cleanable/food/flour,
 /obj/structure/cable/yellow,
@@ -34212,6 +34188,13 @@
 /obj/effect/turf_decal/tile/dark/half,
 /turf/open/floor/iron/dark,
 /area/station/medical/medbay/central)
+"lUU" = (
+/obj/structure/chair/fancy/sofa/old/right{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood,
+/area/station/security/prison)
 "lVb" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/yellow,
@@ -35894,12 +35877,6 @@
 "muC" = (
 /turf/open/floor/plating,
 /area/station/cargo/warehouse)
-"muF" = (
-/obj/effect/turf_decal/tile/red/fourcorners/contrasted,
-/obj/structure/cable/yellow,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/prison,
-/area/station/security/prison)
 "muX" = (
 /obj/effect/turf_decal/tile/blue/anticorner/contrasted{
 	dir = 4
@@ -38703,6 +38680,14 @@
 /obj/effect/turf_decal/tile/red/opposingcorners,
 /turf/open/floor/iron/showroomfloor,
 /area/station/service/bar/atrium)
+"noq" = (
+/obj/effect/turf_decal/tile/red/fourcorners/contrasted,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
+/obj/structure/cable/yellow,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/prison,
+/area/station/security/prison)
 "noD" = (
 /obj/structure/chair/fancy/sofa/old/left{
 	color = "#742925"
@@ -42276,14 +42261,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/disposal)
-"oyz" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/caution,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/techmaint,
-/area/station/security/prison)
 "oyJ" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
@@ -46762,6 +46739,13 @@
 "qbR" = (
 /turf/closed/wall/r_wall/rust,
 /area/station/security/prison/safe)
+"qco" = (
+/obj/effect/turf_decal/tile/red/fourcorners/contrasted,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/prison,
+/area/station/security/prison)
 "qcz" = (
 /turf/closed/wall/r_wall,
 /area/station/maintenance/solars/starboard/fore)
@@ -50270,13 +50254,13 @@
 /obj/machinery/door/airlock/external{
 	name = "Brig Shuttle Airlock"
 	},
-/obj/effect/mapping_helpers/airlock/access/all/security/entrance,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
 	},
 /obj/effect/turf_decal/stripes/closeup{
 	dir = 1
 	},
+/obj/effect/mapping_helpers/airlock/access/any/security/brig,
 /turf/open/floor/iron/dark,
 /area/station/hallway/secondary/exit/departure_lounge)
 "rlF" = (
@@ -53191,6 +53175,11 @@
 /obj/effect/turf_decal/tile/blue,
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
+"srx" = (
+/obj/effect/turf_decal/siding/wood,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood,
+/area/station/security/prison)
 "srz" = (
 /obj/structure/cable/yellow,
 /obj/structure/disposalpipe/segment,
@@ -55220,14 +55209,6 @@
 /obj/structure/sign/poster/contraband/random,
 /turf/closed/wall,
 /area/station/maintenance/port/aft)
-"teV" = (
-/obj/structure/cable/yellow,
-/obj/effect/turf_decal/tile/red/fourcorners/contrasted,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/prison,
-/area/station/security/prison)
 "tfm" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
@@ -56429,6 +56410,13 @@
 	},
 /turf/open/floor/engine,
 /area/station/science/xenobiology)
+"tzu" = (
+/obj/structure/chair/fancy/sofa/old/right{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood,
+/area/station/security/prison)
 "tzA" = (
 /obj/structure/girder,
 /obj/effect/decal/cleanable/dirt,
@@ -59407,6 +59395,14 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/command/bridge)
+"uxb" = (
+/obj/structure/cable/yellow,
+/obj/effect/turf_decal/tile/red/fourcorners/contrasted,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/prison,
+/area/station/security/prison)
 "uxf" = (
 /obj/structure/table,
 /obj/item/radio/intercom{
@@ -62786,6 +62782,13 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/hallway/primary/starboard)
+"vEB" = (
+/obj/structure/chair/fancy/sofa/old{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood,
+/area/station/security/prison)
 "vEF" = (
 /obj/machinery/newscaster{
 	pixel_x = 30
@@ -64188,13 +64191,6 @@
 	burnt = 1
 	},
 /area/station/maintenance/port/fore)
-"weQ" = (
-/obj/effect/turf_decal/tile/red/fourcorners/contrasted,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/prison,
-/area/station/security/prison)
 "weT" = (
 /obj/structure/cable/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
@@ -65999,13 +65995,13 @@
 /obj/machinery/door/airlock/external{
 	name = "Brig Shuttle Airlock"
 	},
-/obj/effect/mapping_helpers/airlock/access/all/security/entrance,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
 	},
 /obj/effect/turf_decal/stripes/closeup{
 	dir = 1
 	},
+/obj/effect/mapping_helpers/airlock/access/any/security/brig,
 /turf/open/floor/iron/dark,
 /area/station/hallway/secondary/exit/departure_lounge)
 "wLN" = (
@@ -66281,6 +66277,13 @@
 /obj/effect/landmark/navigate_destination,
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/hos)
+"wQJ" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/prison,
+/area/station/security/prison)
 "wQP" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 6
@@ -66875,6 +66878,11 @@
 /obj/effect/landmark/start/chemist,
 /turf/open/floor/iron/showroomfloor,
 /area/station/medical/chemistry)
+"xcO" = (
+/obj/effect/turf_decal/tile/red/fourcorners/contrasted,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/prison,
+/area/station/security/prison)
 "xcY" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/grunge{
@@ -67581,14 +67589,6 @@
 	broken = 1
 	},
 /area/station/maintenance/port)
-"xpr" = (
-/obj/effect/turf_decal/tile/red/fourcorners/contrasted,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
-/obj/structure/cable/yellow,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/prison,
-/area/station/security/prison)
 "xpA" = (
 /obj/structure/closet/crate{
 	opened = 1
@@ -87811,7 +87811,7 @@ rII
 rII
 rII
 rII
-oyz
+eee
 kzv
 daL
 pnn
@@ -89349,15 +89349,15 @@ csf
 rfh
 pnn
 beh
-gGd
-iKG
-fMh
-gwT
+dgx
+gtJ
+tzu
+srx
 jnC
 mHP
 kxP
 odo
-dmK
+xcO
 aUP
 boG
 qbR
@@ -89615,7 +89615,7 @@ neN
 mHP
 mHP
 umz
-weQ
+qco
 umz
 tKv
 eOF
@@ -89863,9 +89863,9 @@ lmr
 jpN
 pnn
 sAH
-gAc
-giK
-dDZ
+lUU
+vEB
+fMh
 xJb
 vbq
 kIH
@@ -91156,7 +91156,7 @@ qAw
 buZ
 dEq
 lKc
-erX
+kcD
 oDs
 ena
 lii
@@ -91668,8 +91668,8 @@ jJc
 nhW
 qAw
 iSV
-gwT
-muF
+srx
+aeN
 taw
 hHC
 jwW
@@ -92177,10 +92177,10 @@ mVf
 pnn
 xhe
 pfS
-kdD
+giK
 bVe
 mHP
-jbI
+wQJ
 aFK
 jnC
 lKc
@@ -92436,10 +92436,10 @@ wSB
 qYk
 lOX
 ooQ
-xpr
+noq
 jOx
 bAr
-xpr
+noq
 ciP
 vuo
 ssB
@@ -92695,9 +92695,9 @@ qAw
 qAw
 goZ
 msz
-gvJ
+amZ
 aph
-teV
+uxb
 gkC
 oDs
 haE

--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -314,6 +314,16 @@
 "ahX" = (
 /obj/structure/cable/yellow,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
+/obj/machinery/power/apc{
+	areastring = "/area/station/commons/toilet/restrooms";
+	name = "Restrooms APC";
+	pixel_y = -24
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/iron/showroomfloor,
 /area/station/commons/toilet/restrooms)
 "ail" = (
@@ -982,7 +992,7 @@
 /obj/item/radio/intercom{
 	pixel_x = -28
 	},
-/obj/effect/turf_decal/tile/blue/half/contrasted{
+/obj/effect/turf_decal/tile/blue/anticorner/contrasted{
 	dir = 8
 	},
 /obj/effect/turf_decal/delivery,
@@ -2393,16 +2403,11 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/fore)
 "bcm" = (
-/obj/effect/turf_decal/delivery,
-/obj/machinery/vending/clothing,
-/obj/item/radio/intercom{
-	pixel_y = -28
-	},
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
 	dir = 4
 	},
-/turf/open/floor/iron/dark,
-/area/station/commons/locker)
+/turf/closed/wall,
+/area/station/commons/cryopods)
 "bcB" = (
 /obj/effect/turf_decal/tile/neutral/anticorner/contrasted{
 	dir = 4
@@ -2798,12 +2803,14 @@
 /turf/open/floor/iron,
 /area/station/security/courtroom)
 "bhN" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/yellow,
-/turf/open/floor/plating{
-	burnt = 1
+/obj/machinery/airalarm/directional/north{
+	pixel_y = 22
 	},
-/area/station/maintenance/central)
+/obj/effect/turf_decal/tile/blue/half/contrasted{
+	dir = 4
+	},
+/turf/open/floor/iron/showroomfloor,
+/area/station/commons/cryopods)
 "bif" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet,
@@ -4638,7 +4645,12 @@
 	},
 /area/station/maintenance/aft)
 "bSO" = (
-/obj/machinery/oven,
+/obj/structure/table/reinforced,
+/obj/effect/spawner/random/maintenance,
+/obj/item/book/manual/chef_recipes{
+	pixel_x = 2;
+	pixel_y = 6
+	},
 /turf/open/floor/iron/techmaint,
 /area/station/security/prison)
 "bTa" = (
@@ -5368,18 +5380,15 @@
 /turf/open/floor/prison,
 /area/station/security/prison)
 "cje" = (
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
 /obj/structure/cable/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
-/obj/effect/turf_decal/tile/blue/opposingcorners{
-	dir = 1
+/obj/effect/turf_decal/stripes/closeup,
+/obj/machinery/door/airlock/medical/glass{
+	name = "Cryopod Room"
 	},
-/obj/effect/turf_decal/tile/red,
-/turf/open/floor/iron/showroomfloor,
-/area/station/commons/toilet/restrooms)
+/turf/open/floor/iron/dark,
+/area/station/commons/cryopods)
 "cjK" = (
 /obj/machinery/atmospherics/pipe/smart/simple/orange/visible{
 	dir = 4
@@ -13798,10 +13807,10 @@
 /turf/open/floor/iron/showroomfloor,
 /area/station/science/research)
 "fbZ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/yellow,
-/turf/open/floor/plating,
-/area/station/maintenance/central)
+/obj/item/kirbyplants/random,
+/obj/effect/spawner/random/maintenance,
+/turf/open/floor/prison,
+/area/station/security/prison)
 "fcJ" = (
 /obj/machinery/photocopier,
 /obj/machinery/requests_console{
@@ -15939,7 +15948,8 @@
 /area/station/service/chapel/office)
 "fMh" = (
 /obj/structure/chair/fancy/sofa/old/left{
-	dir = 8
+	dir = 8;
+	color = "#742925"
 	},
 /obj/effect/landmark/start/prisoner,
 /turf/open/floor/wood,
@@ -16028,6 +16038,7 @@
 	dir = 5
 	},
 /obj/item/kirbyplants/random,
+/obj/effect/spawner/random/maintenance,
 /turf/open/floor/wood,
 /area/station/security/prison)
 "fNI" = (
@@ -16533,14 +16544,8 @@
 /turf/open/floor/iron/dark,
 /area/station/hallway/primary/fore)
 "fVz" = (
-/obj/machinery/computer/cryopod{
-	pixel_y = 25
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
-/obj/effect/turf_decal/tile/blue/half/contrasted{
-	dir = 4
-	},
 /turf/open/floor/iron/showroomfloor,
 /area/station/commons/cryopods)
 "fVJ" = (
@@ -17023,9 +17028,21 @@
 /area/station/command/heads_quarters/captain)
 "gfy" = (
 /obj/structure/table/reinforced,
-/obj/item/book/manual/chef_recipes{
-	pixel_x = 2;
+/obj/item/food/grown/carrot{
+	pixel_x = -1;
 	pixel_y = 6
+	},
+/obj/item/food/grown/carrot{
+	pixel_x = -1;
+	pixel_y = 11
+	},
+/obj/item/food/grown/carrot{
+	pixel_x = 4;
+	pixel_y = 4
+	},
+/obj/item/food/grown/carrot{
+	pixel_x = -6;
+	pixel_y = 12
 	},
 /turf/open/floor/iron/techmaint,
 /area/station/security/prison)
@@ -17859,7 +17876,8 @@
 /area/station/commons/vacant_room/commissary)
 "gtJ" = (
 /obj/structure/chair/fancy/sofa/old/left{
-	dir = 4
+	dir = 4;
+	color = "#742925"
 	},
 /obj/effect/landmark/start/prisoner,
 /turf/open/floor/wood,
@@ -18398,23 +18416,12 @@
 /turf/open/floor/iron/dark,
 /area/station/hallway/secondary/exit/departure_lounge)
 "gDd" = (
-/obj/machinery/power/apc{
-	areastring = "/area/station/commons/toilet/restrooms";
-	name = "Restrooms APC";
-	pixel_y = -24
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable/yellow,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/red,
-/turf/open/floor/iron/showroomfloor,
-/area/station/commons/toilet/restrooms)
+/turf/closed/wall,
+/area/station/commons/cryopods)
 "gDr" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/girder,
@@ -29486,14 +29493,18 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "kpp" = (
-/obj/machinery/door/airlock/medical/glass{
-	name = "Cryopod Room"
-	},
 /obj/structure/cable/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
-/obj/effect/turf_decal/stripes/closeup,
-/turf/open/floor/iron/dark,
+/obj/effect/turf_decal/tile/blue/anticorner/contrasted{
+	dir = 1
+	},
+/obj/machinery/power/apc{
+	dir = 8;
+	name = "Cryopod Room APC";
+	pixel_x = -24
+	},
+/turf/open/floor/iron/showroomfloor,
 /area/station/commons/cryopods)
 "kpu" = (
 /obj/structure/table/wood,
@@ -30558,11 +30569,12 @@
 "kGm" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
-/obj/effect/turf_decal/tile/neutral/half/contrasted{
-	dir = 4
+/obj/machinery/door/airlock/medical/glass{
+	name = "Cryopod Room"
 	},
+/obj/effect/turf_decal/stripes/closeup,
 /turf/open/floor/iron/dark,
-/area/station/commons/locker)
+/area/station/commons/cryopods)
 "kGA" = (
 /obj/structure/filingcabinet,
 /obj/effect/turf_decal/tile/neutral/anticorner/contrasted{
@@ -31906,8 +31918,6 @@
 /turf/open/floor/iron,
 /area/station/security/brig/upper)
 "lfS" = (
-/obj/effect/turf_decal/bot,
-/obj/structure/closet/wardrobe/mixed,
 /obj/machinery/light/small,
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
 	dir = 4
@@ -32970,9 +32980,17 @@
 /turf/open/floor/iron/showroomfloor,
 /area/station/medical/storage)
 "lyd" = (
-/obj/effect/spawner/structure/window/reinforced/tinted,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
 /obj/structure/cable/yellow,
-/turf/open/floor/plating,
+/turf/open/floor/iron,
 /area/station/commons/locker)
 "lyl" = (
 /obj/effect/turf_decal/plaque{
@@ -33868,17 +33886,15 @@
 	},
 /area/station/maintenance/port/aft)
 "lPl" = (
-/obj/machinery/power/apc{
-	dir = 8;
-	name = "Cryopod Room APC";
-	pixel_x = -24
-	},
-/obj/structure/cable/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
-/obj/effect/turf_decal/tile/blue/half/contrasted{
+/obj/machinery/cryopod{
 	dir = 4
 	},
+/obj/effect/turf_decal/tile/blue/half/contrasted{
+	dir = 1
+	},
+/obj/effect/turf_decal/delivery,
 /turf/open/floor/iron/showroomfloor,
 /area/station/commons/cryopods)
 "lPp" = (
@@ -33979,12 +33995,14 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
-/obj/effect/turf_decal/tile/blue/half/contrasted{
-	dir = 4
-	},
 /obj/machinery/light_switch{
 	pixel_x = 21
 	},
+/obj/machinery/cryopod{
+	dir = 2
+	},
+/obj/effect/turf_decal/tile/blue/half/contrasted,
+/obj/effect/turf_decal/delivery,
 /turf/open/floor/iron/showroomfloor,
 /area/station/commons/cryopods)
 "lQR" = (
@@ -34146,6 +34164,7 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/red,
+/obj/structure/cable/yellow,
 /turf/open/floor/iron/showroomfloor,
 /area/station/commons/toilet/restrooms)
 "lUp" = (
@@ -35371,9 +35390,7 @@
 /area/station/service/theater)
 "mnH" = (
 /obj/machinery/cryopod,
-/obj/effect/turf_decal/tile/blue/half/contrasted{
-	dir = 8
-	},
+/obj/effect/turf_decal/tile/blue/anticorner/contrasted,
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/iron/showroomfloor,
 /area/station/commons/cryopods)
@@ -36157,8 +36174,8 @@
 /obj/item/kirbyplants{
 	icon_state = "plant-16"
 	},
-/obj/structure/cable/yellow,
 /obj/effect/turf_decal/tile/neutral/half/contrasted,
+/obj/structure/cable/yellow,
 /turf/open/floor/iron,
 /area/station/commons/locker)
 "mzT" = (
@@ -38107,6 +38124,7 @@
 /obj/effect/turf_decal/stripes/closeup{
 	dir = 1
 	},
+/obj/structure/cable/yellow,
 /turf/open/floor/iron/dark,
 /area/station/commons/locker)
 "neH" = (
@@ -39339,6 +39357,9 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
+/obj/item/radio/intercom{
+	pixel_y = -28
+	},
 /turf/open/floor/iron,
 /area/station/commons/locker)
 "nzY" = (
@@ -39813,9 +39834,12 @@
 	dir = 8;
 	color = "#439C1E"
 	},
-/obj/structure/table/glass,
-/obj/item/soap/nanotrasen,
-/obj/item/hand_labeler,
+/obj/machinery/cryopod{
+	dir = 4
+	},
+/obj/machinery/computer/cryopod{
+	pixel_y = -25
+	},
 /turf/open/floor/iron/showroomfloor,
 /area/station/medical/medbay/central)
 "nIU" = (
@@ -40887,25 +40911,9 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard)
 "oaS" = (
-/obj/structure/table/reinforced,
-/obj/item/food/grown/carrot{
-	pixel_x = -6;
-	pixel_y = 12
-	},
-/obj/item/food/grown/carrot{
-	pixel_x = -1;
-	pixel_y = 6
-	},
-/obj/item/food/grown/carrot{
-	pixel_x = -1;
-	pixel_y = 11
-	},
-/obj/item/food/grown/carrot{
-	pixel_x = 4;
-	pixel_y = 4
-	},
-/obj/effect/spawner/random/maintenance,
 /obj/machinery/airalarm/directional/west,
+/obj/machinery/processor,
+/obj/effect/turf_decal/bot,
 /turf/open/floor/iron/techmaint,
 /area/station/security/prison)
 "obt" = (
@@ -41507,11 +41515,6 @@
 /area/station/maintenance/port)
 "onT" = (
 /obj/effect/turf_decal/bot,
-/obj/structure/closet/secure_closet/personal,
-/obj/item/storage/backpack,
-/obj/item/storage/backpack/satchel,
-/obj/item/clothing/suit/hooded/wintercoat,
-/obj/item/clothing/shoes/winterboots,
 /obj/machinery/light/small{
 	dir = 1
 	},
@@ -41519,6 +41522,11 @@
 	dir = 8
 	},
 /obj/machinery/digital_clock/directional/north,
+/obj/structure/closet/secure_closet/personal,
+/obj/item/storage/backpack/satchel,
+/obj/item/clothing/suit/hooded/wintercoat,
+/obj/item/storage/backpack,
+/obj/item/clothing/shoes/winterboots,
 /turf/open/floor/iron/dark,
 /area/station/commons/locker)
 "ooo" = (
@@ -49653,15 +49661,8 @@
 	},
 /area/station/maintenance/aft)
 "qZI" = (
-/obj/machinery/airalarm/directional/north{
-	pixel_y = 22
-	},
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
-/obj/effect/turf_decal/tile/blue/half/contrasted{
-	dir = 4
-	},
 /turf/open/floor/iron/showroomfloor,
 /area/station/commons/cryopods)
 "qZL" = (
@@ -50319,12 +50320,14 @@
 /turf/open/floor/iron/showroomfloor,
 /area/station/science/research)
 "rmw" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/yellow,
-/turf/open/floor/plating{
-	broken = 1
+/obj/effect/turf_decal/tile/blue/half/contrasted{
+	dir = 4
 	},
-/area/station/maintenance/central)
+/obj/machinery/computer/cryopod{
+	pixel_y = 25
+	},
+/turf/open/floor/iron/showroomfloor,
+/area/station/commons/cryopods)
 "rmG" = (
 /obj/machinery/airalarm/directional/east,
 /obj/effect/turf_decal/tile/yellow/half/contrasted{
@@ -52087,15 +52090,11 @@
 	},
 /area/station/maintenance/central)
 "rXh" = (
-/obj/effect/turf_decal/bot,
-/obj/structure/closet/secure_closet/personal,
-/obj/item/storage/backpack,
-/obj/item/storage/backpack/satchel,
-/obj/item/clothing/suit/hooded/wintercoat,
-/obj/item/clothing/shoes/winterboots,
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
 	dir = 8
 	},
+/obj/effect/turf_decal/delivery,
+/obj/machinery/vending/clothing,
 /turf/open/floor/iron/dark,
 /area/station/commons/locker)
 "rXp" = (
@@ -52366,11 +52365,13 @@
 	},
 /area/station/maintenance/fore)
 "scw" = (
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
 /obj/structure/cable/yellow,
 /obj/effect/turf_decal/tile/red,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/iron/showroomfloor,
 /area/station/commons/toilet/restrooms)
 "scF" = (
@@ -54601,6 +54602,11 @@
 "sTJ" = (
 /obj/structure/cable/yellow,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
 /turf/open/floor/iron/showroomfloor,
 /area/station/commons/toilet/restrooms)
 "sUm" = (
@@ -55519,7 +55525,6 @@
 /turf/open/floor/iron,
 /area/station/command/bridge)
 "tkU" = (
-/obj/structure/cable/yellow,
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
@@ -56410,10 +56415,10 @@
 /area/station/science/xenobiology)
 "tzu" = (
 /obj/structure/chair/fancy/sofa/old/right{
+	color = "#742925";
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/start/prisoner,
 /turf/open/floor/wood,
 /area/station/security/prison)
 "tzA" = (
@@ -57272,13 +57277,12 @@
 /turf/closed/wall,
 /area/station/cargo/warehouse)
 "tMf" = (
-/obj/machinery/door/airlock/medical/glass{
-	name = "Cryopod Room"
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
-/obj/effect/turf_decal/stripes/closeup,
-/turf/open/floor/iron/dark,
+/obj/effect/turf_decal/tile/blue/anticorner/contrasted{
+	dir = 4
+	},
+/turf/open/floor/iron/showroomfloor,
 /area/station/commons/cryopods)
 "tMl" = (
 /obj/effect/decal/cleanable/dirt,
@@ -57838,10 +57842,8 @@
 	},
 /area/station/cargo/warehouse)
 "tUO" = (
-/obj/item/kirbyplants{
-	icon_state = "plant-14"
-	},
-/obj/structure/cable/yellow,
+/obj/structure/table,
+/obj/structure/bedsheetbin,
 /turf/open/floor/iron/showroomfloor,
 /area/station/commons/toilet/restrooms)
 "tUQ" = (
@@ -57908,12 +57910,12 @@
 /turf/open/floor/iron/dark,
 /area/station/cargo/storage)
 "tVw" = (
-/obj/item/kirbyplants{
-	icon_state = "applebush"
-	},
 /obj/structure/cable/yellow,
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
 	dir = 1
+	},
+/obj/item/kirbyplants{
+	icon_state = "plant-10"
 	},
 /turf/open/floor/iron,
 /area/station/commons/locker)
@@ -58334,14 +58336,12 @@
 /turf/open/floor/iron,
 /area/station/security/checkpoint/medical)
 "udf" = (
-/obj/structure/table,
-/obj/structure/bedsheetbin,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/neutral/anticorner/contrasted{
 	dir = 1
 	},
-/turf/open/floor/iron/dark,
-/area/station/commons/toilet/restrooms)
+/turf/closed/wall/rust,
+/area/station/commons/cryopods)
 "udE" = (
 /obj/structure/filingcabinet,
 /obj/effect/turf_decal/bot,
@@ -62786,9 +62786,9 @@
 "vEB" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/chair/fancy/sofa/old/right{
+	color = "#742925";
 	dir = 8
 	},
-/obj/effect/landmark/start/prisoner,
 /turf/open/floor/wood,
 /area/station/security/prison)
 "vEF" = (
@@ -66567,6 +66567,7 @@
 	name = "freezer"
 	},
 /obj/effect/spawner/random/maintenance,
+/obj/effect/turf_decal/bot,
 /turf/open/floor/iron/techmaint,
 /area/station/security/prison)
 "wWo" = (
@@ -69441,14 +69442,14 @@
 /turf/closed/wall/r_wall/rust,
 /area/station/medical/virology)
 "xTY" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 9
 	},
 /turf/open/floor/iron/showroomfloor,
 /area/station/commons/toilet/restrooms)
@@ -70071,6 +70072,7 @@
 "yeL" = (
 /obj/item/kirbyplants/random,
 /obj/effect/turf_decal/tile/neutral,
+/obj/effect/spawner/random/maintenance,
 /turf/open/floor/prison,
 /area/station/security/prison)
 "yeU" = (
@@ -90646,7 +90648,7 @@ hdz
 tUO
 lUm
 udf
-xlU
+bhN
 qZI
 scL
 mCU
@@ -90900,10 +90902,10 @@ pbi
 pbi
 cfF
 aQg
-lyd
-neG
 pmc
+neG
 lWl
+rmw
 fVz
 fTz
 mCU
@@ -91158,7 +91160,7 @@ pbi
 vRb
 iAN
 mzP
-ach
+lyd
 kGm
 tMf
 lQI
@@ -93230,7 +93232,7 @@ ooQ
 bAr
 gBm
 qAw
-xhe
+fbZ
 eRW
 cFa
 pnn
@@ -103500,7 +103502,7 @@ ivB
 nsR
 lKU
 qsF
-bhN
+dpK
 vVN
 uEG
 dvy
@@ -103757,7 +103759,7 @@ mzd
 cky
 lKU
 jom
-rmw
+kjR
 aEO
 uEG
 lTr
@@ -104014,7 +104016,7 @@ lKU
 hpL
 lKU
 dos
-fbZ
+vVN
 uEG
 dSA
 muz

--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -1008,6 +1008,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /obj/effect/turf_decal/stripes/closeup,
+/obj/effect/mapping_helpers/airlock/access/all/security/brig_physician,
 /turf/open/floor/iron/dark,
 /area/station/security/office)
 "aAU" = (
@@ -2634,15 +2635,7 @@
 /area/station/cargo/exploration_prep)
 "bfT" = (
 /obj/structure/lattice/catwalk,
-/obj/item/stack/marker_beacon{
-	anchored = 1;
-	icon_state = "markerburgundy-on";
-	light_color = "#FA644B";
-	light_power = 3;
-	light_range = 2;
-	name = "landing marker";
-	picked_color = "Burgundy"
-	},
+/obj/structure/marker_beacon/burgundy,
 /obj/structure/cable/yellow,
 /turf/open/floor/plating/airless{
 	initial_gas_mix = "o2=14;n2=23;TEMP=300"
@@ -5355,6 +5348,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /obj/machinery/holopad,
 /obj/effect/turf_decal/tile/red/fourcorners/contrasted,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison,
 /area/station/security/prison)
 "cje" = (
@@ -7410,6 +7404,7 @@
 /area/station/security/office)
 "dat" = (
 /obj/effect/turf_decal/tile/black/fourcorners,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison,
 /area/station/security/prison)
 "daA" = (
@@ -7755,6 +7750,19 @@
 	dir = 8
 	},
 /obj/machinery/light/very_dim/directional/east,
+/obj/structure/wall_closet/emergency/directional/east,
+/obj/item/clothing/suit/space/hardsuit/skinsuit,
+/obj/item/clothing/suit/space/hardsuit/skinsuit,
+/obj/item/clothing/suit/space/hardsuit/skinsuit,
+/obj/item/clothing/suit/space/hardsuit/skinsuit,
+/obj/item/tank/internals/oxygen,
+/obj/item/tank/internals/oxygen,
+/obj/item/tank/internals/oxygen,
+/obj/item/tank/internals/oxygen,
+/obj/item/clothing/mask/breath,
+/obj/item/clothing/mask/breath,
+/obj/item/clothing/mask/breath,
+/obj/item/clothing/mask/breath,
 /turf/open/floor/iron/techmaint,
 /area/station/security/prison/safe)
 "dgL" = (
@@ -8024,6 +8032,11 @@
 	initial_gas_mix = "o2=14;n2=23;TEMP=300"
 	},
 /area/docking/arrival)
+"dmK" = (
+/obj/effect/turf_decal/tile/red/fourcorners/contrasted,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/prison,
+/area/station/security/prison)
 "dmQ" = (
 /obj/machinery/light_switch{
 	pixel_y = -24
@@ -9089,6 +9102,12 @@
 /obj/structure/cable/yellow,
 /turf/open/floor/iron/techmaint,
 /area/station/security/prison/safe)
+"dDZ" = (
+/obj/structure/chair/fancy/sofa/old/left{
+	dir = 8
+	},
+/turf/open/floor/wood,
+/area/station/security/prison)
 "dEj" = (
 /obj/effect/turf_decal/tile/red/half/contrasted,
 /turf/open/floor/iron/showroomfloor,
@@ -9114,11 +9133,11 @@
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/command/storage/eva)
 "dEq" = (
-/obj/structure/chair/stool/directional/south,
 /obj/item/trash/energybar{
 	pixel_x = 10;
 	pixel_y = 7
 	},
+/obj/structure/chair/stool/directional/north,
 /turf/open/floor/wood,
 /area/station/security/prison)
 "dEv" = (
@@ -9268,6 +9287,7 @@
 "dHe" = (
 /obj/machinery/holopad,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/techmaint,
 /area/station/security/prison)
 "dHm" = (
@@ -11294,6 +11314,13 @@
 /obj/effect/turf_decal/stripes/closeup,
 /turf/open/floor/iron/dark,
 /area/station/security/courtroom)
+"erX" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/prison,
+/area/station/security/prison)
 "esg" = (
 /obj/structure/grille,
 /obj/effect/decal/cleanable/dirt,
@@ -15908,7 +15935,10 @@
 /turf/open/floor/iron/dark,
 /area/station/service/chapel/office)
 "fMh" = (
-/obj/structure/chair/stool/directional/west,
+/obj/structure/chair/fancy/sofa/old/right{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood,
 /area/station/security/prison)
 "fMn" = (
@@ -16550,15 +16580,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/item/stack/marker_beacon{
-	anchored = 1;
-	icon_state = "markerburgundy-on";
-	light_color = "#FA644B";
-	light_power = 3;
-	light_range = 2;
-	name = "landing marker";
-	picked_color = "Burgundy"
-	},
+/obj/structure/marker_beacon/burgundy,
 /obj/structure/cable/yellow,
 /turf/open/floor/plating/airless{
 	initial_gas_mix = "o2=14;n2=23;TEMP=300"
@@ -17197,9 +17219,12 @@
 /turf/open/floor/iron/dark,
 /area/station/security/warden)
 "giK" = (
-/obj/effect/turf_decal/siding/wood,
+/obj/structure/chair/fancy/sofa/old{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood,
-/area/station/security/interrogation)
+/area/station/security/prison)
 "giN" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light_switch{
@@ -17939,6 +17964,11 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/security/courtroom)
+"gvJ" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/prison,
+/area/station/security/prison)
 "gvK" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating{
@@ -18028,6 +18058,11 @@
 /obj/effect/spawner/random/maintenance,
 /turf/open/floor/carpet/green,
 /area/station/cargo/warehouse)
+"gwT" = (
+/obj/effect/turf_decal/siding/wood,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood,
+/area/station/security/prison)
 "gwU" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/rack,
@@ -18191,6 +18226,13 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/security/brig)
+"gAc" = (
+/obj/structure/chair/fancy/sofa/old/right{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood,
+/area/station/security/prison)
 "gAh" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/grille/broken,
@@ -18537,6 +18579,12 @@
 	},
 /turf/open/floor/plating,
 /area/station/cargo/storage)
+"gGd" = (
+/obj/structure/chair/fancy/sofa/old/left{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/station/security/prison)
 "gGe" = (
 /obj/effect/turf_decal/tile/yellow/half/contrasted,
 /obj/effect/turf_decal/tile/blue,
@@ -21138,6 +21186,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/effect/turf_decal/tile/red/fourcorners/contrasted,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison,
 /area/station/security/prison)
 "hAR" = (
@@ -22169,6 +22218,7 @@
 /obj/effect/turf_decal/siding/dark{
 	dir = 6
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison,
 /area/station/security/prison)
 "hTp" = (
@@ -23700,6 +23750,7 @@
 	pixel_y = 4
 	},
 /obj/structure/sink/directional/west,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/freezer,
 /area/station/security/prison)
 "ity" = (
@@ -24505,6 +24556,7 @@
 /obj/structure/table,
 /obj/item/paper_bin,
 /obj/item/pen,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood,
 /area/station/security/prison)
 "iHR" = (
@@ -24651,6 +24703,12 @@
 /obj/effect/landmark/navigate_destination,
 /turf/open/floor/iron/showroomfloor,
 /area/station/security/office)
+"iKG" = (
+/obj/structure/chair/fancy/sofa/old{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/station/security/prison)
 "iKO" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
@@ -25494,6 +25552,7 @@
 	prison_radio = 1;
 	pixel_x = 28
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison,
 /area/station/security/prison)
 "jbE" = (
@@ -25515,6 +25574,13 @@
 /obj/effect/turf_decal/tile/neutral/opposingcorners,
 /turf/open/floor/iron/dark,
 /area/station/service/library)
+"jbI" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/prison,
+/area/station/security/prison)
 "jce" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/engineering{
@@ -27958,6 +28024,7 @@
 /obj/effect/turf_decal/tile/red/fourcorners/contrasted,
 /obj/effect/landmark/event_spawn,
 /obj/structure/cable/yellow,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison,
 /area/station/security/prison)
 "jRh" = (
@@ -28726,6 +28793,12 @@
 /obj/item/pickaxe,
 /turf/open/floor/plating/asteroid/airless,
 /area/misc/space/nearstation)
+"kdD" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/prison,
+/area/station/security/prison)
 "kdG" = (
 /obj/effect/decal/cleanable/food/flour,
 /obj/structure/cable/yellow,
@@ -30020,6 +30093,7 @@
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "kxP" = (
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison,
 /area/station/security/prison)
 "kxT" = (
@@ -32135,6 +32209,7 @@
 	pixel_y = 8
 	},
 /obj/effect/spawner/random/maintenance,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison,
 /area/station/security/prison)
 "llc" = (
@@ -32475,9 +32550,10 @@
 /turf/open/floor/iron/dark,
 /area/station/science/lab)
 "lqh" = (
-/obj/machinery/airalarm/directional/east,
-/turf/open/floor/engine,
-/area/station/science/xenobiology)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/techmaint,
+/area/station/security/prison)
 "lqJ" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/on/layer4,
 /turf/open/floor/plating/airless,
@@ -33380,9 +33456,6 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/main)
 "lGV" = (
-/obj/machinery/airalarm/directional/south{
-	pixel_y = -22
-	},
 /obj/machinery/light_switch{
 	pixel_x = -24;
 	pixel_y = -24
@@ -34081,6 +34154,7 @@
 /obj/effect/turf_decal/bot_white,
 /obj/structure/punching_bag,
 /obj/effect/turf_decal/siding/dark,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison,
 /area/station/security/prison)
 "lTM" = (
@@ -35820,6 +35894,12 @@
 "muC" = (
 /turf/open/floor/plating,
 /area/station/cargo/warehouse)
+"muF" = (
+/obj/effect/turf_decal/tile/red/fourcorners/contrasted,
+/obj/structure/cable/yellow,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/prison,
+/area/station/security/prison)
 "muX" = (
 /obj/effect/turf_decal/tile/blue/anticorner/contrasted{
 	dir = 4
@@ -38073,6 +38153,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /obj/machinery/holopad,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison,
 /area/station/security/prison)
 "neO" = (
@@ -39632,6 +39713,7 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/siding/wood,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood,
 /area/station/security/prison)
 "nHq" = (
@@ -42194,6 +42276,14 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/disposal)
+"oyz" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/caution,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/techmaint,
+/area/station/security/prison)
 "oyJ" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
@@ -42717,6 +42807,7 @@
 /area/station/maintenance/port/aft)
 "oGM" = (
 /obj/structure/cable/yellow,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison,
 /area/station/security/prison)
 "oHl" = (
@@ -43945,6 +44036,7 @@
 	dir = 8;
 	light_color = "#e8eaff"
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison,
 /area/station/security/prison)
 "pcZ" = (
@@ -44128,6 +44220,7 @@
 	dir = 8;
 	light_color = "#e8eaff"
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison,
 /area/station/security/prison)
 "pfV" = (
@@ -46595,6 +46688,7 @@
 /obj/effect/turf_decal/stripes/closeup{
 	dir = 1
 	},
+/obj/effect/mapping_helpers/airlock/access/all/security/brig_physician,
 /turf/open/floor/iron/dark,
 /area/station/security/office)
 "qbs" = (
@@ -49609,6 +49703,7 @@
 "qZR" = (
 /obj/effect/turf_decal/tile/red/fourcorners/contrasted,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison,
 /area/station/security/prison)
 "qZZ" = (
@@ -51715,9 +51810,6 @@
 /turf/open/floor/iron/dark,
 /area/station/science/storage)
 "rPa" = (
-/obj/machinery/airalarm/directional/south{
-	pixel_y = -22
-	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/binary/pump/on/layer2{
 	dir = 8;
@@ -52241,6 +52333,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison,
 /area/station/security/prison)
 "sbQ" = (
@@ -54869,6 +54962,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /obj/effect/turf_decal/tile/neutral,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison,
 /area/station/security/prison)
 "tay" = (
@@ -55126,6 +55220,14 @@
 /obj/structure/sign/poster/contraband/random,
 /turf/closed/wall,
 /area/station/maintenance/port/aft)
+"teV" = (
+/obj/structure/cable/yellow,
+/obj/effect/turf_decal/tile/red/fourcorners/contrasted,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/prison,
+/area/station/security/prison)
 "tfm" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
@@ -60216,6 +60318,7 @@
 	pixel_y = -25
 	},
 /obj/effect/turf_decal/tile/neutral,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison,
 /area/station/security/prison)
 "uNl" = (
@@ -60786,6 +60889,7 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 5
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood,
 /area/station/security/prison)
 "uXx" = (
@@ -61948,15 +62052,7 @@
 /area/station/maintenance/port)
 "vsG" = (
 /obj/structure/lattice/catwalk,
-/obj/item/stack/marker_beacon{
-	anchored = 1;
-	icon_state = "markerburgundy-on";
-	light_color = "#FA644B";
-	light_power = 3;
-	light_range = 2;
-	name = "landing marker";
-	picked_color = "Burgundy"
-	},
+/obj/structure/marker_beacon/burgundy,
 /turf/open/floor/plating/asteroid/airless,
 /area/misc/space/nearstation)
 "vsN" = (
@@ -62071,6 +62167,7 @@
 /obj/structure/cable/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison,
 /area/station/security/prison)
 "vuu" = (
@@ -64041,15 +64138,7 @@
 /area/station/maintenance/disposal/incinerator)
 "wdO" = (
 /obj/structure/lattice/catwalk,
-/obj/item/stack/marker_beacon{
-	anchored = 1;
-	icon_state = "markerburgundy-on";
-	light_color = "#FA644B";
-	light_power = 3;
-	light_range = 2;
-	name = "landing marker";
-	picked_color = "Burgundy"
-	},
+/obj/structure/marker_beacon/burgundy,
 /turf/open/space/basic,
 /area/misc/space/nearstation)
 "web" = (
@@ -64099,6 +64188,13 @@
 	burnt = 1
 	},
 /area/station/maintenance/port/fore)
+"weQ" = (
+/obj/effect/turf_decal/tile/red/fourcorners/contrasted,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/prison,
+/area/station/security/prison)
 "weT" = (
 /obj/structure/cable/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
@@ -66251,6 +66347,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 4
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/techmaint,
 /area/station/security/prison)
 "wSc" = (
@@ -67484,6 +67581,14 @@
 	broken = 1
 	},
 /area/station/maintenance/port)
+"xpr" = (
+/obj/effect/turf_decal/tile/red/fourcorners/contrasted,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
+/obj/structure/cable/yellow,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/prison,
+/area/station/security/prison)
 "xpA" = (
 /obj/structure/closet/crate{
 	opened = 1
@@ -69857,8 +69962,9 @@
 /turf/open/floor/iron/dark,
 /area/station/security/execution/transfer)
 "ycW" = (
-/obj/structure/chair/stool/directional/south,
 /obj/effect/turf_decal/siding/wood,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/stool/directional/north,
 /turf/open/floor/wood,
 /area/station/security/prison)
 "ycX" = (
@@ -87705,7 +87811,7 @@ rII
 rII
 rII
 rII
-ciN
+oyz
 kzv
 daL
 pnn
@@ -88220,7 +88326,7 @@ rII
 rII
 rII
 ciN
-kzv
+lqh
 bSO
 pnn
 jPl
@@ -89243,15 +89349,15 @@ csf
 rfh
 pnn
 beh
+gGd
+iKG
 fMh
-fMh
-fMh
-xJb
+gwT
 jnC
 mHP
 kxP
 odo
-jhQ
+dmK
 aUP
 boG
 qbR
@@ -89503,13 +89609,13 @@ nkx
 nPx
 iHQ
 gdf
-giK
+xJb
 jhQ
 neN
 mHP
 mHP
 umz
-umz
+weQ
 umz
 tKv
 eOF
@@ -89757,9 +89863,9 @@ lmr
 jpN
 pnn
 sAH
-fMh
-fMh
-fMh
+gAc
+giK
+dDZ
 xJb
 vbq
 kIH
@@ -91050,7 +91156,7 @@ qAw
 buZ
 dEq
 lKc
-han
+erX
 oDs
 ena
 lii
@@ -91562,8 +91668,8 @@ jJc
 nhW
 qAw
 iSV
-xJb
-lKc
+gwT
+muF
 taw
 hHC
 jwW
@@ -92071,10 +92177,10 @@ mVf
 pnn
 xhe
 pfS
-iex
+kdD
 bVe
 mHP
-jnC
+jbI
 aFK
 jnC
 lKc
@@ -92330,10 +92436,10 @@ wSB
 qYk
 lOX
 ooQ
-jOx
+xpr
 jOx
 bAr
-jOx
+xpr
 ciP
 vuo
 ssB
@@ -92589,9 +92695,9 @@ qAw
 qAw
 goZ
 msz
-msz
+gvJ
 aph
-eRW
+teV
 gkC
 oDs
 haE
@@ -108707,7 +108813,7 @@ xxE
 xxE
 hEp
 mcK
-lqh
+jDI
 gIg
 hEp
 mue

--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -4650,6 +4650,7 @@
 	pixel_x = 2;
 	pixel_y = 6
 	},
+/obj/machinery/camera,
 /turf/open/floor/iron/techmaint,
 /area/station/security/prison)
 "bTa" = (
@@ -66545,7 +66546,6 @@
 /turf/open/floor/iron/dark,
 /area/station/cargo/warehouse)
 "wWd" = (
-/obj/machinery/camera,
 /obj/item/food/meat/slab/monkey,
 /obj/item/food/meat/slab/monkey,
 /obj/item/food/meat/slab/monkey,

--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -1034,7 +1034,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /obj/effect/turf_decal/stripes/closeup,
-/obj/effect/mapping_helpers/airlock/access/all/security/brig_physician,
 /turf/open/floor/iron/dark,
 /area/station/security/office)
 "aAU" = (
@@ -13807,10 +13806,14 @@
 /turf/open/floor/iron/showroomfloor,
 /area/station/science/research)
 "fbZ" = (
-/obj/item/kirbyplants/random,
-/obj/effect/spawner/random/maintenance,
-/turf/open/floor/prison,
-/area/station/security/prison)
+/obj/effect/turf_decal/tile/blue/half/contrasted{
+	dir = 4
+	},
+/obj/machinery/computer/cryopod{
+	pixel_y = 25
+	},
+/turf/open/floor/iron/showroomfloor,
+/area/station/commons/cryopods)
 "fcJ" = (
 /obj/machinery/photocopier,
 /obj/machinery/requests_console{
@@ -32980,18 +32983,10 @@
 /turf/open/floor/iron/showroomfloor,
 /area/station/medical/storage)
 "lyd" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/structure/cable/yellow,
-/turf/open/floor/iron,
-/area/station/commons/locker)
+/obj/item/kirbyplants/random,
+/obj/effect/spawner/random/maintenance,
+/turf/open/floor/prison,
+/area/station/security/prison)
 "lyl" = (
 /obj/effect/turf_decal/plaque{
 	icon_state = "L1"
@@ -50320,14 +50315,18 @@
 /turf/open/floor/iron/showroomfloor,
 /area/station/science/research)
 "rmw" = (
-/obj/effect/turf_decal/tile/blue/half/contrasted{
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/computer/cryopod{
-	pixel_y = 25
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
 	},
-/turf/open/floor/iron/showroomfloor,
-/area/station/commons/cryopods)
+/obj/structure/cable/yellow,
+/turf/open/floor/iron,
+/area/station/commons/locker)
 "rmG" = (
 /obj/machinery/airalarm/directional/east,
 /obj/effect/turf_decal/tile/yellow/half/contrasted{
@@ -90905,7 +90904,7 @@ aQg
 pmc
 neG
 lWl
-rmw
+fbZ
 fVz
 fTz
 mCU
@@ -91160,7 +91159,7 @@ pbi
 vRb
 iAN
 mzP
-lyd
+rmw
 kGm
 tMf
 lQI
@@ -93232,7 +93231,7 @@ ooQ
 bAr
 gBm
 qAw
-fbZ
+lyd
 eRW
 cFa
 pnn

--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -45020,10 +45020,6 @@
 /obj/effect/turf_decal/stripes/closeup,
 /turf/open/floor/iron/dark,
 /area/station/hallway/primary/fore)
-"pwv" = (
-/obj/machinery/airalarm/directional/north,
-/turf/open/floor/plating,
-/area/station/maintenance/port/aft)
 "pwx" = (
 /obj/structure/cable/yellow,
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
@@ -83944,7 +83940,7 @@ rwb
 iya
 umF
 jZK
-pwv
+gvq
 glH
 gvq
 iRd

--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -522,9 +522,14 @@
 /turf/open/floor/iron/showroomfloor,
 /area/station/medical/cryo)
 "aph" = (
-/obj/machinery/airalarm/directional/east,
-/obj/effect/turf_decal/tile/neutral,
-/turf/open/floor/prison,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
+/obj/effect/turf_decal/stripes/closeup,
+/obj/machinery/door/airlock{
+	id_tag = "Cell";
+	name = "Cell 2"
+	},
+/turf/open/floor/iron/dark,
 /area/station/security/prison)
 "aps" = (
 /obj/effect/decal/cleanable/dirt,
@@ -2497,6 +2502,8 @@
 	prison_radio = 1;
 	pixel_y = 25
 	},
+/obj/structure/table/reinforced,
+/obj/effect/spawner/random/maintenance,
 /turf/open/floor/wood,
 /area/station/security/prison)
 "bek" = (
@@ -4631,9 +4638,7 @@
 	},
 /area/station/maintenance/aft)
 "bSO" = (
-/obj/machinery/airalarm/directional/south,
-/obj/structure/table/reinforced,
-/obj/machinery/camera,
+/obj/machinery/oven,
 /turf/open/floor/iron/techmaint,
 /area/station/security/prison)
 "bTa" = (
@@ -7428,10 +7433,7 @@
 "daL" = (
 /obj/structure/table/reinforced,
 /obj/item/reagent_containers/cup/bowl,
-/obj/item/book/manual/chef_recipes{
-	pixel_x = 2;
-	pixel_y = 6
-	},
+/obj/item/kitchen/rollingpin,
 /turf/open/floor/iron/techmaint,
 /area/station/security/prison)
 "daM" = (
@@ -7739,12 +7741,6 @@
 	broken = 1
 	},
 /area/station/maintenance/starboard)
-"dgx" = (
-/obj/structure/chair/fancy/sofa/old/left{
-	dir = 4
-	},
-/turf/open/floor/wood,
-/area/station/security/prison)
 "dgz" = (
 /obj/machinery/atmospherics/pipe/smart/simple/green/visible,
 /obj/machinery/button/door{
@@ -15945,6 +15941,7 @@
 /obj/structure/chair/fancy/sofa/old/left{
 	dir = 8
 	},
+/obj/effect/landmark/start/prisoner,
 /turf/open/floor/wood,
 /area/station/security/prison)
 "fMn" = (
@@ -17026,13 +17023,9 @@
 /area/station/command/heads_quarters/captain)
 "gfy" = (
 /obj/structure/table/reinforced,
-/obj/machinery/microwave{
-	pixel_x = -3;
-	pixel_y = 6
-	},
-/obj/item/storage/box/donkpockets{
+/obj/item/book/manual/chef_recipes{
 	pixel_x = 2;
-	pixel_y = 1
+	pixel_y = 6
 	},
 /turf/open/floor/iron/techmaint,
 /area/station/security/prison)
@@ -17678,6 +17671,7 @@
 	dir = 1
 	},
 /obj/structure/cable/yellow,
+/obj/structure/sign/poster/official/no_erp/directional/north,
 /turf/open/floor/prison,
 /area/station/security/prison)
 "gpa" = (
@@ -17864,9 +17858,10 @@
 /turf/open/floor/iron/dark,
 /area/station/commons/vacant_room/commissary)
 "gtJ" = (
-/obj/structure/chair/fancy/sofa/old{
+/obj/structure/chair/fancy/sofa/old/left{
 	dir = 4
 	},
+/obj/effect/landmark/start/prisoner,
 /turf/open/floor/wood,
 /area/station/security/prison)
 "gtL" = (
@@ -18296,6 +18291,7 @@
 	},
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/delivery,
+/obj/structure/sign/warning/radiation/directional/east,
 /turf/open/floor/prison,
 /area/station/security/prison)
 "gBr" = (
@@ -23739,6 +23735,7 @@
 	},
 /obj/structure/sink/directional/west,
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/start/prisoner,
 /turf/open/floor/iron/freezer,
 /area/station/security/prison)
 "ity" = (
@@ -24916,14 +24913,13 @@
 /turf/closed/wall,
 /area/station/science/lower)
 "iPM" = (
-/obj/machinery/door/airlock{
-	id_tag = "Cell";
-	name = "Cell 1"
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /obj/effect/turf_decal/stripes/closeup{
 	dir = 1
+	},
+/obj/machinery/door/airlock{
+	name = "Bathroom"
 	},
 /turf/open/floor/iron/dark,
 /area/station/security/prison)
@@ -32180,12 +32176,10 @@
 /turf/open/floor/iron/showroomfloor,
 /area/station/security/office)
 "lkV" = (
-/obj/structure/table/wood,
-/obj/item/clothing/head/hats/bowler{
-	pixel_y = 8
-	},
-/obj/effect/spawner/random/maintenance,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/wall_closet/generic/directional/east,
+/obj/effect/spawner/random/maintenance,
+/obj/effect/spawner/random/maintenance,
 /turf/open/floor/prison,
 /area/station/security/prison)
 "llc" = (
@@ -32916,6 +32910,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
+/obj/item/kirbyplants/random,
 /turf/open/floor/wood,
 /area/station/security/prison)
 "lxA" = (
@@ -34189,9 +34184,6 @@
 /turf/open/floor/iron/dark,
 /area/station/medical/medbay/central)
 "lUU" = (
-/obj/structure/chair/fancy/sofa/old/right{
-	dir = 8
-	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood,
 /area/station/security/prison)
@@ -38203,10 +38195,11 @@
 /turf/open/floor/iron/dark,
 /area/station/science/lower)
 "ngf" = (
-/obj/structure/bed{
-	dir = 8
+/obj/structure/table/wood,
+/obj/item/clothing/head/hats/bowler{
+	pixel_y = 8
 	},
-/obj/item/bedsheet/brown,
+/obj/effect/spawner/random/maintenance,
 /turf/open/floor/prison,
 /area/station/security/prison)
 "ngs" = (
@@ -38483,8 +38476,16 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
 	},
-/obj/item/kirbyplants/random,
 /obj/machinery/camera/directional/north,
+/obj/structure/table/reinforced,
+/obj/item/storage/box/donkpockets{
+	pixel_x = 2;
+	pixel_y = 1
+	},
+/obj/item/plate/small{
+	pixel_x = -15;
+	pixel_y = 5
+	},
 /turf/open/floor/wood,
 /area/station/security/prison)
 "nkJ" = (
@@ -40237,8 +40238,6 @@
 /turf/closed/wall/r_wall/rust,
 /area/station/security/courtroom)
 "nPx" = (
-/obj/structure/table,
-/obj/item/book/manual/wiki/sopsecurity,
 /turf/open/floor/wood,
 /area/station/security/prison)
 "nPH" = (
@@ -40506,7 +40505,9 @@
 	},
 /area/station/maintenance/aft)
 "nUe" = (
-/obj/machinery/door/airlock/highsecurity,
+/obj/machinery/door/airlock/highsecurity{
+	name = "Emergency Shelter"
+	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /obj/structure/cable/yellow,
@@ -40904,6 +40905,7 @@
 	pixel_y = 4
 	},
 /obj/effect/spawner/random/maintenance,
+/obj/machinery/airalarm/directional/west,
 /turf/open/floor/iron/techmaint,
 /area/station/security/prison)
 "obt" = (
@@ -41007,11 +41009,10 @@
 /turf/closed/wall,
 /area/station/cargo/warehouse)
 "odU" = (
-/obj/machinery/door/airlock{
-	id_tag = "Cell";
-	name = "Cell 1"
-	},
 /obj/effect/turf_decal/stripes/closeup,
+/obj/machinery/door/airlock{
+	name = "Bathroom"
+	},
 /turf/open/floor/iron/dark,
 /area/station/security/prison)
 "oef" = (
@@ -41554,7 +41555,7 @@
 /area/station/service/chapel)
 "ooQ" = (
 /obj/effect/spawner/structure/window,
-/obj/structure/curtain/directional,
+/obj/structure/curtain/bounty,
 /turf/open/floor/plating,
 /area/station/security/prison)
 "ooT" = (
@@ -44005,15 +44006,11 @@
 /turf/open/floor/iron,
 /area/station/cargo/miningoffice)
 "pcL" = (
-/obj/structure/sign/poster/contraband/random{
-	pixel_x = -32
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
-/obj/machinery/light{
-	dir = 8;
-	light_color = "#e8eaff"
-	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/tile/neutral,
+/obj/structure/closet/crate/wooden,
+/obj/effect/spawner/random/maintenance,
+/obj/item/clothing/suit/apron/chef,
+/obj/item/clothing/head/utility/chefhat,
 /turf/open/floor/prison,
 /area/station/security/prison)
 "pcZ" = (
@@ -44189,9 +44186,6 @@
 	},
 /area/station/maintenance/port)
 "pfS" = (
-/obj/structure/sign/poster/official/no_erp{
-	pixel_x = -32
-	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
 /obj/machinery/light{
 	dir = 8;
@@ -45020,6 +45014,12 @@
 /obj/effect/turf_decal/stripes/closeup,
 /turf/open/floor/iron/dark,
 /area/station/hallway/primary/fore)
+"pwv" = (
+/obj/structure/wall_closet/generic/directional/east,
+/obj/effect/spawner/random/maintenance,
+/obj/effect/spawner/random/maintenance,
+/turf/open/floor/prison,
+/area/station/security/prison)
 "pwx" = (
 /obj/structure/cable/yellow,
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
@@ -45869,13 +45869,7 @@
 /turf/open/floor/circuit/green/telecomms/mainframe,
 /area/station/science/server)
 "pQG" = (
-/obj/structure/table/reinforced,
-/obj/item/reagent_containers/condiment/flour{
-	pixel_x = -2;
-	pixel_y = 6
-	},
-/obj/item/kitchen/rollingpin,
-/obj/item/clothing/head/utility/chefhat,
+/obj/machinery/griddle,
 /turf/open/floor/iron/techmaint,
 /area/station/security/prison)
 "pQO" = (
@@ -46661,7 +46655,7 @@
 /obj/effect/turf_decal/stripes/closeup{
 	dir = 1
 	},
-/obj/effect/mapping_helpers/airlock/access/all/security/brig_physician,
+/obj/effect/mapping_helpers/airlock/access/any/security/brig_physician,
 /turf/open/floor/iron/dark,
 /area/station/security/office)
 "qbs" = (
@@ -52113,11 +52107,11 @@
 	pixel_y = -26
 	},
 /obj/machinery/light,
+/obj/structure/table/reinforced,
 /obj/machinery/reagentgrinder{
 	pixel_x = -1;
 	pixel_y = 12
 	},
-/obj/structure/table/reinforced,
 /turf/open/floor/iron/techmaint,
 /area/station/security/prison)
 "rYg" = (
@@ -52741,6 +52735,9 @@
 	},
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
+	},
+/obj/structure/sign/painting/library{
+	pixel_y = 32
 	},
 /turf/open/floor/wood,
 /area/station/security/prison)
@@ -53664,6 +53661,11 @@
 "sAH" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
+	},
+/obj/structure/table/reinforced,
+/obj/machinery/microwave{
+	pixel_x = -3;
+	pixel_y = 6
 	},
 /turf/open/floor/wood,
 /area/station/security/prison)
@@ -56411,6 +56413,7 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/start/prisoner,
 /turf/open/floor/wood,
 /area/station/security/prison)
 "tzA" = (
@@ -60882,6 +60885,8 @@
 	dir = 5
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/crate/bin,
+/obj/effect/spawner/random/maintenance,
 /turf/open/floor/wood,
 /area/station/security/prison)
 "uXx" = (
@@ -62779,10 +62784,11 @@
 /turf/open/floor/iron/dark,
 /area/station/hallway/primary/starboard)
 "vEB" = (
-/obj/structure/chair/fancy/sofa/old{
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/fancy/sofa/old/right{
 	dir = 8
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/start/prisoner,
 /turf/open/floor/wood,
 /area/station/security/prison)
 "vEF" = (
@@ -66375,10 +66381,9 @@
 /obj/structure/bed{
 	dir = 8
 	},
-/obj/structure/sign/poster/contraband/random{
-	pixel_x = 32
-	},
 /obj/item/bedsheet/dorms,
+/obj/structure/sign/poster/contraband/random/directional/north,
+/obj/effect/landmark/start/prisoner,
 /turf/open/floor/prison,
 /area/station/security/prison)
 "wSC" = (
@@ -66541,8 +66546,26 @@
 /turf/open/floor/iron/dark,
 /area/station/cargo/warehouse)
 "wWd" = (
-/obj/structure/closet/crate/wooden,
-/obj/effect/turf_decal/bot,
+/obj/machinery/camera,
+/obj/item/food/meat/slab/monkey,
+/obj/item/food/meat/slab/monkey,
+/obj/item/food/meat/slab/monkey,
+/obj/item/reagent_containers/condiment/milk,
+/obj/item/reagent_containers/condiment/milk,
+/obj/item/reagent_containers/condiment/milk,
+/obj/item/reagent_containers/condiment/soymilk,
+/obj/item/reagent_containers/condiment/soymilk,
+/obj/item/reagent_containers/condiment/flour,
+/obj/item/reagent_containers/condiment/flour,
+/obj/item/reagent_containers/condiment/sugar,
+/obj/item/reagent_containers/condiment/sugar,
+/obj/item/reagent_containers/condiment/rice,
+/obj/item/reagent_containers/condiment/rice,
+/obj/item/storage/fancy/egg_box,
+/obj/item/storage/fancy/egg_box,
+/obj/structure/closet/secure_closet/freezer{
+	name = "freezer"
+	},
 /obj/effect/spawner/random/maintenance,
 /turf/open/floor/iron/techmaint,
 /area/station/security/prison)
@@ -68214,10 +68237,11 @@
 /turf/closed/wall,
 /area/station/medical/genetics/cloning)
 "xBb" = (
-/obj/structure/table/reinforced,
 /obj/effect/turf_decal/siding/dark{
 	dir = 4
 	},
+/obj/machinery/vending/dinnerware,
+/obj/effect/turf_decal/bot,
 /turf/open/floor/iron/techmaint,
 /area/station/security/prison)
 "xBd" = (
@@ -89094,7 +89118,7 @@ iiY
 nHm
 sbM
 mHP
-msz
+pcL
 pnn
 iIx
 pnn
@@ -89345,7 +89369,7 @@ csf
 rfh
 pnn
 beh
-dgx
+nPx
 gtJ
 tzu
 srx
@@ -92171,7 +92195,7 @@ cfF
 wMR
 mVf
 pnn
-xhe
+qYk
 pfS
 giK
 bVe
@@ -92429,8 +92453,8 @@ vZW
 mVf
 pnn
 wSB
-qYk
-lOX
+pwv
+xhe
 ooQ
 noq
 jOx
@@ -92692,7 +92716,7 @@ qAw
 goZ
 msz
 amZ
-aph
+msz
 uxb
 gkC
 oDs
@@ -92942,10 +92966,10 @@ cfF
 hCK
 gmL
 pnn
-xhe
-pcL
+ngf
+pfS
 iex
-bVe
+aph
 jOx
 sDF
 qAw
@@ -93199,9 +93223,9 @@ cfF
 pTM
 quT
 cCe
-ngf
-lkV
 lOX
+lkV
+xhe
 ooQ
 bAr
 gBm

--- a/_maps/map_files/KiloStation/map_adjustment_kilo.dm
+++ b/_maps/map_files/KiloStation/map_adjustment_kilo.dm
@@ -1,5 +1,0 @@
-//Kilo aint neither the time nor place for prisoners, pardner.
-
-/datum/map_adjustment/kilo_station
-	map_file_name = "KiloStation.dmm"
-	blacklisted_jobs = list(JOB_NAME_PRISONER)

--- a/code/datums/map_adjustment_include.dm
+++ b/code/datums/map_adjustment_include.dm
@@ -8,4 +8,3 @@
 */
 
 #include "..\..\_maps\map_files\EchoStation\map_adjustment_echo.dm"
-#include "..\..\_maps\map_files\KiloStation\map_adjustment_kilo.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

A few minor additions/fixes to Kilostation. I also touched up some details in the prison, and enabled the role to be played on this station.

Other fixes are as follows
- Changing marker beacons in space to the proper structure, instead of the stack. Now they glow properly.
- Expanded the cryopod room to accommodate 2 more pods, and added a cryopod in medbay. Since antags hog a cryopod now there was a need for more.
- Removed some random cable in maints that led nowhere (unsure if it was initially a design choice but o well)
- Brig Physicians can now access their room again
- Made a few minor design alterations in the prison, fixed a small wrong area, and misnamed doors. Added an emergency closet. 
- Turned plating in a doorway to floor on Box dorms.
- Removed air alarm in the xenobio testing room.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

More cryopods were needed, given it was very possible to run into a shortage with there only being 3 pods across 2 areas, now there are 6 across 3 areas.
No reason for prisoner to be disabled on only this map (and Echo which is off-rotation) given there isn't a player requirement for the role anymore.
The rest were changes varying from essential (brig phys access), to aesthetic, but all should have a positive effect on the game.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

<img width="382" height="387" alt="KILO1" src="https://github.com/user-attachments/assets/e2fd5973-f5b4-4d8c-b862-bbf907bae65c" />
<img width="713" height="359" alt="KILO2" src="https://github.com/user-attachments/assets/6008255c-6aae-4962-bc48-26afb2160739" />
<img width="338" height="283" alt="KILO3" src="https://github.com/user-attachments/assets/9561f688-90ba-4f48-961b-fa22453e7429" />
<img width="1346" height="525" alt="KILO4" src="https://github.com/user-attachments/assets/b93a7145-85fa-4cbc-b238-a944fdeb2773" />


</details>

## Changelog
:cl:
add: Enabled the Prisoner role on Kilostation.
add: Added two additional cryopods in the cryopod room, and one in medbay on Kilostation.
fix: Fixed Brig Physicians lacking access to their room on Kilostation.
fix: Fixed the wrong type of marker beacon being used in space on Kilostation.
fix: Made some small alterations and fixes to Kilostation's prison. 
fix: Fixed some stray cable on Kilostation, and plating in Boxstation's dorms.
fix: Removed an extra air alarm in xenobio on Kilostation.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
