### PR TITLE
Fixes loadout accessory backpacks not spawning

### DIFF
--- a/code/modules/client/loadout/loadout_accessories.dm
+++ b/code/modules/client/loadout/loadout_accessories.dm
@@ -254,6 +254,7 @@
 
 /datum/gear/accessory/backpack
 	subtype_path = /datum/gear/accessory/backpack
+	slot = ITEM_SLOT_BACK
 	cost = 2000
 
 /datum/gear/accessory/backpack/engineer_borg_bag


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
They didn't have a slot defined.
Closes https://github.com/BeeStation/BeeStation-Hornet/issues/14630
## Why It's Good For The Game
fix

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>

<img width="1464" height="610" alt="dreamseeker_20H8TBoomG" src="https://github.com/user-attachments/assets/2c359d1b-fd35-4982-b60e-8aa3fc222b1b" />

<summary>Screenshots&Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>

## Changelog
:cl:
fix: Fixes loadout accessory backpacks(cyborg ones) not spawning
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
