### PR TITLE
Your dead, beautiful eyes: An eye PR

### DIFF
--- a/code/__DEFINES/colors.dm
+++ b/code/__DEFINES/colors.dm
@@ -289,3 +289,9 @@ GLOBAL_LIST_INIT(color_list_rainbow, list(
 #define CM_COLOR_SAT_MAX 0.7
 #define CM_COLOR_LUM_MIN 0.65
 #define CM_COLOR_LUM_MAX 0.75
+
+// Lowest priority
+#define EYE_COLOR_ORGAN_PRIORITY 1
+#define EYE_COLOR_SPECIES_PRIORITY 10
+#define EYE_COLOR_WEED_PRIORITY 20
+#define EYE_COLOR_CULT_PRIORITY 30

--- a/code/datums/dna.dm
+++ b/code/datums/dna.dm
@@ -580,7 +580,7 @@ GLOBAL_LIST_INIT(total_uf_len_by_block, populate_total_uf_len_by_block())
 
 		if (dna.species.properly_gained)
 			dna.species.on_species_loss(src, new_race, pref_load)
-			
+
 		var/datum/species/old_species = dna.species
 		dna.update_species(new_race)
 
@@ -761,15 +761,10 @@ GLOBAL_LIST_INIT(total_uf_len_by_block, populate_total_uf_len_by_block())
 	var/obj/item/organ/eyes/organ_eyes = get_organ_by_type(/obj/item/organ/eyes)
 	if(organ_eyes)
 		organ_eyes.eye_color_left = eye_color_left
-		organ_eyes.old_eye_color_left = eye_color_left
 		organ_eyes.eye_color_right = eye_color_right
-		organ_eyes.old_eye_color_right = eye_color_right
 
 	if(icon_update)
-		if(mutcolor_update)
-			update_body(is_creating = TRUE)
-		else
-			update_body()
+		update_body(is_creating = mutcolor_update)
 		if(mutations_overlay_update)
 			update_mutations_overlay()
 

--- a/code/datums/elements/cult_eyes.dm
+++ b/code/datums/elements/cult_eyes.dm
@@ -27,13 +27,11 @@
 		return
 
 	ADD_TRAIT(target, TRAIT_UNNATURAL_RED_GLOWY_EYES, CULT_TRAIT)
-	if (ishuman(target))
-		var/mob/living/carbon/human/human_parent = target
-		human_parent.eye_color_left = BLOODCULT_EYE
-		human_parent.eye_color_right = BLOODCULT_EYE
-		human_parent.dna.update_ui_block(DNA_EYE_COLOR_LEFT_BLOCK)
-		human_parent.dna.update_ui_block(DNA_EYE_COLOR_RIGHT_BLOCK)
-		human_parent.update_body()
+	if (!ishuman(target))
+		return
+	var/mob/living/carbon/human/human_parent = target
+	human_parent.add_eye_color(BLOODCULT_EYE, EYE_COLOR_CULT_PRIORITY)
+	human_parent.update_body()
 
 /**
  * Detach proc
@@ -44,10 +42,7 @@
 	REMOVE_TRAIT(target, TRAIT_UNNATURAL_RED_GLOWY_EYES, CULT_TRAIT)
 	if (ishuman(target))
 		var/mob/living/carbon/human/human_parent = target
-		human_parent.eye_color_left = initial(human_parent.eye_color_left)
-		human_parent.eye_color_right = initial(human_parent.eye_color_right)
-		human_parent.dna.update_ui_block(DNA_EYE_COLOR_LEFT_BLOCK)
-		human_parent.dna.update_ui_block(DNA_EYE_COLOR_RIGHT_BLOCK)
+		human_parent.remove_eye_color(EYE_COLOR_CULT_PRIORITY)
 		human_parent.update_body()
 	UnregisterSignal(target, list(COMSIG_CHANGELING_TRANSFORM, COMSIG_HUMAN_MONKEYIZE, COMSIG_MONKEY_HUMANIZE))
 	return ..()

--- a/code/datums/status_effects/drug_effects.dm
+++ b/code/datums/status_effects/drug_effects.dm
@@ -65,19 +65,13 @@
 	duration = 10 SECONDS
 	alert_type = /atom/movable/screen/alert/status_effect/stoned
 	status_type = STATUS_EFFECT_REFRESH
-	var/original_eye_color_left
-	var/original_eye_color_right
 
 /datum/status_effect/stoned/on_apply()
 	if(!ishuman(owner))
 		return FALSE
 	var/mob/living/carbon/human/human_owner = owner
-	original_eye_color_left = human_owner.eye_color_left
-	original_eye_color_right = human_owner.eye_color_right
 	human_owner.add_movespeed_modifier(/datum/movespeed_modifier/reagent/cannabis) //slows you down
-	human_owner.eye_color_left = BLOODCULT_EYE //makes cult eyes less obvious
-	human_owner.eye_color_right = BLOODCULT_EYE //makes cult eyes less obvious
-	human_owner.update_body() //updates eye color
+	human_owner.add_eye_color(BLOODCULT_EYE, EYE_COLOR_WEED_PRIORITY) //makes cult eyes less obvious
 	human_owner.add_traits(list(TRAIT_CLUMSY, TRAIT_BLOODSHOT_EYES), TRAIT_STATUS_EFFECT(id)) // impairs motor coordination and dilates blood vessels in eyes
 	SEND_SIGNAL(human_owner, COMSIG_ADD_MOOD_EVENT, "stoned", /datum/mood_event/stoned) //improves mood
 	human_owner.sound_environment_override = SOUND_ENVIRONMENT_DRUGGED //not realistic but very immersive
@@ -88,9 +82,7 @@
 		return
 	var/mob/living/carbon/human/human_owner = owner
 	human_owner.remove_movespeed_modifier(/datum/movespeed_modifier/reagent/cannabis)
-	human_owner.eye_color_left = original_eye_color_left
-	human_owner.eye_color_right = original_eye_color_right
-	human_owner.update_body()
+	human_owner.remove_eye_color(EYE_COLOR_WEED_PRIORITY)
 	human_owner.remove_traits(list(TRAIT_CLUMSY, TRAIT_BLOODSHOT_EYES), TRAIT_STATUS_EFFECT(id))
 	SEND_SIGNAL(human_owner, COMSIG_CLEAR_MOOD_EVENT, "stoned")
 	human_owner.sound_environment_override = SOUND_ENVIRONMENT_NONE

--- a/code/modules/client/preferences/entries/character/species_features/basic.dm
+++ b/code/modules/client/preferences/entries/character/species_features/basic.dm
@@ -40,14 +40,12 @@
 
 	if (!initial(eyes_organ.eye_color_left))
 		eyes_organ.eye_color_left = value
-	eyes_organ.old_eye_color_left = value
 
 	if(hetero) // Don't override the snowflakes please
 		return
 
 	if (!initial(eyes_organ.eye_color_right))
 		eyes_organ.eye_color_right = value
-	eyes_organ.old_eye_color_right = value
 	eyes_organ.refresh()
 
 /datum/preference/color/eye_color/create_default_value()

--- a/code/modules/client/preferences/entries/character/species_features/ipc.dm
+++ b/code/modules/client/preferences/entries/character/species_features/ipc.dm
@@ -51,7 +51,6 @@
 	if (istype(eyes_organ))
 		if (!initial(eyes_organ.eye_color_left))
 			eyes_organ.eye_color_left = value
-		eyes_organ.old_eye_color_left = value
 
 /datum/preference/color/ipc_screen_color/create_default_value()
 	return COLOR_WHITE

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1095,6 +1095,52 @@
 	if(mind.assigned_role.title in SSjob.name_occupations)
 		.[mind.assigned_role.title] = minutes
 
+/mob/living/carbon/human/proc/add_eye_color_left(color, color_priority, update_body = TRUE)
+	LAZYSET(eye_color_left_overrides, "[color_priority]", color)
+	if (update_body)
+		update_body()
+
+/mob/living/carbon/human/proc/add_eye_color_right(color, color_priority, update_body = TRUE)
+	LAZYSET(eye_color_right_overrides, "[color_priority]", color)
+	if (update_body)
+		update_body()
+
+/mob/living/carbon/human/proc/add_eye_color(color, color_priority, update_body = TRUE)
+	add_eye_color_left(color, color_priority, update_body = FALSE)
+	add_eye_color_right(color, color_priority, update_body = update_body)
+
+/mob/living/carbon/human/proc/remove_eye_color(color_priority, update_body = TRUE)
+	LAZYREMOVE(eye_color_left_overrides, "[color_priority]")
+	LAZYREMOVE(eye_color_right_overrides, "[color_priority]")
+	if (update_body)
+		update_body()
+
+/mob/living/carbon/human/proc/get_right_eye_color()
+	if (!LAZYLEN(eye_color_right_overrides))
+		return eye_color_right
+
+	var/eye_color = eye_color_right
+	var/priority
+	for (var/override_priority in eye_color_right_overrides)
+		var/new_priority = text2num(override_priority)
+		if (new_priority > priority)
+			priority = new_priority
+			eye_color = eye_color_right_overrides[override_priority]
+	return eye_color
+
+/mob/living/carbon/human/proc/get_left_eye_color()
+	if (!LAZYLEN(eye_color_left_overrides))
+		return eye_color_left
+
+	var/eye_color = eye_color_left
+	var/priority
+	for (var/override_priority in eye_color_left_overrides)
+		var/new_priority = text2num(override_priority)
+		if (new_priority > priority)
+			priority = new_priority
+			eye_color = eye_color_left_overrides[override_priority]
+	return eye_color
+
 /mob/living/carbon/human/monkeybrain
 	ai_controller = /datum/ai_controller/monkey
 

--- a/code/modules/mob/living/carbon/human/human_defines.dm
+++ b/code/modules/mob/living/carbon/human/human_defines.dm
@@ -29,10 +29,13 @@
 	///Facial hair style
 	var/facial_hairstyle = "Shaved"
 
-	//Eye colour
+	// Base "natural" eye color
 	var/eye_color_left = COLOR_BLACK
 	var/eye_color_right = COLOR_BLACK
 	var/eye_color_heterochromatic = FALSE
+	// Eye color overrides assoc lists - priority key to hex color
+	var/list/eye_color_left_overrides
+	var/list/eye_color_right_overrides
 
 	var/skin_tone = "caucasian1" //Skin tone
 

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1660,9 +1660,7 @@ GLOBAL_LIST_EMPTY(fire_appearances)
 		if(CONSCIOUS)
 			if(stat >= UNCONSCIOUS)
 				ADD_TRAIT(src, TRAIT_IMMOBILIZED, TRAIT_KNOCKEDOUT)
-			ADD_TRAIT(src, TRAIT_HANDS_BLOCKED, STAT_TRAIT)
-			ADD_TRAIT(src, TRAIT_INCAPACITATED, STAT_TRAIT)
-			ADD_TRAIT(src, TRAIT_FLOORED, STAT_TRAIT)
+			add_traits(list(TRAIT_HANDS_BLOCKED, TRAIT_INCAPACITATED, TRAIT_FLOORED), STAT_TRAIT)
 		if(SOFT_CRIT)
 			if(stat >= UNCONSCIOUS)
 				ADD_TRAIT(src, TRAIT_IMMOBILIZED, TRAIT_KNOCKEDOUT) //adding trait sources should come before removing to avoid unnecessary updates
@@ -1681,10 +1679,7 @@ GLOBAL_LIST_EMPTY(fire_appearances)
 		if(CONSCIOUS)
 			if(. >= UNCONSCIOUS)
 				REMOVE_TRAIT(src, TRAIT_IMMOBILIZED, TRAIT_KNOCKEDOUT)
-			REMOVE_TRAIT(src, TRAIT_HANDS_BLOCKED, STAT_TRAIT)
-			REMOVE_TRAIT(src, TRAIT_INCAPACITATED, STAT_TRAIT)
-			REMOVE_TRAIT(src, TRAIT_FLOORED, STAT_TRAIT)
-			REMOVE_TRAIT(src, TRAIT_CRITICAL_CONDITION, STAT_TRAIT)
+			remove_traits(list(TRAIT_HANDS_BLOCKED, TRAIT_INCAPACITATED, TRAIT_FLOORED, TRAIT_CRITICAL_CONDITION), STAT_TRAIT)
 		if(SOFT_CRIT)
 			if(pulledby)
 				ADD_TRAIT(src, TRAIT_IMMOBILIZED, PULLED_WHILE_SOFTCRIT_TRAIT) //adding trait sources should come before removing to avoid unnecessary updates
@@ -1715,7 +1710,8 @@ GLOBAL_LIST_EMPTY(fire_appearances)
 	. = buckled
 	buckled = new_buckled
 	if(buckled)
-		ADD_TRAIT(src, TRAIT_IMMOBILIZED, BUCKLED_TRAIT)
+		if(!HAS_TRAIT(buckled, TRAIT_NO_IMMOBILIZE))
+			ADD_TRAIT(src, TRAIT_IMMOBILIZED, BUCKLED_TRAIT)
 		switch(buckled.buckle_lying)
 			if(NO_BUCKLE_LYING) // The buckle doesn't force a lying angle.
 				REMOVE_TRAIT(src, TRAIT_FLOORED, BUCKLED_TRAIT)
@@ -1728,8 +1724,7 @@ GLOBAL_LIST_EMPTY(fire_appearances)
 				set_body_position(LYING_DOWN)
 				set_lying_angle(buckled.buckle_lying)
 	else
-		REMOVE_TRAIT(src, TRAIT_IMMOBILIZED, BUCKLED_TRAIT)
-		REMOVE_TRAIT(src, TRAIT_FLOORED, BUCKLED_TRAIT)
+		remove_traits(list(TRAIT_IMMOBILIZED, TRAIT_FLOORED), BUCKLED_TRAIT)
 		if(.) // We unbuckled from something.
 			var/atom/movable/old_buckled = .
 			if(old_buckled.buckle_lying == 0 && (resting || HAS_TRAIT(src, TRAIT_FLOORED))) // The buckle forced us to stay up (like a chair)

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1652,6 +1652,10 @@ GLOBAL_LIST_EMPTY(fire_appearances)
 	. = ..()
 	if(isnull(.))
 		return
+
+	if(. <= UNCONSCIOUS || new_stat >= UNCONSCIOUS)
+		update_body() // to update eyes
+
 	switch(.) //Previous stat.
 		if(CONSCIOUS)
 			if(stat >= UNCONSCIOUS)

--- a/code/modules/surgery/organs/eyes.dm
+++ b/code/modules/surgery/organs/eyes.dm
@@ -141,8 +141,19 @@
 	var/obj/item/bodypart/head/my_head = parent.get_bodypart(BODY_ZONE_HEAD)
 	if(my_head)
 		if(my_head.head_flags & HEAD_EYECOLOR)
-			eye_right.color = eye_color_right
-			eye_left.color = eye_color_left
+			if(IS_ROBOTIC_ORGAN(src) || !my_head.draw_color || (parent.appears_alive() && !HAS_TRAIT(parent, TRAIT_KNOCKEDOUT)))
+				// show the eyes as open
+				eye_right.color = eye_color_right
+				eye_left.color = eye_color_left
+			else
+				// show the eyes as closed, and as such color them like eyelids wound be colored
+				var/list/base_color = rgb2num(my_head.draw_color, COLORSPACE_HSL)
+				base_color[2] *= 0.85
+				base_color[3] *= 0.85
+				var/eyelid_color = rgb(base_color[1], base_color[2], base_color[3], (length(base_color) >= 4 ? base_color[4] : null), COLORSPACE_HSL)
+				eye_right.color = eyelid_color
+				eye_left.color = eyelid_color
+				
 		if(my_head.worn_face_offset)
 			my_head.worn_face_offset.apply_offset(eye_left)
 			my_head.worn_face_offset.apply_offset(eye_right)

--- a/code/modules/surgery/organs/eyes.dm
+++ b/code/modules/surgery/organs/eyes.dm
@@ -41,8 +41,6 @@
 	var/eye_icon = 'icons/mob/human/human_eyes.dmi'
 	/// The icon state of that eyes as its applied to the mob
 	var/eye_icon_state = "eyes"
-	var/old_eye_color_left = COLOR_WHITE
-	var/old_eye_color_right = COLOR_WHITE
 
 	/// Glasses cannot be worn over these eyes. Currently unused
 	var/no_glasses = FALSE
@@ -50,14 +48,7 @@
 	var/damaged = FALSE
 
 /obj/item/organ/eyes/Insert(mob/living/carbon/eye_recipient, special = FALSE, drop_if_replaced = FALSE, pref_load = FALSE)
-	// If we don't do this before everything else, heterochromia will be reset leading to eye_color_right no longer being accurate
-	if(ishuman(eye_recipient))
-		var/mob/living/carbon/human/human_recipient = eye_recipient
-		old_eye_color_left = human_recipient.eye_color_left
-		old_eye_color_right = human_recipient.eye_color_right
-
 	. = ..()
-
 	if(!.)
 		return
 
@@ -75,14 +66,10 @@
 		return
 
 	var/mob/living/carbon/human/affected_human = eye_owner
-	if(initial(eye_color_left))
-		affected_human.eye_color_left = eye_color_left
-	else
-		eye_color_left = affected_human.eye_color_left
-	if(initial(eye_color_right))
-		affected_human.eye_color_right = eye_color_right
-	else
-		eye_color_right = affected_human.eye_color_right
+	if(eye_color_left)
+		affected_human.add_eye_color_left(eye_color_left, EYE_COLOR_ORGAN_PRIORITY, update_body = FALSE)
+	if(eye_color_right)
+		affected_human.add_eye_color_right(eye_color_right, EYE_COLOR_ORGAN_PRIORITY, update_body = FALSE)
 	if(HAS_TRAIT(affected_human, TRAIT_NIGHT_VISION_WEAK) && !lighting_alpha)
 		lighting_alpha = LIGHTING_PLANE_ALPHA_NV_TRAIT
 
@@ -93,10 +80,7 @@
 	..()
 	if(ishuman(eye_owner))
 		var/mob/living/carbon/human/human_owner = eye_owner
-		if(initial(eye_color_left))
-			human_owner.eye_color_left = old_eye_color_left
-		if(initial(eye_color_right))
-			human_owner.eye_color_right = old_eye_color_right
+		human_owner.remove_eye_color(EYE_COLOR_ORGAN_PRIORITY, update_body = FALSE)
 		human_owner.update_body()
 
 	// Cure blindness from eye damage
@@ -143,8 +127,8 @@
 		if(my_head.head_flags & HEAD_EYECOLOR)
 			if(IS_ROBOTIC_ORGAN(src) || !my_head.draw_color || (parent.appears_alive() && !HAS_TRAIT(parent, TRAIT_KNOCKEDOUT)))
 				// show the eyes as open
-				eye_right.color = eye_color_right
-				eye_left.color = eye_color_left
+				eye_right.color = parent.get_right_eye_color()
+				eye_left.color = parent.get_left_eye_color()
 			else
 				// show the eyes as closed, and as such color them like eyelids wound be colored
 				var/list/base_color = rgb2num(my_head.draw_color, COLORSPACE_HSL)
@@ -153,7 +137,7 @@
 				var/eyelid_color = rgb(base_color[1], base_color[2], base_color[3], (length(base_color) >= 4 ? base_color[4] : null), COLORSPACE_HSL)
 				eye_right.color = eyelid_color
 				eye_left.color = eyelid_color
-				
+
 		if(my_head.worn_face_offset)
 			my_head.worn_face_offset.apply_offset(eye_left)
 			my_head.worn_face_offset.apply_offset(eye_right)
@@ -374,8 +358,8 @@
 /// Set the initial color of the eyes on insert to be the mob's previous eye color.
 /obj/item/organ/eyes/robotic/glow/Insert(mob/living/carbon/eye_recipient, special = FALSE, drop_if_replaced = FALSE)
 	. = ..()
-	left_eye_color_string = old_eye_color_left
-	right_eye_color_string = old_eye_color_right
+	left_eye_color_string = eye_color_left
+	right_eye_color_string = eye_color_right
 	update_mob_eye_color(eye_recipient)
 
 /obj/item/organ/eyes/robotic/glow/on_insert(mob/living/carbon/eye_recipient)

--- a/code/modules/surgery/surgery.dm
+++ b/code/modules/surgery/surgery.dm
@@ -6,7 +6,7 @@
 	var/desc
 
 	///From __DEFINES/surgery.dm
-	///Selection: SURGERY_IGNORE_CLOTHES | SURGERY_SELF_OPERABLE | SURGERY_REQUIRE_RESTING | SURGERY_REQUIRE_LIMB | SURGERY_REQUIRES_REAL_LIMBExpand commentComment on line R8Resolved
+	///Selection: SURGERY_IGNORE_CLOTHES | SURGERY_SELF_OPERABLE | SURGERY_REQUIRE_RESTING | SURGERY_REQUIRE_LIMB | SURGERY_REQUIRES_REAL_LIMB
 	var/surgery_flags = SURGERY_REQUIRE_RESTING | SURGERY_REQUIRE_LIMB
 	///The surgery step we're currently on, increases each time we do a step.
 	var/status = 1


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Carbon eyes close if mob state is unconscious or dead

Not really related to kapulimbs, but made possible by it: 
- #14376 

Attributions
- https://github.com/tgstation/tgstation/pull/87782
- https://github.com/tgstation/tgstation/pull/88927

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Mob states not visual outside of examination are boring

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>


https://github.com/user-attachments/assets/d3bbc04b-daab-4ace-849f-9a6385809704



</details>

## Changelog
:cl: rkz, smartkar, melbert
add: A carbons eyes close if unconscious or dead, and reopen when not
code: refactors eye color handling
fix: fixes wheelchair bug that immobilized wheelchair'd mobs, they can do more stuff now
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
