### PR TITLE
Gender Clone Fixes

### DIFF
--- a/code/__DEFINES/record_args.dm
+++ b/code/__DEFINES/record_args.dm
@@ -22,5 +22,5 @@ arg01, arg02, arg03, arg04, arg05, arg06, arg07, arg08, arg09, arg10, arg11, arg
 
 /// Strict the number of args, so that you won't make any mistake.
 /// This is specifically used in /proc/growclone()
-#define CLONING_STRICT_ARGS(arg01, arg02, arg03, arg04, arg05, arg06, arg07, arg08, arg09, arg10, arg11, arg12)\
-arg01, arg02, arg03, arg04, arg05, arg06, arg07, arg08, arg09, arg10, arg11, arg12
+#define CLONING_STRICT_ARGS(arg01, arg02, arg03, arg04, arg05, arg06, arg07, arg08, arg09, arg10, arg11, arg12, arg13)\
+arg01, arg02, arg03, arg04, arg05, arg06, arg07, arg08, arg09, arg10, arg11, arg12, arg13

--- a/code/game/machinery/cloning.dm
+++ b/code/game/machinery/cloning.dm
@@ -183,7 +183,7 @@ SCREENTIP_ATTACK_HAND(/obj/machinery/clonepod, "Examine")
 		. = (100 * ((mob_occupant.health + 100) / (heal_level + 100)))
 
 //Start growing a human clone in the pod!
-/obj/machinery/clonepod/proc/growclone(CLONING_STRICT_ARGS(clonename, unique_identity, mutation_index, given_mind, last_death, datum/species/mrace, list/features, factions, datum/bank_account/insurance, list/traumas, body_only, experimental))
+/obj/machinery/clonepod/proc/growclone(CLONING_STRICT_ARGS(clonename, unique_identity, mutation_index, given_mind, last_death, datum/species/mrace, list/features, factions, datum/bank_account/insurance, list/traumas, body_only, experimental, gender))
 	var/result = CLONING_SUCCESS
 	if(!reagents.has_reagent(/datum/reagent/medicine/synthflesh, fleshamnt))
 		connected_message("Cannot start cloning: Not enough synthflesh.")
@@ -222,6 +222,8 @@ SCREENTIP_ATTACK_HAND(/obj/machinery/clonepod, "Examine")
 	var/mob/living/carbon/human/H = new /mob/living/carbon/human(src)
 
 	H.hardset_dna(unique_identity, mutation_index, H.real_name, null, mrace, features)
+	if(gender)
+		H.gender = gender
 
 	if(!HAS_TRAIT(H, TRAIT_RADIMMUNE))//dont apply mutations if the species is Mutation proof.
 		if(efficiency > 2)

--- a/code/game/machinery/computer/cloning.dm
+++ b/code/game/machinery/computer/cloning.dm
@@ -448,7 +448,8 @@ DEFINE_BUFFER_HANDLER(/obj/machinery/computer/cloning)
 		/* 09 */ insurance = found_record.resolve_mind_account_id(),
 		/* 10 */ traumas = found_record.traumas.Copy(),
 		/* 11 */ body_only = found_record.body_only,
-		/* 12 */ experimental = experimental ))
+		/* 12 */ experimental = experimental,
+		/* 13 */ gender = found_record.gender ))
 	switch(cloning_attempt_result)
 		if(CLONING_SUCCESS)
 			temp = "Notice: [found_record.name] => Cloning cycle in progress..."

--- a/code/modules/mob/living/carbon/human/species_types/jellypeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/jellypeople.dm
@@ -141,6 +141,7 @@
 	spare.real_name = spare.dna.real_name
 	spare.name = spare.dna.real_name
 	spare.updateappearance(mutcolor_update=1)
+	spare.gender = H.gender
 	spare.domutcheck()
 	spare.Move(get_step(H.loc, pick(NORTH,SOUTH,EAST,WEST)))
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Did you know, cloning someone turns them male because the gender was saved by cloner but not the cloning process itself?
Let's fix that

Fixed aswell an issue regarding slimeperson body clones, which as the same as above their gender was incorrectly set to male, even if the original was female

## Why It's Good For The Game

Bugs bad, also i dont want  my female character to be male if cloned

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

yes

</details>

## Changelog
:cl:
fix: Cloning respects your original gender, it'll no longer default to male only
fix: Slimeperson clones will respect your gender, it'll no longer default to male
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
