### PR TITLE
Fixes meth grenades not exploding

### DIFF
--- a/code/modules/reagents/chemistry/recipes/pyrotechnics.dm
+++ b/code/modules/reagents/chemistry/recipes/pyrotechnics.dm
@@ -222,11 +222,11 @@
 
 /datum/chemical_reaction/reagent_explosion/methsplosion/on_reaction(datum/reagents/holder, created_volume)
 	var/turf/T = get_turf(holder.my_atom)
+	holder.chem_temp = 1000 // hot as shit
+	..()
 	for(var/turf/open/turf in RANGE_TURFS(1,T))
 		if(!locate(/obj/effect/hotspot) in turf)
 			new /obj/effect/hotspot/bright(turf)
-	holder.chem_temp = 1000 // hot as shit
-	..()
 
 /datum/chemical_reaction/reagent_explosion/methsplosion/methboom2
 	name = "Weak meth explosion"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Currently the hotspot burns the grenade to ash instantly so the explosion loses it's location, after this we do the explosion and then the hotspot stuff.
From what I can tell this wasn't an issue before https://github.com/BeeStation/BeeStation-Hornet/pull/13550 because the reagents doing the explosion were tied to the turf of the grenade instead of the grenade.

Closes https://github.com/BeeStation/BeeStation-Hornet/issues/13864
## Why It's Good For The Game
fix

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

https://github.com/user-attachments/assets/ee40f2a6-6caf-4cdf-80fa-8d018d5fb3bd


Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>

## Changelog
:cl:
fix: Fixes meth grenades not exploding
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
