### PR TITLE
Fixes cloners randomizing non-human appearance and more

### DIFF
--- a/code/__DEFINES/record_args.dm
+++ b/code/__DEFINES/record_args.dm
@@ -22,5 +22,5 @@ arg01, arg02, arg03, arg04, arg05, arg06, arg07, arg08, arg09, arg10, arg11, arg
 
 /// Strict the number of args, so that you won't make any mistake.
 /// This is specifically used in /proc/growclone()
-#define CLONING_STRICT_ARGS(arg01, arg02, arg03, arg04, arg05, arg06, arg07, arg08, arg09, arg10, arg11, arg12, arg13)\
-arg01, arg02, arg03, arg04, arg05, arg06, arg07, arg08, arg09, arg10, arg11, arg12, arg13
+#define CLONING_STRICT_ARGS(arg01, arg02, arg03, arg04, arg05, arg06, arg07, arg08, arg09, arg10, arg11, arg12, arg13, arg14, arg15, arg16)\
+arg01, arg02, arg03, arg04, arg05, arg06, arg07, arg08, arg09, arg10, arg11, arg12, arg13, arg14, arg15, arg16

--- a/code/datums/components/phylactery.dm
+++ b/code/datums/components/phylactery.dm
@@ -188,7 +188,7 @@
 	lich_mind.grab_ghost(force = TRUE)
 	// Make sure they're a spooky skeleton, and their DNA is right
 	lich.set_species(/datum/species/skeleton)
-	lich.dna.generate_unique_enzymes()
+	lich.dna.unique_enzymes = lich.dna.generate_unique_enzymes()
 
 	to_chat(lich, ("<span class='green'>Your bones clatter and shudder as you are pulled back into this world!</span>"))
 	num_resurrections++

--- a/code/datums/dna.dm
+++ b/code/datums/dna.dm
@@ -615,7 +615,7 @@ GLOBAL_LIST_INIT(total_uf_len_by_block, populate_total_uf_len_by_block())
 //Do not use force_transfer_mutations for stuff like cloners without some precautions, otherwise some conditional mutations could break (timers, drill hat etc)
 	if(newfeatures)
 		dna.features = newfeatures
-		dna.generate_unique_features()
+		dna.unique_features = dna.generate_unique_features()
 
 	if(mrace)
 		var/datum/species/newrace = new mrace.type
@@ -624,7 +624,7 @@ GLOBAL_LIST_INIT(total_uf_len_by_block, populate_total_uf_len_by_block())
 
 	if(newreal_name)
 		real_name = newreal_name
-		dna.generate_unique_enzymes()
+		dna.unique_enzymes = dna.generate_unique_enzymes()
 
 	dna.age = age
 	dna.gender = gender

--- a/code/game/machinery/cloning.dm
+++ b/code/game/machinery/cloning.dm
@@ -183,7 +183,7 @@ SCREENTIP_ATTACK_HAND(/obj/machinery/clonepod, "Examine")
 		. = (100 * ((mob_occupant.health + 100) / (heal_level + 100)))
 
 //Start growing a human clone in the pod!
-/obj/machinery/clonepod/proc/growclone(CLONING_STRICT_ARGS(clonename, unique_identity, mutation_index, given_mind, last_death, datum/species/mrace, list/features, factions, datum/bank_account/insurance, list/traumas, body_only, experimental, gender))
+/obj/machinery/clonepod/proc/growclone(CLONING_STRICT_ARGS(clonename, unique_identity, unique_enzymes, mutation_index, given_mind, last_death, datum/species/mrace, list/features, factions, datum/bank_account/insurance, list/traumas, body_only, experimental, gender, age, datum/blood_type/blood_type))
 	var/result = CLONING_SUCCESS
 	if(!reagents.has_reagent(/datum/reagent/medicine/synthflesh, fleshamnt))
 		connected_message("Cannot start cloning: Not enough synthflesh.")
@@ -221,9 +221,18 @@ SCREENTIP_ATTACK_HAND(/obj/machinery/clonepod, "Examine")
 
 	var/mob/living/carbon/human/H = new /mob/living/carbon/human(src)
 
-	H.hardset_dna(unique_identity, mutation_index, H.real_name, null, mrace, features)
+	if(!clonename)	//to prevent null names
+		clonename = "clone ([rand(1,999)])"
+	H.real_name = clonename
 	if(gender)
 		H.gender = gender
+	if(age)
+		H.age = age
+
+	H.hardset_dna(unique_identity, mutation_index, clonename, blood_type, mrace, features)
+	//The record holds the authoritative enzymes, which are not always the hash of the current name.
+	if(unique_enzymes)
+		H.dna.unique_enzymes = unique_enzymes
 
 	if(!HAS_TRAIT(H, TRAIT_RADIMMUNE))//dont apply mutations if the species is Mutation proof.
 		if(efficiency > 2)
@@ -238,10 +247,6 @@ SCREENTIP_ATTACK_HAND(/obj/machinery/clonepod, "Examine")
 
 	H.adjust_silence(40 SECONDS) //Prevents an extreme edge case where clones could speak if they said something at exactly the right moment.
 	occupant = H
