### PR TITLE
Fixes Integrated Radios on Ecto Sniffer, Security Pager and Fax Machines

### DIFF
--- a/code/game/machinery/ecto_sniffer.dm
+++ b/code/game/machinery/ecto_sniffer.dm
@@ -22,7 +22,7 @@
 	. = ..()
 	wires = new/datum/wires/ecto_sniffer(src)
 	radio = new(src)
-	radio.keyslot = /obj/item/encryptionkey/headset_sci
+	radio.keyslot = new /obj/item/encryptionkey/headset_sci
 	radio.subspace_transmission = TRUE
 	radio.canhear_range = 0
 	radio.recalculateChannels()

--- a/code/modules/paperwork/fax.dm
+++ b/code/modules/paperwork/fax.dm
@@ -510,7 +510,7 @@
 /obj/machinery/fax/centcom/Initialize(mapload)
 	. = ..()
 	radio.set_on(TRUE)
-	radio.keyslot = /obj/item/encryptionkey/headset_cent
+	radio.keyslot = new /obj/item/encryptionkey/headset_cent
 	radio.recalculateChannels()
 
 /obj/machinery/fax/bridge
@@ -521,7 +521,7 @@
 /obj/machinery/fax/bridge/Initialize(mapload)
 	. = ..()
 	radio.set_on(TRUE)
-	radio.keyslot = /obj/item/encryptionkey/headset_com
+	radio.keyslot = new /obj/item/encryptionkey/headset_com
 	radio.recalculateChannels()
 
 /obj/machinery/fax/cargo
@@ -532,7 +532,7 @@
 /obj/machinery/fax/cargo/Initialize(mapload)
 	. = ..()
 	radio.set_on(TRUE)
-	radio.keyslot = /obj/item/encryptionkey/headset_cargo
+	radio.keyslot = new /obj/item/encryptionkey/headset_cargo
 	radio.recalculateChannels()
 
 /obj/machinery/fax/eng
@@ -543,7 +543,7 @@
 /obj/machinery/fax/eng/Initialize(mapload)
 	. = ..()
 	radio.set_on(TRUE)
-	radio.keyslot = /obj/item/encryptionkey/headset_eng
+	radio.keyslot = new /obj/item/encryptionkey/headset_eng
 	radio.recalculateChannels()
 
 /obj/machinery/fax/law
@@ -554,7 +554,7 @@
 /obj/machinery/fax/law/Initialize(mapload)
 	. = ..()
 	radio.set_on(TRUE)
-	radio.keyslot = /obj/item/encryptionkey/headset_srvsec
+	radio.keyslot = new /obj/item/encryptionkey/headset_srvsec
 	radio.recalculateChannels()
 
 /obj/machinery/fax/med
@@ -565,7 +565,7 @@
 /obj/machinery/fax/med/Initialize(mapload)
 	. = ..()
 	radio.set_on(TRUE)
-	radio.keyslot = /obj/item/encryptionkey/headset_med
+	radio.keyslot = new /obj/item/encryptionkey/headset_med
 	radio.recalculateChannels()
 
 /obj/machinery/fax/sci
@@ -576,7 +576,7 @@
 /obj/machinery/fax/sci/Initialize(mapload)
 	. = ..()
 	radio.set_on(TRUE)
-	radio.keyslot = /obj/item/encryptionkey/headset_sci
+	radio.keyslot = new /obj/item/encryptionkey/headset_sci
 	radio.recalculateChannels()
 
 /obj/machinery/fax/sec
@@ -587,7 +587,7 @@
 /obj/machinery/fax/sec/Initialize(mapload)
 	. = ..()
 	radio.set_on(TRUE)
-	radio.keyslot = /obj/item/encryptionkey/headset_sec
+	radio.keyslot = new /obj/item/encryptionkey/headset_sec
 	radio.recalculateChannels()
 
 /obj/machinery/fax/service
@@ -598,5 +598,5 @@
 /obj/machinery/fax/service/Initialize(mapload)
 	. = ..()
 	radio.set_on(TRUE)
-	radio.keyslot = /obj/item/encryptionkey/headset_service
+	radio.keyslot = new /obj/item/encryptionkey/headset_service
 	radio.recalculateChannels()

--- a/code/modules/security/security_pager.dm
+++ b/code/modules/security/security_pager.dm
@@ -9,7 +9,7 @@
 /obj/item/clothing/accessory/security_pager/Initialize(mapload)
 	. = ..()
 	radio = new(src)
-	radio.keyslot = /obj/item/encryptionkey/headset_sec
+	radio.keyslot = new /obj/item/encryptionkey/headset_sec
 	radio.subspace_transmission = TRUE
 	radio.canhear_range = 0
 	radio.recalculateChannels()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes some machines with integrated radio keys not working.
1. Fax Machines
2. Ecto Sniffer
3. Security Pager

Closes #14683 

## Why It's Good For The Game

Bugs bad

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>
<img width="825" height="275" alt="faxes" src="https://github.com/user-attachments/assets/9d5a4798-23b9-4d40-b536-85b67c204647" />
<img width="636" height="255" alt="Fax radios" src="https://github.com/user-attachments/assets/52ed6c57-8169-44e6-97f1-6cd7d6d5f51c" />
<img width="832" height="62" alt="ecto sniffer" src="https://github.com/user-attachments/assets/0eb6444b-4e88-4a1b-ab7d-847b01121096" />
<img width="718" height="76" alt="Security Pager" src="https://github.com/user-attachments/assets/162fe09e-ffee-419b-bba5-2f97198330f2" />

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>

## Changelog
:cl:
fix: Ecto Sniffer, Fax Machines, and Security Pager Radios Work again.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