-
-	if(!clonename)	//to prevent null names
-		clonename = "clone ([rand(1,999)])"
-	H.real_name = clonename
 
 	icon_state = "pod_1"
 	//Get the clone body ready

--- a/code/game/machinery/computer/cloning.dm
+++ b/code/game/machinery/computer/cloning.dm
@@ -439,17 +439,20 @@ DEFINE_BUFFER_HANDLER(/obj/machinery/computer/cloning)
 	var/cloning_attempt_result = pod.growclone(CLONING_STRICT_ARGS(
 		/* 01 */ clonename = found_record.name,
 		/* 02 */ unique_identity = found_record.unique_identity,
-		/* 03 */ mutation_index = found_record.datum_dna.mutation_index.Copy(),
-		/* 04 */ given_mind = found_record.resolve_mind(),
-		/* 05 */ last_death = found_record.last_death,
-		/* 06 */ mrace = found_record.species,
-		/* 07 */ features = found_record.datum_dna.features.Copy(),
-		/* 08 */ factions = found_record.factions.Copy(),
-		/* 09 */ insurance = found_record.resolve_mind_account_id(),
-		/* 10 */ traumas = found_record.traumas.Copy(),
-		/* 11 */ body_only = found_record.body_only,
-		/* 12 */ experimental = experimental,
-		/* 13 */ gender = found_record.gender ))
+		/* 03 */ unique_enzymes = found_record.unique_enzymes,
+		/* 04 */ mutation_index = found_record.datum_dna.mutation_index.Copy(),
+		/* 05 */ given_mind = found_record.resolve_mind(),
+		/* 06 */ last_death = found_record.last_death,
+		/* 07 */ mrace = found_record.species,
+		/* 08 */ features = found_record.datum_dna.features.Copy(),
+		/* 09 */ factions = found_record.factions.Copy(),
+		/* 10 */ insurance = found_record.resolve_mind_account_id(),
+		/* 11 */ traumas = found_record.traumas.Copy(),
+		/* 12 */ body_only = found_record.body_only,
+		/* 13 */ experimental = experimental,
+		/* 14 */ gender = found_record.gender,
+		/* 15 */ age = found_record.age,
+		/* 16 */ blood_type = found_record.datum_dna.blood_type ))
 	switch(cloning_attempt_result)
 		if(CLONING_SUCCESS)
 			temp = "Notice: [found_record.name] => Cloning cycle in progress..."

--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -349,8 +349,9 @@ Traitors and the like can also be revived with the previous role mostly intact.
 		new_character.real_name = record_found.name
 		new_character.gender = record_found.gender
 		new_character.age = record_found.age
-		var/datum/dna/found_dna = record_found.weakref_dna.resolve()
-		new_character.hardset_dna(found_dna.unique_identity, record_found.unique_enzymes, null, record_found.name, record_found.blood_type, new record_found.species, found_dna.features)
+		var/datum/dna/found_dna = record_found.datum_dna
+		new_character.hardset_dna(found_dna.unique_identity, found_dna.mutation_index.Copy(), record_found.name, found_dna.blood_type, found_dna.species, found_dna.features.Copy())
+		new_character.dna.unique_enzymes = record_found.unique_enzymes
 	else
 		randomize_human(new_character)
 		//Whats the point of this?

--- a/code/modules/mob/transform_procs.dm
+++ b/code/modules/mob/transform_procs.dm
@@ -352,7 +352,7 @@
 
 	if(findtext(O.dna.real_name, "monkey", 1, 7)) //7 == length("monkey") + 1
 		O.real_name = generate_random_mob_name()
-		O.dna.generate_unique_enzymes(O)
+		O.dna.unique_enzymes = O.dna.generate_unique_enzymes()
 	else
 		O.real_name = O.dna.real_name
 	O.name = O.real_name

--- a/code/modules/mob/transform_procs.dm
+++ b/code/modules/mob/transform_procs.dm
@@ -352,7 +352,7 @@
 
 	if(findtext(O.dna.real_name, "monkey", 1, 7)) //7 == length("monkey") + 1
 		O.real_name = generate_random_mob_name()
-		O.dna.generate_unique_enzymes(O)
+		O.dna.unique_enzymes = O.dna.generate_unique_enzymes(O)
 	else
 		O.real_name = O.dna.real_name
 	O.name = O.real_name


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
the generate_unique_whatever procs only return the string they generate, not assign it. Cloning also just neglects to copy over age, blood type, and enzymes.

## Why It's Good For The Game
i'd like it if bugs didn't make new players think this is intended behaviour

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

Original above clone below, appearance is the same. Human hair getting changed is an explicit decision.

<img width="296" height="340" alt="dreamseeker_AB8EpALPbu" src="https://github.com/user-attachments/assets/39045707-260e-4f08-94c9-5f69953e1796" />

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>

## Changelog
:cl: r1ks, rkz
fix: Fixes cloning randomizing unique enzymes(relevant to blood,  identity checks) and non-human appearance, and a few other sources of enzymes not being assigned.
fix: Fixes cloning not respecting the cloned's enzymes, blood type, age
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
